### PR TITLE
Revert "[NUI] Make GetParent() protected (#165)"

### DIFF
--- a/src/Tizen.NUI/src/internal/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application.cs
@@ -515,11 +515,6 @@ namespace Tizen.NUI
         // Callback for Application InitSignal
         private void OnApplicationInit(IntPtr data)
         {
-            if (Version.DaliVersionMatchWithNUI() == false)
-            {
-                Tizen.Log.Fatal("NUI", "Dali and NUI are version mismatched!");
-            }
-
             // Initialize DisposeQueue Singleton class. This is also required to create DisposeQueue on main thread.
             DisposeQueue.Instance.Initialize();
 

--- a/src/Tizen.NUI/src/internal/DaliEnumConstants.cs
+++ b/src/Tizen.NUI/src/internal/DaliEnumConstants.cs
@@ -201,7 +201,7 @@ namespace Tizen.NUI
 
 internal class NUILog
 {
-    //[Conditional("DEBUG_ON")]
+    [Conditional("DEBUG_ON")]
     public static void Debug(string msg,
         [CallerLineNumber] int lineNum = 0,
         [CallerMemberName] string caller = null,

--- a/src/Tizen.NUI/src/internal/FrameBuffer.cs
+++ b/src/Tizen.NUI/src/internal/FrameBuffer.cs
@@ -99,8 +99,12 @@ namespace Tizen.NUI
 
         public Texture GetColorTexture()
         {
-            Texture texture = new Texture(NDalicPINVOKE.FrameBuffer_GetColorTexture(swigCPtr), true);
-            Texture ret = Registry.GetManagedBaseHandleFromNativePtr(texture) as Texture;
+            //to fix memory leak issue, match the handle count with native side.
+            global::System.IntPtr cPtr = NDalicPINVOKE.FrameBuffer_GetColorTexture(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            Texture ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as Texture;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;

--- a/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
@@ -1742,8 +1742,5 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_ImageView_IMAGE_VISUAL_ACTION_STOP_get")]
         public static extern int ImageView_IMAGE_VISUAL_ACTION_STOP_get();
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_NUI_InternalAPIVersionCheck")]
-        public static extern bool InternalAPIVersionCheck(ref int ver1, ref int ver2, ref int ver3);
-
     }
 }

--- a/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
@@ -11514,5 +11514,5 @@ class NDalicPINVOKE {
   public static extern uint GetMaxTextureSize();
 
     }
-
 }
+

--- a/src/Tizen.NUI/src/internal/VersionCheck.cs
+++ b/src/Tizen.NUI/src/internal/VersionCheck.cs
@@ -16,17 +16,20 @@
  */
 
 using System;
-using System.Diagnostics;
 
 namespace Tizen.NUI
 {
     //This version should be updated and synced for every Dali native release
     internal static class Version
     {
-        //dali_1.3.xx : NUI internal API version 500
-        public const int nuiAPIVer = 500;
-        public const int reservedVer1 = 0;
-        public const int reservedVer2 = 0;
+        public const int daliVer1 = 1;
+        public const int daliVer2 = 2;
+        public const int daliVer3 = 83;
+        public const int nuiVer1 = 1;
+        public const int nuiVer2 = 2;
+        public const int nuiVer3 = 83;
+        public const string nuiRelease = "";
+
 
         static internal bool DaliVersionMatchWithNUI()
         {
@@ -36,39 +39,27 @@ namespace Tizen.NUI
 
             try
             {
-                if (NDalicManualPINVOKE.InternalAPIVersionCheck(ref ver1, ref ver2, ref ver3) == true)
+                if (NDalicManualPINVOKE.NativeVersionCheck(ref ver1, ref ver2, ref ver3))
                 {
-                    if (ver1 != nuiAPIVer)
+                    if (ver1 != daliVer1 || ver2 != daliVer2 || ver3 != daliVer3)
                     {
-                        NUILog.Error($"NUI API version mismatch error! NUI API Version: ({nuiAPIVer}) but read version from native: ({ver1}.{ver2}.{ver3})");
-                        throw new System.InvalidOperationException($"NUI API version mismatch error! NUI API version should be ({nuiAPIVer}) but read version from native: ({ver1}.{ver2}.{ver3})");
+                        NUILog.Error($"Dali native version mismatch error! nui={ nuiVer1}.{ nuiVer2}.{ nuiVer3} but dali= { ver1 }.{ ver2}.{ ver3}");
+                        throw new System.InvalidOperationException($"Dali native version mismatch error! nui={ nuiVer1}.{ nuiVer2}.{ nuiVer3} but dali={ ver1 }.{ ver2}.{ ver3}");
                     }
                 }
                 else
                 {
-                    NUILog.Error($"NUI API version mismatch error! NUI API Version: ({nuiAPIVer}) but read version from native: ({ver1}.{ver2}.{ver3})");
-                    throw new System.InvalidOperationException($"NUI API version mismatch error! NUI API version should be ({nuiAPIVer}) but read version from native: ({ver1}.{ver2}.{ver3})");
+                    NUILog.Error($"Dali native version mismatch error! nui={ nuiVer1}.{ nuiVer2}.{ nuiVer3} but dali= { ver1 }.{ ver2}.{ ver3}");
+                    throw new System.InvalidOperationException($"Dali native version mismatch error! nui={ nuiVer1}.{ nuiVer2}.{ nuiVer3} but dali={ ver1 }.{ ver2}.{ ver3}");
                 }
             }
             catch (Exception)
             {
-                NUILog.Error($"NUI API version mismatch error! NUI API Version: ({nuiAPIVer}) but read version from native: ({ver1}.{ver2}.{ver3})");
-                throw new System.InvalidOperationException($"NUI API version mismatch error! NUI API version should be ({nuiAPIVer}) but read version from native: ({ver1}.{ver2}.{ver3})");
+                NUILog.Error($"Dali native version mismatch error! nui={ nuiVer1}.{ nuiVer2}.{ nuiVer3} but dali= { ver1 }.{ ver2}.{ ver3}");
+                throw new System.InvalidOperationException($"Dali native version mismatch error! nui={ nuiVer1}.{ nuiVer2}.{ nuiVer3} but dali={ ver1 }.{ ver2}.{ ver3}");
             }
-
-            PrintDaliNativeVersion();
+            NUILog.Debug($"version info: nui={ nuiVer1}.{ nuiVer2}.{ nuiVer3}, dali= { ver1 }.{ ver2}.{ ver3}");
             return true;
-        }
-
-        //[Conditional("DEBUG_ON")]
-        static private void PrintDaliNativeVersion()
-        {
-            int ver1 = -1;
-            int ver2 = -1;
-            int ver3 = -1;
-
-            NDalicManualPINVOKE.NativeVersionCheck(ref ver1, ref ver2, ref ver3);
-            NUILog.Debug($"DALi Version: ({ver1}.{ver2}.{ver3}), NUI API Version: ({nuiAPIVer})");
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewWrapperImpl.cs
@@ -252,8 +252,12 @@ namespace Tizen.NUI
 
         public VisualBase GetVisual(int index)
         {
-            VisualBase visualBase = new VisualBase(NDalicManualPINVOKE.ViewWrapperImpl_GetVisual(swigCPtr, index), true);
-            VisualBase ret = Registry.GetManagedBaseHandleFromNativePtr(visualBase) as VisualBase;
+            //to fix memory leak issue, match the handle count with native side.
+            System.IntPtr cPtr = NDalicManualPINVOKE.ViewWrapperImpl_GetVisual(swigCPtr, index);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            VisualBase ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as VisualBase;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -379,8 +379,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public View GetChildAt(TableView.CellPosition position)
         {
-            View view = new View(NDalicPINVOKE.TableView_GetChildAt(swigCPtr, TableView.CellPosition.getCPtr(position)), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.TableView_GetChildAt(swigCPtr, TableView.CellPosition.getCPtr(position));
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
@@ -394,8 +398,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public View RemoveChildAt(TableView.CellPosition position)
         {
-            View view = new View(NDalicPINVOKE.TableView_RemoveChildAt(swigCPtr, TableView.CellPosition.getCPtr(position)), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.TableView_RemoveChildAt(swigCPtr, TableView.CellPosition.getCPtr(position));
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -38,11 +38,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool ignore) : base(NDalicPINVOKE.View_SWIGUpcast(cPtr), cMemoryOwn)
-        {
-            swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
-        }
-
         internal static global::System.Runtime.InteropServices.HandleRef getCPtr(View obj)
         {
             return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
@@ -68,7 +63,6 @@ namespace Tizen.NUI.BaseComponents
                 if (NDalicPINVOKE.SWIGPendingException.Pending)
                     throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 Children.Add(child);
-                child.SetParent(this);
             }
         }
 
@@ -84,7 +78,6 @@ namespace Tizen.NUI.BaseComponents
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
             Children.Remove(child);
-            child.SetParent(null);
         }
 
         /// <summary>
@@ -119,9 +112,19 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <seealso cref="Container.GetParent()" />
         /// <since_tizen> 4 </since_tizen>
-        protected override Container GetParent()
+        public override Container GetParent()
         {
-            return Parent;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Actor_GetParent(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            BaseHandle basehandle = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle);
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            return basehandle as Container;
         }
 
         internal bool IsTopLevelView()
@@ -2607,8 +2610,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 5 </since_tizen>
         public Layer GetLayer()
         {
-            Layer layer = new Layer(NDalicPINVOKE.Actor_GetLayer(swigCPtr), true);
-            Layer ret = Registry.GetManagedBaseHandleFromNativePtr(layer) as Layer;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Actor_GetLayer(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            Layer ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as Layer;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -2635,8 +2642,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public View FindChildByName(string viewName)
         {
-            View view = new View(NDalicPINVOKE.Actor_FindChildByName(swigCPtr, viewName), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Actor_FindChildByName(swigCPtr, viewName);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -2645,8 +2656,12 @@ namespace Tizen.NUI.BaseComponents
 
         internal View FindChildById(uint id)
         {
-            View view = new View(NDalicPINVOKE.Actor_FindChildById(swigCPtr, id), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Actor_FindChildById(swigCPtr, id);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -3240,8 +3255,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public Renderer GetRendererAt(uint index)
         {
-            Renderer renderer = new Renderer(NDalicPINVOKE.Actor_GetRendererAt(swigCPtr, index), true);
-            Renderer ret = Registry.GetManagedBaseHandleFromNativePtr(renderer) as Renderer;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Actor_GetRendererAt(swigCPtr, index);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            Renderer ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as Renderer;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/public/Container.cs
+++ b/src/Tizen.NUI/src/public/Container.cs
@@ -30,7 +30,6 @@ namespace Tizen.NUI
     {
 
         private List<View> _childViews = new List<View>();
-        private Container _parent = null;
 
         /// <summary>
         /// List of children of Container.
@@ -64,12 +63,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// This should be implemented in derived child classes such as View and Layer
-        /// </summary>
-        /// <returns>parent object of mine, which will be Container class</returns>
-        protected abstract Container GetParent();
-
-        /// <summary>
         /// Adds a child view to this Container.
         /// </summary>
         /// <pre>This Container (the parent) has been initialized. The child view has been initialized. The child view is not the same as the parent view.</pre>
@@ -97,6 +90,14 @@ namespace Tizen.NUI
         public abstract View GetChildAt( uint index );
 
         /// <summary>
+        /// Gets the parent of this container.
+        /// </summary>
+        /// <pre>The child container has been initialized.</pre>
+        /// <returns>The parent container.</returns>
+        /// <since_tizen> 4 </since_tizen>
+        public abstract Container GetParent();
+
+        /// <summary>
         /// Gets the number of children for this container.
         /// </summary>
         /// <pre>The container has been initialized.</pre>
@@ -115,13 +116,8 @@ namespace Tizen.NUI
         {
             get
             {
-                return _parent;
+                return GetParent();
             }
-        }
-
-        internal void SetParent(Container parent)
-        {
-            _parent = parent;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/FocusManager.cs
@@ -449,8 +449,12 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public View GetCurrentFocusView()
         {
-            View view = new View(NDalicManualPINVOKE.FocusManager_GetCurrentFocusActor(swigCPtr), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicManualPINVOKE.FocusManager_GetCurrentFocusActor(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             return ret;
         }
@@ -553,8 +557,12 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public View GetFocusGroup(View view)
         {
-            View localView = new View(NDalicManualPINVOKE.FocusManager_GetFocusGroup(swigCPtr, View.getCPtr(view)), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(localView) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicManualPINVOKE.FocusManager_GetFocusGroup(swigCPtr, View.getCPtr(view));
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             return ret;
         }
@@ -584,8 +592,12 @@ namespace Tizen.NUI
 
         internal View GetFocusIndicatorView()
         {
-            View view = new View(NDalicManualPINVOKE.FocusManager_GetFocusIndicatorActor(swigCPtr), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicManualPINVOKE.FocusManager_GetFocusIndicatorActor(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Layer.cs
+++ b/src/Tizen.NUI/src/public/Layer.cs
@@ -61,7 +61,6 @@ namespace Tizen.NUI
                 if (NDalicPINVOKE.SWIGPendingException.Pending)
                     throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 Children.Add(child);
-                child.SetParent(this);
             }
         }
 
@@ -78,7 +77,6 @@ namespace Tizen.NUI
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
             Children.Remove(child);
-            child.SetParent(null);
         }
 
         /// <summary>
@@ -101,10 +99,11 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// protected override method derived from Container abstract parent class
+        /// Get parent of the layer.
         /// </summary>
-        /// <returns>always return null, because in NUI, Layer can be added under Window</returns>
-        protected override Container GetParent()
+        /// <returns>The view's container</returns>
+        /// <since_tizen> 4 </since_tizen>
+        public override Container GetParent()
         {
             return null;
         }
@@ -212,8 +211,12 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public View FindChildById(uint id)
         {
-            View view = new View(NDalicPINVOKE.Actor_FindChildById(swigCPtr, id), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Actor_FindChildById(swigCPtr, id);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/public/UIComponents/Popup.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/Popup.cs
@@ -405,8 +405,12 @@ namespace Tizen.NUI.UIComponents
 
         internal View GetTitle()
         {
-            View view = new View(NDalicPINVOKE.Popup_GetTitle(swigCPtr), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Popup_GetTitle(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
@@ -425,8 +429,12 @@ namespace Tizen.NUI.UIComponents
 
         internal View GetContent()
         {
-            View view = new View(NDalicPINVOKE.Popup_GetContent(swigCPtr), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Popup_GetContent(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
@@ -445,8 +453,12 @@ namespace Tizen.NUI.UIComponents
 
         internal View GetFooter()
         {
-            View view = new View(NDalicPINVOKE.Popup_GetFooter(swigCPtr), true, true);
-            View ret = Registry.GetManagedBaseHandleFromNativePtr(view) as View;
+            //to fix memory leak issue, match the handle count with native side.
+            IntPtr cPtr = NDalicPINVOKE.Popup_GetFooter(swigCPtr);
+            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as View;
+            NDalicPINVOKE.delete_BaseHandle(CPtr);
+            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;

--- a/src/Tizen.NUI/src/public/Window.cs
+++ b/src/Tizen.NUI/src/public/Window.cs
@@ -1398,8 +1398,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="transparent">Whether the window is transparent.</param>
         /// <since_tizen> 5 </since_tizen>
-        public void SetTransparency(bool transparent) 
-        {
+        public void SetTransparency(bool transparent) {
             NDalicManualPINVOKE.SetTransparency(swigCPtr, transparent);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -1609,7 +1608,7 @@ namespace Tizen.NUI
         /// <param name="keyEvent">The key event to feed.</param>
         /// <since_tizen> 4 </since_tizen>
         [Obsolete("Please do not use! This will be deprecated! Please use FeedKey(Key keyEvent) instead!")]
-        public void FeedKeyEvent(Key keyEvent)
+        public static void FeedKeyEvent(Key keyEvent)
         {
             NDalicManualPINVOKE.Window_FeedKeyEvent(Key.getCPtr(keyEvent));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();


### PR DESCRIPTION
This reverts commit 7aa84bbdff8f176b5c67907129dd90e85cfae36b.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###

Describe your changes here.

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: 

If you don't have the ACR, List all API changes here (or just put None), example:

Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

