### PR TITLE
[Build] Remove dali native version check from rpm spec

### DIFF
--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -3,8 +3,6 @@
 %define TIZEN_NET_RPM_VERSION @rpm_version@
 %define TIZEN_NET_NUGET_VERSION @nuget_version@
 %define TIZEN_NET_INTERNAL_NUGET_VERSION @internal_nuget_version@
-%define NATIVE_DALI_VERSION @dali_version@
-%define CHECK_NATIVE_DEPS @check_native_deps@
 
 %define DOTNET_ASSEMBLY_PATH /usr/share/dotnet.tizen/framework
 %define DOTNET_ASSEMBLY_DUMMY_PATH %{DOTNET_ASSEMBLY_PATH}/ref
@@ -27,10 +25,6 @@ AutoReqProv: no
 
 BuildRequires: dotnet-build-tools
 Requires(post): /usr/bin/vconftool
-
-%if 0%{CHECK_NATIVE_DEPS}
-BuildRequires: dali = %{NATIVE_DALI_VERSION}
-%endif
 
 %description
 %{summary}

--- a/packaging/makespec.sh
+++ b/packaging/makespec.sh
@@ -7,8 +7,6 @@ VERSION_FILE=$SCRIPT_DIR/version.txt
 RPMSPEC=$SCRIPT_DIR/csapi-tizenfx.spec
 RPMSPEC_IN=$RPMSPEC.in
 
-CHECK_NATIVE_DEPS=0
-
 source $VERSION_FILE
 
 while getopts ":r:n:i:c:" opt; do
@@ -16,7 +14,6 @@ while getopts ":r:n:i:c:" opt; do
     r) RPM_VERSION=$OPTARG ;;
     n) NUGET_VERSION=$OPTARG ;;
     i) INTERNAL_NUGET_VERSION=$OPTARG ;;
-    c) CHECK_NATIVE_DEPS=$OPTARG ;;
     :) echo "Option -$OPTARG requires an argument."; exit 1 ;;
   esac
 done
@@ -29,5 +26,3 @@ sed -i -e "s/@api_version@/$API_VERSION/g" $RPMSPEC
 sed -i -e "s/@rpm_version@/$RPM_VERSION/g" $RPMSPEC
 sed -i -e "s/@nuget_version@/$NUGET_VERSION/g" $RPMSPEC
 sed -i -e "s/@internal_nuget_version@/$INTERNAL_NUGET_VERSION/g" $RPMSPEC
-sed -i -e "s/@dali_version@/$DALI_VERSION/g" $RPMSPEC
-sed -i -e "s/@check_native_deps@/$CHECK_NATIVE_DEPS/g" $RPMSPEC

--- a/packaging/version.txt
+++ b/packaging/version.txt
@@ -8,6 +8,3 @@ INTERNAL_NUGET_VERSION=4.0.1.999
 
 # RPM Version Suffix
 RPM_VERSION_SUFFIX=nui401
-
-# Native Dependencies
-DALI_VERSION=0


### PR DESCRIPTION
### Description of Change ###

Remove version check for dali native package from packaging/csapi-tizenfx.spec 