### PR TITLE
[ElmSharp] Changed Background widget Color property internal implementation

### DIFF
--- a/src/ElmSharp/ElmSharp/Background.cs
+++ b/src/ElmSharp/ElmSharp/Background.cs
@@ -43,26 +43,11 @@ namespace ElmSharp
         {
             get
             {
-                int r = 0;
-                int g = 0;
-                int b = 0;
-                int a = 0;
-                var swallowContent = GetPartContent("elm.swallow.rectangle");
-                if (swallowContent != IntPtr.Zero)
-                {
-                    Interop.Evas.evas_object_color_get(swallowContent, out r, out g, out b, out a);
-                }
-                return new Color(r, g, b, a);
+                return BackgroundColor;
             }
             set
             {
-                var swallowContent = GetPartContent("elm.swallow.rectangle");
-                if (swallowContent == IntPtr.Zero)
-                {
-                    Interop.Elementary.elm_bg_color_set(RealHandle, value.R, value.G, value.B);
-                    swallowContent = GetPartContent("elm.swallow.rectangle");
-                }
-                Interop.Evas.evas_object_color_set(swallowContent, value.R, value.G, value.B, value.A);
+                BackgroundColor = value;
             }
         }
 


### PR DESCRIPTION
[ElmSharp] Changed Background widget Color property internal implementation to Widget BackgroundColor property

Signed-off-by: Jeonghyun Yun <jh0506.yun@samsung.com>

### Description of Change ###

There are two ways for setting background color to Background widget. (Color & BackgroundColor property)
Two properties are almost same for Background widget but internal implementation is different.
I changed Background widget Color property internal implementation to Widget BackgroundColor property.
