### PR TITLE
[StreamRecorder] fix after as derefence issue

### DIFF
--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -326,7 +326,8 @@ namespace Tizen.Multimedia
                         throw new InvalidOperationException("Video option is not set.");
                     }
 
-                    if (AreVideoTypesMatched(_sourceFormat, (packet.Format as VideoMediaFormat).MimeType) == false)
+                    if ((packet.Format is VideoMediaFormat format) &&
+                        (AreVideoTypesMatched(_sourceFormat, format.MimeType) == false))
                     {
                         throw new InvalidOperationException("Video format does not match.");
                     }


### PR DESCRIPTION
### Description of Change ###
as operator can have null.
It is needed to check for null value.

Checker: DEREF_AFTER_AS.INSTANT
File: StreamRecorder.cs
Line:  329
