### PR TITLE
[Build] Remove mono dependency

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -42,15 +42,9 @@ goto :EOF
 
 :Pack
 set VERSION=%2
-set VERSION_INTERNAL=%3
 call :GetUnixTime TIMESTAMP
 if /I [%VERSION%] == [] set VERSION=4.0.1-local-%TIMESTAMP%
-if /I [%VERSION_INTERNAL%] == [] set VERSION_INTERNAL=%VERSION%
-set OUTDIR=%~dp0Artifacts
-set NUGET_CMD=%~dp0tools\NuGet.exe
-%NUGET_CMD% pack %~dp0pkg\Tizen.NET.nuspec -NoPackageAnalysis -Version %VERSION% -BasePath %~dp0 -OutputDirectory %OUTDIR%
-%NUGET_CMD% pack %~dp0pkg\Tizen.NET.API4.nuspec -NoPackageAnalysis -Version %VERSION% -BasePath %~dp0 -OutputDirectory %OUTDIR%
-%NUGET_CMD% pack %~dp0pkg\Tizen.NET.Internals.nuspec -NoPackageAnalysis -Version %VERSION_INTERNAL% -BasePath %~dp0 -OutputDirectory %OUTDIR%
+call dotnet msbuild %~dp0build\build.proj /nologo /t:pack /p:Version=%VERSION%
 goto :EOF
 
 :Clean

--- a/build.sh
+++ b/build.sh
@@ -53,18 +53,12 @@ cmd_dummy_build() {
 
 cmd_pack() {
   VERSION=$1
-  VERSION_INTERNAL=$2
   if [ -z "$VERSION" ]; then
     TIMESTAMP=$(date +"%s")
     VERSION="4.0.1-local-$TIMESTAMP"
   fi
-  if [ -z "$VERSION_INTERNAL" ]; then
-    VERSION_INTERNAL=$VERSION
-  fi
 
-  $NUGET_CMD pack $SCRIPT_DIR/pkg/Tizen.NET.nuspec -NoPackageAnalysis -Version $VERSION -BasePath $SCRIPT_DIR -OutputDirectory $OUTDIR
-  $NUGET_CMD pack $SCRIPT_DIR/pkg/Tizen.NET.API4.nuspec -NoPackageAnalysis -Version $VERSION -BasePath $SCRIPT_DIR -OutputDirectory $OUTDIR
-  $NUGET_CMD pack $SCRIPT_DIR/pkg/Tizen.NET.Internals.nuspec -NoPackageAnalysis -Version $VERSION_INTERNAL -BasePath $SCRIPT_DIR -OutputDirectory $OUTDIR
+  $RUN_BUILD /t:pack /p:Version=$VERSION
 }
 
 cmd_clean() {

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,6 @@ SCRIPT_DIR=$(dirname $SCRIPT_FILE)
 
 OUTDIR=$SCRIPT_DIR/Artifacts
 
-NUGET_CMD="mono $SCRIPT_DIR/tools/NuGet.exe"
 RETRY_CMD="$SCRIPT_DIR/tools/retry.sh"
 TIMEOUT_CMD="$SCRIPT_DIR/tools/timeout.sh"
 DOTNET_CMD="$RETRY_CMD $TIMEOUT_CMD 600 dotnet"

--- a/build/build.proj
+++ b/build/build.proj
@@ -14,6 +14,11 @@
     <ProjectToBuild Include="$(InternalProjectSrcDir)**\*.csproj" Condition="'$(Project)' == ''" />
   </ItemGroup>
 
+  <!-- Nuspec files to pack -->
+  <ItemGroup>
+    <NuspecFiles Include="$(ProjectRootDir)pkg\*.nuspec" />
+  </ItemGroup>
+
   <!--
     Target : Clean
     ==============
@@ -68,6 +73,23 @@
              Properties="Configuration=$(Configuration)"
              BuildInParallel="false"
              Targets="CopyToArtifactsDirectory" />
+
+  </Target>
+
+  <!--
+    Target : Pack
+    ==============
+    Generate nuget packages.
+  -->
+  <Target Name="Pack">
+
+    <MSBuild Projects="$(MSBuildThisFileDirectory)pack.csproj"
+             Properties="NoBuild=True"
+             Targets="Restore" />
+
+    <MSBuild Projects="$(MSBuildThisFileDirectory)pack.csproj"
+             Properties="NoBuild=True;Version=$(Version);NuspecFile=%(NuspecFiles.Identity)"
+             Targets="Pack" />
 
   </Target>
 

--- a/build/pack.csproj
+++ b/build/pack.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="$(MSBuildThisFileDirectory)directories.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <NuspecBasePath>$(ProjectRootDir)</NuspecBasePath>
+    <NuspecProperties>$(NuspecProperties);version=$(Version)</NuspecProperties>
+    <PackageOutputPath>$(OutputBaseDir)</PackageOutputPath>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
### Description of Change ###

Use dotnet-cli instead of nuget.exe to remove mono dependency.

