### PR TITLE
[NUI]Refactor ImfManager to InputMethodContext

### DIFF
--- a/src/Tizen.NUI/src/internal/ActivatedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/ActivatedSignalType.cs
@@ -177,9 +177,9 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="arg">The first value to pass to callbacks</param>
         /// <since_tizen> 4 </since_tizen>
-        public void Emit(ImfManager arg)
+        public void Emit(InputMethodContext arg)
         {
-            NDalicManualPINVOKE.ActivatedSignalType_Emit(swigCPtr, ImfManager.getCPtr(arg));
+            NDalicManualPINVOKE.ActivatedSignalType_Emit(swigCPtr, InputMethodContext.getCPtr(arg));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/internal/KeyboardEventSignalType.cs
+++ b/src/Tizen.NUI/src/internal/KeyboardEventSignalType.cs
@@ -20,7 +20,7 @@ using System.ComponentModel;
 
 namespace Tizen.NUI
 {
-    internal class ImfEventSignalType : global::System.IDisposable
+    internal class KeyboardEventSignalType : global::System.IDisposable
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
         /// <summary>
@@ -29,13 +29,13 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         protected bool swigCMemOwn;
 
-        internal ImfEventSignalType(global::System.IntPtr cPtr, bool cMemoryOwn)
+        internal KeyboardEventSignalType(global::System.IntPtr cPtr, bool cMemoryOwn)
         {
             swigCMemOwn = cMemoryOwn;
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ImfEventSignalType obj)
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyboardEventSignalType obj)
         {
             return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
         }
@@ -52,7 +52,7 @@ namespace Tizen.NUI
         /// Dispose
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        ~ImfEventSignalType()
+        ~KeyboardEventSignalType()
         {
             if (!isDisposeQueued)
             {
@@ -112,7 +112,7 @@ namespace Tizen.NUI
                 if (swigCMemOwn)
                 {
                     swigCMemOwn = false;
-                    NDalicManualPINVOKE.delete_ImfEventSignalType(swigCPtr);
+                    NDalicManualPINVOKE.delete_KeyboardEventSignalType(swigCPtr);
                 }
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
             }
@@ -127,7 +127,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public bool Empty()
         {
-            bool ret = NDalicManualPINVOKE.ImfEventSignalType_Empty(swigCPtr);
+            bool ret = NDalicManualPINVOKE.KeyboardEventSignalType_Empty(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -139,7 +139,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public uint GetConnectionCount()
         {
-            uint ret = NDalicManualPINVOKE.ImfEventSignalType_GetConnectionCount(swigCPtr);
+            uint ret = NDalicManualPINVOKE.KeyboardEventSignalType_GetConnectionCount(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -153,7 +153,7 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
             {
-                NDalicManualPINVOKE.ImfEventSignalType_Connect(swigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                NDalicManualPINVOKE.KeyboardEventSignalType_Connect(swigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -167,7 +167,7 @@ namespace Tizen.NUI
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
             {
-                NDalicManualPINVOKE.ImfEventSignalType_Disconnect(swigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                NDalicManualPINVOKE.KeyboardEventSignalType_Disconnect(swigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -179,9 +179,9 @@ namespace Tizen.NUI
         /// <param name="arg2">The second value to pass to callbacks</param>
         /// <returns>The value returned by the last callback, or a default constructed value if no callbacks are connected</returns>
         /// <since_tizen> 4 </since_tizen>
-        public ImfManager.ImfCallbackData Emit(ImfManager arg1, ImfManager.ImfEventData arg2)
+        public InputMethodContext.CallbackData Emit(InputMethodContext arg1, InputMethodContext.EventData arg2)
         {
-            ImfManager.ImfCallbackData ret = new ImfManager.ImfCallbackData(NDalicManualPINVOKE.ImfEventSignalType_Emit(swigCPtr, ImfManager.getCPtr(arg1), ImfManager.ImfEventData.getCPtr(arg2)), true);
+            InputMethodContext.CallbackData ret = new InputMethodContext.CallbackData(NDalicManualPINVOKE.KeyboardEventSignalType_Emit(swigCPtr, InputMethodContext.getCPtr(arg1), InputMethodContext.EventData.getCPtr(arg2)), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -190,7 +190,7 @@ namespace Tizen.NUI
         /// The contructor.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public ImfEventSignalType() : this(NDalicManualPINVOKE.new_ImfEventSignalType(), true)
+        public KeyboardEventSignalType() : this(NDalicManualPINVOKE.new_KeyboardEventSignalType(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/internal/KeyboardTypeSignalType.cs
+++ b/src/Tizen.NUI/src/internal/KeyboardTypeSignalType.cs
@@ -179,7 +179,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="arg">The member function to connect</param>
         /// <since_tizen> 4 </since_tizen>
-        public void Emit(ImfManager.KeyboardType arg)
+        public void Emit(InputMethodContext.KeyboardType arg)
         {
             NDalicManualPINVOKE.KeyboardTypeSignalType_Emit(swigCPtr, (int)arg);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
@@ -305,177 +305,187 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_GetNativeWindowHandler")]
         public static extern System.IntPtr GetNativeWindowHandler(System.IntPtr Window);
 
-        //////////////////////ImfManager
+        //////////////////////InputMethodContext
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_SWIGUpcast")]
-        public static extern global::System.IntPtr ImfManager_SWIGUpcast(global::System.IntPtr jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_SWIGUpcast")]
+        public static extern global::System.IntPtr InputMethodContext_SWIGUpcast(global::System.IntPtr jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_ImfManager_ImfEventData__SWIG_0")]
-        public static extern global::System.IntPtr new_ImfManager_ImfEventData__SWIG_0();
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_InputMethodContext_EventData__SWIG_0")]
+        public static extern global::System.IntPtr new_InputMethodContext_EventData__SWIG_0();
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_ImfManager_ImfEventData__SWIG_1")]
-        public static extern global::System.IntPtr new_ImfManager_ImfEventData__SWIG_1(int jarg1, string jarg2, int jarg3, int jarg4);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_InputMethodContext_EventData__SWIG_1")]
+        public static extern global::System.IntPtr new_InputMethodContext_EventData__SWIG_1(int jarg1, string jarg2, int jarg3, int jarg4);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_predictiveString_set")]
-        public static extern void ImfManager_ImfEventData_predictiveString_set(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_predictiveString_set")]
+        public static extern void InputMethodContext_EventData_predictiveString_set(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_predictiveString_get")]
-        public static extern string ImfManager_ImfEventData_predictiveString_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_predictiveString_get")]
+        public static extern string InputMethodContext_EventData_predictiveString_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_eventName_set")]
-        public static extern void ImfManager_ImfEventData_eventName_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_eventName_set")]
+        public static extern void InputMethodContext_EventData_eventName_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_eventName_get")]
-        public static extern int ImfManager_ImfEventData_eventName_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_eventName_get")]
+        public static extern int InputMethodContext_EventData_eventName_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_cursorOffset_set")]
-        public static extern void ImfManager_ImfEventData_cursorOffset_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_cursorOffset_set")]
+        public static extern void InputMethodContext_EventData_cursorOffset_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_cursorOffset_get")]
-        public static extern int ImfManager_ImfEventData_cursorOffset_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_cursorOffset_get")]
+        public static extern int InputMethodContext_EventData_cursorOffset_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_numberOfChars_set")]
-        public static extern void ImfManager_ImfEventData_numberOfChars_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_numberOfChars_set")]
+        public static extern void InputMethodContext_EventData_numberOfChars_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfEventData_numberOfChars_get")]
-        public static extern int ImfManager_ImfEventData_numberOfChars_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventData_numberOfChars_get")]
+        public static extern int InputMethodContext_EventData_numberOfChars_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_ImfManager_ImfEventData")]
-        public static extern void delete_ImfManager_ImfEventData(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_InputMethodContext_EventData")]
+        public static extern void delete_InputMethodContext_EventData(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_ImfManager_ImfCallbackData__SWIG_0")]
-        public static extern global::System.IntPtr new_ImfManager_ImfCallbackData__SWIG_0();
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_InputMethodContext_CallbackData__SWIG_0")]
+        public static extern global::System.IntPtr new_InputMethodContext_CallbackData__SWIG_0();
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_ImfManager_ImfCallbackData__SWIG_1")]
-        public static extern global::System.IntPtr new_ImfManager_ImfCallbackData__SWIG_1(bool jarg1, int jarg2, string jarg3, bool jarg4);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_InputMethodContext_CallbackData__SWIG_1")]
+        public static extern global::System.IntPtr new_InputMethodContext_CallbackData__SWIG_1(bool jarg1, int jarg2, string jarg3, bool jarg4);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_currentText_set")]
-        public static extern void ImfManager_ImfCallbackData_currentText_set(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_currentText_set")]
+        public static extern void InputMethodContext_CallbackData_currentText_set(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_currentText_get")]
-        public static extern string ImfManager_ImfCallbackData_currentText_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_currentText_get")]
+        public static extern string InputMethodContext_CallbackData_currentText_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_cursorPosition_set")]
-        public static extern void ImfManager_ImfCallbackData_cursorPosition_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_cursorPosition_set")]
+        public static extern void InputMethodContext_CallbackData_cursorPosition_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_cursorPosition_get")]
-        public static extern int ImfManager_ImfCallbackData_cursorPosition_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_cursorPosition_get")]
+        public static extern int InputMethodContext_CallbackData_cursorPosition_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_update_set")]
-        public static extern void ImfManager_ImfCallbackData_update_set(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_update_set")]
+        public static extern void InputMethodContext_CallbackData_update_set(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_update_get")]
-        public static extern bool ImfManager_ImfCallbackData_update_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_update_get")]
+        public static extern bool InputMethodContext_CallbackData_update_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_preeditResetRequired_set")]
-        public static extern void ImfManager_ImfCallbackData_preeditResetRequired_set(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_preeditResetRequired_set")]
+        public static extern void InputMethodContext_CallbackData_preeditResetRequired_set(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ImfCallbackData_preeditResetRequired_get")]
-        public static extern bool ImfManager_ImfCallbackData_preeditResetRequired_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_CallbackData_preeditResetRequired_get")]
+        public static extern bool InputMethodContext_CallbackData_preeditResetRequired_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_ImfManager_ImfCallbackData")]
-        public static extern void delete_ImfManager_ImfCallbackData(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_InputMethodContext_CallbackData")]
+        public static extern void delete_InputMethodContext_CallbackData(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_Finalize")]
-        public static extern void ImfManager_Finalize(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_Finalize")]
+        public static extern void InputMethodContext_Finalize(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_Get")]
-        public static extern global::System.IntPtr ImfManager_Get();
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_InputMethodContext__SWIG_0")]
+        public static extern global::System.IntPtr new_InputMethodContext__SWIG_0();
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_Activate")]
-        public static extern void ImfManager_Activate(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_InputMethodContext")]
+        public static extern void delete_InputMethodContext(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_Deactivate")]
-        public static extern void ImfManager_Deactivate(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_New")]
+        public static extern global::System.IntPtr InputMethodContext_New();
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_RestoreAfterFocusLost")]
-        public static extern bool ImfManager_RestoreAfterFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_InputMethodContext__SWIG_1")]
+        public static extern global::System.IntPtr new_InputMethodContext__SWIG_1(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_SetRestoreAfterFocusLost")]
-        public static extern void ImfManager_SetRestoreAfterFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_Assign")]
+        public static extern global::System.IntPtr InputMethodContext_Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_Reset")]
-        public static extern void ImfManager_Reset(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_DownCast")]
+        public static extern global::System.IntPtr InputMethodContext_DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_NotifyCursorPosition")]
-        public static extern void ImfManager_NotifyCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_Activate")]
+        public static extern void InputMethodContext_Activate(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_SetCursorPosition")]
-        public static extern void ImfManager_SetCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_Deactivate")]
+        public static extern void InputMethodContext_Deactivate(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetCursorPosition")]
-        public static extern uint ImfManager_GetCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_RestoreAfterFocusLost")]
+        public static extern bool InputMethodContext_RestoreAfterFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_SetSurroundingText")]
-        public static extern void ImfManager_SetSurroundingText(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_SetRestoreAfterFocusLost")]
+        public static extern void InputMethodContext_SetRestoreAfterFocusLost(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetSurroundingText")]
-        public static extern string ImfManager_GetSurroundingText(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_Reset")]
+        public static extern void InputMethodContext_Reset(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_NotifyTextInputMultiLine")]
-        public static extern void ImfManager_NotifyTextInputMultiLine(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_NotifyCursorPosition")]
+        public static extern void InputMethodContext_NotifyCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetTextDirection")]
-        public static extern int ImfManager_GetTextDirection(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_SetCursorPosition")]
+        public static extern void InputMethodContext_SetCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetInputMethodArea")]
-        public static extern global::System.IntPtr ImfManager_GetInputMethodArea(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetCursorPosition")]
+        public static extern uint InputMethodContext_GetCursorPosition(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ApplyOptions")]
-        public static extern void ImfManager_ApplyOptions(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_SetSurroundingText")]
+        public static extern void InputMethodContext_SetSurroundingText(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_SetInputPanelUserData")]
-        public static extern void ImfManager_SetInputPanelUserData(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetSurroundingText")]
+        public static extern string InputMethodContext_GetSurroundingText(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetInputPanelUserData")]
-        public static extern void ImfManager_GetInputPanelUserData(global::System.Runtime.InteropServices.HandleRef jarg1, out string jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_NotifyTextInputMultiLine")]
+        public static extern void InputMethodContext_NotifyTextInputMultiLine(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetInputPanelState")]
-        public static extern int ImfManager_GetInputPanelState(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetTextDirection")]
+        public static extern int InputMethodContext_GetTextDirection(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_SetReturnKeyState")]
-        public static extern void ImfManager_SetReturnKeyState(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetInputMethodArea")]
+        public static extern global::System.IntPtr InputMethodContext_GetInputMethodArea(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_AutoEnableInputPanel")]
-        public static extern void ImfManager_AutoEnableInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_ApplyOptions")]
+        public static extern void InputMethodContext_ApplyOptions(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ShowInputPanel")]
-        public static extern void ImfManager_ShowInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_SetInputPanelUserData")]
+        public static extern void InputMethodContext_SetInputPanelUserData(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_HideInputPanel")]
-        public static extern void ImfManager_HideInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetInputPanelUserData")]
+        public static extern void InputMethodContext_GetInputPanelUserData(global::System.Runtime.InteropServices.HandleRef jarg1, out string jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetKeyboardType")]
-        public static extern int ImfManager_GetKeyboardType(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetInputPanelState")]
+        public static extern int InputMethodContext_GetInputPanelState(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_GetInputPanelLocale")]
-        public static extern string ImfManager_GetInputPanelLocale(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_SetReturnKeyState")]
+        public static extern void InputMethodContext_SetReturnKeyState(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ActivatedSignal")]
-        public static extern global::System.IntPtr ImfManager_ActivatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_AutoEnableInputPanel")]
+        public static extern void InputMethodContext_AutoEnableInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_EventReceivedSignal")]
-        public static extern global::System.IntPtr ImfManager_EventReceivedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_ShowInputPanel")]
+        public static extern void InputMethodContext_ShowInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_StatusChangedSignal")]
-        public static extern global::System.IntPtr ImfManager_StatusChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_HideInputPanel")]
+        public static extern void InputMethodContext_HideInputPanel(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_ResizedSignal")]
-        public static extern global::System.IntPtr ImfManager_ResizedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetKeyboardType")]
+        public static extern int InputMethodContext_GetKeyboardType(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_LanguageChangedSignal")]
-        public static extern global::System.IntPtr ImfManager_LanguageChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_GetInputPanelLocale")]
+        public static extern string InputMethodContext_GetInputPanelLocale(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfManager_KeyboardTypeChangedSignal")]
-        public static extern global::System.IntPtr ImfManager_KeyboardTypeChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_ActivatedSignal")]
+        public static extern global::System.IntPtr InputMethodContext_ActivatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_ImfManager")]
-        public static extern global::System.IntPtr new_ImfManager();
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_EventReceivedSignal")]
+        public static extern global::System.IntPtr InputMethodContext_EventReceivedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_ImfManager")]
-        public static extern void delete_ImfManager(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_StatusChangedSignal")]
+        public static extern global::System.IntPtr InputMethodContext_StatusChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        ////////////////////// ImfManager signals
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_ResizedSignal")]
+        public static extern global::System.IntPtr InputMethodContext_ResizedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_LanguageChangedSignal")]
+        public static extern global::System.IntPtr InputMethodContext_LanguageChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_InputMethodContext_KeyboardTypeChangedSignal")]
+        public static extern global::System.IntPtr InputMethodContext_KeyboardTypeChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+
+        ////////////////////// InputMethodContext signals
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ActivatedSignalType_Empty")]
         public static extern bool ActivatedSignalType_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -497,50 +507,50 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_ActivatedSignalType")]
         public static extern void delete_ActivatedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfEventSignalType_Empty")]
-        public static extern bool ImfEventSignalType_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_KeyboardEventSignalType_Empty")]
+        public static extern bool KeyboardEventSignalType_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfEventSignalType_GetConnectionCount")]
-        public static extern uint ImfEventSignalType_GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_KeyboardEventSignalType_GetConnectionCount")]
+        public static extern uint KeyboardEventSignalType_GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfEventSignalType_Connect")]
-        public static extern void ImfEventSignalType_Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_KeyboardEventSignalType_Connect")]
+        public static extern void KeyboardEventSignalType_Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfEventSignalType_Disconnect")]
-        public static extern void ImfEventSignalType_Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_KeyboardEventSignalType_Disconnect")]
+        public static extern void KeyboardEventSignalType_Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfEventSignalType_Emit")]
-        public static extern global::System.IntPtr ImfEventSignalType_Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_KeyboardEventSignalType_Emit")]
+        public static extern global::System.IntPtr KeyboardEventSignalType_Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_ImfEventSignalType")]
-        public static extern global::System.IntPtr new_ImfEventSignalType();
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_KeyboardEventSignalType")]
+        public static extern global::System.IntPtr new_KeyboardEventSignalType();
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_ImfEventSignalType")]
-        public static extern void delete_ImfEventSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_KeyboardEventSignalType")]
+        public static extern void delete_KeyboardEventSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_ImfVoidSignalType")]
-        public static extern global::System.IntPtr new_ImfVoidSignalType();
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_VoidSignalType")]
+        public static extern global::System.IntPtr new_VoidSignalType();
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_ImfVoidSignalType")]
-        public static extern void delete_ImfVoidSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_delete_VoidSignalType")]
+        public static extern void delete_VoidSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfVoidSignalType_Empty")]
-        public static extern bool ImfVoidSignalType_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VoidSignalType_Empty")]
+        public static extern bool VoidSignalType_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfVoidSignalType_GetConnectionCount")]
-        public static extern uint ImfVoidSignalType_GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VoidSignalType_GetConnectionCount")]
+        public static extern uint VoidSignalType_GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfVoidSignalType_Connect__SWIG_0")]
-        public static extern void ImfVoidSignalType_Connect__SWIG_0(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VoidSignalType_Connect__SWIG_0")]
+        public static extern void VoidSignalType_Connect__SWIG_0(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfVoidSignalType_Disconnect")]
-        public static extern void ImfVoidSignalType_Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VoidSignalType_Disconnect")]
+        public static extern void VoidSignalType_Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfVoidSignalType_Connect__SWIG_4")]
-        public static extern void ImfVoidSignalType_Connect__SWIG_4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VoidSignalType_Connect__SWIG_4")]
+        public static extern void VoidSignalType_Connect__SWIG_4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_ImfVoidSignalType_Emit")]
-        public static extern void ImfVoidSignalType_Emit(global::System.Runtime.InteropServices.HandleRef jarg1);
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VoidSignalType_Emit")]
+        public static extern void VoidSignalType_Emit(global::System.Runtime.InteropServices.HandleRef jarg1);
 
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_StatusSignalType_Empty")]
         public static extern bool StatusSignalType_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
@@ -9147,6 +9147,9 @@ class NDalicPINVOKE {
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TextEditor_DownCast")]
   public static extern global::System.IntPtr TextEditor_DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TextEditor_GetInputMethodContext")]
+  public static extern global::System.IntPtr TextEditor_GetInputMethodContext(global::System.Runtime.InteropServices.HandleRef jarg1);
+
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TextEditor_TextChangedSignal")]
   public static extern global::System.IntPtr TextEditor_TextChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -9323,6 +9326,9 @@ class NDalicPINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TextField_DownCast")]
   public static extern global::System.IntPtr TextField_DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TextField_GetInputMethodContext")]
+  public static extern global::System.IntPtr TextField_GetInputMethodContext(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TextField_TextChangedSignal")]
   public static extern global::System.IntPtr TextField_TextChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -336,6 +336,16 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Get the InputMethodContext instance.
+        /// </summary>
+        /// <returns>The InputMethodContext instance.</returns>
+        public InputMethodContext GetInputMethodContext() {
+            InputMethodContext ret = new InputMethodContext(NDalicPINVOKE.TextEditor_GetInputMethodContext(swigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         internal TextEditorSignal TextChangedSignal()
         {
             TextEditorSignal ret = new TextEditorSignal(NDalicPINVOKE.TextEditor_TextChangedSignal(swigCPtr), false);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -322,6 +322,16 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Get the InputMethodContext instance.
+        /// </summary>
+        /// <returns>The InputMethodContext instance.</returns>
+        public InputMethodContext GetInputMethodContext() {
+            InputMethodContext ret = new InputMethodContext(NDalicPINVOKE.TextEditor_GetInputMethodContext(swigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         internal TextFieldSignal TextChangedSignal()
         {
             TextFieldSignal ret = new TextFieldSignal(NDalicPINVOKE.TextField_TextChangedSignal(swigCPtr), false);

--- a/src/Tizen.NUI/src/public/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/InputMethodContext.cs
@@ -25,39 +25,71 @@ namespace Tizen.NUI
     /// Specifically manages the input method framework which enables the virtual or hardware keyboards.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    public class ImfManager : BaseHandle
+    public class InputMethodContext : BaseHandle
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal ImfManager(IntPtr cPtr, bool cMemoryOwn) : base(NDalicManualPINVOKE.ImfManager_SWIGUpcast(cPtr), cMemoryOwn)
+        internal InputMethodContext(IntPtr cPtr, bool cMemoryOwn) : base(NDalicManualPINVOKE.InputMethodContext_SWIGUpcast(cPtr), cMemoryOwn)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ImfManager obj)
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(InputMethodContext obj)
         {
             return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, IntPtr.Zero) : obj.swigCPtr;
         }
 
-        private static readonly ImfManager instance = ImfManager.Get();
 
         /// <summary>
-        /// Gets the singleton of the ImfManager object.
+        /// Dispose
         /// </summary>
-        /// <since_tizen> 5 </since_tizen>
-        public static ImfManager Instance
+        /// <param name="type">Dispose Type</param>
+        /// <since_tizen> 3 </since_tizen>
+        /// Please DO NOT use! This will be deprecated!
+        /// Dispose() method in Singletone classes (ex: FocusManager, StyleManager, VisualFactory, InputMethodContext, TtsPlayer, Window) is not required.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
         {
-            get
+            if (disposed)
             {
-                return instance;
+                return;
             }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+
+            }
+
+            //Release your own unmanaged resources here.
+            //You should not access any managed member here except static instance.
+            //because the execution order of Finalizes is non-deterministic.
+
+            if (_keyboardTypeChangedEventCallback != null)
+            {
+                KeyboardTypeChangedSignal().Disconnect(_keyboardTypeChangedEventCallback);
+            }
+
+            if (swigCPtr.Handle != global::System.IntPtr.Zero)
+            {
+                if (swigCMemOwn)
+                {
+                    swigCMemOwn = false;
+                    NDalicManualPINVOKE.delete_InputMethodContext(swigCPtr);
+                }
+                swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, IntPtr.Zero);
+            }
+
+            base.Dispose(type);
         }
 
         /// <summary>
         /// This structure is used to pass on data from the IMF regarding predictive text.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public class ImfEventData : global::System.IDisposable
+        public class EventData : global::System.IDisposable
         {
             private global::System.Runtime.InteropServices.HandleRef swigCPtr;
             /// <summary>
@@ -66,13 +98,13 @@ namespace Tizen.NUI
             /// <since_tizen> 3 </since_tizen>
             protected bool swigCMemOwn;
 
-            internal ImfEventData(IntPtr cPtr, bool cMemoryOwn)
+            internal EventData(IntPtr cPtr, bool cMemoryOwn)
             {
                 swigCMemOwn = cMemoryOwn;
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
             }
 
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ImfEventData obj)
+            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(EventData obj)
             {
                 return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, IntPtr.Zero) : obj.swigCPtr;
             }
@@ -89,7 +121,7 @@ namespace Tizen.NUI
             /// Dispose.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
-            ~ImfEventData()
+            ~EventData()
             {
                 if (!isDisposeQueued)
                 {
@@ -149,7 +181,7 @@ namespace Tizen.NUI
                     if (swigCMemOwn)
                     {
                         swigCMemOwn = false;
-                        NDalicManualPINVOKE.delete_ImfManager_ImfEventData(swigCPtr);
+                        NDalicManualPINVOKE.delete_InputMethodContext_EventData(swigCPtr);
                     }
                     swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, IntPtr.Zero);
                 }
@@ -157,9 +189,9 @@ namespace Tizen.NUI
                 disposed = true;
             }
 
-            internal static ImfEventData GetImfEventDataFromPtr(IntPtr cPtr)
+            internal static EventData GetEventDataFromPtr(IntPtr cPtr)
             {
-                ImfEventData ret = new ImfEventData(cPtr, false);
+                EventData ret = new EventData(cPtr, false);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
@@ -168,7 +200,7 @@ namespace Tizen.NUI
             /// The default constructor.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
-            public ImfEventData() : this(NDalicManualPINVOKE.new_ImfManager_ImfEventData__SWIG_0(), true)
+            public EventData() : this(NDalicManualPINVOKE.new_InputMethodContext_EventData__SWIG_0(), true)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -181,7 +213,7 @@ namespace Tizen.NUI
             /// <param name="aCursorOffset">Start the position from the current cursor position to start deleting characters.</param>
             /// <param name="aNumberOfChars">The number of characters to delete from the cursorOffset.</param>
             /// <since_tizen> 3 </since_tizen>
-            public ImfEventData(ImfManager.ImfEvent aEventName, string aPredictiveString, int aCursorOffset, int aNumberOfChars) : this(NDalicManualPINVOKE.new_ImfManager_ImfEventData__SWIG_1((int)aEventName, aPredictiveString, aCursorOffset, aNumberOfChars), true)
+            public EventData(InputMethodContext.EventType aEventName, string aPredictiveString, int aCursorOffset, int aNumberOfChars) : this(NDalicManualPINVOKE.new_InputMethodContext_EventData__SWIG_1((int)aEventName, aPredictiveString, aCursorOffset, aNumberOfChars), true)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -194,12 +226,12 @@ namespace Tizen.NUI
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfEventData_predictiveString_set(swigCPtr, value);
+                    NDalicManualPINVOKE.InputMethodContext_EventData_predictiveString_set(swigCPtr, value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    string ret = NDalicManualPINVOKE.ImfManager_ImfEventData_predictiveString_get(swigCPtr);
+                    string ret = NDalicManualPINVOKE.InputMethodContext_EventData_predictiveString_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -209,16 +241,16 @@ namespace Tizen.NUI
             /// The name of the event from the IMF.
             /// </summary>
             /// <since_tizen> 4 </since_tizen>
-            public ImfManager.ImfEvent EventName
+            public InputMethodContext.EventType EventName
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfEventData_eventName_set(swigCPtr, (int)value);
+                    NDalicManualPINVOKE.InputMethodContext_EventData_eventName_set(swigCPtr, (int)value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    ImfManager.ImfEvent ret = (ImfManager.ImfEvent)NDalicManualPINVOKE.ImfManager_ImfEventData_eventName_get(swigCPtr);
+                    InputMethodContext.EventType ret = (InputMethodContext.EventType)NDalicManualPINVOKE.InputMethodContext_EventData_eventName_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -232,12 +264,12 @@ namespace Tizen.NUI
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfEventData_cursorOffset_set(swigCPtr, value);
+                    NDalicManualPINVOKE.InputMethodContext_EventData_cursorOffset_set(swigCPtr, value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    int ret = NDalicManualPINVOKE.ImfManager_ImfEventData_cursorOffset_get(swigCPtr);
+                    int ret = NDalicManualPINVOKE.InputMethodContext_EventData_cursorOffset_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -251,12 +283,12 @@ namespace Tizen.NUI
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfEventData_numberOfChars_set(swigCPtr, value);
+                    NDalicManualPINVOKE.InputMethodContext_EventData_numberOfChars_set(swigCPtr, value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    int ret = NDalicManualPINVOKE.ImfManager_ImfEventData_numberOfChars_get(swigCPtr);
+                    int ret = NDalicManualPINVOKE.InputMethodContext_EventData_numberOfChars_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -268,7 +300,7 @@ namespace Tizen.NUI
         /// Data required by the IMF from the callback.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public class ImfCallbackData : global::System.IDisposable
+        public class CallbackData : global::System.IDisposable
         {
             private global::System.Runtime.InteropServices.HandleRef swigCPtr;
             /// <summary>
@@ -277,18 +309,18 @@ namespace Tizen.NUI
             /// <since_tizen> 3 </since_tizen>
             protected bool swigCMemOwn;
 
-            internal IntPtr GetImfCallbackDataPtr()
+            internal IntPtr GetCallbackDataPtr()
             {
                 return (IntPtr)swigCPtr;
             }
 
-            internal ImfCallbackData(IntPtr cPtr, bool cMemoryOwn)
+            internal CallbackData(IntPtr cPtr, bool cMemoryOwn)
             {
                 swigCMemOwn = cMemoryOwn;
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
             }
 
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ImfCallbackData obj)
+            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CallbackData obj)
             {
                 return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, IntPtr.Zero) : obj.swigCPtr;
             }
@@ -306,7 +338,7 @@ namespace Tizen.NUI
             /// Dispose.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
-            ~ImfCallbackData()
+            ~CallbackData()
             {
                 if (!isDisposeQueued)
                 {
@@ -366,7 +398,7 @@ namespace Tizen.NUI
                     if (swigCMemOwn)
                     {
                         swigCMemOwn = false;
-                        NDalicManualPINVOKE.delete_ImfManager_ImfCallbackData(swigCPtr);
+                        NDalicManualPINVOKE.delete_InputMethodContext_CallbackData(swigCPtr);
                     }
                     swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, IntPtr.Zero);
                 }
@@ -374,9 +406,9 @@ namespace Tizen.NUI
                 disposed = true;
             }
 
-            internal static ImfCallbackData GetImfCallbackDataFromPtr(IntPtr cPtr)
+            internal static CallbackData GetCallbackDataFromPtr(IntPtr cPtr)
             {
-                ImfCallbackData ret = new ImfCallbackData(cPtr, false);
+                CallbackData ret = new CallbackData(cPtr, false);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
@@ -385,7 +417,7 @@ namespace Tizen.NUI
             /// The default constructor.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
-            public ImfCallbackData() : this(NDalicManualPINVOKE.new_ImfManager_ImfCallbackData__SWIG_0(), true)
+            public CallbackData() : this(NDalicManualPINVOKE.new_InputMethodContext_CallbackData__SWIG_0(), true)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -398,7 +430,7 @@ namespace Tizen.NUI
             /// <param name="aCurrentText">The current text string.</param>
             /// <param name="aPreeditResetRequired">Flag if preedit reset is required.</param>
             /// <since_tizen> 3 </since_tizen>
-            public ImfCallbackData(bool aUpdate, int aCursorPosition, string aCurrentText, bool aPreeditResetRequired) : this(NDalicManualPINVOKE.new_ImfManager_ImfCallbackData__SWIG_1(aUpdate, aCursorPosition, aCurrentText, aPreeditResetRequired), true)
+            public CallbackData(bool aUpdate, int aCursorPosition, string aCurrentText, bool aPreeditResetRequired) : this(NDalicManualPINVOKE.new_InputMethodContext_CallbackData__SWIG_1(aUpdate, aCursorPosition, aCurrentText, aPreeditResetRequired), true)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -411,12 +443,12 @@ namespace Tizen.NUI
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfCallbackData_currentText_set(swigCPtr, value);
+                    NDalicManualPINVOKE.InputMethodContext_CallbackData_currentText_set(swigCPtr, value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    string ret = NDalicManualPINVOKE.ImfManager_ImfCallbackData_currentText_get(swigCPtr);
+                    string ret = NDalicManualPINVOKE.InputMethodContext_CallbackData_currentText_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -430,12 +462,12 @@ namespace Tizen.NUI
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfCallbackData_cursorPosition_set(swigCPtr, value);
+                    NDalicManualPINVOKE.InputMethodContext_CallbackData_cursorPosition_set(swigCPtr, value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    int ret = NDalicManualPINVOKE.ImfManager_ImfCallbackData_cursorPosition_get(swigCPtr);
+                    int ret = NDalicManualPINVOKE.InputMethodContext_CallbackData_cursorPosition_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -449,12 +481,12 @@ namespace Tizen.NUI
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfCallbackData_update_set(swigCPtr, value);
+                    NDalicManualPINVOKE.InputMethodContext_CallbackData_update_set(swigCPtr, value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    bool ret = NDalicManualPINVOKE.ImfManager_ImfCallbackData_update_get(swigCPtr);
+                    bool ret = NDalicManualPINVOKE.InputMethodContext_CallbackData_update_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -468,12 +500,12 @@ namespace Tizen.NUI
             {
                 set
                 {
-                    NDalicManualPINVOKE.ImfManager_ImfCallbackData_preeditResetRequired_set(swigCPtr, value);
+                    NDalicManualPINVOKE.InputMethodContext_CallbackData_preeditResetRequired_set(swigCPtr, value);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 get
                 {
-                    bool ret = NDalicManualPINVOKE.ImfManager_ImfCallbackData_preeditResetRequired_get(swigCPtr);
+                    bool ret = NDalicManualPINVOKE.InputMethodContext_CallbackData_preeditResetRequired_get(swigCPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -487,7 +519,7 @@ namespace Tizen.NUI
         /// <since_tizen> 5 </since_tizen>
         public void DestroyContext()
         {
-            NDalicManualPINVOKE.ImfManager_Finalize(swigCPtr);
+            NDalicManualPINVOKE.InputMethodContext_Finalize(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -495,8 +527,8 @@ namespace Tizen.NUI
         /// Destroy the context of the IMF.<br/>
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        /// Please do not use! This will be deprecated, instead please USE Tizen.NUI.ImfManager.Instance.DestroyContext()!
-        [Obsolete("Please do not use! This will be deprecated! Please use ImfManager.Instance.DestroyContext() instead!")]
+        /// Please do not use! This will be deprecated, instead please USE Tizen.NUI.InputMethodContext.Instance.DestroyContext()!
+        [Obsolete("Please do not use! This will be deprecated! Please use InputMethodContext.Instance.DestroyContext() instead!")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Finalize()
         {
@@ -504,13 +536,26 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Retrieves a handle to the instance of the ImfManager.
+        /// Constructor.<br/>
         /// </summary>
-        /// <returns>A handle to the ImfManager.</returns>
-        /// <since_tizen> 3 </since_tizen>
-        public static ImfManager Get()
-        {
-            ImfManager ret = new ImfManager(NDalicManualPINVOKE.ImfManager_Get(), true);
+        /// <since_tizen> 5 </since_tizen>
+        public InputMethodContext () : this (NDalicManualPINVOKE.InputMethodContext_New(), true) {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+        }
+  
+        internal InputMethodContext(InputMethodContext inputMethodContext) : this(NDalicManualPINVOKE.new_InputMethodContext__SWIG_1(InputMethodContext.getCPtr(inputMethodContext)), true) {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal InputMethodContext Assign(InputMethodContext inputMethodContext) {
+            InputMethodContext ret = new InputMethodContext(NDalicManualPINVOKE.InputMethodContext_Assign(swigCPtr, InputMethodContext.getCPtr(inputMethodContext)), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal static InputMethodContext DownCast(BaseHandle handle) {
+            InputMethodContext ret = new InputMethodContext(NDalicManualPINVOKE.InputMethodContext_DownCast(BaseHandle.getCPtr(handle)), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -523,7 +568,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void Activate()
         {
-            NDalicManualPINVOKE.ImfManager_Activate(swigCPtr);
+            NDalicManualPINVOKE.InputMethodContext_Activate(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -534,7 +579,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void Deactivate()
         {
-            NDalicManualPINVOKE.ImfManager_Deactivate(swigCPtr);
+            NDalicManualPINVOKE.InputMethodContext_Deactivate(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -546,7 +591,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public bool RestoreAfterFocusLost()
         {
-            bool ret = NDalicManualPINVOKE.ImfManager_RestoreAfterFocusLost(swigCPtr);
+            bool ret = NDalicManualPINVOKE.InputMethodContext_RestoreAfterFocusLost(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -558,7 +603,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void SetRestoreAfterFocusLost(bool toggle)
         {
-            NDalicManualPINVOKE.ImfManager_SetRestoreAfterFocusLost(swigCPtr, toggle);
+            NDalicManualPINVOKE.InputMethodContext_SetRestoreAfterFocusLost(swigCPtr, toggle);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -568,7 +613,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public new void Reset()
         {
-            NDalicManualPINVOKE.ImfManager_Reset(swigCPtr);
+            NDalicManualPINVOKE.InputMethodContext_Reset(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -578,7 +623,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void NotifyCursorPosition()
         {
-            NDalicManualPINVOKE.ImfManager_NotifyCursorPosition(swigCPtr);
+            NDalicManualPINVOKE.InputMethodContext_NotifyCursorPosition(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -589,7 +634,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void SetCursorPosition(uint cursorPosition)
         {
-            NDalicManualPINVOKE.ImfManager_SetCursorPosition(swigCPtr, cursorPosition);
+            NDalicManualPINVOKE.InputMethodContext_SetCursorPosition(swigCPtr, cursorPosition);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -600,7 +645,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public uint GetCursorPosition()
         {
-            uint ret = NDalicManualPINVOKE.ImfManager_GetCursorPosition(swigCPtr);
+            uint ret = NDalicManualPINVOKE.InputMethodContext_GetCursorPosition(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -612,7 +657,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void SetSurroundingText(string text)
         {
-            NDalicManualPINVOKE.ImfManager_SetSurroundingText(swigCPtr, text);
+            NDalicManualPINVOKE.InputMethodContext_SetSurroundingText(swigCPtr, text);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -623,7 +668,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public string GetSurroundingText()
         {
-            string ret = NDalicManualPINVOKE.ImfManager_GetSurroundingText(swigCPtr);
+            string ret = NDalicManualPINVOKE.InputMethodContext_GetSurroundingText(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -635,7 +680,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void NotifyTextInputMultiLine(bool multiLine)
         {
-            NDalicManualPINVOKE.ImfManager_NotifyTextInputMultiLine(swigCPtr, multiLine);
+            NDalicManualPINVOKE.InputMethodContext_NotifyTextInputMultiLine(swigCPtr, multiLine);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -644,9 +689,9 @@ namespace Tizen.NUI
         /// </summary>
         /// <returns>The direction of the text.</returns>
         /// <since_tizen> 3 </since_tizen>
-        public ImfManager.TextDirection GetTextDirection()
+        public InputMethodContext.TextDirection GetTextDirection()
         {
-            ImfManager.TextDirection ret = (ImfManager.TextDirection)NDalicManualPINVOKE.ImfManager_GetTextDirection(swigCPtr);
+            InputMethodContext.TextDirection ret = (InputMethodContext.TextDirection)NDalicManualPINVOKE.InputMethodContext_GetTextDirection(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -662,14 +707,14 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public Rectangle GetInputMethodArea()
         {
-            Rectangle ret = new Rectangle(NDalicManualPINVOKE.ImfManager_GetInputMethodArea(swigCPtr), true);
+            Rectangle ret = new Rectangle(NDalicManualPINVOKE.InputMethodContext_GetInputMethodArea(swigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         internal void ApplyOptions(InputMethodOptions options)
         {
-            NDalicManualPINVOKE.ImfManager_ApplyOptions(swigCPtr, InputMethodOptions.getCPtr(options));
+            NDalicManualPINVOKE.InputMethodContext_ApplyOptions(swigCPtr, InputMethodOptions.getCPtr(options));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -680,7 +725,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void SetInputPanelUserData(string text)
         {
-            NDalicManualPINVOKE.ImfManager_SetInputPanelUserData(swigCPtr, text);
+            NDalicManualPINVOKE.InputMethodContext_SetInputPanelUserData(swigCPtr, text);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -691,7 +736,7 @@ namespace Tizen.NUI
         /// <since_tizen> 4 </since_tizen>
         public void GetInputPanelUserData(out string text)
         {
-            NDalicManualPINVOKE.ImfManager_GetInputPanelUserData(swigCPtr, out text);
+            NDalicManualPINVOKE.InputMethodContext_GetInputPanelUserData(swigCPtr, out text);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -700,9 +745,9 @@ namespace Tizen.NUI
         /// </summary>
         /// <returns>The state of the input panel.</returns>
         /// <since_tizen> 3 </since_tizen>
-        public ImfManager.State GetInputPanelState()
+        public InputMethodContext.State GetInputPanelState()
         {
-            ImfManager.State ret = (ImfManager.State)NDalicManualPINVOKE.ImfManager_GetInputPanelState(swigCPtr);
+            InputMethodContext.State ret = (InputMethodContext.State)NDalicManualPINVOKE.InputMethodContext_GetInputPanelState(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -715,7 +760,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void SetReturnKeyState(bool visible)
         {
-            NDalicManualPINVOKE.ImfManager_SetReturnKeyState(swigCPtr, visible);
+            NDalicManualPINVOKE.InputMethodContext_SetReturnKeyState(swigCPtr, visible);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -726,7 +771,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void AutoEnableInputPanel(bool enabled)
         {
-            NDalicManualPINVOKE.ImfManager_AutoEnableInputPanel(swigCPtr, enabled);
+            NDalicManualPINVOKE.InputMethodContext_AutoEnableInputPanel(swigCPtr, enabled);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -736,7 +781,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void ShowInputPanel()
         {
-            NDalicManualPINVOKE.ImfManager_ShowInputPanel(swigCPtr);
+            NDalicManualPINVOKE.InputMethodContext_ShowInputPanel(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -746,7 +791,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void HideInputPanel()
         {
-            NDalicManualPINVOKE.ImfManager_HideInputPanel(swigCPtr);
+            NDalicManualPINVOKE.InputMethodContext_HideInputPanel(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -756,9 +801,9 @@ namespace Tizen.NUI
         /// </summary>
         /// <returns>The keyboard type.</returns>
         /// <since_tizen> 4 </since_tizen>
-        public ImfManager.KeyboardType GetKeyboardType()
+        public InputMethodContext.KeyboardType GetKeyboardType()
         {
-            ImfManager.KeyboardType ret = (ImfManager.KeyboardType)NDalicManualPINVOKE.ImfManager_GetKeyboardType(swigCPtr);
+            InputMethodContext.KeyboardType ret = (InputMethodContext.KeyboardType)NDalicManualPINVOKE.InputMethodContext_GetKeyboardType(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -771,31 +816,22 @@ namespace Tizen.NUI
         /// <since_tizen> 4 </since_tizen>
         public string GetInputPanelLocale()
         {
-            string ret = NDalicManualPINVOKE.ImfManager_GetInputPanelLocale(swigCPtr);
+            string ret = NDalicManualPINVOKE.InputMethodContext_GetInputPanelLocale(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         /// <summary>
-        /// The constructor.
-        /// </summary>
-        /// <since_tizen> 3 </since_tizen>
-        public ImfManager() : this(NDalicManualPINVOKE.new_ImfManager(), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// <summary>
-        /// ImfManager activated event arguments.
+        /// InputMethodContext activated event arguments.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public class ActivatedEventArgs : EventArgs
         {
             /// <summary>
-            /// ImfManager
+            /// InputMethodContext
             /// </summary>
             /// <since_tizen> 4 </since_tizen>
-            public ImfManager ImfManager
+            public InputMethodContext InputMethodContext
             {
                 get;
                 set;
@@ -808,7 +844,7 @@ namespace Tizen.NUI
         private event EventHandler<ActivatedEventArgs> _activatedEventHandler;
 
         /// <summary>
-        /// ImfManager activated.
+        /// InputMethodContext activated.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<ActivatedEventArgs> Activated
@@ -840,7 +876,7 @@ namespace Tizen.NUI
 
             if (data != null)
             {
-                e.ImfManager = Registry.GetManagedBaseHandleFromNativePtr(data) as ImfManager;
+                e.InputMethodContext = Registry.GetManagedBaseHandleFromNativePtr(data) as InputMethodContext;
             }
 
             if (_activatedEventHandler != null)
@@ -851,47 +887,47 @@ namespace Tizen.NUI
 
         internal ActivatedSignalType ActivatedSignal()
         {
-            ActivatedSignalType ret = new ActivatedSignalType(NDalicManualPINVOKE.ImfManager_ActivatedSignal(swigCPtr), false);
+            ActivatedSignalType ret = new ActivatedSignalType(NDalicManualPINVOKE.InputMethodContext_ActivatedSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         /// <summary>
-        /// ImfManager event received event arguments.
+        /// InputMethodContext event received event arguments.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public class EventReceivedEventArgs : EventArgs
         {
             /// <summary>
-            /// ImfManager
+            /// InputMethodContext
             /// </summary>
             /// <since_tizen> 4 </since_tizen>
-            public ImfManager ImfManager
+            public InputMethodContext InputMethodContext
             {
                 get;
                 set;
             }
 
             /// <summary>
-            /// ImfEventData
+            /// EventData
             /// </summary>
             /// <since_tizen> 4 </since_tizen>
-            public ImfEventData ImfEventData
+            public EventData EventData
             {
                 get;
                 set;
             }
         }
 
-        private delegate IntPtr EventReceivedEventCallbackType(IntPtr imfManager, IntPtr imfEventData);
+        private delegate IntPtr EventReceivedEventCallbackType(IntPtr inputMethodContext, IntPtr eventData);
         private EventReceivedEventCallbackType _eventReceivedEventCallback;
-        private event EventHandlerWithReturnType<object, EventReceivedEventArgs, ImfCallbackData> _eventReceivedEventHandler;
+        private event EventHandlerWithReturnType<object, EventReceivedEventArgs, CallbackData> _eventReceivedEventHandler;
 
         /// <summary>
-        /// ImfManager event received.
+        /// InputMethodContext event received.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public event EventHandlerWithReturnType<object, EventReceivedEventArgs, ImfCallbackData> EventReceived
+        public event EventHandlerWithReturnType<object, EventReceivedEventArgs, CallbackData> EventReceived
         {
             add
             {
@@ -914,50 +950,50 @@ namespace Tizen.NUI
             }
         }
 
-        private IntPtr OnEventReceived(IntPtr imfManager, IntPtr imfEventData)
+        private IntPtr OnEventReceived(IntPtr inputMethodContext, IntPtr eventData)
         {
-            ImfCallbackData imfCallbackData = null;
+            CallbackData callbackData = null;
 
             EventReceivedEventArgs e = new EventReceivedEventArgs();
 
-            if (imfManager != null)
+            if (inputMethodContext != null)
             {
-                e.ImfManager = Registry.GetManagedBaseHandleFromNativePtr(imfManager) as ImfManager;
+                e.InputMethodContext = Registry.GetManagedBaseHandleFromNativePtr(inputMethodContext) as InputMethodContext;
             }
-            if (imfEventData != null)
+            if (eventData != null)
             {
-                e.ImfEventData = ImfEventData.GetImfEventDataFromPtr(imfEventData);
+                e.EventData = EventData.GetEventDataFromPtr(eventData);
             }
 
             if (_eventReceivedEventHandler != null)
             {
-                imfCallbackData = _eventReceivedEventHandler(this, e);
+                callbackData = _eventReceivedEventHandler(this, e);
             }
-            if (imfCallbackData != null)
+            if (callbackData != null)
             {
-                return imfCallbackData.GetImfCallbackDataPtr();
+                return callbackData.GetCallbackDataPtr();
             }
             else
             {
-                return new ImfCallbackData().GetImfCallbackDataPtr();
+                return new CallbackData().GetCallbackDataPtr();
             }
         }
 
-        internal ImfEventSignalType EventReceivedSignal()
+        internal KeyboardEventSignalType EventReceivedSignal()
         {
-            ImfEventSignalType ret = new ImfEventSignalType(NDalicManualPINVOKE.ImfManager_EventReceivedSignal(swigCPtr), false);
+            KeyboardEventSignalType ret = new KeyboardEventSignalType(NDalicManualPINVOKE.InputMethodContext_EventReceivedSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         /// <summary>
-        /// ImfManager status changed event arguments.
+        /// InputMethodContext status changed event arguments.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public class StatusChangedEventArgs : EventArgs
         {
             /// <summary>
-            /// ImfManager status
+            /// InputMethodContext status
             /// </summary>
             /// <since_tizen> 4 </since_tizen>
             public bool StatusChanged
@@ -972,7 +1008,7 @@ namespace Tizen.NUI
         private event EventHandler<StatusChangedEventArgs> _statusChangedEventHandler;
 
         /// <summary>
-        /// ImfManager status changed.
+        /// InputMethodContext status changed.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<StatusChangedEventArgs> StatusChanged
@@ -1012,13 +1048,13 @@ namespace Tizen.NUI
 
         internal StatusSignalType StatusChangedSignal()
         {
-            StatusSignalType ret = new StatusSignalType(NDalicManualPINVOKE.ImfManager_StatusChangedSignal(swigCPtr), false);
+            StatusSignalType ret = new StatusSignalType(NDalicManualPINVOKE.InputMethodContext_StatusChangedSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         /// <summary>
-        /// ImfManager resized event.
+        /// InputMethodContext resized event.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public class ResizedEventArgs : EventArgs
@@ -1039,7 +1075,7 @@ namespace Tizen.NUI
         private event EventHandler<ResizedEventArgs> _resizedEventHandler;
 
         /// <summary>
-        /// ImfManager resized.
+        /// InputMethodContext resized.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<ResizedEventArgs> Resized
@@ -1078,13 +1114,13 @@ namespace Tizen.NUI
 
         internal KeyboardResizedSignalType ResizedSignal()
         {
-            KeyboardResizedSignalType ret = new KeyboardResizedSignalType(NDalicManualPINVOKE.ImfManager_ResizedSignal(swigCPtr), false);
+            KeyboardResizedSignalType ret = new KeyboardResizedSignalType(NDalicManualPINVOKE.InputMethodContext_ResizedSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         /// <summary>
-        /// ImfManager language changed event args.
+        /// InputMethodContext language changed event args.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public class LanguageChangedEventArgs : EventArgs
@@ -1105,7 +1141,7 @@ namespace Tizen.NUI
         private event EventHandler<LanguageChangedEventArgs> _languageChangedEventHandler;
 
         /// <summary>
-        /// ImfManager language changed.
+        /// InputMethodContext language changed.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<LanguageChangedEventArgs> LanguageChanged
@@ -1144,19 +1180,19 @@ namespace Tizen.NUI
 
         internal LanguageChangedSignalType LanguageChangedSignal()
         {
-            LanguageChangedSignalType ret = new LanguageChangedSignalType(NDalicManualPINVOKE.ImfManager_LanguageChangedSignal(swigCPtr), false);
+            LanguageChangedSignalType ret = new LanguageChangedSignalType(NDalicManualPINVOKE.InputMethodContext_LanguageChangedSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         /// <summary>
-        /// ImfManager keyboard type changed event arguments.
+        /// InputMethodContext keyboard type changed event arguments.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public class KeyboardTypeChangedEventArgs : EventArgs
         {
             /// <summary>
-            /// ImfManager keyboard type
+            /// InputMethodContext keyboard type
             /// </summary>
             /// <since_tizen> 4 </since_tizen>
             public KeyboardType KeyboardType
@@ -1171,7 +1207,7 @@ namespace Tizen.NUI
         private event EventHandler<KeyboardTypeChangedEventArgs> _keyboardTypeChangedEventHandler;
 
         /// <summary>
-        /// ImfManager keyboard type changed.
+        /// InputMethodContext keyboard type changed.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<KeyboardTypeChangedEventArgs> KeyboardTypeChanged
@@ -1211,7 +1247,7 @@ namespace Tizen.NUI
 
         internal KeyboardTypeSignalType KeyboardTypeChangedSignal()
         {
-            KeyboardTypeSignalType ret = new KeyboardTypeSignalType(NDalicManualPINVOKE.ImfManager_KeyboardTypeChangedSignal(swigCPtr), false);
+            KeyboardTypeSignalType ret = new KeyboardTypeSignalType(NDalicManualPINVOKE.InputMethodContext_KeyboardTypeChangedSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -1236,7 +1272,7 @@ namespace Tizen.NUI
         /// Events that are generated by the IMF.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public enum ImfEvent
+        public enum EventType
         {
             /// <summary>
             /// No event.


### PR DESCRIPTION
Here are some changes:
1. Refractor ImfManager as a normal class
2. Rename ImfManager to InputMethodContext
3. ImfEvent -> EventType
4. ImfEventData -> EventData
5. ImfCallbackData -> CallbackData

### Description of Change ###

Describe your changes here.

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: 

If you don't have the ACR, List all API changes here (or just put None), example:

Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);

### Behavioral Changes ###

Describe any non-bug related behavioral changes that may change how users app behaves when upgrading to this version of the codebase.

