### PR TITLE
[MediaPlayer] add API to set audio-only mode

### DIFF
--- a/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
@@ -261,6 +261,12 @@ internal static partial class Interop
         [DllImport(Libraries.Player, EntryPoint = "player_get_track_language_code")]
         internal static extern PlayerErrorCode GetTrackLanguageCode(IntPtr player, StreamType type,
             int index, out IntPtr code);
+
+        [DllImport(Libraries.Player, EntryPoint = "player_set_audio_only")]
+        internal static extern PlayerErrorCode SetAudioOnly(IntPtr player, bool audioonly);
+
+        [DllImport(Libraries.Player, EntryPoint = "player_is_audio_only")]
+        internal static extern PlayerErrorCode IsAudioOnly(IntPtr player, out bool audioonly);
     }
 
     internal class PlayerHandle : SafeHandle

--- a/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
@@ -263,10 +263,10 @@ internal static partial class Interop
             int index, out IntPtr code);
 
         [DllImport(Libraries.Player, EntryPoint = "player_set_audio_only")]
-        internal static extern PlayerErrorCode SetAudioOnly(IntPtr player, bool audioonly);
+        internal static extern PlayerErrorCode SetAudioOnly(IntPtr player, bool audioOnly);
 
         [DllImport(Libraries.Player, EntryPoint = "player_is_audio_only")]
-        internal static extern PlayerErrorCode IsAudioOnly(IntPtr player, out bool audioonly);
+        internal static extern PlayerErrorCode IsAudioOnly(IntPtr player, out bool audioOnly);
     }
 
     internal class PlayerHandle : SafeHandle

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
@@ -413,5 +413,32 @@ namespace Tizen.Multimedia
                     ThrowIfFailed(this, "Failed to set the volume of the player");
             }
         }
+
+        /// <summary>
+        /// Gets or sets the audio-only state.
+        /// </summary>
+        /// <value>true if the playback is audio-only mode; otherwise, false. The default value is false.</value>
+        /// The <see cref="Player"/> To set or get the player must be in the <see cref="PlayerState.Ready"/>,
+        /// <see cref="PlayerState.Playing"/>, or <see cref="PlayerState.Paused"/> state.
+        /// <exception cref="InvalidOperationException">The player is not in the valid state.</exception>
+        /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
+        /// <since_tizen> 5 </since_tizen>
+        public bool IsAudioOnly
+        {
+            get
+            {
+                ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
+                NativePlayer.IsAudioOnly(Handle, out var value).
+                    ThrowIfFailed(this, "Failed to get the audio-only state of the player");
+                return value;
+            }
+            set
+            {
+                ValidateNotDisposed();
+                ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
+                NativePlayer.SetAudioOnly(Handle, value).
+                    ThrowIfFailed(this, "Failed to set the audio-only state of the player");
+            }
+        }
     }
 }

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
@@ -418,7 +418,7 @@ namespace Tizen.Multimedia
         /// Gets or sets the audio-only state.
         /// </summary>
         /// <value>true if the playback is audio-only mode; otherwise, false. The default value is false.</value>
-        /// The <see cref="Player"/> To set or get, the player must be in the <see cref="PlayerState.Ready"/>,
+        /// The <see cref="Player"/> must be in the <see cref="PlayerState.Ready"/>,
         /// <see cref="PlayerState.Playing"/>, or <see cref="PlayerState.Paused"/> state.
         /// <exception cref="InvalidOperationException">The player is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
@@ -418,7 +418,7 @@ namespace Tizen.Multimedia
         /// Gets or sets the audio-only state.
         /// </summary>
         /// <value>true if the playback is audio-only mode; otherwise, false. The default value is false.</value>
-        /// The <see cref="Player"/> To set or get the player must be in the <see cref="PlayerState.Ready"/>,
+        /// The <see cref="Player"/> To set or get, the player must be in the <see cref="PlayerState.Ready"/>,
         /// <see cref="PlayerState.Playing"/>, or <see cref="PlayerState.Paused"/> state.
         /// <exception cref="InvalidOperationException">The player is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>


### PR DESCRIPTION
### Description of Change ###

add API to set audio-only mode

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-138 

Added:
 - IsAudioOnly { get; set;} // Property

### Behavioral Changes ###

N/A

