### PR TITLE
[TCSACR-150] Add telephony privilege to use telephony API.

### DIFF
--- a/src/Tizen.Applications.AttachPanel/Tizen.Applications.AttachPanel/AttachPanel.cs
+++ b/src/Tizen.Applications.AttachPanel/Tizen.Applications.AttachPanel/AttachPanel.cs
@@ -145,6 +145,7 @@ namespace Tizen.Applications.AttachPanel
         /// <param name="extraData">The AttachPanel sends some information using the Bundle.</param>
         /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
         /// <privilege>http://tizen.org/privilege/camera</privilege>
+        /// <privilege>http://tizen.org/privilege/telephony</privilege>
         /// <privilege>http://tizen.org/privilege/recorder</privilege>
         /// <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
         /// <feature>http://tizen.org/feature/camera</feature>
@@ -158,6 +159,7 @@ namespace Tizen.Applications.AttachPanel
         /// Privileges,
         /// http://tizen.org/privilege/mediastorage, for using Image or Camera.
         /// http://tizen.org/privilege/camera, for using Camera or TakePicture.
+        /// http://tizen.org/privilege/telephony, for using Camera, Since(5.0).
         /// http://tizen.org/privilege/recorder, for using Voice.
         /// http://tizen.org/privilege/appmanager.launch, for adding content categories on the More tab.
         /// http://tizen.org/feature/camera, for using Camera or TakePicture.


### PR DESCRIPTION

### Description of Change ###

In public attach-panel API attach_panel_add_content_category(), under CAMERA content, 
 Camera app should not be launched if video call is active. To check the status of the video call,
 Telephony API (telephony_call_get_type) is called, and telephony privilege is necessary to use telephony API.

### API Changes ###
        List of API changes
        API:  public void AddCategory(ContentCategory category, Bundle extraData)
        Description: add http://tizen.org/privilege/telephony to use camera content category.

 - ACR: TCSACR-150


Added:
- added http://tizen.org/privilege/telephony privilege requirement in API description
         /// <privilege>http://tizen.org/privilege/camera</privilege>
+        /// <privilege>http://tizen.org/privilege/telephony</privilege>
         /// <privilege>http://tizen.org/privilege/recorder</privilege>

         /// http://tizen.org/privilege/camera, for using Camera or TakePicture.
+       /// http://tizen.org/privilege/telephony, for using Camera, Since(5.0).
         /// http://tizen.org/privilege/recorder, for using Voice.

Changed:
N/A

### Behavioral Changes ###
N/A

