### PR TITLE
[MediaContent] Fixed possible memory leak.

### DIFF
--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/ObjectKeeper.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/ObjectKeeper.cs
@@ -53,10 +53,7 @@ namespace Tizen.Content.MediaContent
             {
                 if (!disposedValue)
                 {
-                    if (disposing)
-                    {
-                        _handle.Free();
-                    }
+                    _handle.Free();
 
                     disposedValue = true;
                 }


### PR DESCRIPTION
### Description of Change ###

- GChandle must be freed.
- Handles could be leaked if the object is not disposed manually.
