### PR TITLE
[NUI] Add protected codes to avoid the crash when the IntPtr of key is 0

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -410,6 +410,12 @@ namespace Tizen.NUI.BaseComponents
 
         private bool OnKeyEvent(IntPtr view, IntPtr keyEvent)
         {
+            if (keyEvent == global::System.IntPtr.Zero)
+            {
+                Tizen.Log.Error("NUI", "keyEvent should not be null!");
+                return true;
+            }
+
             KeyEventArgs e = new KeyEventArgs();
 
             bool result = false;
@@ -537,6 +543,12 @@ namespace Tizen.NUI.BaseComponents
         // Callback for View TouchSignal
         private bool OnTouch(IntPtr view, IntPtr touchData)
         {
+            if (touchData == global::System.IntPtr.Zero)
+            {
+                Tizen.Log.Error("NUI", "touchData should not be null!");
+                return true;
+            }
+
             TouchEventArgs e = new TouchEventArgs();
 
             e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);
@@ -612,6 +624,12 @@ namespace Tizen.NUI.BaseComponents
         // Callback for View Hover signal
         private bool OnHoverEvent(IntPtr view, IntPtr hoverEvent)
         {
+            if (hoverEvent == global::System.IntPtr.Zero)
+            {
+                Tizen.Log.Error("NUI", "hoverEvent should not be null!");
+                return true;
+            }
+
             HoverEventArgs e = new HoverEventArgs();
 
             e.Hover = Tizen.NUI.Hover.GetHoverFromPtr(hoverEvent);
@@ -687,6 +705,12 @@ namespace Tizen.NUI.BaseComponents
         // Callback for View Wheel signal
         private bool OnWheelEvent(IntPtr view, IntPtr wheelEvent)
         {
+            if (wheelEvent == global::System.IntPtr.Zero)
+            {
+                Tizen.Log.Error("NUI", "wheelEvent should not be null!");
+                return true;
+            }
+
             WheelEventArgs e = new WheelEventArgs();
 
             e.Wheel = Tizen.NUI.Wheel.GetWheelFromPtr(wheelEvent);


### PR DESCRIPTION
Signed-off-by: dongsug.song <dongsug.song@samsung.com>

### Description of Change ###

[NUI] Add protected codes to avoid the crash when the IntPtr of key is 0

### Bugs Fixed ###

[NUI] Add protected codes to avoid the crash when the IntPtr of key is 0

### API Changes ###

N/A

### Behavioral Changes ###

N/A
