### PR TITLE
[Storage] Add new enum and new methods

### DIFF
--- a/src/Tizen.System.Storage/Interop/Interop.Storage.cs
+++ b/src/Tizen.System.Storage/Interop/Interop.Storage.cs
@@ -35,6 +35,7 @@ internal static partial class Interop
         {
             Internal = 0,
             External = 1,
+            ExtendedInternal = 2,
         }
 
         // Any change here might require changes in Tizen.System.StorageState enum
@@ -59,6 +60,17 @@ internal static partial class Interop
             Others = 7,
             Ringtones = 8,
         }
+
+        // Any change here might require changes in Tizen.System.StorageDevice enum
+        internal enum StorageDevice
+        {
+            ExternalSDCard = 1001,
+            ExternalUSBMassStorage = 1002,
+            ExtendedInternalStorage = 1003,
+        }
+
+        [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
+        internal delegate void StorageChangedCallback(int id, StorageDevice devicetype, StorageState state, string fstype, string fsuuid, string mountpath, bool primary, int flags, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void StorageStateChangedCallback(int id, StorageState state, IntPtr userData);
@@ -92,5 +104,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.Storage, EntryPoint = "storage_foreach_device_supported")]
         public static extern ErrorCode StorageManagerGetForeachDeviceSupported(StorageDeviceSupportedCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.Storage, EntryPoint = "storage_set_changed_cb")]
+        internal static extern ErrorCode StorageSetChanged(int id, StorageChangedCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.Storage, EntryPoint = "storage_unset_changed_cb")]
+        internal static extern ErrorCode StorageUnsetChanged(int id, StorageChangedCallback callback);
     }
 }

--- a/src/Tizen.System.Storage/Storage/Storage.cs
+++ b/src/Tizen.System.Storage/Storage/Storage.cs
@@ -192,7 +192,7 @@ namespace Tizen.System
         /// <summary>
         /// The StorageDevice
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
+        /// <since_tizen> 4 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when DeviceType is not initialized.</exception>
         public StorageDevice DeviceType
         {
@@ -210,7 +210,7 @@ namespace Tizen.System
         /// <summary>
         /// The type of file system
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
+        /// <since_tizen> 4 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when Fstype is not initialized.</exception>
         public string Fstype
         {
@@ -228,7 +228,7 @@ namespace Tizen.System
         /// <summary>
         /// The uuid of the file system
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
+        /// <since_tizen> 4 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when Fsuuid is not initialized.</exception>
         public string Fsuuid
         {
@@ -246,7 +246,7 @@ namespace Tizen.System
         /// <summary>
         /// Information about whether this is primary partition
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
+        /// <since_tizen> 4 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when Primary is not initialized.</exception>
         public bool Primary
         {
@@ -264,7 +264,7 @@ namespace Tizen.System
         /// <summary>
         /// The flags for the storage status
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
+        /// <since_tizen> 4 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when Flags is not initialized.</exception>
         public int Flags
         {

--- a/src/Tizen.System.Storage/Storage/Storage.cs
+++ b/src/Tizen.System.Storage/Storage/Storage.cs
@@ -26,7 +26,13 @@ namespace Tizen.System
     {
         private const string LogTag = "Tizen.System";
         private Interop.Storage.StorageState _state;
+        private StorageDevice _devicetype;
+        private string _fstype;
+        private string _fsuuid;
         private ulong _totalSpace;
+        private bool _primary;
+        private int _flags;
+        private bool information_set = false;
 
         internal Storage(int storageID, Interop.Storage.StorageArea storageType, Interop.Storage.StorageState storagestate, string rootDirectory)
         {
@@ -34,6 +40,36 @@ namespace Tizen.System
             StorageType = (StorageArea)storageType;
             RootDirectory = rootDirectory;
             _state = storagestate;
+
+
+            Interop.Storage.ErrorCode err = Interop.Storage.StorageGetTotalSpace(Id, out _totalSpace);
+            if (err != Interop.Storage.ErrorCode.None)
+            {
+                Log.Warn(LogTag, string.Format("Failed to get total storage space for storage Id: {0}. err = {1}", Id, err));
+            }
+
+            s_stateChangedEventCallback = (id, state, userData) =>
+            {
+                if (id == Id)
+                {
+                    _state = state;
+                    s_stateChangedEventHandler?.Invoke(this, EventArgs.Empty);
+                }
+            };
+        }
+
+        internal Storage(int storageID, Interop.Storage.StorageArea storageType, Interop.Storage.StorageState storagestate, string rootDirectory, Interop.Storage.StorageDevice devicetype, string fstype, string fsuuid, bool primary, int flags)
+        {
+            Id = storageID;
+            StorageType = (StorageArea)storageType;
+            RootDirectory = rootDirectory;
+            _state = storagestate;
+            _devicetype = (StorageDevice)devicetype;
+            _fstype = fstype;
+            _fsuuid = fsuuid;
+            _primary = primary;
+            _flags = flags;
+            information_set = true;
 
             Interop.Storage.ErrorCode err = Interop.Storage.StorageGetTotalSpace(Id, out _totalSpace);
             if (err != Interop.Storage.ErrorCode.None)
@@ -150,6 +186,96 @@ namespace Tizen.System
                     }
                 }
                 return (StorageState)_state;
+            }
+        }
+
+        /// <summary>
+        /// The StorageDevice
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <exception cref="InvalidOperationException">Thrown when DeviceType is not initialized.</exception>
+        public StorageDevice DeviceType
+        {
+            get
+            {
+                if (!information_set)
+                {
+                    Log.Error(LogTag, string.Format("Doesn't know StorageDevice type."));
+                    throw new InvalidOperationException("Doesn't know StorageDevice type");
+                }
+                return (StorageDevice)_devicetype;
+            }
+        }
+
+        /// <summary>
+        /// The type of file system
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <exception cref="InvalidOperationException">Thrown when Fstype is not initialized.</exception>
+        public string Fstype
+        {
+            get
+            {
+                if (!information_set)
+                {
+                    Log.Error(LogTag, string.Format("Doesn't know fstype."));
+                    throw new InvalidOperationException("Doesn't know type of file system");
+                }
+                return _fstype;
+            }
+        }
+
+        /// <summary>
+        /// The uuid of the file system
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <exception cref="InvalidOperationException">Thrown when Fsuuid is not initialized.</exception>
+        public string Fsuuid
+        {
+            get
+            {
+                if (!information_set)
+                {
+                    Log.Error(LogTag, string.Format("Doesn't know fsuuid."));
+                    throw new InvalidOperationException("Doesn't know uuid of file system");
+                }
+                return _fsuuid;
+            }
+        }
+
+        /// <summary>
+        /// Information about whether this is primary partition
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <exception cref="InvalidOperationException">Thrown when Primary is not initialized.</exception>
+        public bool Primary
+        {
+            get
+            {
+                if (!information_set)
+                {
+                    Log.Error(LogTag, string.Format("Doesn't know primary information."));
+                    throw new InvalidOperationException("Doesn't know primary information");
+                }
+                return _primary;
+            }
+        }
+
+        /// <summary>
+        /// The flags for the storage status
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <exception cref="InvalidOperationException">Thrown when Flags is not initialized.</exception>
+        public int Flags
+        {
+            get
+            {
+                if (!information_set)
+                {
+                    Log.Error(LogTag, string.Format("Doesn't know flags."));
+                    throw new InvalidOperationException("Doesn't know flags");
+                }
+                return _flags;
             }
         }
 

--- a/src/Tizen.System.Storage/Storage/StorageDevice.cs
+++ b/src/Tizen.System.Storage/Storage/StorageDevice.cs
@@ -19,18 +19,18 @@ namespace Tizen.System
     /// <summary>
     /// Enumeration for storage devices.
     /// </summary>
-    /// <since_tizen> 3 </since_tizen>
+    /// <since_tizen> 4 </since_tizen>
     public enum StorageDevice
     {
         /// <summary>
         /// External sd card device
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
+        /// <since_tizen> 4 </since_tizen>
         ExternalSDCard = Interop.Storage.StorageDevice.ExternalSDCard,
         /// <summary>
         /// External usb mass storage
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
+        /// <since_tizen> 4 </since_tizen>
         ExternalUSBMassStorage = Interop.Storage.StorageDevice.ExternalUSBMassStorage,
         /// <summary>
         /// Extended internal storage

--- a/src/Tizen.System.Storage/Storage/StorageDevice.cs
+++ b/src/Tizen.System.Storage/Storage/StorageDevice.cs
@@ -17,25 +17,25 @@
 namespace Tizen.System
 {
     /// <summary>
-    /// Enumeration for the storage area types.
+    /// Enumeration for storage devices.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    public enum StorageArea
+    public enum StorageDevice
     {
         /// <summary>
-        /// Internal device storage (built-in storage in a device, non-removable).
+        /// External sd card device
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        Internal = Interop.Storage.StorageArea.Internal,
+        ExternalSDCard = Interop.Storage.StorageDevice.ExternalSDCard,
         /// <summary>
-        /// External storage.
+        /// External usb mass storage
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        External = Interop.Storage.StorageArea.External,
+        ExternalUSBMassStorage = Interop.Storage.StorageDevice.ExternalUSBMassStorage,
         /// <summary>
         /// Extended internal storage
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        ExtendedInternal = Interop.Storage.StorageArea.ExtendedInternal,
+        ExtendedInternalStorage = Interop.Storage.StorageDevice.ExtendedInternalStorage,
     }
 }

--- a/src/Tizen.System.Storage/Storage/StorageManager.cs
+++ b/src/Tizen.System.Storage/Storage/StorageManager.cs
@@ -86,6 +86,7 @@ namespace Tizen.System
         /// </summary>
         /// <param name="type">Storage type</param>
         /// <param name="handler">An eventhandler to register</param>
+        /// <since_tizen> 4 </since_tizen>
         public static void SetChangedEvent(StorageArea type, EventHandler handler)
         {
             if (type == StorageArea.Internal)
@@ -112,6 +113,7 @@ namespace Tizen.System
         /// </summary>
         /// <param name="type">Storage type</param>
         /// <param name="handler">An eventhandler to unregister</param>
+        /// <since_tizen> 4 </since_tizen>
         public static void UnsetChangedEvent(StorageArea type, EventHandler handler)
         {
             if (type == StorageArea.Internal)


### PR DESCRIPTION
Change-Id: Ic5af889a8bcc40b3667081e0ec8088df697006ee
Signed-off-by: pr.jung <pr.jung@samsung.com>

### Description of Change ###

- Add ExtendedInternal on StorageArea
- Add StorageDevice enumerations
- Add SetChangedEvent and UnsetChangedEvent on StorageManager class for storage_set_changed_cb and storage_unset_changed_cb apis

### Bugs Fixed ###

- N/A

### API Changes ###

Added:
 - ExtendedInternal = Interop.Storage.StorageArea.ExtendedInternal,
 - public enum StorageDevice
    { 
        ExternalSDCard = Interop.Storage.StorageDevice.ExternalSDCard,
        ExternalUSBMassStorage = Interop.Storage.StorageDevice.ExternalUSBMassStorage,
        ExtendedInternalStorage = Interop.Storage.StorageDevice.ExtendedInternalStorage,
    }   
 - public static void SetChangedEvent(StorageArea type, EventHandler handler)
 - public static void UnsetChangedEvent(StorageArea type, EventHandler handler)

### Behavioral Changes ###

N/A (All features are added)