### PR TITLE
[NUI] Remove apis which are using internal APIs

### DIFF
--- a/src/Tizen.NUI/src/internal/AsyncImageLoader.cs
+++ b/src/Tizen.NUI/src/internal/AsyncImageLoader.cs
@@ -129,11 +129,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        public AsyncImageLoader(SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader impl) : this(NDalicPINVOKE.new_AsyncImageLoader__SWIG_2(SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader.getCPtr(impl)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
     }
 
 }

--- a/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
@@ -2068,9 +2068,6 @@ class NDalicPINVOKE {
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TypeRegistry_GetTypeName")]
   public static extern string TypeRegistry_GetTypeName(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_TypeRegistry__SWIG_2")]
-  public static extern global::System.IntPtr new_TypeRegistry__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1);
-
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_TypeRegistration__SWIG_0")]
   public static extern global::System.IntPtr new_TypeRegistration__SWIG_0(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
@@ -2415,9 +2412,6 @@ class NDalicPINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_Texture_GetHeight")]
   public static extern uint Texture_GetHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_Texture__SWIG_2")]
-  public static extern global::System.IntPtr new_Texture__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_Sampler_New")]
   public static extern global::System.IntPtr Sampler_New();
@@ -6838,9 +6832,6 @@ class NDalicPINVOKE {
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TransitionData_GetAnimatorAt")]
   public static extern global::System.IntPtr TransitionData_GetAnimatorAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_TransitionData__SWIG_2")]
-  public static extern global::System.IntPtr new_TransitionData__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1);
-
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_TOOLTIP_CONTENT_get")]
   public static extern int TOOLTIP_CONTENT_get();
 
@@ -10170,9 +10161,6 @@ class NDalicPINVOKE {
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VisualBase_CreatePropertyMap")]
   public static extern void VisualBase_CreatePropertyMap(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_VisualBase__SWIG_2")]
-  public static extern global::System.IntPtr new_VisualBase__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1);
-
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_VisualFactory_Get")]
   public static extern global::System.IntPtr VisualFactory_Get();
 
@@ -10232,9 +10220,6 @@ class NDalicPINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_AsyncImageLoader_ImageLoadedSignal")]
   public static extern global::System.IntPtr AsyncImageLoader_ImageLoadedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_AsyncImageLoader__SWIG_2")]
-  public static extern global::System.IntPtr new_AsyncImageLoader__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_LoadImageSynchronously__SWIG_0")]
   public static extern global::System.IntPtr LoadImageSynchronously__SWIG_0(string jarg1);
@@ -11464,9 +11449,6 @@ class NDalicPINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_PixelBuffer_Resize")]
   public static extern void PixelBuffer_Resize(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2, ushort jarg3);
-
-  [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_new_PixelBuffer__SWIG_2")]
-  public static extern global::System.IntPtr new_PixelBuffer__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint="CSharp_Dali_LoadImageFromFile__SWIG_0")]
   public static extern global::System.IntPtr LoadImageFromFile__SWIG_0(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, int jarg4, bool jarg5);

--- a/src/Tizen.NUI/src/internal/TypeRegistry.cs
+++ b/src/Tizen.NUI/src/internal/TypeRegistry.cs
@@ -116,11 +116,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal TypeRegistry(SWIGTYPE_p_Dali__Internal__TypeRegistry typeRegistry) : this(NDalicPINVOKE.new_TypeRegistry__SWIG_2(SWIGTYPE_p_Dali__Internal__TypeRegistry.getCPtr(typeRegistry)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
     }
 
 }

--- a/src/Tizen.NUI/src/internal/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewImpl.cs
@@ -15,6 +15,8 @@
  *
  */
 
+using System;
+using System.ComponentModel;
 using System.Reflection;
 using Tizen.NUI.BaseComponents;
 
@@ -204,12 +206,26 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// [Obsolete("Please do not use! this will be deprecated")]
+        /// </summary>
+        /// Please do not use! this will be deprecated!
+        /// <since_tizen> 5 </since_tizen>
+        [Obsolete("Please do not use! this will be deprecated.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void AccessibilityActivate()
         {
             NDalicPINVOKE.ViewImpl_AccessibilityActivate(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// [Obsolete("Please do not use! this will be deprecated")]
+        /// </summary>
+        /// Please do not use! this will be deprecated!
+        /// <since_tizen> 5 </since_tizen>
+        [Obsolete("Please do not use! this will be deprecated.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void KeyboardEnter()
         {
             NDalicPINVOKE.ViewImpl_KeyboardEnter(swigCPtr);
@@ -237,6 +253,13 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// [Obsolete("Please do not use! this will be deprecated")]
+        /// </summary>
+        /// Please do not use! this will be deprecated!
+        /// <since_tizen> 5 </since_tizen>
+        [Obsolete("Please do not use! this will be deprecated.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EmitKeyEventSignal(Key arg0)
         {
             bool ret = NDalicPINVOKE.ViewImpl_EmitKeyEventSignal(swigCPtr, Key.getCPtr(arg0));

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -180,32 +180,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Called by the AccessibilityManager to activate the control.
-        /// </summary>
-        internal void AccessibilityActivate()
-        {
-            viewWrapperImpl.AccessibilityActivate();
-        }
-
-        /// <summary>
-        /// Called by the KeyboardFocusManager.
-        /// </summary>
-        internal void KeyboardEnter()
-        {
-            viewWrapperImpl.KeyboardEnter();
-        }
-
-        /// <summary>
-        /// Called by the KeyInputFocusManager to emit key event signals.
-        /// </summary>
-        /// <param name="key">The key event.</param>
-        /// <returns>True if the event was consumed.</returns>
-        internal bool EmitKeyEventSignal(Key key)
-        {
-            return viewWrapperImpl.EmitKeyEventSignal(key);
-        }
-
-        /// <summary>
         /// Requests a relayout, which means performing a size negotiation on this view, its parent, and children (and potentially whole scene).<br />
         /// This method can also be called from a derived class every time it needs a different size.<br />
         /// At the end of event processing, the relayout process starts and all controls which requested relayout will have their sizes (re)negotiated.<br />

--- a/src/Tizen.NUI/src/public/PixelBuffer.cs
+++ b/src/Tizen.NUI/src/public/PixelBuffer.cs
@@ -302,11 +302,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PixelBuffer(SWIGTYPE_p_unsigned_char pointer) : this(NDalicPINVOKE.new_PixelBuffer__SWIG_2(SWIGTYPE_p_unsigned_char.getCPtr(pointer)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
     }
 
 }

--- a/src/Tizen.NUI/src/public/Texture.cs
+++ b/src/Tizen.NUI/src/public/Texture.cs
@@ -157,11 +157,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal Texture(SWIGTYPE_p_Dali__Internal__Texture pointer) : this(NDalicPINVOKE.new_Texture__SWIG_2(SWIGTYPE_p_Dali__Internal__Texture.getCPtr(pointer)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
     }
 
 }

--- a/src/Tizen.NUI/src/public/TransitionData.cs
+++ b/src/Tizen.NUI/src/public/TransitionData.cs
@@ -129,11 +129,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal TransitionData(SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData impl) : this(NDalicPINVOKE.new_TransitionData__SWIG_2(SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData.getCPtr(impl)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
     }
 
 }

--- a/src/Tizen.NUI/src/public/VisualBase.cs
+++ b/src/Tizen.NUI/src/public/VisualBase.cs
@@ -220,11 +220,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal VisualBase(SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base impl) : this(NDalicPINVOKE.new_VisualBase__SWIG_2(SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base.getCPtr(impl)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
     }
 
 }


### PR DESCRIPTION
Some apis are using DALi internal APIs.
Clean up these wrong apis to prevent future errors.

Signed-off-by: minho.sun <minho.sun@samsung.com>

### Description of Change ###

Remove some apis which are using DALi internal APIs.

### Bugs Fixed ###

- http://suprem.sec.samsung.net/jira/browse/GRE-823

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: Will be prepared.

Removed public APIs which need ACR:
[ViewImpl.cs]
- void AccessibilityActivate() 
- void KeyboardEnter()
- bool EmitKeyEventSignal(Key arg0)

Removed internal APIs which don't need ACR:
[AsyncImageLoader.cs]
 - AsyncImageLoader(SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader impl) : this(NDalicPINVOKE.new_AsyncImageLoader__SWIG_2(SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader.getCPtr(impl)), true)

[TypeRegistry.cs]
 - TypeRegistry(SWIGTYPE_p_Dali__Internal__TypeRegistry typeRegistry) : this(NDalicPINVOKE.new_TypeRegistry__SWIG_2(SWIGTYPE_p_Dali__Internal__TypeRegistry.getCPtr(typeRegistry)), true)

[CustomView.cs]
- void AccessibilityActivate()
- void KeyboardEnter()
- bool EmitKeyEventSignal(Key key)

[PixelBuffer.cs]
- PixelBuffer(SWIGTYPE_p_unsigned_char pointer) : this(NDalicPINVOKE.new_PixelBuffer__SWIG_2(SWIGTYPE_p_unsigned_char.getCPtr(pointer)), true)

[Texture.cs]
- Texture(SWIGTYPE_p_Dali__Internal__Texture pointer) : this(NDalicPINVOKE.new_Texture__SWIG_2(SWIGTYPE_p_Dali__Internal__Texture.getCPtr(pointer)), true)

[TransitionData.cs]
- TransitionData(SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData impl) : this(NDalicPINVOKE.new_TransitionData__SWIG_2(SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData.getCPtr(impl)), true)

[VisualBase.cs]
- VisualBase(SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base impl) : this(NDalicPINVOKE.new_VisualBase__SWIG_2(SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base.getCPtr(impl)), true)        