### PR TITLE
[Tizen.Applications.MessagePort] Remove checking name of remoteport

### DIFF
--- a/src/Tizen.Applications.MessagePort/Tizen.Applications.Messages/MessagePort.cs
+++ b/src/Tizen.Applications.MessagePort/Tizen.Applications.Messages/MessagePort.cs
@@ -161,7 +161,7 @@ namespace Tizen.Applications.Messages
                         Message = new Bundle(new SafeBundleHandle(message, false))
                     };
 
-                    if (!String.IsNullOrEmpty(remotePortName) && !String.IsNullOrEmpty(remoteAppId))
+                    if (!String.IsNullOrEmpty(remoteAppId))
                     {
                         args.Remote = new RemoteValues()
                         {


### PR DESCRIPTION
### Description of Change ###
To get remote app id regardless of the remote-port name

### Bugs Fixed ###


### API Changes ###
Changed:
 - public void Listen()

### Behavioral Changes ###
- If remote port is not valid it can't get remote appid on C# API,
  Because it is different from native implementation, we should provide backward compatibility

