### PR TITLE
[Connection][WiFi] Assign zero to Handle only when Interop.Destroy()

### DIFF
--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
@@ -110,6 +110,7 @@ namespace Tizen.Network.Connection
             if ((ConnectionError)ret != ConnectionError.None)
             {
                 Log.Error(Globals.LogTag, "It failed to register callback for changing profile state, " + (ConnectionError)ret);
+                ConnectionErrorFactory.ThrowConnectionException(ret);
             }
         }
 
@@ -120,6 +121,7 @@ namespace Tizen.Network.Connection
             if ((ConnectionError)ret != ConnectionError.None)
             {
                 Log.Error(Globals.LogTag, "It failed to unregister callback for changing profile state, " + (ConnectionError)ret);
+                ConnectionErrorFactory.ThrowConnectionException(ret);
             }
         }
 

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
@@ -170,8 +170,12 @@ namespace Tizen.Network.Connection
 
         private void Destroy()
         {
-            Interop.ConnectionProfile.Destroy(ProfileHandle);
-            ProfileHandle = IntPtr.Zero;
+            int ret = Interop.ConnectionProfile.Destroy(ProfileHandle);
+            if ((ConnectionError)ret == ConnectionError.None)
+            {
+                ProfileHandle = IntPtr.Zero;
+            }
+            
         }
 
         internal void CheckDisposed()

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAP.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAP.cs
@@ -135,8 +135,12 @@ namespace Tizen.Network.WiFi
             if (_disposed)
                 return;
 
-            Interop.WiFi.AP.Destroy(_apHandle);
-            _apHandle = IntPtr.Zero;
+            Log.Info(Globals.LogTag, "WiFiAP Handle HashCode: " + _apHandle.GetHashCode());
+            int ret = Interop.WiFi.AP.Destroy(_apHandle);
+            if (ret == (int)WiFiError.None)
+            {
+                _apHandle = IntPtr.Zero;
+            }
             _disposed = true;
         }
 
@@ -217,7 +221,7 @@ namespace Tizen.Network.WiFi
         /// <exception cref="InvalidOperationException">Thrown when the method failed due to an invalid operation.</exception>
         public Task ConnectAsync()
         {
-            Log.Info(Globals.LogTag, "ConnectAsync");
+            Log.Info(Globals.LogTag, "ConnectAsync HashCode: " + _apHandle.GetHashCode());
             if (_disposed)
             {
                 throw new ObjectDisposedException("Invalid AP instance (Object may have been disposed or released)");


### PR DESCRIPTION
### Description of Change ###

Dispose() of WiFiAP and ConnectionProfile calls the corresponding destroy function of native capi.
Each handle is set to zero only when the Interop call is successful