### PR TITLE
[Privilege] Add privacy feature and deprecate redundant API

### DIFF
--- a/src/Tizen.Security/Tizen.Security/Privilege.cs
+++ b/src/Tizen.Security/Tizen.Security/Privilege.cs
@@ -143,6 +143,7 @@ namespace Tizen.Security
         /// <summary>
         /// Gets the display name of the privacy group in which the given privilege is included.
         /// </summary>
+        /// <feature>http://tizen.org/feature/security.privacy_privilege</feature>
         /// <since_tizen> 3 </since_tizen>
         /// <param name="privilege">The privilege.</param>
         /// <remarks>The privilege must be privacy related.</remarks>
@@ -151,7 +152,7 @@ namespace Tizen.Security
         /// <exception cref="System.ArgumentException">Thrown when there is an invalid parameter.</exception>
         /// <exception cref="System.OutOfMemoryException">Thrown when out of memory occurs.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when an internal error occurs.</exception>
-        /// <exception cref="System.NotSupportedException">Thrown when security.privacy_privilege feature is not supported in the device.</exception>
+        /// <exception cref="System.NotSupportedException">The required feature is not supported.</exception>
         public static string GetPrivacyDisplayName(string privilege)
         {
             string displayName;
@@ -166,6 +167,7 @@ namespace Tizen.Security
         /// <summary>
         /// Gets the status of the given privacy related privilege.
         /// </summary>
+        /// <feature>http://tizen.org/feature/security.privacy_privilege</feature>
         /// <since_tizen> 3 </since_tizen>
         /// <param name="privilege">The privilege.</param>
         /// <remarks>The privilege must be privacy related.</remarks>
@@ -174,7 +176,7 @@ namespace Tizen.Security
         /// <exception cref="System.ArgumentException">Thrown when there is an invalid parameter.</exception>
         /// <exception cref="System.OutOfMemoryException">Thrown when out of memory occurs.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when an internal error occurs.</exception>
-        /// <exception cref="System.NotSupportedException">Thrown when security.privacy_privilege feature is not supported in the device.</exception>
+        /// <exception cref="System.NotSupportedException">The required feature is not supported.</exception>
         [Obsolete("Deprecated since API level 5. Please use PrivacyPrivilegeManager.CheckPermission instead.")]
         public static bool GetPrivacyPrivilegeStatus(string privilege)
         {

--- a/src/Tizen.Security/Tizen.Security/Privilege.cs
+++ b/src/Tizen.Security/Tizen.Security/Privilege.cs
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
+ *  Copyright (c) 2016-2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -151,6 +151,7 @@ namespace Tizen.Security
         /// <exception cref="System.ArgumentException">Thrown when there is an invalid parameter.</exception>
         /// <exception cref="System.OutOfMemoryException">Thrown when out of memory occurs.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when an internal error occurs.</exception>
+        /// <exception cref="System.NotSupportedException">Thrown when security.privacy_privilege feature is not supported in the device.</exception>
         public static string GetPrivacyDisplayName(string privilege)
         {
             string displayName;
@@ -173,6 +174,8 @@ namespace Tizen.Security
         /// <exception cref="System.ArgumentException">Thrown when there is an invalid parameter.</exception>
         /// <exception cref="System.OutOfMemoryException">Thrown when out of memory occurs.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when an internal error occurs.</exception>
+        /// <exception cref="System.NotSupportedException">Thrown when security.privacy_privilege feature is not supported in the device.</exception>
+        [Obsolete("Deprecated since API level 5. Please use PrivacyPrivilegeManager.CheckPermission instead.")]
         public static bool GetPrivacyPrivilegeStatus(string privilege)
         {
             bool status;
@@ -199,6 +202,8 @@ namespace Tizen.Security
             Tizen.Log.Error(Interop.Privilege.LogTag, "[" + ErrorFacts.GetErrorMessage(err) + "] " + msg);
             switch (err)
             {
+                case (int)ErrorCode.NotSupported:
+                    throw new NotSupportedException();
                 case (int)ErrorCode.InvalidParameter:
                     throw new ArgumentException();
                 case (int)ErrorCode.OutOfMemory:


### PR DESCRIPTION
### Description of Change ###

Add security.privacy_privilege feature and deprecate redundant API

### Bugs Fixed ###

- Provide links to bugs here

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-142

- Added security.privacy_privilege feature to:
GetPrivacyDisplayName
GetPrivacyPrivilegeStatus

- Deprecate:
GetPrivacyPrivilegeStatus


### Behavioral Changes ###

If the value of the feature security.privacy_privilege is false then it returns NotSupported exception.

