### PR TITLE
[NUI] Fix widget application crash issue

### DIFF
--- a/src/Tizen.NUI/src/internal/Registry.cs
+++ b/src/Tizen.NUI/src/internal/Registry.cs
@@ -154,6 +154,11 @@ namespace Tizen.NUI
 
         private static void RegistryCurrentThreadCheck()
         {
+            if(savedApplicationThread == null)
+            {
+                Tizen.Log.Fatal("NUI", $"Error! maybe main thread is created by other process ");
+                return;
+            }
             int currentId = Thread.CurrentThread.ManagedThreadId;
             int mainThreadId = savedApplicationThread.ManagedThreadId;
 


### PR DESCRIPTION
Widget Application can't get thread id because it works in different process
So Registry need to avoid in this case