### PR TITLE
[NUI] Fix svace issue

### DIFF
--- a/src/Tizen.NUI/src/internal/WidgetApplication.cs
+++ b/src/Tizen.NUI/src/internal/WidgetApplication.cs
@@ -147,7 +147,10 @@ namespace Tizen.NUI
                 if (widgetInfo[widgetType] == widgetName)
                 {
                     Widget widget = Activator.CreateInstance(widgetType) as Widget;
-                    return widget.GetIntPtr();
+                    if (widget)
+                    {
+                        return widget.GetIntPtr();
+                    }
                 }
             }
 

--- a/src/Tizen.NUI/src/public/UIComponents/Button.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/Button.cs
@@ -757,7 +757,7 @@ namespace Tizen.NUI.UIComponents
                 Tizen.NUI.PropertyMap map = new Tizen.NUI.PropertyMap();
                 GetProperty( Button.Property.LABEL).Get(map);
                 Tizen.NUI.PropertyValue value = map.Find( TextVisualProperty.Text, "Text");
-                string str;
+                string str = "";
                 value?.Get(out str);
                 return str;
             }

--- a/src/Tizen.NUI/src/public/UIComponents/Button.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/Button.cs
@@ -758,7 +758,7 @@ namespace Tizen.NUI.UIComponents
                 GetProperty( Button.Property.LABEL).Get(map);
                 Tizen.NUI.PropertyValue value = map.Find( TextVisualProperty.Text, "Text");
                 string str;
-                value.Get(out str);
+                value?.Get(out str);
                 return str;
             }
             set


### PR DESCRIPTION
Value widget, which was created by as-operator, so can be null,
is dereferenced in method call widget.GetIntPtr()

Value value, which is result of method invocation with possible null return value,
is dereferenced in method call value.Get()

Signed-off-by: huiyu,eun <huiyu.eun@samsung.com>

### Description of Change ###
Fix svace issue
