### PR TITLE
[ElmSharp] Fix EcoreEventCallback delegate

### DIFF
--- a/src/ElmSharp/ElmSharp/EcoreEvent.cs
+++ b/src/ElmSharp/ElmSharp/EcoreEvent.cs
@@ -180,6 +180,7 @@ namespace ElmSharp
                 {
                     TEventArgs ea = _parser == null ? (TEventArgs)EventArgs.Empty : _parser(data, _eventType, info);
                     handler(this, ea);
+                    return true;
                 });
                 IntPtr hNative = Interop.Ecore.ecore_event_handler_add(_eventType.GetValue(), cb, IntPtr.Zero);
                 _nativeCallbacks.Add(new NativeCallback { callback = cb, eventHandler = handler, nativeHandler = hNative });

--- a/src/ElmSharp/Interop/Interop.Ecore.cs
+++ b/src/ElmSharp/Interop/Interop.Ecore.cs
@@ -38,7 +38,7 @@ internal static partial class Interop
 
         internal delegate void EcoreCallback(IntPtr data);
         internal delegate bool EcoreTaskCallback(IntPtr data);
-        internal delegate void EcoreEventCallback(IntPtr data, int type, IntPtr evt);
+        internal delegate bool EcoreEventCallback(IntPtr data, int type, IntPtr evt);
         internal delegate bool EcoreTimelineCallback(IntPtr data, double pos);
 
         [DllImport(Libraries.Ecore)]


### PR DESCRIPTION
### Description of Change ###

Fix the wrong signature of EcoreEventCallback delegate.
The return type of delegate should be boolean type.

### Bugs Fixed ###

The registered Ecore events invoke without unexpected stop.

### API Changes ###

None

### Behavioral Changes ###

The registered Ecore events invoke without unexpected stop.

