### PR TITLE
[TEEC] Add TempMemoryReference with generic

### DIFF
--- a/src/Tizen.Security.TEEC/Interop/Interop.Libteec.cs
+++ b/src/Tizen.Security.TEEC/Interop/Interop.Libteec.cs
@@ -127,4 +127,9 @@ internal static partial class Interop
         [DllImport(Libraries.Libteec, EntryPoint = "TEEC_RequestCancellation", CallingConvention = CallingConvention.Cdecl)]
         static public extern void RequestCancellation(IntPtr operation);
     }
+
+    internal static partial class Libc {
+        [DllImport("msvcrt.dll", EntryPoint = "memcpy", CallingConvention = CallingConvention.Cdecl)]
+        static public extern int Memcpy(IntPtr dst, IntPtr src, UIntPtr len);
+    }
 }


### PR DESCRIPTION
### Description of Change ###

Add generic for convenient passing C# object to TA with TempMemoryReference parameter.

### Bugs Fixed ###

- N/A

### API Changes ###

 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-133

If you don't have the ACR, List all API changes here (or just put None), example:

Added:
 - class TempMemoryRefBase (abstract)
 - class class TempMemoryReference<T> (sealed)

Changed:
 - class class TempMemoryReference (obsolete)

### Behavioral Changes ###
none

