### PR TITLE
[Device] add lock for global variable of led and battery

### DIFF
--- a/src/Tizen.System/Device/Battery.cs
+++ b/src/Tizen.System/Device/Battery.cs
@@ -129,7 +129,7 @@ namespace Tizen.System
             }
         }
 
-        private static EventHandler<BatteryPercentChangedEventArgs> s_capacityChanged;
+        private static event EventHandler<BatteryPercentChangedEventArgs> s_capacityChanged;
         /// <summary>
         /// CapacityChanged is triggered when the battery charge percentage is changed.
         /// </summary>

--- a/src/Tizen.System/Device/Led.cs
+++ b/src/Tizen.System/Device/Led.cs
@@ -172,7 +172,7 @@ namespace Tizen.System
         }
 
 
-        private static EventHandler<LedBrightnessChangedEventArgs> s_brightnessChanged;
+        private static event EventHandler<LedBrightnessChangedEventArgs> s_brightnessChanged;
         /// <summary>
         /// StateChanged is raised when the LED state is changed.
         /// </summary>


### PR DESCRIPTION
Signed-off-by: lokilee73 <changjoo.lee@samsung.com>

Description of Change

Apply fixes based on static analysis results
Bugs about thread safety were detected

Bugs Fixed

    Kona WorkItemID : DF180112-01404
        Checker: NO_LOCKSTAT
        File: /Device/Battery.cs
        Line: 285

    Kona WorkItemID : DF180112-01407
        Checker: NO_LOCKSTAT
        File: /Device/Led.cs
        Line: 216
