### PR TITLE
[MediaCodec] Fix error enum bug

### DIFF
--- a/src/Tizen.Multimedia.MediaCodec/MediaCodec/MediaCodecError.cs
+++ b/src/Tizen.Multimedia.MediaCodec/MediaCodec/MediaCodecError.cs
@@ -25,7 +25,7 @@ namespace Tizen.Multimedia.MediaCodec
         None = ErrorCode.None,
         OutOfMemory = ErrorCode.OutOfMemory,
         InvalidParameter = ErrorCode.InvalidParameter,
-        InvalidOperation = ErrorCode.InvalidParameter,
+        InvalidOperation = ErrorCode.InvalidOperation,
         NotSupportedOnDevice = ErrorCode.NotSupported,
         PermissionDenied = ErrorCode.PermissionDenied,
 


### PR DESCRIPTION
### Description of Change ###

Fix error enum bug

### Bugs Fixed ###

- InvalidOperation was defined as InvalidParameter. So fix it to valid type.

