### PR TITLE
[Notification] Fix handle leak

### DIFF
--- a/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/NotificationStyleBinder.cs
+++ b/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/NotificationStyleBinder.cs
@@ -253,6 +253,7 @@ namespace Tizen.Applications.Notifications
                         Interop.Notification.GetExtentionData(notification.Handle, replyKey, out bundleHandle);
                         Bundle bundle = new Bundle(bundleHandle);
                         reply.ParentIndex = (ButtonIndex)int.Parse(bundle.GetItem(replyKey).ToString());
+                        bundle.Dispose();
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
### Bugs Fixed ###
[Notification] Fix handle leak

- After the duplicated Bundle object is used, Dispose is called to release the unmanaged resource.