### PR TITLE
[NUI] Connect NUI.Window touch event to dali root layer touch event

### DIFF
--- a/src/Tizen.NUI/src/public/Window.cs
+++ b/src/Tizen.NUI/src/public/Window.cs
@@ -728,6 +728,14 @@ namespace Tizen.NUI
             return ret;
         }
 
+        internal TouchDataSignal TouchDataSignal()
+        {
+            TouchDataSignal ret = new TouchDataSignal(NDalicPINVOKE.Actor_TouchSignal(Layer.getCPtr(GetRootLayer())), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         private StageWheelSignal WheelEventSignal()
         {
             StageWheelSignal ret = new StageWheelSignal(NDalicPINVOKE.Stage_WheelEventSignal(stageCPtr), false);
@@ -975,9 +983,11 @@ namespace Tizen.NUI
             }
         }
 
-        private event EventHandler<TouchEventArgs> _stageTouchHandler;
-        private EventCallbackDelegateType1 _stageTouchCallbackDelegate;
 
+        private event EventHandler<TouchEventArgs> _rootLayerTouchDataEventHandler;
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate bool RootLayerTouchDataCallbackType(IntPtr view, IntPtr touchData);
+        private RootLayerTouchDataCallbackType _rootLayerTouchDataCallback;
         /// <summary>
         /// This event is emitted when the screen is touched and when the touch ends.<br />
         /// If there are multiple touch points, then this will be emitted when the first touch occurs and
@@ -989,39 +999,40 @@ namespace Tizen.NUI
         {
             add
             {
-                lock (this)
+                if (_rootLayerTouchDataEventHandler == null)
                 {
-                    _stageTouchHandler += value;
-                    _stageTouchCallbackDelegate = OnStageTouch;
-                    this.TouchSignal().Connect(_stageTouchCallbackDelegate);
+                    _rootLayerTouchDataCallback = OnWindowTouch;
+                    this.TouchDataSignal().Connect(_rootLayerTouchDataCallback);
                 }
+                _rootLayerTouchDataEventHandler += value;
             }
             remove
             {
-                lock (this)
+                _rootLayerTouchDataEventHandler -= value;
+                if (_rootLayerTouchDataEventHandler == null && TouchSignal().Empty() == false)
                 {
-                    if (_stageTouchHandler != null)
-                    {
-                        this.TouchSignal().Disconnect(_stageTouchCallbackDelegate);
-                    }
-                    _stageTouchHandler -= value;
+                    this.TouchDataSignal().Disconnect(_rootLayerTouchDataCallback);
                 }
             }
         }
 
-        private void OnStageTouch(IntPtr data)
+        private bool OnWindowTouch(IntPtr view, IntPtr touchData)
         {
+            if (touchData == global::System.IntPtr.Zero)
+            {
+                NUILog.Error("touchData should not be null!");
+                return false;
+            }
+
             TouchEventArgs e = new TouchEventArgs();
 
-            if (data != null)
-            {
-                e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(data);
-            }
+            e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);
 
-            if (_stageTouchHandler != null)
+            if (_rootLayerTouchDataEventHandler != null)
             {
-                _stageTouchHandler(this, e);
+                _rootLayerTouchDataEventHandler(this, e);
             }
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###

Connect NUI.Window touch event to dali root layer touch event
need to support Motion event (mouse drag)
dali stage's touch motion is never comming, so change the NUI.Window touch event to connect with dali root-layer's touch event

### Bugs Fixed ###

None

### API Changes ###

None

### Behavioral Changes ###

None