### PR TITLE
[Multimedia] Code cleaning of MediaTool.

### DIFF
--- a/src/Tizen.Multimedia/Interop/Interop.EvasObject.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.EvasObject.cs
@@ -25,10 +25,9 @@ namespace Tizen.Multimedia
         {
             [DllImport("libevas.so.1")]
             internal static extern IntPtr evas_object_image_add(IntPtr parent);
+
             [DllImport("libevas.so.1")]
             internal static extern IntPtr evas_object_evas_get(IntPtr obj);
-            [DllImport("libevas.so.1")]
-            internal static extern void evas_object_show(IntPtr obj);
         }
     }
 }

--- a/src/Tizen.Multimedia/Interop/Interop.Libc.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Libc.cs
@@ -32,8 +32,6 @@ namespace Tizen.Multimedia
             [DllImport(Libraries.Libc, EntryPoint = "free")]
             public static extern void Free(IntPtr ptr);
 
-
-
             [DllImport(Libraries.Libc, EntryPoint = "access")]
             public static extern int Access(string path, int mode);
         }

--- a/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
@@ -83,7 +83,6 @@ namespace Tizen.Multimedia
             [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_dts")]
             internal static extern int SetDts(IntPtr handle, ulong value);
 
-
             [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_extra")]
             internal static extern int SetExtra(IntPtr handle, IntPtr value);
 
@@ -100,24 +99,26 @@ namespace Tizen.Multimedia
             internal static extern int Unref(IntPtr handle);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_type")]
-            internal static extern int GetType(IntPtr handle, out int type);
+            internal static extern int GetType(IntPtr handle, out MediaFormatType type);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_container_mime")]
-            internal static extern int GetContainerMimeType(IntPtr handle, out int mimeType);
+            internal static extern int GetContainerMimeType(IntPtr handle,
+                out MediaFormatContainerMimeType mimeType);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_container_mime")]
-            internal static extern int SetContainerMimeType(IntPtr handle, int mimeType);
+            internal static extern int SetContainerMimeType(IntPtr handle,
+                MediaFormatContainerMimeType mimeType);
 
             #region Video apis
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_video_info")]
-            internal static extern int GetVideoInfo(IntPtr handle, out int mimeType,
+            internal static extern int GetVideoInfo(IntPtr handle, out MediaFormatVideoMimeType mimeType,
                 out int width, out int height, out int averageBps, out int maxBps);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_video_frame_rate")]
             internal static extern int GetVideoFrameRate(IntPtr handle, out int frameRate);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_mime")]
-            internal static extern int SetVideoMimeType(IntPtr handle, int value);
+            internal static extern int SetVideoMimeType(IntPtr handle, MediaFormatVideoMimeType value);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_video_width")]
             internal static extern int SetVideoWidth(IntPtr handle, int value);
@@ -134,14 +135,14 @@ namespace Tizen.Multimedia
 
             #region Audio apis
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_info")]
-            internal static extern int GetAudioInfo(IntPtr handle, out int mimeType,
+            internal static extern int GetAudioInfo(IntPtr handle, out MediaFormatAudioMimeType mimeType,
                 out int channel, out int sampleRate, out int bit, out int averageBps);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_audio_aac_header_type")]
-            internal static extern int GetAudioAacType(IntPtr handle, out int aacType);
+            internal static extern int GetAudioAacType(IntPtr handle, out MediaFormatAacType aacType);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_mime")]
-            internal static extern int SetAudioMimeType(IntPtr handle, int value);
+            internal static extern int SetAudioMimeType(IntPtr handle, MediaFormatAudioMimeType value);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_channel")]
             internal static extern int SetAudioChannel(IntPtr handle, int value);
@@ -156,17 +157,18 @@ namespace Tizen.Multimedia
             internal static extern int SetAudioAverageBps(IntPtr handle, int value);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_audio_aac_header_type")]
-            internal static extern int SetAudioAacType(IntPtr handle, int value);
+            internal static extern int SetAudioAacType(IntPtr handle, MediaFormatAacType value);
             #endregion
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_get_text_info")]
-            internal static extern int GetTextInfo(IntPtr handle, out int mimeType, out int textType);
+            internal static extern int GetTextInfo(IntPtr handle,
+                out MediaFormatTextMimeType mimeType, out MediaFormatTextType textType);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_text_mime")]
-            internal static extern int SetTextMimeType(IntPtr handle, int value);
+            internal static extern int SetTextMimeType(IntPtr handle, MediaFormatTextMimeType value);
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_format_set_text_type")]
-            internal static extern int SetTextType(IntPtr handle, int value);
+            internal static extern int SetTextType(IntPtr handle, MediaFormatTextType value);
         }
     }
 }

--- a/src/Tizen.Multimedia/MediaTool/ContainerMediaFormat.cs
+++ b/src/Tizen.Multimedia/MediaTool/ContainerMediaFormat.cs
@@ -34,10 +34,9 @@ namespace Tizen.Multimedia
         public ContainerMediaFormat(MediaFormatContainerMimeType mimeType)
             : base(MediaFormatType.Container)
         {
-            if (!Enum.IsDefined(typeof(MediaFormatContainerMimeType), mimeType))
-            {
-                throw new ArgumentException($"Invalid mime type value : { (int)mimeType }");
-            }
+            ValidationUtil.ValidateEnum(typeof(MediaFormatContainerMimeType), mimeType,
+                nameof(mimeType));
+
             MimeType = mimeType;
         }
 
@@ -50,16 +49,14 @@ namespace Tizen.Multimedia
         {
             Debug.Assert(handle != IntPtr.Zero, "The handle is invalid!");
 
-            int mimeType = 0;
-
-            int ret = Interop.MediaFormat.GetContainerMimeType(handle, out mimeType);
+            int ret = Interop.MediaFormat.GetContainerMimeType(handle, out var mimeType);
 
             MultimediaDebug.AssertNoError(ret);
 
             Debug.Assert(Enum.IsDefined(typeof(MediaFormatContainerMimeType), mimeType),
                 "Invalid container mime type!");
 
-            MimeType = (MediaFormatContainerMimeType)mimeType;
+            MimeType = mimeType;
         }
 
         /// <summary>
@@ -72,7 +69,7 @@ namespace Tizen.Multimedia
         {
             Debug.Assert(Type == MediaFormatType.Container);
 
-            int ret = Interop.MediaFormat.SetContainerMimeType(handle, (int)MimeType);
+            int ret = Interop.MediaFormat.SetContainerMimeType(handle, MimeType);
 
             MultimediaDebug.AssertNoError(ret);
         }
@@ -106,7 +103,6 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <returns>The hash code for this instance of <see cref="ContainerMediaFormat"/>.</returns>
         /// <since_tizen> 3 </since_tizen>
-        public override int GetHashCode()
-            => (int)MimeType;
+        public override int GetHashCode() => MimeType.GetHashCode();
     }
 }

--- a/src/Tizen.Multimedia/MediaTool/MediaFormat.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaFormat.cs
@@ -39,10 +39,7 @@ namespace Tizen.Multimedia
         /// Gets the type of the current format.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public MediaFormatType Type
-        {
-            get;
-        }
+        public MediaFormatType Type { get; }
 
         /// <summary>
         /// Creates a media format from a native handle.
@@ -53,17 +50,16 @@ namespace Tizen.Multimedia
         {
             if (handle == IntPtr.Zero)
             {
-                throw new ArgumentException("The handle value is invalid.");
+                throw new ArgumentException("The handle value is invalid.", nameof(handle));
             }
 
-            int type = 0;
-            int ret = Interop.MediaFormat.GetType(handle, out type);
+            int ret = Interop.MediaFormat.GetType(handle, out var type);
 
             if (ret != (int)ErrorCode.InvalidOperation)
             {
                 MultimediaDebug.AssertNoError(ret);
 
-                switch ((MediaFormatType)type)
+                switch (type)
                 {
                     case MediaFormatType.Container:
                         return new ContainerMediaFormat(handle);
@@ -89,8 +85,7 @@ namespace Tizen.Multimedia
         /// <remarks>The returned handle must be destroyed using <see cref="Interop.MediaFormat.Unref(IntPtr)"/>.</remarks>
         internal IntPtr AsNativeHandle()
         {
-            IntPtr handle;
-            int ret = Interop.MediaFormat.Create(out handle);
+            int ret = Interop.MediaFormat.Create(out var handle);
 
             MultimediaDebug.AssertNoError(ret);
 

--- a/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
@@ -45,12 +45,8 @@ namespace Tizen.Multimedia
                 throw new ArgumentNullException(nameof(format));
             }
 
-            if (format.Type == MediaFormatType.Container)
-            {
-                throw new ArgumentException("Container format can't be used to create a new packet.");
-            }
-
             Initialize(format);
+
             _format = format;
             _buffer = new Lazy<IMediaBuffer>(GetBuffer);
         }
@@ -98,7 +94,8 @@ namespace Tizen.Multimedia
         {
             if (format.Type == MediaFormatType.Container)
             {
-                throw new ArgumentException("Creating a packet for container is not supported.");
+                throw new ArgumentException("Container format can't be used to create a new packet.",
+                    nameof(format));
             }
 
             IntPtr formatHandle = IntPtr.Zero;
@@ -187,8 +184,7 @@ namespace Tizen.Multimedia
             {
                 ValidateNotDisposed();
 
-                ulong value = 0;
-                int ret = Interop.MediaPacket.GetPts(_handle, out value);
+                int ret = Interop.MediaPacket.GetPts(_handle, out var value);
 
                 MultimediaDebug.AssertNoError(ret);
 
@@ -219,8 +215,7 @@ namespace Tizen.Multimedia
             {
                 ValidateNotDisposed();
 
-                ulong value = 0;
-                int ret = Interop.MediaPacket.GetDts(_handle, out value);
+                int ret = Interop.MediaPacket.GetDts(_handle, out var value);
 
                 MultimediaDebug.AssertNoError(ret);
 
@@ -249,8 +244,7 @@ namespace Tizen.Multimedia
             {
                 ValidateNotDisposed();
 
-                bool value = false;
-                int ret = Interop.MediaPacket.IsEncoded(_handle, out value);
+                int ret = Interop.MediaPacket.IsEncoded(_handle, out var value);
 
                 MultimediaDebug.AssertNoError(ret);
 
@@ -304,8 +298,7 @@ namespace Tizen.Multimedia
             {
                 ValidateNotDisposed();
 
-                ulong value = 0;
-                int ret = Interop.MediaPacket.GetBufferSize(_handle, out value);
+                int ret = Interop.MediaPacket.GetBufferSize(_handle, out var value);
                 MultimediaDebug.AssertNoError(ret);
 
                 Debug.Assert(value < int.MaxValue);
@@ -327,7 +320,8 @@ namespace Tizen.Multimedia
 
                 if (value < 0 || value >= Buffer.Length)
                 {
-                    throw new ArgumentOutOfRangeException("value must be less than Buffer.Size.");
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "value must be less than Buffer.Size.");
                 }
 
                 int ret = Interop.MediaPacket.SetBufferSize(_handle, (ulong)value);
@@ -499,13 +493,7 @@ namespace Tizen.Multimedia
         /// Gets a value indicating whether the packet is in the raw video format.
         /// </summary>
         /// <value>true if the packet is in the raw video format; otherwise, false.</value>
-        private bool IsVideoPlaneSupported
-        {
-            get
-            {
-                return !IsEncoded && Format.Type == MediaFormatType.Video;
-            }
-        }
+        private bool IsVideoPlaneSupported => !IsEncoded && Format.Type == MediaFormatType.Video;
 
         /// <summary>
         /// Retrieves video planes of the current packet.
@@ -515,8 +503,7 @@ namespace Tizen.Multimedia
         {
             Debug.Assert(_handle != IntPtr.Zero, "The handle is invalid!");
 
-            uint numberOfPlanes = 0;
-            int ret = Interop.MediaPacket.GetNumberOfVideoPlanes(_handle, out numberOfPlanes);
+            int ret = Interop.MediaPacket.GetNumberOfVideoPlanes(_handle, out var numberOfPlanes);
 
             MultimediaDebug.AssertNoError(ret);
 
@@ -540,15 +527,12 @@ namespace Tizen.Multimedia
 
             Debug.Assert(_handle != IntPtr.Zero, "The handle is invalid!");
 
-            IntPtr dataHandle;
-
-            int ret = Interop.MediaPacket.GetBufferData(_handle, out dataHandle);
+            int ret = Interop.MediaPacket.GetBufferData(_handle, out var dataHandle);
             MultimediaDebug.AssertNoError(ret);
 
             Debug.Assert(dataHandle != IntPtr.Zero, "Data handle is invalid!");
 
-            int size = 0;
-            ret = Interop.MediaPacket.GetAllocatedBufferSize(_handle, out size);
+            ret = Interop.MediaPacket.GetAllocatedBufferSize(_handle, out var size);
             MultimediaDebug.AssertNoError(ret);
 
             Debug.Assert(size >= 0, "size must not be negative!");

--- a/src/Tizen.Multimedia/MediaTool/MediaPacketVideoPlane.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaPacketVideoPlane.cs
@@ -47,8 +47,7 @@ namespace Tizen.Multimedia
 
             Debug.Assert(_strideWidth >= 0 && _strideHeight >= 0, "size must not be negative!");
 
-            IntPtr dataHandle;
-            ret = Interop.MediaPacket.GetVideoPlaneData(packet.GetHandle(), index, out dataHandle);
+            ret = Interop.MediaPacket.GetVideoPlaneData(packet.GetHandle(), index, out var dataHandle);
             MultimediaDebug.AssertNoError(ret);
 
             Debug.Assert(dataHandle != IntPtr.Zero, "Data handle is invalid!");

--- a/src/Tizen.Multimedia/MediaTool/TextMediaFormat.cs
+++ b/src/Tizen.Multimedia/MediaTool/TextMediaFormat.cs
@@ -38,14 +38,9 @@ namespace Tizen.Multimedia
         public TextMediaFormat(MediaFormatTextMimeType mimeType, MediaFormatTextType textType)
             : base(MediaFormatType.Text)
         {
-            if (!Enum.IsDefined(typeof(MediaFormatTextMimeType), mimeType))
-            {
-                throw new ArgumentException($"Invalid mime type value : { (int)mimeType }");
-            }
-            if (!Enum.IsDefined(typeof(MediaFormatTextType), textType))
-            {
-                throw new ArgumentException($"Invalid text type value : { (int)textType }");
-            }
+            ValidationUtil.ValidateEnum(typeof(MediaFormatTextMimeType), mimeType, nameof(mimeType));
+            ValidationUtil.ValidateEnum(typeof(MediaFormatTextType), textType, nameof(textType));
+
             MimeType = mimeType;
             TextType = textType;
         }
@@ -59,48 +54,27 @@ namespace Tizen.Multimedia
         {
             Debug.Assert(handle != IntPtr.Zero, "The handle is invalid!");
 
-            MediaFormatTextMimeType mimeType;
-            MediaFormatTextType textType;
-
-            GetInfo(handle, out mimeType, out textType);
-
-            MimeType = mimeType;
-            TextType = textType;
-        }
-
-        /// <summary>
-        /// Retrieves text properties of the media format from a native handle.
-        /// </summary>
-        /// <param name="handle">A native handle that the properties are retrieved from.</param>
-        /// <param name="mimeType">An out parameter for the mime type.</param>
-        /// <param name="textType">An out parameter for the text type.</param>
-        private static void GetInfo(IntPtr handle, out MediaFormatTextMimeType mimeType,
-            out MediaFormatTextType textType)
-        {
-            int mimeTypeValue = 0;
-            int textTypeValue = 0;
-
-            int ret = Interop.MediaFormat.GetTextInfo(handle, out mimeTypeValue, out textTypeValue);
+            int ret = Interop.MediaFormat.GetTextInfo(handle, out var mimeType, out var textType);
 
             MultimediaDebug.AssertNoError(ret);
-
-            mimeType = (MediaFormatTextMimeType)mimeTypeValue;
-            textType = (MediaFormatTextType)textTypeValue;
 
             Debug.Assert(Enum.IsDefined(typeof(MediaFormatTextMimeType), mimeType),
                 "Invalid text mime type!");
             Debug.Assert(Enum.IsDefined(typeof(MediaFormatTextType), textType),
                 "Invalid text type!");
+
+            MimeType = mimeType;
+            TextType = textType;
         }
 
         internal override void AsNativeHandle(IntPtr handle)
         {
             Debug.Assert(Type == MediaFormatType.Text);
 
-            int ret = Interop.MediaFormat.SetTextMimeType(handle, (int)MimeType);
+            int ret = Interop.MediaFormat.SetTextMimeType(handle, MimeType);
             MultimediaDebug.AssertNoError(ret);
 
-            ret = Interop.MediaFormat.SetTextType(handle, (int)TextType);
+            ret = Interop.MediaFormat.SetTextType(handle, TextType);
             MultimediaDebug.AssertNoError(ret);
         }
 


### PR DESCRIPTION
### Description of Change ###

- Use out variable.
- Validate enum with util method.
- MediaPacket.Lock now uses a field of MediaPacket not MediaPacket it self.
- And minor code improvement.
