### PR TITLE
[Connection][WiFi] Use TizenSynchronizationContext.Post for asynchron…

### DIFF
--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -34,7 +34,7 @@ namespace Tizen.Network.Connection
         public HandleHolder()
         {
             _tid = Thread.CurrentThread.ManagedThreadId;
-            Log.Info(Globals.LogTag, "PInvoke connection_destroy for Thread " + _tid);
+            Log.Info(Globals.LogTag, "PInvoke connection_create for Thread " + _tid);
             int ret = Interop.Connection.Create(_tid, out Handle);
             Log.Info(Globals.LogTag, "Handle: " + Handle);
             if(ret != (int)ConnectionError.None)
@@ -119,29 +119,30 @@ namespace Tizen.Network.Connection
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_ConnectionTypeChanged == null)
-                            {
-                                ConnectionTypeChangedStart();
-                            }
-                            _ConnectionTypeChanged += value;
-                        }, null);
+                {
+                    if (_ConnectionTypeChanged == null)
+                    {
+                        ConnectionTypeChangedStart();
+                    }
+                    _ConnectionTypeChanged += value;
+                }, null);
             }
             remove
             {
                 context.Post((x) =>
-                        {
-                            _ConnectionTypeChanged -= value;
-                            if (_ConnectionTypeChanged == null)
-                            {
-                                ConnectionTypeChangedStop();
-                            }
-                        }, null);
+                {
+                    _ConnectionTypeChanged -= value;
+                    if (_ConnectionTypeChanged == null)
+                    {
+                        ConnectionTypeChangedStop();
+                    }
+                }, null);
             }
         }
 
         private void ConnectionTypeChangedStart()
         {
+            Log.Info(Globals.LogTag, "Register ConnectionTypeChanged");
             _connectionTypeChangedCallback = (ConnectionType type, IntPtr user_data) =>
             {
                 if (_ConnectionTypeChanged != null)
@@ -160,6 +161,7 @@ namespace Tizen.Network.Connection
 
         private void ConnectionTypeChangedStop()
         {
+            Log.Info(Globals.LogTag, "Unregister ConnectionTypeChanged");
             int ret = Interop.Connection.UnsetTypeChangedCallback(GetHandle());
             if ((ConnectionError)ret != ConnectionError.None)
             {
@@ -173,29 +175,30 @@ namespace Tizen.Network.Connection
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_EthernetCableStateChanged == null)
-                            {
-                                EthernetCableStateChangedStart();
-                            }
-                            _EthernetCableStateChanged += value;
-                        }, null);
+                {
+                    if (_EthernetCableStateChanged == null)
+                    {
+                        EthernetCableStateChangedStart();
+                    }
+                    _EthernetCableStateChanged += value;
+                }, null);
             }
             remove
             {
                 context.Post((x) =>
-                        {
-                            _EthernetCableStateChanged -= value;
-                            if (_EthernetCableStateChanged == null)
-                            {
-                                EthernetCableStateChangedStop();
-                            }
-                        }, null);
+                {
+                    _EthernetCableStateChanged -= value;
+                    if (_EthernetCableStateChanged == null)
+                    {
+                        EthernetCableStateChangedStop();
+                    }
+                }, null);
             }
         }
 
         private void EthernetCableStateChangedStart()
         {
+            Log.Info(Globals.LogTag, "Register EthernetCableStateChanged");
             _ethernetCableStateChangedCallback = (EthernetCableState state, IntPtr user_data) =>
             {
                 if (_EthernetCableStateChanged != null)
@@ -216,6 +219,7 @@ namespace Tizen.Network.Connection
 
         private void EthernetCableStateChangedStop()
         {
+            Log.Info(Globals.LogTag, "Unregister EthernetCableStateChanged");
             int ret = Interop.Connection.UnsetEthernetCableStateChagedCallback(GetHandle());
             if ((ConnectionError)ret != ConnectionError.None)
             {
@@ -231,30 +235,31 @@ namespace Tizen.Network.Connection
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_IPAddressChanged == null)
-                            {
-                                IPAddressChangedStart();
-                            }
-                            _IPAddressChanged += value;
-                        }, null);
+                {
+                    if (_IPAddressChanged == null)
+                    {
+                        IPAddressChangedStart();
+                    }
+                    _IPAddressChanged += value;
+                }, null);
             }
 
             remove
             {
                 context.Post((x) =>
-                        {
-                            _IPAddressChanged -= value;
-                            if (_IPAddressChanged == null)
-                            {
-                                IPAddressChangedStop();
-                            }
-                        }, null);
+                {
+                    _IPAddressChanged -= value;
+                    if (_IPAddressChanged == null)
+                    {
+                        IPAddressChangedStop();
+                    }
+                }, null);
             }
         }
 
         private void IPAddressChangedStart()
         {
+            Log.Info(Globals.LogTag, "Register IPAddressChanged");
             _connectionAddressChangedCallback = (IntPtr IPv4, IntPtr IPv6, IntPtr UserData) =>
             {
                 if (_IPAddressChanged != null)
@@ -278,6 +283,7 @@ namespace Tizen.Network.Connection
 
         private void IPAddressChangedStop()
         {
+            Log.Info(Globals.LogTag, "Unregister IPAddressChanged");
             int ret = Interop.Connection.UnsetIPAddressChangedCallback(GetHandle());
             if ((ConnectionError)ret != ConnectionError.None)
             {
@@ -290,29 +296,30 @@ namespace Tizen.Network.Connection
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_ProxyAddressChanged == null)
-                            {
-                               ProxyAddressChangedStart();
-                            }
-                            _ProxyAddressChanged += value;
-                        }, null);
+                {
+                    if (_ProxyAddressChanged == null)
+                    {
+                        ProxyAddressChangedStart();
+                    }
+                    _ProxyAddressChanged += value;
+                }, null);
             }
             remove
             {
                 context.Post((x) =>
-                        {
-                            _ProxyAddressChanged -= value;
-                            if (_ProxyAddressChanged == null)
-                            {
-                                ProxyAddressChangedStop();
-                            }
-                        }, null);
+                {
+                    _ProxyAddressChanged -= value;
+                    if (_ProxyAddressChanged == null)
+                    {
+                        ProxyAddressChangedStop();
+                    }
+                }, null);
             }
         }
 
         private void ProxyAddressChangedStart()
         {
+            Log.Info(Globals.LogTag, "Register ProxyAddressChanged");
             _proxyAddressChangedCallback = (IntPtr IPv4, IntPtr IPv6, IntPtr UserData) =>
             {
                 if (_ProxyAddressChanged != null)
@@ -336,6 +343,7 @@ namespace Tizen.Network.Connection
 
         private void ProxyAddressChangedStop()
         {
+            Log.Info(Globals.LogTag, "Unregister ProxyAddressChanged");
             int ret = Interop.Connection.UnsetProxyAddressChangedCallback(GetHandle());
             if ((ConnectionError)ret != ConnectionError.None)
             {
@@ -791,12 +799,13 @@ namespace Tizen.Network.Connection
 
         internal Task SetDefaultCellularProfile(CellularServiceType type, ConnectionProfile profile)
         {
-            Log.Debug(Globals.LogTag, "SetDefaultCellularProfile");
+            Log.Info(Globals.LogTag, "SetDefaultCellularProfile");
             if (profile != null)
             {
                 TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
                 Interop.Connection.ConnectionCallback Callback = (ConnectionError Result, IntPtr Data) =>
                 {
+                    Log.Info(Globals.LogTag, "SetDefaultCellularProfile done " + profile.Name);
                     if (Result != ConnectionError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during set default cellular profile, " + Result);
@@ -808,18 +817,21 @@ namespace Tizen.Network.Connection
                     }
                 };
 
-                int ret = Interop.Connection.SetDefaultCellularServiceProfileAsync(GetHandle(), (int)type, profile.ProfileHandle, Callback, (IntPtr)0);
-                if ((ConnectionError)ret != ConnectionError.None)
+                context.Post((x) =>
                 {
-                    Log.Error(Globals.LogTag, "It failed to set default cellular profile, " + (ConnectionError)ret);
-                    ConnectionErrorFactory.CheckFeatureUnsupportedException(ret, "http://tizen.org/feature/network.telephony");
-                    ConnectionErrorFactory.CheckHandleNullException(ret, (GetHandle() == IntPtr.Zero || profile.ProfileHandle == IntPtr.Zero), "Connection or Profile Handle may have been disposed or released");
-                    ConnectionErrorFactory.ThrowConnectionException(ret);
-                }
+                    Log.Info(Globals.LogTag, "Interop.Connection.SetDefaultCellularServiceProfileAsync " + profile.Name);
+                    int ret = Interop.Connection.SetDefaultCellularServiceProfileAsync(GetHandle(), (int)type, profile.ProfileHandle, Callback, (IntPtr)0);
+                    if ((ConnectionError)ret != ConnectionError.None)
+                    {
+                        Log.Error(Globals.LogTag, "It failed to set default cellular profile, " + (ConnectionError)ret);
+                        ConnectionErrorFactory.CheckFeatureUnsupportedException(ret, "http://tizen.org/feature/network.telephony");
+                        ConnectionErrorFactory.CheckHandleNullException(ret, (GetHandle() == IntPtr.Zero || profile.ProfileHandle == IntPtr.Zero), "Connection or Profile Handle may have been disposed or released");
+                        ConnectionErrorFactory.ThrowConnectionException(ret);
+                    }
+                }, null);
 
                 return task.Task;
             }
-
             else
             {
                 throw new ArgumentNullException("Profile is null");
@@ -876,14 +888,14 @@ namespace Tizen.Network.Connection
 
         internal Task OpenProfileAsync(ConnectionProfile profile)
         {
-            Log.Debug(Globals.LogTag, "OpenProfileAsync");
+            Log.Info(Globals.LogTag, "OpenProfileAsync");
             if (profile != null)
             {
                 Log.Debug(Globals.LogTag, "OpenProfileAsync " + profile.Name);
                 TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
                 Interop.Connection.ConnectionCallback Callback = (ConnectionError Result, IntPtr Data) =>
                 {
-                    Log.Debug(Globals.LogTag, "Connected " + profile.Name);
+                    Log.Info(Globals.LogTag, "OpenProfileAsync done " + profile.Name);
                     if (Result != ConnectionError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during connecting profile, " + Result);
@@ -895,14 +907,18 @@ namespace Tizen.Network.Connection
                     }
                 };
 
-                int ret = Interop.Connection.OpenProfile(GetHandle(), profile.ProfileHandle, Callback, IntPtr.Zero);
-                if ((ConnectionError)ret != ConnectionError.None)
+                context.Post((x) =>
                 {
-                    Log.Error(Globals.LogTag, "It failed to connect profile, " + (ConnectionError)ret);
-                    ConnectionErrorFactory.CheckFeatureUnsupportedException(ret, "http://tizen.org/feature/network.telephony " + "http://tizen.org/feature/network.wifi " + "http://tizen.org/feature/network.tethering.bluetooth");
-                    ConnectionErrorFactory.CheckHandleNullException(ret, (GetHandle() == IntPtr.Zero || profile.ProfileHandle == IntPtr.Zero), "Connection or Profile Handle may have been disposed or released");
-                    ConnectionErrorFactory.ThrowConnectionException(ret);
-                }
+                    Log.Info(Globals.LogTag, "Interop.Connection.OpenProfile " + profile.Name);
+                    int ret = Interop.Connection.OpenProfile(GetHandle(), profile.ProfileHandle, Callback, IntPtr.Zero);
+                    if ((ConnectionError)ret != ConnectionError.None)
+                    {
+                        Log.Error(Globals.LogTag, "It failed to connect profile, " + (ConnectionError)ret);
+                        ConnectionErrorFactory.CheckFeatureUnsupportedException(ret, "http://tizen.org/feature/network.telephony " + "http://tizen.org/feature/network.wifi " + "http://tizen.org/feature/network.tethering.bluetooth");
+                        ConnectionErrorFactory.CheckHandleNullException(ret, (GetHandle() == IntPtr.Zero || profile.ProfileHandle == IntPtr.Zero), "Connection or Profile Handle may have been disposed or released");
+                        ConnectionErrorFactory.ThrowConnectionException(ret);
+                    }
+                }, null);
 
                 return task.Task;
             }
@@ -915,13 +931,14 @@ namespace Tizen.Network.Connection
 
         internal Task CloseProfileAsync(ConnectionProfile profile)
         {
-            Log.Debug(Globals.LogTag, "CloseProfileAsync");
+            Log.Info(Globals.LogTag, "CloseProfileAsync");
             if (profile != null)
             {
-                Log.Debug(Globals.LogTag, "CloseProfileAsync " + profile.Name);
+                Log.Info(Globals.LogTag, "CloseProfileAsync " + profile.Name);
                 TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
                 Interop.Connection.ConnectionCallback Callback = (ConnectionError Result, IntPtr Data) =>
                 {
+                    Log.Info(Globals.LogTag, "CloseProfileAsync done " + profile.Name);
                     if (Result != ConnectionError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during disconnecting profile, " + Result);
@@ -933,15 +950,19 @@ namespace Tizen.Network.Connection
                     }
                 };
 
-                int ret = Interop.Connection.CloseProfile(GetHandle(), profile.ProfileHandle, Callback, IntPtr.Zero);
-                if ((ConnectionError)ret != ConnectionError.None)
+                context.Post((x) =>
                 {
-                    Log.Error(Globals.LogTag, "It failed to disconnect profile, " + (ConnectionError)ret);
-                    ConnectionErrorFactory.CheckFeatureUnsupportedException(ret, "http://tizen.org/feature/network.telephony " + "http://tizen.org/feature/network.wifi " + "http://tizen.org/feature/network.tethering.bluetooth");
-                    ConnectionErrorFactory.CheckPermissionDeniedException(ret, "(http://tizen.org/privilege/network.set)");
-                    ConnectionErrorFactory.CheckHandleNullException(ret, (GetHandle() == IntPtr.Zero || profile.ProfileHandle == IntPtr.Zero), "Connection or Profile Handle may have been disposed or released");
-                    ConnectionErrorFactory.ThrowConnectionException(ret);
-                }
+                    Log.Info(Globals.LogTag, "Interop.Connection.CloseProfile " + profile.Name);
+                    int ret = Interop.Connection.CloseProfile(GetHandle(), profile.ProfileHandle, Callback, IntPtr.Zero);
+                    if ((ConnectionError)ret != ConnectionError.None)
+                    {
+                        Log.Error(Globals.LogTag, "It failed to disconnect profile, " + (ConnectionError)ret);
+                        ConnectionErrorFactory.CheckFeatureUnsupportedException(ret, "http://tizen.org/feature/network.telephony " + "http://tizen.org/feature/network.wifi " + "http://tizen.org/feature/network.tethering.bluetooth");
+                        ConnectionErrorFactory.CheckPermissionDeniedException(ret, "(http://tizen.org/privilege/network.set)");
+                        ConnectionErrorFactory.CheckHandleNullException(ret, (GetHandle() == IntPtr.Zero || profile.ProfileHandle == IntPtr.Zero), "Connection or Profile Handle may have been disposed or released");
+                        ConnectionErrorFactory.ThrowConnectionException(ret);
+                    }
+                }, null);
 
                 return task.Task;
             }

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
@@ -59,25 +59,25 @@ namespace Tizen.Network.Connection
             {
                 Log.Debug(Globals.LogTag, "ProfileStateChanged add");
                 context.Post((x) =>
-                        {
-                            if (_ProfileStateChanged == null)
-                            {
-                                ProfileStateChangedStart();
-                            }
-                            _ProfileStateChanged += value;
-                        }, null);
+                {
+                    if (_ProfileStateChanged == null)
+                    {
+                        ProfileStateChangedStart();
+                    }
+                    _ProfileStateChanged += value;
+                }, null);
             }
             remove
             {
                 Log.Debug(Globals.LogTag, "ProfileStateChanged remove");
                 context.Post((x) =>
-                        {
-                            _ProfileStateChanged -= value;
-                            if (_ProfileStateChanged == null)
-                            {
-                                ProfileStateChangedStop();
-                            }
-                        }, null);
+                {
+                    _ProfileStateChanged -= value;
+                    if (_ProfileStateChanged == null)
+                    {
+                        ProfileStateChangedStop();
+                    }
+                }, null);
             }
         }
 

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAP.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAP.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Tizen.Applications;
 
 namespace Tizen.Network.WiFi
 {
@@ -34,6 +35,9 @@ namespace Tizen.Network.WiFi
         private WiFiNetwork _network;
         private WiFiSecurity _security;
         private bool _disposed = false;
+
+        private TizenSynchronizationContext context = new TizenSynchronizationContext();
+        private static TizenSynchronizationContext s_context = new TizenSynchronizationContext();
 
         /// <summary>
         /// The network information of the access point (AP).
@@ -213,7 +217,7 @@ namespace Tizen.Network.WiFi
         /// <exception cref="InvalidOperationException">Thrown when the method failed due to an invalid operation.</exception>
         public Task ConnectAsync()
         {
-            Log.Debug(Globals.LogTag, "ConnectAsync");
+            Log.Info(Globals.LogTag, "ConnectAsync");
             if (_disposed)
             {
                 throw new ObjectDisposedException("Invalid AP instance (Object may have been disposed or released)");
@@ -225,7 +229,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Debug(Globals.LogTag, "Connecting finished : " + (WiFiError)error);
+                    Log.Info(Globals.LogTag, "ConnectAsync done " + (WiFiError)error);
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi connecting, " + (WiFiError)error);
@@ -242,12 +246,16 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            int ret = Interop.WiFi.Connect(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, _callback_map[id], id);
-            if (ret != (int)WiFiError.None)
+            context.Post((x) =>
             {
-                Log.Error(Globals.LogTag, "Failed to connect wifi, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle(), _apHandle);
-            }
+                Log.Info(Globals.LogTag, "Interop.WiFi.Connect");
+                int ret = Interop.WiFi.Connect(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, _callback_map[id], id);
+                if (ret != (int)WiFiError.None)
+                {
+                    Log.Error(Globals.LogTag, "Failed to connect wifi, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle(), _apHandle);
+                }
+            }, null);
 
             return task.Task;
         }
@@ -271,7 +279,7 @@ namespace Tizen.Network.WiFi
         /// <exception cref="InvalidOperationException">Thrown when the method failed due to an invalid operation.</exception>
         public Task ConnectWpsAsync(WpsInfo info)
         {
-            Log.Debug(Globals.LogTag, "ConnectWpsAsync");
+            Log.Info(Globals.LogTag, "ConnectWpsAsync");
             if (_disposed)
             {
                 throw new ObjectDisposedException("Invalid AP instance (Object may have been disposed or released)");
@@ -283,7 +291,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Debug(Globals.LogTag, "Connecting by WPS finished");
+                    Log.Info(Globals.LogTag, "ConnectWpsAsync done");
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi connecting, " + (WiFiError)error);
@@ -300,33 +308,37 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            int ret = -1;
-            if (info.GetType() == typeof(WpsPbcInfo))
+            context.Post((x) =>
             {
-                ret = Interop.WiFi.ConnectByWpsPbc(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, _callback_map[id], id);
-            }
-
-            else if (info.GetType() == typeof(WpsPinInfo))
-            {
-                WpsPinInfo pinInfo = (WpsPinInfo)info;
-                if (pinInfo.GetWpsPin() == null)
+                int ret = -1;
+                if (info.GetType() == typeof(WpsPbcInfo))
                 {
-                    throw new ArgumentNullException("Wps pin should not be null");
+                    Log.Info(Globals.LogTag, "Interop.WiFi.ConnectByWpsPb");
+                    ret = Interop.WiFi.ConnectByWpsPbc(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, _callback_map[id], id);
+                }
+                else if (info.GetType() == typeof(WpsPinInfo))
+                {
+                    WpsPinInfo pinInfo = (WpsPinInfo)info;
+                    if (pinInfo.GetWpsPin() == null)
+                    {
+                        throw new ArgumentNullException("Wps pin should not be null");
+                    }
+
+                    if (pinInfo.GetWpsPin().Length == 0 || pinInfo.GetWpsPin().Length > 8)
+                    {
+                        throw new ArgumentOutOfRangeException("Wps pin should not be empty or more than 7 characters");
+                    }
+
+                    Log.Info(Globals.LogTag, "Interop.WiFi.ConnectByWpsPin");
+                    ret = Interop.WiFi.ConnectByWpsPin(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, pinInfo.GetWpsPin(), _callback_map[id], id);
                 }
 
-                if (pinInfo.GetWpsPin().Length == 0 || pinInfo.GetWpsPin().Length > 8)
+                if (ret != (int)WiFiError.None)
                 {
-                    throw new ArgumentOutOfRangeException("Wps pin should not be empty or more than 7 characters");
+                    Log.Error(Globals.LogTag, "Failed to connect wifi, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle(), _apHandle);
                 }
-
-                ret = Interop.WiFi.ConnectByWpsPin(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, pinInfo.GetWpsPin(), _callback_map[id], id);
-            }
-
-            if (ret != (int)WiFiError.None)
-            {
-                Log.Error(Globals.LogTag, "Failed to connect wifi, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle(), _apHandle);
-            }
+            }, null);
 
             return task.Task;
         }
@@ -353,6 +365,7 @@ namespace Tizen.Network.WiFi
         /// <exception cref="InvalidOperationException">Thrown when the method failed due to an invalid operation.</exception>
         public static Task<WiFiAP> ConnectWpsWithoutSsidAsync(WpsInfo info)
         {
+            Log.Info(Globals.LogTag, "ConnectWpsWithoutSsidAsync");
             TaskCompletionSource<WiFiAP> task = new TaskCompletionSource<WiFiAP>();
             IntPtr id;
             lock (s_callbackMap)
@@ -360,7 +373,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)s_requestId++;
                 s_callbackMap[id] = (error, key) =>
                 {
-                    Log.Debug(Globals.LogTag, "Connecting by WPS finished");
+                    Log.Info(Globals.LogTag, "ConnectWpsWithoutSsidAsync done");
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi connecting, " + (WiFiError)error);
@@ -378,33 +391,37 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            int ret = -1;
-            if (info.GetType() == typeof(WpsPbcInfo))
+            s_context.Post((x) =>
             {
-                ret = Interop.WiFi.ConnectByWpsPbcWithoutSsid(WiFiManagerImpl.Instance.GetSafeHandle(), s_callbackMap[id], id);   
-            }
-
-            else if (info.GetType() == typeof(WpsPinInfo))
-            {
-                WpsPinInfo pinInfo = (WpsPinInfo)info;
-                if (pinInfo.GetWpsPin() == null)
+                int ret = -1;
+                if (info.GetType() == typeof(WpsPbcInfo))
                 {
-                    throw new ArgumentNullException("Wps pin should not be null");
+                    Log.Info(Globals.LogTag, "Interop.WiFi.ConnectByWpsPbcWithoutSsid");
+                    ret = Interop.WiFi.ConnectByWpsPbcWithoutSsid(WiFiManagerImpl.Instance.GetSafeHandle(), s_callbackMap[id], id);
+                }
+                else if (info.GetType() == typeof(WpsPinInfo))
+                {
+                    WpsPinInfo pinInfo = (WpsPinInfo)info;
+                    if (pinInfo.GetWpsPin() == null)
+                    {
+                        throw new ArgumentNullException("Wps pin should not be null");
+                    }
+
+                    if (pinInfo.GetWpsPin().Length != 4 && pinInfo.GetWpsPin().Length != 8)
+                    {
+                        throw new ArgumentOutOfRangeException("Wps pin should be of 4 or 8 characters long");
+                    }
+
+                    Log.Info(Globals.LogTag, "Interop.WiFi.ConnectByWpsPinWithoutSsid");
+                    ret = Interop.WiFi.ConnectByWpsPinWithoutSsid(WiFiManagerImpl.Instance.GetSafeHandle(), pinInfo.GetWpsPin(), s_callbackMap[id], id);
                 }
 
-                if (pinInfo.GetWpsPin().Length != 4 && pinInfo.GetWpsPin().Length != 8)
+                if (ret != (int)WiFiError.None)
                 {
-                    throw new ArgumentOutOfRangeException("Wps pin should be of 4 or 8 characters long");
+                    Log.Error(Globals.LogTag, "Failed to connect wifi, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle());
                 }
-
-                ret = Interop.WiFi.ConnectByWpsPinWithoutSsid(WiFiManagerImpl.Instance.GetSafeHandle(), pinInfo.GetWpsPin(), s_callbackMap[id], id);
-            }
-
-            if (ret != (int)WiFiError.None)
-            {
-                Log.Error(Globals.LogTag, "Failed to connect wifi, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle());
-            }
+            }, null);
 
             return task.Task;
         }
@@ -437,7 +454,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Debug(Globals.LogTag, "Disconnecting finished");
+                    Log.Info(Globals.LogTag, "DisconnectAsync done");
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi disconnecting, " + (WiFiError)error);
@@ -453,12 +470,18 @@ namespace Tizen.Network.WiFi
                     }
                 };
             }
-            int ret = Interop.WiFi.Disconnect(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, _callback_map[id], id);
-            if (ret != (int)WiFiError.None)
+
+            context.Post((x) =>
             {
-                Log.Error(Globals.LogTag, "Failed to disconnect wifi, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle(), _apHandle);
-            }
+                Log.Info(Globals.LogTag, "Interop.WiFi.Disconnect");
+                int ret = Interop.WiFi.Disconnect(WiFiManagerImpl.Instance.GetSafeHandle(), _apHandle, _callback_map[id], id);
+                if (ret != (int)WiFiError.None)
+                {
+                    Log.Error(Globals.LogTag, "Failed to disconnect wifi, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, WiFiManagerImpl.Instance.GetSafeHandle().DangerousGetHandle(), _apHandle);
+                }
+            }, null);
+
             return task.Task;
         }
 

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
+using Tizen.Applications;
 
 namespace Tizen.Network.WiFi
 {
@@ -48,7 +49,12 @@ namespace Tizen.Network.WiFi
     {
         private static readonly Lazy<WiFiManagerImpl> _instance =
             new Lazy<WiFiManagerImpl>(() => new WiFiManagerImpl());
-        private Dictionary<IntPtr, Interop.WiFi.VoidCallback> _callback_map = new Dictionary<IntPtr, Interop.WiFi.VoidCallback>();
+
+        private TizenSynchronizationContext context = new TizenSynchronizationContext();
+        
+        private Dictionary<IntPtr, Interop.WiFi.VoidCallback> _callback_map =
+            new Dictionary<IntPtr, Interop.WiFi.VoidCallback>();
+        
         private int _requestId = 0;
         private string _macAddress;
 
@@ -288,7 +294,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Info(Globals.LogTag, "wifi activated");
+                    Log.Info(Globals.LogTag, "ActivateAsync done");
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi activating, " + (WiFiError)error);
@@ -304,18 +310,24 @@ namespace Tizen.Network.WiFi
                     }
                 };
             }
-            int ret = Interop.WiFi.Activate(GetSafeHandle(), _callback_map[id], id);
-            if (ret != (int)WiFiError.None)
+
+            context.Post((x) =>
             {
+                Log.Info(Globals.LogTag, "Interop.WiFi.ActivateAsync");
+                int ret = Interop.WiFi.Activate(GetSafeHandle(), _callback_map[id], id);
+                if (ret != (int)WiFiError.None)
+                {
                 Log.Error(Globals.LogTag, "Failed to activate wifi, Error - " + (WiFiError)ret);
                 WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
-            }
+                }
+            }, null);
+
             return task.Task;
         }
 
         internal Task ActivateWithWiFiPickerTestedAsync()
         {
-            Log.Debug(Globals.LogTag, "ActivateWithWiFiPickerTestedAsync");
+            Log.Info(Globals.LogTag, "ActivateWithWiFiPickerTestedAsync");
             TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
             IntPtr id;
             lock (_callback_map)
@@ -323,7 +335,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Debug(Globals.LogTag, "Activation finished");
+                    Log.Info(Globals.LogTag, "ActivateWithWiFiPickerTestedAsync done");
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi activating, " + (WiFiError)error);
@@ -339,12 +351,18 @@ namespace Tizen.Network.WiFi
                     }
                 };
             }
-            int ret = Interop.WiFi.ActivateWithWiFiPickerTested(GetSafeHandle(), _callback_map[id], id);
-            if (ret != (int)WiFiError.None)
+
+            context.Post((x) =>
             {
-                Log.Error(Globals.LogTag, "Failed to activate wifi, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
-            }
+                Log.Info(Globals.LogTag, "Interop.WiFi.ActivateWithWiFiPickerTestedAsync");
+                int ret = Interop.WiFi.ActivateWithWiFiPickerTested(GetSafeHandle(), _callback_map[id], id);
+                if (ret != (int)WiFiError.None)
+                {
+                    Log.Error(Globals.LogTag, "Failed to activate wifi, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
+                }
+            }, null);
+            
             return task.Task;
         }
 
@@ -358,7 +376,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Info(Globals.LogTag, "Deactivation finished");
+                    Log.Info(Globals.LogTag, "DeactivateAsync done");
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi deactivating, " + (WiFiError)error);
@@ -374,13 +392,19 @@ namespace Tizen.Network.WiFi
                     }
                 };
             }
-            int ret = Interop.WiFi.Deactivate(GetSafeHandle(), _callback_map[id], id);
-            if (ret != (int)WiFiError.None)
+
+            context.Post((x) =>
             {
-                Log.Error(Globals.LogTag, "Failed to deactivate wifi, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
-            }
-            return task.Task;
+                Log.Info(Globals.LogTag, "Interop.WiFi.Deactivate");
+                int ret = Interop.WiFi.Deactivate(GetSafeHandle(), _callback_map[id], id);
+                if (ret != (int)WiFiError.None)
+                {
+                    Log.Error(Globals.LogTag, "Failed to deactivate wifi, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
+                }
+            }, null);
+
+            return task.Task;           
         }
 
         internal Task ScanAsync()
@@ -393,7 +417,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Info(Globals.LogTag, "Scanning finished");
+                    Log.Info(Globals.LogTag, "ScanAsync done");
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi scanning, " + (WiFiError)error);
@@ -409,12 +433,18 @@ namespace Tizen.Network.WiFi
                     }
                 };
             }
-            int ret = Interop.WiFi.Scan(GetSafeHandle(), _callback_map[id], id);
-            if (ret != (int)WiFiError.None)
+
+            context.Post((x) =>
             {
-                Log.Error(Globals.LogTag, "Failed to scan all AP, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
-            }
+                Log.Info(Globals.LogTag, "Interop.WiFi.Scan");
+                int ret = Interop.WiFi.Scan(GetSafeHandle(), _callback_map[id], id);
+                if (ret != (int)WiFiError.None)
+                {
+                    Log.Error(Globals.LogTag, "Failed to scan all AP, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
+                }
+            }, null);
+
             return task.Task;
         }
 
@@ -428,7 +458,7 @@ namespace Tizen.Network.WiFi
                 id = (IntPtr)_requestId++;
                 _callback_map[id] = (error, key) =>
                 {
-                    Log.Info(Globals.LogTag, "Scanning with specific AP finished");
+                    Log.Info(Globals.LogTag, "ScanSpecificAPAsync Done " + essid);
                     if (error != (int)WiFiError.None)
                     {
                         Log.Error(Globals.LogTag, "Error occurs during WiFi scanning, " + (WiFiError)error);
@@ -444,12 +474,18 @@ namespace Tizen.Network.WiFi
                     }
                 };
             }
-            int ret = Interop.WiFi.ScanSpecificAP(GetSafeHandle(), essid, _callback_map[id], id);
-            if (ret != (int)WiFiError.None)
+
+            context.Post((x) =>
             {
-                Log.Error(Globals.LogTag, "Failed to scan with specific AP, Error - " + (WiFiError)ret);
-                WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
-            }
+                Log.Info(Globals.LogTag, "Interop.WiFi.ScanSpecificAPAsync");
+                int ret = Interop.WiFi.ScanSpecificAP(GetSafeHandle(), essid, _callback_map[id], id);
+                if (ret != (int)WiFiError.None)
+                {
+                    Log.Error(Globals.LogTag, "Failed to scan with specific AP, Error - " + (WiFiError)ret);
+                    WiFiErrorFactory.ThrowWiFiException(ret, GetSafeHandle().DangerousGetHandle());
+                }
+            }, null);
+
             return task.Task;
         }
     }

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiNetworkChange.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiNetworkChange.cs
@@ -17,7 +17,6 @@
 using System;
 using System.Threading.Tasks;
 using System.Threading;
-using Tizen.Applications;
 
 namespace Tizen.Network.WiFi
 {
@@ -54,30 +53,29 @@ namespace Tizen.Network.WiFi
         private Interop.WiFi.RssiLevelChangedCallback _rssiChangedCallback;
         private Interop.WiFi.VoidCallback _backgroundScanFinishedCallback;
 
-        private TizenSynchronizationContext context = new TizenSynchronizationContext();
         internal event EventHandler<DeviceStateChangedEventArgs> DeviceStateChanged
         {
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_deviceStateChanged == null)
-                            {
-                                RegisterDeviceStateChangedEvent(); 
-                            }
-                            _deviceStateChanged += value;
-                        }, null);
+                {
+                    if (_deviceStateChanged == null)
+                    {
+                        RegisterDeviceStateChangedEvent(); 
+                    }
+                    _deviceStateChanged += value;
+                }, null);
             }
             remove
             {
                 context.Post((x) =>
-                        {
-                            _deviceStateChanged -= value;
-                            if (_deviceStateChanged == null)
-                            {
-                                UnregisterDeviceStateChangedEvent();
-                            }
-                        }, null);
+                {
+                    _deviceStateChanged -= value;
+                    if (_deviceStateChanged == null)
+                    {
+                        UnregisterDeviceStateChangedEvent();
+                    }
+                }, null);
             }
         }
 
@@ -86,24 +84,24 @@ namespace Tizen.Network.WiFi
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_connectionStateChanged == null)
-                            {
-                                RegisterConnectionStateChangedEvent();
-                            }
-                            _connectionStateChanged += value;
-                        }, null);
+                {
+                    if (_connectionStateChanged == null)
+                    {
+                        RegisterConnectionStateChangedEvent();
+                    }
+                    _connectionStateChanged += value;
+                }, null);
             }
             remove
             {
                 context.Post((x) =>
-                        {
-                            _connectionStateChanged -= value;
-                            if (_connectionStateChanged == null)
-                            {
-                                UnregisterConnectionStateChangedEvent();
-                            }
-                        }, null);
+                {
+                    _connectionStateChanged -= value;
+                    if (_connectionStateChanged == null)
+                    {
+                        UnregisterConnectionStateChangedEvent();
+                    }
+                }, null);
             }
         }
 
@@ -112,24 +110,24 @@ namespace Tizen.Network.WiFi
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_rssiLevelChanged == null)
-                            {
-                                RegisterRssiLevelChangedEvent();
-                            }
-                            _rssiLevelChanged += value;
-                        }, null);
+                {
+                    if (_rssiLevelChanged == null)
+                    {
+                        RegisterRssiLevelChangedEvent();
+                    }
+                    _rssiLevelChanged += value;
+                }, null);
             }
             remove
             {
                 context.Post((x) =>
-                        {
-                            _rssiLevelChanged -= value;
-                            if (_rssiLevelChanged == null)
-                            {
-                                UnregisterRssiLevelChangedEvent();
-                            }
-                        }, null);
+                {
+                    _rssiLevelChanged -= value;
+                    if (_rssiLevelChanged == null)
+                    {
+                        UnregisterRssiLevelChangedEvent();
+                    }
+                }, null);
             }
         }
 
@@ -138,24 +136,24 @@ namespace Tizen.Network.WiFi
             add
             {
                 context.Post((x) =>
-                        {
-                            if (_backgroundScanFinished == null)
-                            {
-                                RegisterBackgroundScanFinishedEvent();
-                            }
-                            _backgroundScanFinished += value;
-                        }, null);
+                {
+                    if (_backgroundScanFinished == null)
+                    {
+                        RegisterBackgroundScanFinishedEvent();
+                    }
+                    _backgroundScanFinished += value;
+                }, null);
             }
             remove
             {
                 context.Post((x) =>
-                        {
-                            _backgroundScanFinished -= value;
-                            if (_backgroundScanFinished == null)
-                            {
-                                UnregisterBackgroundScanFinishedEvent();
-                            }
-                        }, null);
+                {
+                    _backgroundScanFinished -= value;
+                    if (_backgroundScanFinished == null)
+                    {
+                        UnregisterBackgroundScanFinishedEvent();
+                    }
+                }, null);
             }
         }
 


### PR DESCRIPTION
### Description of Change ###

Apply TizenSynchronizationContext to asynchronous methods.
Prior to this change, those methods are used in a thread other than the main thread, they can be blocked because the callback from being passed from native is not delivered.


