### PR TITLE
[Build] Add Tizen.NET.API4 dependency for tizen40 TFM

### DIFF
--- a/pkg/Tizen.NET.nuspec
+++ b/pkg/Tizen.NET.nuspec
@@ -12,7 +12,12 @@
     <description>A set of Tizen .NET APIs. This includes all of the APIs built on top of Tizen Platform.</description>
     <copyright>© Samsung Electronics Co., Ltd All Rights Reserved</copyright>
     <dependencies>
-      <dependency id="Tizen.NET.API5" version="$version$" />
+      <group targetFramework="Tizen40">
+        <dependency id="Tizen.NET.API4" version="4.0.1.14139" />
+      </group>
+      <group targetFramework="Tizen50">
+        <dependency id="Tizen.NET.API5" version="$version$" />
+      </group>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Add Tizen.NET.API4 dependency for Tizen40 TFM.
Tizen.NET.API4 package will be referenced if choose tizen40 tfm and Tizen.NET.API5 package will be referenced in case of tizen50 tfm.
