### PR TITLE
[Tizen.Network.WiFi] Use lock on checking if instance is null

### DIFF
--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -86,7 +86,8 @@ namespace Tizen.Network.Connection
     internal class ConnectionInternalManager
     {
         private bool disposed = false;
-        private static Lazy<ConnectionInternalManager> s_instance = null;
+        private static readonly Lazy<ConnectionInternalManager> s_instance =
+            new Lazy<ConnectionInternalManager>(() => new ConnectionInternalManager());
 
         private EventHandler<ConnectionTypeEventArgs> _ConnectionTypeChanged = null;
         private EventHandler<AddressEventArgs> _IPAddressChanged = null;
@@ -102,14 +103,6 @@ namespace Tizen.Network.Connection
         {
             get
             {
-                if (s_instance == null)
-                {
-                    s_instance = new Lazy<ConnectionInternalManager>(() =>
-                            {
-                                return new ConnectionInternalManager();
-                            });
-                }
-
                 return s_instance.Value;
             }
         }
@@ -122,7 +115,7 @@ namespace Tizen.Network.Connection
 
         private ConnectionInternalManager()
         {
-
+            Log.Info(Globals.LogTag, "ConnectionInternalManager constructor");
         }
 
         ~ConnectionInternalManager()

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -86,7 +86,7 @@ namespace Tizen.Network.Connection
     internal class ConnectionInternalManager
     {
         private bool disposed = false;
-        private static ConnectionInternalManager s_instance = null;
+        private static Lazy<ConnectionInternalManager> s_instance = null;
 
         private EventHandler<ConnectionTypeEventArgs> _ConnectionTypeChanged = null;
         private EventHandler<AddressEventArgs> _IPAddressChanged = null;
@@ -104,10 +104,13 @@ namespace Tizen.Network.Connection
             {
                 if (s_instance == null)
                 {
-                    s_instance = new ConnectionInternalManager();
+                    s_instance = new Lazy<ConnectionInternalManager>(() =>
+                            {
+                                return new ConnectionInternalManager();
+                            });
                 }
 
-                return s_instance;
+                return s_instance.Value;
             }
         }
 

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -46,7 +46,7 @@ namespace Tizen.Network.WiFi
 
     internal partial class WiFiManagerImpl
     {
-        private static WiFiManagerImpl _instance = null;
+        private static Lazy<WiFiManagerImpl> _instance = null;
         private Dictionary<IntPtr, Interop.WiFi.VoidCallback> _callback_map = new Dictionary<IntPtr, Interop.WiFi.VoidCallback>();
         private int _requestId = 0;
         private string _macAddress;
@@ -124,10 +124,13 @@ namespace Tizen.Network.WiFi
                 if (_instance == null)
                 {
                     Log.Debug(Globals.LogTag, "Instance is null");
-                    _instance = new WiFiManagerImpl();
+                    _instance = new Lazy<WiFiManagerImpl>(() =>
+                            {
+                                return new WiFiManagerImpl();
+                            });
                 }
 
-                return _instance;
+                return _instance.Value;
             }
         }
 

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -46,7 +46,8 @@ namespace Tizen.Network.WiFi
 
     internal partial class WiFiManagerImpl
     {
-        private static Lazy<WiFiManagerImpl> _instance = null;
+        private static readonly Lazy<WiFiManagerImpl> _instance =
+            new Lazy<WiFiManagerImpl>(() => new WiFiManagerImpl());
         private Dictionary<IntPtr, Interop.WiFi.VoidCallback> _callback_map = new Dictionary<IntPtr, Interop.WiFi.VoidCallback>();
         private int _requestId = 0;
         private string _macAddress;
@@ -121,16 +122,7 @@ namespace Tizen.Network.WiFi
         {
             get
             {
-                if (_instance == null)
-                {
-                    Log.Debug(Globals.LogTag, "Instance is null");
-                    _instance = new Lazy<WiFiManagerImpl>(() =>
-                            {
-                                return new WiFiManagerImpl();
-                            });
-                }
-
-                return _instance.Value;
+               return _instance.Value;
             }
         }
 
@@ -142,6 +134,7 @@ namespace Tizen.Network.WiFi
 
         private WiFiManagerImpl()
         {
+            Log.Info(Globals.LogTag, "WiFiManagerImpl constructor");
         }
 
         internal SafeWiFiManagerHandle GetSafeHandle()


### PR DESCRIPTION
### Description of Change ###

WiFiManagerImple class has only single instance, but in multi-thread environment, race condition occurs when checking if the instance is null

### Bugs Fixed ###

- Add lock before checkint if the instance is null



