### PR TITLE
[NUI] Add ChildAdded, ChildRemoved, PropertySet events

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
@@ -262,6 +262,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.Property.CONTENT_DIRECTION, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -280,6 +281,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.Property.FLEX_DIRECTION, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -298,6 +300,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.Property.FLEX_WRAP, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -316,6 +319,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.Property.JUSTIFY_CONTENT, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -334,6 +338,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.Property.ALIGN_ITEMS, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -352,6 +357,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.Property.ALIGN_CONTENT, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -305,6 +305,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 _url = (value == null? "" : value);
                 UpdateImage();
+                NotifyPropertyChanged();
             }
         }
 
@@ -336,6 +337,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     if (_url != null) { value.Add("url", new PropertyValue(_url)); }
                     SetProperty(ImageView.Property.IMAGE, new Tizen.NUI.PropertyValue(value));
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -365,6 +367,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     if(_url != null) { value.Add("url", new PropertyValue(_url)); }
                     SetProperty(ImageView.Property.IMAGE, new Tizen.NUI.PropertyValue(value));
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -385,6 +388,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(ImageView.Property.PRE_MULTIPLIED_ALPHA, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -404,6 +408,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(ImageView.Property.PIXEL_AREA, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -424,6 +429,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 _border = value;
                 UpdateImage();
+                NotifyPropertyChanged();
             }
         }
 
@@ -444,6 +450,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 _borderOnly = value;
                 UpdateImage();
+                NotifyPropertyChanged();
             }
         }
 
@@ -461,6 +468,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 _synchronousLoading = value;
                 UpdateImage();
+                NotifyPropertyChanged();
             }
         }
 
@@ -478,6 +486,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 _orientationCorrection = value;
                 UpdateImage();
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
@@ -513,6 +513,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.OVERSHOOT_EFFECT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -531,6 +532,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.OVERSHOOT_ANIMATION_SPEED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -549,6 +551,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.OVERSHOOT_ENABLED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -567,6 +570,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.OVERSHOOT_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -585,6 +589,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.SCROLL_TO_ALPHA_FUNCTION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -603,6 +608,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.SCROLL_RELATIVE_POSITION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -621,6 +627,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.SCROLL_POSITION_MIN, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -639,6 +646,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.SCROLL_POSITION_MAX, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -657,6 +665,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.CAN_SCROLL_VERTICAL, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -675,6 +684,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(Scrollable.Property.CAN_SCROLL_HORIZONTAL, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -260,6 +260,8 @@ namespace Tizen.NUI.BaseComponents
             /// The index of a row.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [Obsolete("Please do not use! This will be deprecated! Please use RowIndex instead!")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public uint rowIndex
             {
                 set
@@ -276,9 +278,28 @@ namespace Tizen.NUI.BaseComponents
             }
 
             /// <summary>
+            /// The index of a row.
+            /// </summary>
+            /// <since_tizen> 5 </since_tizen>
+            /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public uint RowIndex
+            {
+                get
+                {
+                    uint ret = NDalicPINVOKE.TableView_CellPosition_rowIndex_get(swigCPtr);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                    return ret;
+                }
+            }
+
+
+            /// <summary>
             /// The index of a column.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [Obsolete("Please do not use! This will be deprecated! Please use ColumnIndex instead!")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public uint columnIndex
             {
                 set
@@ -295,9 +316,27 @@ namespace Tizen.NUI.BaseComponents
             }
 
             /// <summary>
+            /// The index of a column.
+            /// </summary>
+            /// <since_tizen> 5 </since_tizen>
+            /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public uint ColumnIndex
+            {
+                get
+                {
+                    uint ret = NDalicPINVOKE.TableView_CellPosition_columnIndex_get(swigCPtr);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                    return ret;
+                }
+            }
+
+            /// <summary>
             /// The span of a row.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [Obsolete("Please do not use! This will be deprecated! Please use RowSpan instead!")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public uint rowSpan
             {
                 set
@@ -314,9 +353,27 @@ namespace Tizen.NUI.BaseComponents
             }
 
             /// <summary>
+            /// The span of a row.
+            /// </summary>
+            /// <since_tizen> 5 </since_tizen>
+            /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public uint RowSpan
+            {
+                get
+                {
+                    uint ret = NDalicPINVOKE.TableView_CellPosition_rowSpan_get(swigCPtr);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                    return ret;
+                }
+            }
+
+            /// <summary>
             /// The span of a column.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [Obsolete("Please do not use! This will be deprecated! Please use ColumnSpan instead!")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public uint columnSpan
             {
                 set
@@ -331,6 +388,23 @@ namespace Tizen.NUI.BaseComponents
                     return ret;
                 }
             }
+
+            /// <summary>
+            /// The span of a column.
+            /// </summary>
+            /// <since_tizen> 5 </since_tizen>
+            /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public uint ColumnSpan
+            {
+                get
+                {
+                    uint ret = NDalicPINVOKE.TableView_CellPosition_columnSpan_get(swigCPtr);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                    return ret;
+                }
+            }
+
 
         }
 
@@ -724,6 +798,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.Property.ROWS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
         /// <summary>
@@ -741,6 +816,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.Property.COLUMNS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
         /// <summary>
@@ -758,6 +834,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.Property.CELL_PADDING, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -776,6 +853,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.Property.LAYOUT_ROWS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -794,6 +872,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.Property.LAYOUT_COLUMNS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -389,6 +389,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 textEditorTextSid = value;
                 Text = SetTranslatable(textEditorTextSid);
+                NotifyPropertyChanged();
             }
         }
         /// <summary>
@@ -413,6 +414,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 textEditorPlaceHolderTextSid = value;
                 PlaceholderText = SetTranslatable(textEditorPlaceHolderTextSid);
+                NotifyPropertyChanged();
             }
         }
         private string SetTranslatable(string textEditorSid)
@@ -460,6 +462,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.TEXT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -478,6 +481,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.TEXT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -496,6 +500,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.FONT_FAMILY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -514,6 +519,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.FONT_STYLE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -532,6 +538,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.POINT_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -588,6 +595,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                 }
                 SetProperty(TextEditor.Property.HORIZONTAL_ALIGNMENT, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -606,6 +614,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SCROLL_THRESHOLD, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -624,6 +633,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SCROLL_SPEED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -642,6 +652,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.PRIMARY_CURSOR_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -660,6 +671,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SECONDARY_CURSOR_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -678,6 +690,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.ENABLE_CURSOR_BLINK, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -696,6 +709,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.CURSOR_BLINK_INTERVAL, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -714,6 +728,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.CURSOR_BLINK_DURATION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -732,6 +747,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.CURSOR_WIDTH, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -750,6 +766,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.GRAB_HANDLE_IMAGE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -768,6 +785,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.GRAB_HANDLE_PRESSED_IMAGE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -786,6 +804,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SELECTION_HANDLE_IMAGE_LEFT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -804,6 +823,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SELECTION_HANDLE_IMAGE_RIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -822,6 +842,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SELECTION_HANDLE_PRESSED_IMAGE_LEFT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -840,6 +861,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SELECTION_HANDLE_PRESSED_IMAGE_RIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -858,6 +880,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SELECTION_HANDLE_MARKER_IMAGE_LEFT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -876,6 +899,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SELECTION_HANDLE_MARKER_IMAGE_RIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -894,6 +918,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SELECTION_HIGHLIGHT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -912,6 +937,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.DECORATION_BOUNDING_BOX, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -930,6 +956,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.ENABLE_MARKUP, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -948,6 +975,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -966,6 +994,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_FONT_FAMILY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -984,6 +1013,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_FONT_STYLE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1002,6 +1032,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_POINT_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1020,6 +1051,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.LINE_SPACING, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1038,6 +1070,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_LINE_SPACING, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1056,6 +1089,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.UNDERLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1074,6 +1108,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_UNDERLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1092,6 +1127,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SHADOW, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1110,6 +1146,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_SHADOW, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1128,6 +1165,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.EMBOSS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1146,6 +1184,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_EMBOSS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1164,6 +1203,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.OUTLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1182,6 +1222,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.INPUT_OUTLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1200,6 +1241,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SMOOTH_SCROLL, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1218,6 +1260,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SMOOTH_SCROLL_DURATION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1236,6 +1279,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.ENABLE_SCROLL_BAR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1254,6 +1298,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SCROLL_BAR_SHOW_DURATION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1272,6 +1317,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.SCROLL_BAR_FADE_DURATION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1290,6 +1336,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.PIXEL_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1322,6 +1369,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.PLACEHOLDER_TEXT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1340,6 +1388,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.PLACEHOLDER_TEXT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1358,6 +1407,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.ENABLE_SELECTION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1397,6 +1447,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.PLACEHOLDER, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1419,6 +1470,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.LINE_WRAP_MODE, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1438,6 +1490,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextEditor.Property.ENABLE_SHIFT_SELECTION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -381,6 +381,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 textFieldTextSid = value;
                 Text = SetTranslatable(textFieldTextSid);
+                NotifyPropertyChanged();
             }
         }
         /// <summary>
@@ -405,6 +406,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 textFieldPlaceHolderTextSid = value;
                 PlaceholderText = SetTranslatable(textFieldPlaceHolderTextSid);
+                NotifyPropertyChanged();
             }
         }
         private string SetTranslatable(string textFieldSid)
@@ -452,6 +454,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.TEXT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -470,6 +473,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.PLACEHOLDER_TEXT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -488,6 +492,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.PLACEHOLDER_TEXT_FOCUSED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -506,6 +511,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.FONT_FAMILY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -524,6 +530,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.FONT_STYLE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -542,6 +549,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.POINT_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -560,6 +568,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.MAX_LENGTH, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -578,6 +587,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.EXCEED_POLICY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -634,6 +644,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                 }
                 SetProperty(TextField.Property.HORIZONTAL_ALIGNMENT, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -690,6 +701,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                 }
                 SetProperty(TextField.Property.VERTICAL_ALIGNMENT, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -708,6 +720,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.TEXT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -726,6 +739,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.PLACEHOLDER_TEXT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -744,6 +758,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SHADOW_OFFSET, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -762,6 +777,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SHADOW_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -780,6 +796,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.PRIMARY_CURSOR_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -798,6 +815,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SECONDARY_CURSOR_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -816,6 +834,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.ENABLE_CURSOR_BLINK, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -834,6 +853,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.CURSOR_BLINK_INTERVAL, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -852,6 +872,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.CURSOR_BLINK_DURATION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -870,6 +891,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.CURSOR_WIDTH, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -888,6 +910,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.GRAB_HANDLE_IMAGE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -906,6 +929,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.GRAB_HANDLE_PRESSED_IMAGE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -924,6 +948,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SCROLL_THRESHOLD, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -942,6 +967,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SCROLL_SPEED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -960,6 +986,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SELECTION_HANDLE_IMAGE_LEFT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -978,6 +1005,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SELECTION_HANDLE_IMAGE_RIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -996,6 +1024,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SELECTION_HANDLE_PRESSED_IMAGE_LEFT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1014,6 +1043,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SELECTION_HANDLE_PRESSED_IMAGE_RIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1032,6 +1062,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SELECTION_HANDLE_MARKER_IMAGE_LEFT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1050,6 +1081,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SELECTION_HANDLE_MARKER_IMAGE_RIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1068,6 +1100,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SELECTION_HIGHLIGHT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1086,6 +1119,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.DECORATION_BOUNDING_BOX, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1104,6 +1138,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_METHOD_SETTINGS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1122,6 +1157,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1140,6 +1176,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.ENABLE_MARKUP, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1158,6 +1195,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_FONT_FAMILY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1176,6 +1214,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_FONT_STYLE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1194,6 +1233,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_POINT_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1212,6 +1252,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.UNDERLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1230,6 +1271,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_UNDERLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1248,6 +1290,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.SHADOW, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1266,6 +1309,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_SHADOW, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1284,6 +1328,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.EMBOSS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1302,6 +1347,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_EMBOSS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1320,6 +1366,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.OUTLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1338,6 +1385,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.INPUT_OUTLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1356,6 +1404,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.HIDDEN_INPUT_SETTINGS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1374,6 +1423,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.PIXEL_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1392,6 +1442,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.ENABLE_SELECTION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1431,6 +1482,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.PLACEHOLDER, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1451,6 +1503,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.ELLIPSIS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1470,6 +1523,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextField.Property.ENABLE_SHIFT_SELECTION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -196,6 +196,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     Text = "";
                 }
+                NotifyPropertyChanged();
             }
         }
         private void SystemSettings_LocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
@@ -219,6 +220,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.TEXT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -238,6 +240,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.FONT_FAMILY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -257,6 +260,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.FONT_STYLE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -276,6 +280,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.POINT_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -295,6 +300,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.MULTI_LINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -351,6 +357,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                 }
                 SetProperty(TextLabel.Property.HORIZONTAL_ALIGNMENT, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -408,6 +415,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                 }
                 SetProperty(TextLabel.Property.VERTICAL_ALIGNMENT, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -429,6 +437,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.TEXT_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -448,6 +457,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.SHADOW_OFFSET, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -467,6 +477,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.SHADOW_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -486,6 +497,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.UNDERLINE_ENABLED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -505,6 +517,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.UNDERLINE_COLOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -524,6 +537,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.UNDERLINE_HEIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -543,6 +557,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.ENABLE_MARKUP, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -562,6 +577,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.ENABLE_AUTO_SCROLL, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -581,6 +597,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.AUTO_SCROLL_SPEED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -600,6 +617,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.AUTO_SCROLL_LOOP_COUNT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -619,6 +637,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.AUTO_SCROLL_GAP, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -638,6 +657,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.LINE_SPACING, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -657,6 +677,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.UNDERLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -676,6 +697,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.SHADOW, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -695,6 +717,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.EMBOSS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -714,6 +737,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.OUTLINE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -733,6 +757,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.PIXEL_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -752,6 +777,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.ELLIPSIS, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -771,6 +797,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.AUTO_SCROLL_LOOP_DELAY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -801,6 +828,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.AUTO_SCROLL_STOP_MODE, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -837,6 +865,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.LINE_WRAP_MODE, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -869,6 +898,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TextLabel.Property.VERTICAL_LINE_ALIGNMENT, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -261,6 +261,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(VideoView.Property.VIDEO, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -279,6 +280,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(VideoView.Property.LOOPING, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -297,6 +299,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(VideoView.Property.MUTED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -315,6 +318,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(VideoView.Property.VOLUME, new PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -334,6 +338,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(VideoView.Property.UNDERLAY, new PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -352,6 +357,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(VideoView.Property.VIDEO, new PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -43,8 +43,30 @@ namespace Tizen.NUI.BaseComponents
             return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
         }
 
-        // From Container Base class
+        /// <summary>
+        /// Event argument passed through ChildAdded event
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public class ChildAddedEventArgs : EventArgs
+        {
+            /// <summary>
+            /// Added child View at moment
+            /// </summary>
+            /// <since_tizen> 5 </since_tizen>
+            public View Added { get; set; }
+        }
 
+        /// <summary>
+        /// Event when a child is added
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event EventHandler<ChildAddedEventArgs> ChildAdded;
+
+        // From Container Base class
         /// <summary>
         /// Adds a child view to this view.
         /// </summary>
@@ -63,8 +85,41 @@ namespace Tizen.NUI.BaseComponents
                 if (NDalicPINVOKE.SWIGPendingException.Pending)
                     throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 Children.Add(child);
+
+                if (ChildAdded != null)
+                {
+                    ChildAddedEventArgs e = new ChildAddedEventArgs
+                    {
+                        Added = child
+                    };
+                    ChildAdded(this, e);
             }
         }
+        }
+
+        /// <summary>
+        /// Event argument passed through ChildRemoved event
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public class ChildRemovedEventArgs : EventArgs
+        {
+            /// <summary>
+            /// Removed child View at moment
+            /// </summary>
+            /// <since_tizen> 5 </since_tizen>
+            public View Removed { get; set; }
+        }
+
+        /// <summary>
+        /// Event when a child is removed
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event EventHandler<ChildRemovedEventArgs> ChildRemoved;
+        
 
         /// <summary>
         /// Removes a child view from this View. If the view was not a child of this view, this is a no-op.
@@ -78,6 +133,15 @@ namespace Tizen.NUI.BaseComponents
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
             Children.Remove(child);
+
+            if (ChildRemoved != null)
+            {
+                ChildRemovedEventArgs e = new ChildRemovedEventArgs
+                {
+                    Removed = child
+                };
+                ChildRemoved(this, e);
+            }
         }
 
         /// <summary>
@@ -1362,6 +1426,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.STYLE_NAME, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1388,6 +1453,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.BACKGROUND, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1478,6 +1544,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.BACKGROUND, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1496,6 +1563,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.BACKGROUND, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1536,6 +1604,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.STATE, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1591,6 +1660,7 @@ namespace Tizen.NUI.BaseComponents
                         }
                 }
                 SetProperty(View.Property.SUB_STATE, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1609,6 +1679,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.TOOLTIP, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1621,6 +1692,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.TOOLTIP, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1697,6 +1769,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.ChildProperty.FLEX, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1716,6 +1789,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.ChildProperty.ALIGN_SELF, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1735,6 +1809,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(FlexContainer.ChildProperty.FLEX_MARGIN, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1753,6 +1828,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.ChildProperty.CELL_INDEX, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1771,6 +1847,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.ChildProperty.ROW_SPAN, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1789,6 +1866,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(TableView.ChildProperty.COLUMN_SPAN, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1845,6 +1923,7 @@ namespace Tizen.NUI.BaseComponents
                         }
                 }
                 SetProperty(TableView.ChildProperty.CELL_HORIZONTAL_ALIGNMENT, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1901,6 +1980,7 @@ namespace Tizen.NUI.BaseComponents
                         }
                 }
                 SetProperty(TableView.ChildProperty.CELL_VERTICAL_ALIGNMENT, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -1931,6 +2011,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     LeftFocusableViewId = -1;
                 }
+                NotifyPropertyChanged();
             }
         }
 
@@ -1961,6 +2042,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     RightFocusableViewId = -1;
                 }
+                NotifyPropertyChanged();
             }
         }
 
@@ -1991,6 +2073,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     UpFocusableViewId = -1;
                 }
+                NotifyPropertyChanged();
             }
         }
 
@@ -2021,6 +2104,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     DownFocusableViewId = -1;
                 }
+                NotifyPropertyChanged();
             }
         }
 
@@ -2033,6 +2117,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetKeyboardFocusable(value);
+                NotifyPropertyChanged();
             }
             get
             {
@@ -2092,6 +2177,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE, new Tizen.NUI.PropertyValue(new Size(value)));
+                NotifyPropertyChanged();
             }
         }
 
@@ -2123,6 +2209,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.OPACITY, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -2143,6 +2230,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION, new Tizen.NUI.PropertyValue(new Position(value)));
+                NotifyPropertyChanged();
             }
         }
 
@@ -2179,6 +2267,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION_USES_ANCHOR_POINT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -2205,6 +2294,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION_USES_ANCHOR_POINT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -2310,6 +2400,7 @@ namespace Tizen.NUI.BaseComponents
                         }
                     }
                 }
+                NotifyPropertyChanged();
             }
         }
 
@@ -3373,6 +3464,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.PARENT_ORIGIN, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3387,6 +3479,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.PARENT_ORIGIN_X, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3401,6 +3494,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.PARENT_ORIGIN_Y, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3415,6 +3509,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.PARENT_ORIGIN_Z, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3438,6 +3533,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.ANCHOR_POINT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3498,6 +3594,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE_WIDTH, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3516,6 +3613,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE_HEIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3536,6 +3634,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3554,6 +3653,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION_X, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3572,6 +3672,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION_Y, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3590,6 +3691,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.POSITION_Z, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3654,6 +3756,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.ORIENTATION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3686,6 +3789,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SCALE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3704,6 +3808,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SCALE_X, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3722,6 +3827,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SCALE_Y, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3740,6 +3846,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SCALE_Z, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3814,6 +3921,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.NAME, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3857,6 +3965,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SENSITIVE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3875,6 +3984,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.LEAVE_REQUIRED, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3893,6 +4003,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.INHERIT_ORIENTATION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3911,6 +4022,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.INHERIT_SCALE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3947,6 +4059,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.DRAW_MODE, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -3967,6 +4080,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE_MODE_FACTOR, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4008,6 +4122,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.WIDTH_RESIZE_POLICY, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4049,6 +4164,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.HEIGHT_RESIZE_POLICY, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4105,6 +4221,7 @@ namespace Tizen.NUI.BaseComponents
                         }
                 }
                 SetProperty(View.Property.SIZE_SCALE_POLICY, new Tizen.NUI.PropertyValue(valueToString));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4123,6 +4240,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.WIDTH_FOR_HEIGHT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4141,6 +4259,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.HEIGHT_FOR_WIDTH, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4159,6 +4278,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.PADDING, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4177,6 +4297,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.MINIMUM_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4195,6 +4316,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.MAXIMUM_SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4215,6 +4337,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.INHERIT_POSITION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4246,6 +4369,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.CLIPPING_MODE, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4284,6 +4408,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.ANCHOR_POINT, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4307,6 +4432,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.SIZE, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4362,6 +4488,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.INHERIT_LAYOUT_DIRECTION, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4383,6 +4510,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.LAYOUT_DIRECTION, new Tizen.NUI.PropertyValue((int)value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4401,6 +4529,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.MARGIN, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 
@@ -4423,6 +4552,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetProperty(View.Property.PADDING, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/BaseHandle.cs
@@ -16,6 +16,7 @@
  */
 using System;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Tizen.NUI.Binding;
 using Tizen.NUI.Internals;
 
@@ -28,6 +29,18 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class BaseHandle : Element, global::System.IDisposable
     {
+        /// <summary>
+        /// Event which is occurred when a property is set
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event PropertyChangedEventHandler PropertySet;
+
+        internal void NotifyPropertyChanged([CallerMemberName] String propertyName = "")
+        {
+            PropertySet?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
 
         internal static readonly BindablePropertyKey NavigationPropertyKey = BindableProperty.CreateReadOnly("Navigation", typeof(INavigation), typeof(/*VisualElement*/BaseHandle), default(INavigation));
         /// <summary>


### PR DESCRIPTION
### Description of Change ###

Add ChildAdded, ChildRemoved, PropertySet events.

TableView.CellPosition class's rowIndex, columnIndex, rowSpan, columnSpan are name changed as Pascal case, and they are all just struct in dali native, so no connection with TableView instance.
making them as read-only properties.

ACR is under progress

### Bugs Fixed ###

None

### API Changes ###

http://suprem.sec.samsung.net/jira/browse/TCSACR-148

### Behavioral Changes ###

None