### PR TITLE
[Build] Add RIDs of Tizen platform to Tizen.NET nuget

### DIFF
--- a/pkg/Tizen.NET.nuspec
+++ b/pkg/Tizen.NET.nuspec
@@ -14,16 +14,20 @@
     <dependencies>
       <group targetFramework="Tizen4.0">
         <dependency id="Tizen.NET.API4" version="4.0.1.14139" />
+        <dependency id="Microsoft.NETCore.Platforms" version="2.0.0" />
       </group>
       <group targetFramework="Tizen5.0">
         <dependency id="Tizen.NET.API5" version="$version$" />
+        <dependency id="Microsoft.NETCore.Platforms" version="2.0.0" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Tizen.NET.API5" version="$version$" />
+        <dependency id="Microsoft.NETCore.Platforms" version="2.0.0" />
       </group>
     </dependencies>
   </metadata>
   <files>
     <file src="pkg\build\**" target="build" />
+    <file src="pkg\runtime.json" />
   </files>
 </package>

--- a/pkg/runtime.json
+++ b/pkg/runtime.json
@@ -1,0 +1,55 @@
+{
+  "runtimes": {
+    "tizen": {
+      "#import": [
+        "linux"
+      ]
+    },
+    "tizen-armel": {
+      "#import": [
+        "tizen",
+        "linux-armel"
+      ]
+    },
+    "tizen-x86": {
+      "#import": [
+        "tizen",
+        "linux-x86"
+      ]
+    },
+    "tizen.4.0.0": {
+      "#import": [
+        "tizen"
+      ]
+    },
+    "tizen.4.0.0-armel": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-armel"
+      ]
+    },
+    "tizen.4.0.0-x86": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-x86"
+      ]
+    },
+    "tizen.5.0.0": {
+      "#import": [
+        "tizen.4.0.0"
+      ]
+    },
+    "tizen.5.0.0-armel": {
+      "#import": [
+        "tizen.5.0.0",
+        "tizen.4.0.0-armel"
+      ]
+    },
+    "tizen.5.0.0-x86": {
+      "#import": [
+        "tizen.5.0.0",
+        "tizen.4.0.0-x86"
+      ]
+    },
+  }
+}


### PR DESCRIPTION
Add missing RIDs of Tizen platform. 
- tizen.4.0.0-x86 and tizen.5.0.0-x86, tizen.5.0.0-armel

This is temporary solution, it will be removed when https://github.com/dotnet/corefx/pull/29684 is merged.