### PR TITLE
[Tizen.Security.TEEC] Check for TEE feature when creating context

### DIFF
--- a/src/Tizen.Security.TEEC/Interop/Interop.Errors.cs
+++ b/src/Tizen.Security.TEEC/Interop/Interop.Errors.cs
@@ -14,7 +14,9 @@ internal static partial class Interop
     internal enum LibteecError : uint
     {
         None = 0,
+        Generic = 0xFFFF0000,
         NotImplemented = 0xFFFF0009,
+        NotSupported = 0xFFFF000A,
         CommunicationFailed = 0xFFFF000E,
     };
 
@@ -25,9 +27,11 @@ internal static partial class Interop
             case (uint)LibteecError.None:
                 return ;
             case (uint)LibteecError.NotImplemented:
+            case (uint)LibteecError.NotSupported:
                 throw new NotSupportedException(string.Format("[{0}] {1} error=0x{2}",
                         LogTag, msg, err.ToString("X")));
             case (uint)LibteecError.CommunicationFailed:
+            case (uint)LibteecError.Generic:
                 throw new Exception(string.Format("[{0}] {1} error=0x{2}",
                         LogTag, msg, err.ToString("X")));
             default:

--- a/src/Tizen.Security.TEEC/Tizen.Security.TEEC.csproj
+++ b/src/Tizen.Security.TEEC/Tizen.Security.TEEC.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Tizen\Tizen.csproj" />
     <ProjectReference Include="..\Tizen.Log\Tizen.Log.csproj" />
+    <ProjectReference Include="..\Tizen.System.Information\Tizen.System.Information.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Signed-off-by: Igor Kotrasinski <i.kotrasinsk@partner.samsung.com>

### Description of Change ###

Check for enablement of http://tizen.org/feature/security.tee before initializing a context. Return a 'not supported' error if it's disabled.

### Bugs Fixed ###

None.

### API Changes ###

None.

### Behavioral Changes ###

Disabling security.tee feature will cause any attempts to initialize a TEE context to return an error.

