### PR TITLE
[ElmSharp] Changed Widget.SetFocus() internal routine

### DIFF
--- a/src/ElmSharp/ElmSharp/Widget.cs
+++ b/src/ElmSharp/ElmSharp/Widget.cs
@@ -293,14 +293,11 @@ namespace ElmSharp
         /// <since_tizen> preview </since_tizen>
         public void SetFocus(bool isFocus)
         {
-            Interop.Elementary.elm_object_focus_set(RealHandle, isFocus);
-
-            // Temporary code due to focus issue (will be removed at Tizen 5.0)
-            if (this is Window)
-            {
-                if (isFocus && !Interop.Evas.evas_object_focus_get(RealHandle))
-                    Interop.Evas.evas_object_focus_set(RealHandle, true);
-            }
+            if (isFocus)
+                Interop.Elementary.elm_object_focus_set(RealHandle, isFocus);
+            else
+                // Temporary code due to focus issue (will be removed at Tizen 5.0)
+                Interop.Elementary.elm_object_focused_clear(RealHandle);
         }
 
         /// <summary>

--- a/src/ElmSharp/Interop/Interop.Elementary.cs
+++ b/src/ElmSharp/Interop/Interop.Elementary.cs
@@ -103,10 +103,10 @@ internal static partial class Interop
             }
 
             IntPtr win = elm_widget_top_get(handle);
-            if (win == IntPtr.Zero || Eo.eo_class_name_get(Eo.eo_class_get(win)) != "Elm_Win")
-                return;
-
-            Evas.evas_object_focus_set(win, true);
+            if (win != IntPtr.Zero && Eo.eo_class_name_get(Eo.eo_class_get(win)) == "Elm_Win")
+            {
+                Evas.evas_object_focus_set(win, true);
+            }
         }
 
         [DllImport(Libraries.Elementary)]

--- a/src/ElmSharp/Interop/Interop.Elementary.cs
+++ b/src/ElmSharp/Interop/Interop.Elementary.cs
@@ -91,6 +91,34 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(_elm_config_profile_get());
         }
 
+        internal static void elm_object_focused_clear(IntPtr handle)
+        {
+            IntPtr win = elm_widget_top_get(handle);
+
+            if (win == IntPtr.Zero || Interop.Eo.eo_class_name_get(win) != "Elm_Win")
+                return;
+
+            if (elm_widget_is(handle))
+            {
+                elm_widget_focused_object_clear(handle);
+            }
+            else
+            {
+                Evas.evas_object_focus_set(handle, false);
+            }
+
+            Evas.evas_object_focus_set(win, true);
+        }
+
+        [DllImport(Libraries.Elementary)]
+        internal static extern IntPtr elm_widget_top_get(IntPtr handle);
+
+        [DllImport(Libraries.Elementary)]
+        internal static extern bool elm_widget_is(IntPtr handle);
+
+        [DllImport(Libraries.Elementary)]
+        internal static extern void elm_widget_focused_object_clear(IntPtr handle);
+
         [DllImport(Libraries.Elementary)]
         internal static extern void elm_config_preferred_engine_set(string name);
 

--- a/src/ElmSharp/Interop/Interop.Elementary.cs
+++ b/src/ElmSharp/Interop/Interop.Elementary.cs
@@ -93,11 +93,6 @@ internal static partial class Interop
 
         internal static void elm_object_focused_clear(IntPtr handle)
         {
-            IntPtr win = elm_widget_top_get(handle);
-
-            if (win == IntPtr.Zero || Interop.Eo.eo_class_name_get(win) != "Elm_Win")
-                return;
-
             if (elm_widget_is(handle))
             {
                 elm_widget_focused_object_clear(handle);
@@ -106,6 +101,10 @@ internal static partial class Interop
             {
                 Evas.evas_object_focus_set(handle, false);
             }
+
+            IntPtr win = elm_widget_top_get(handle);
+            if (win == IntPtr.Zero || Eo.eo_class_name_get(Eo.eo_class_get(win)) != "Elm_Win")
+                return;
 
             Evas.evas_object_focus_set(win, true);
         }


### PR DESCRIPTION
### Description of Change ###
Focus Chain gets lost due to the malfunction of calling SetFocus(false).
Eventually, the focus is missing forever on the app.

We created an internal API to return the initial focus state to the same state as when the App was first launched. This change is about adding an exeption logic to make focus chain normalized.
