### PR TITLE
[NUI] Enable Window's mouse Motion event

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2092,6 +2092,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE, new Tizen.NUI.PropertyValue(new Size(value)));
+                NotifyPropertyChanged();
             }
         }
 
@@ -2143,6 +2144,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION, new Tizen.NUI.PropertyValue(new Position(value)));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3498,6 +3500,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE_WIDTH, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3516,6 +3519,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE_HEIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/BaseHandle.cs
@@ -16,6 +16,7 @@
  */
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Tizen.NUI.Binding;
 using Tizen.NUI.Internals;
 
@@ -26,8 +27,17 @@ namespace Tizen.NUI
     /// BaseHandle is a handle to an internal Dali resource.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    public class BaseHandle : Element, global::System.IDisposable
+    public class BaseHandle : Element, global::System.IDisposable, INotifyPropertyChanged
     {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        internal void NotifyPropertyChanged([CallerMemberName] String propertyName = "")
+        {
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
 
         internal static readonly BindablePropertyKey NavigationPropertyKey = BindableProperty.CreateReadOnly("Navigation", typeof(INavigation), typeof(/*VisualElement*/BaseHandle), default(INavigation));
         /// <summary>


### PR DESCRIPTION
### Description of Change ###

Enable Window's mouse Motion event
This is temporary fix. if this patch is applied, the mouse Motion event will be working.
but the mouse Interrupted event is not working as like as View's touch Interrupted event's issue.
by the way, the View's touch Interrupted event issue will be resolved later and if this is fixed, 
this Windows's Interrupted event issue also will be resolved together.

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

this is temporary fix