### PR TITLE
[AttachPanel] Remove static instance (related #85)

### DIFF
--- a/src/Tizen.Applications.AttachPanel/Tizen.Applications.AttachPanel/AttachPanelInternal.cs
+++ b/src/Tizen.Applications.AttachPanel/Tizen.Applications.AttachPanel/AttachPanelInternal.cs
@@ -10,14 +10,14 @@ namespace Tizen.Applications.AttachPanel
     /// <since_tizen> 4 </since_tizen>
     public partial class AttachPanel
     {
-        private static IntPtr s_attachPanel = IntPtr.Zero;
+        private IntPtr s_attachPanel = IntPtr.Zero;
 
-        private static event EventHandler<StateEventArgs> s_eventEventHandler;
+        private event EventHandler<StateEventArgs> s_eventEventHandler;
 
-        private static event EventHandler<ResultEventArgs> s_resultEventHandler;
+        private event EventHandler<ResultEventArgs> s_resultEventHandler;
 
-        private static Interop.AttachPanel.AttachPanelEventCallback s_setEventListener;
-        private static Interop.AttachPanel.AttachPanelResultCallback s_setResultListener;
+        private Interop.AttachPanel.AttachPanelEventCallback s_setEventListener;
+        private Interop.AttachPanel.AttachPanelResultCallback s_setResultListener;
 
         private void StateEventListenStart()
         {
@@ -81,7 +81,7 @@ namespace Tizen.Applications.AttachPanel
             return Information.TryGetValue("http://tizen.org/feature/attach_panel", out bool isAttachPanelSupported) && isAttachPanelSupported;
         }
 
-        internal static bool IsInitialized()
+        internal bool IsInitialized()
         {
             return s_attachPanel != IntPtr.Zero;
         }


### PR DESCRIPTION
### Description of Change ###

Remove static instance.

### Bugs Fixed ###

- Created AttachPanel instance is removed because of wrongly created AttacPanel's instance.

### API Changes ###

None

### Behavioral Changes ###

- The bug is fixed.
- There is no behavioral change. Even removing static instance, it couldn't affect to the AttachPanel's behavior.
