### PR TITLE
[MediaContent] Added "content.scanning.others" feature tags to related methods.

### DIFF
--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaDatabase.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaDatabase.cs
@@ -207,7 +207,10 @@ namespace Tizen.Content.MediaContent
         /// the record of the media file will be deleted from the database.<br/>
         /// <br/>
         /// If you want to access internal storage, you should add privilege http://tizen.org/privilege/mediastorage.<br/>
-        /// If you want to access external storage, you should add privilege http://tizen.org/privilege/externalstorage.
+        /// If you want to access external storage, you should add privilege http://tizen.org/privilege/externalstorage.<br/>
+        /// <br/>
+        /// If http://tizen.org/feature/content.scanning.others feature is not supported and the specified file is other-type,
+        /// <see cref="NotSupportedException"/> will be thrown.
         /// </remarks>
         /// <privilege>http://tizen.org/privilege/content.write</privilege>
         /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
@@ -223,6 +226,7 @@ namespace Tizen.Content.MediaContent
         ///     <paramref name="path"/> contains a directory containing the ".scan_ignore" file.
         /// </exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
         /// <since_tizen> 4 </since_tizen>
         public void ScanFile(string path)
         {

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfoCommand.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfoCommand.cs
@@ -511,7 +511,10 @@ namespace Tizen.Content.MediaContent
         ///     The <see cref="MediaDatabase.ScanFile(string)"/> or the <see cref="MediaDatabase.ScanFolderAsync(string)"/> can be used instead.<br/>
         ///     <br/>
         ///     If you want to access internal storage, you should add privilege http://tizen.org/privilege/mediastorage.<br/>
-        ///     If you want to access external storage, you should add privilege http://tizen.org/privilege/externalstorage.
+        ///     If you want to access external storage, you should add privilege http://tizen.org/privilege/externalstorage.<br/>
+        ///     <br/>
+        ///     If http://tizen.org/feature/content.scanning.others feature is not supported and the specified file is other-type,
+        ///     <see cref="NotSupportedException"/> will be thrown.
         /// </remarks>
         /// <privilege>http://tizen.org/privilege/content.write</privilege>
         /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
@@ -529,6 +532,7 @@ namespace Tizen.Content.MediaContent
         /// </exception>
         /// <exception cref="FileNotFoundException"><paramref name="path"/> does not exists.</exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
         /// <since_tizen> 4 </since_tizen>
         public MediaInfo Add(string path)
         {
@@ -598,7 +602,10 @@ namespace Tizen.Content.MediaContent
         ///     At most 300 items can be added at once.<br/>
         ///     <br/>
         ///     If you want to access internal storage, you should add privilege http://tizen.org/privilege/mediastorage.<br/>
-        ///     If you want to access external storage, you should add privilege http://tizen.org/privilege/externalstorage.
+        ///     If you want to access external storage, you should add privilege http://tizen.org/privilege/externalstorage.<br/>
+        ///     <br/>
+        ///     If http://tizen.org/feature/content.scanning.others feature is not supported and the specified file is other-type,
+        ///     <see cref="NotSupportedException"/> will be thrown.
         /// </remarks>
         /// <privilege>http://tizen.org/privilege/content.write</privilege>
         /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
@@ -618,6 +625,7 @@ namespace Tizen.Content.MediaContent
         /// </exception>
         /// <exception cref="FileNotFoundException"><paramref name="paths"/> contains a path that does not exist.</exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
         /// <since_tizen> 4 </since_tizen>
         public async Task AddAsync(IEnumerable<string> paths)
         {

--- a/src/Tizen.Content.MediaContent/doc/api/Tizen.Content.MediaContent.md
+++ b/src/Tizen.Content.MediaContent/doc/api/Tizen.Content.MediaContent.md
@@ -16,6 +16,8 @@
 uid: Tizen.Content.MediaContent
 summary: *content
 remarks: The media content service does not manage hidden files.
+In addition, if "http://tizen.org/feature/content.scanning.others" feature is not supported,
+other-type files which are not included in the media content types such as image, video, sound or music, are ignored.
 ---
 The Tizen.Content.MediaContent namespace provides types used in the entire content service.
 The information about media items (i.e. image, audio, and video) are managed in the content database


### PR DESCRIPTION
### Description of Change ###

Added "content.scanning.others" feature tags to related methods.

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: http://suprem.sec.samsung.net/jira/projects/TCSACR/issues/TCSACR-125

### Behavioral Changes ###

The "content.scanning.others" feature related methods(which are MediaDatabase.ScanFile, MediaInfoCommand.Add, and MediaInfoCommand.AddAsync) work differently now based on whether the specified feature is supported.
  