### PR TITLE
[NUI] Fix SiblingOrder return value

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2234,14 +2234,18 @@ namespace Tizen.NUI.BaseComponents
                 if (parentChildren != null)
                 {
                     currentOrder = parentChildren.IndexOf(this);
-                    
-                    if (currentOrder < parentChildren.Count)
+
+                    if (currentOrder < 0)
+                    {
+                        return 0;
+                    }
+                    else if (currentOrder < parentChildren.Count)
                     {
                         return currentOrder;
                     }
                 }
-                
-                return currentOrder;
+
+                return 0;
             }
             set
             {


### PR DESCRIPTION
If parentChildren count is empty, return 0
Signed-off-by: huiyu,eun <huiyu.eun@samsung.com>

### Description of Change ###
Fix SiblingOrder return value