### PR TITLE
[Connection][TCSACR-156] Remove ArgumentException

### DIFF
--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -824,6 +824,10 @@ namespace Tizen.Network.Connection
                     Log.Error(Globals.LogTag, "No connection " + (ConnectionError)ret);
                     return null;
                 }
+                else if ((ConnectionError)ret == ConnectionError.InvalidParameter)
+                {
+                    throw new InvalidOperationException("Invalid handle");
+                }
                 else
                 {
                     Log.Error(Globals.LogTag, "It failed to get current profile, " + (ConnectionError)ret);

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
@@ -281,7 +281,6 @@ namespace Tizen.Network.Connection
         /// <feature>http://tizen.org/feature/network.wifi</feature>
         /// <exception cref="System.NotSupportedException">Thrown when a feature is not supported.</exception>
         /// <exception cref="System.UnauthorizedAccessException">Thrown when a permission is denied.</exception>
-        /// <exception cref="System.ArgumentException">Thrown when a value is an invalid parameter.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when a profile instance is invalid or when a method fails due to an invalid operation.</exception>
         /// <exception cref="System.ObjectDisposedException">Thrown when an operation is performed on a disposed object.</exception>
         public void Refresh()
@@ -291,6 +290,10 @@ namespace Tizen.Network.Connection
             if ((ConnectionError)ret != ConnectionError.None)
             {
                 Log.Error(Globals.LogTag, "It failed to get network interface name, " + (ConnectionError)ret);
+                if ((ConnectionError)ret == ConnectionError.InvalidParameter)
+                {
+                    throw new InvalidOperationException("Invalid handle");
+                }
                 ConnectionErrorFactory.CheckFeatureUnsupportedException(ret, "http://tizen.org/feature/network.telephony " + "http://tizen.org/feature/network.wifi " + "http://tizen.org/feature/network.tethering.bluetooth " + "http://tizen.org/feature/network.ethernet");
                 ConnectionErrorFactory.CheckPermissionDeniedException(ret, "(http://tizen.org/privilege/network.get)");
                 ConnectionErrorFactory.CheckHandleNullException(ret, (ProfileHandle == IntPtr.Zero), "ProfileHandle may have been disposed or released");

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfileManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfileManager.cs
@@ -188,7 +188,6 @@ namespace Tizen.Network.Connection
         /// <feature>http://tizen.org/feature/network.ethernet</feature>
         /// <exception cref="System.NotSupportedException">Thrown when a feature is not supported.</exception>
         /// <exception cref="System.UnauthorizedAccessException">Thrown when a permission is denied.</exception>
-        /// <exception cref="System.ArgumentException">Thrown when a value is an invalid parameter.</exception>
         /// <exception cref="System.OutOfMemoryException">Thrown when memory is not enough to continue execution.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when a connection instance is invalid or when a method fails due to an invalid operation.</exception>
         public static ConnectionProfile GetCurrentProfile()


### PR DESCRIPTION
Description of Change
Methods which have no parameter cannot throw ArgumentException.
Therefore ArgumentException description of those APIs need to be removed.

TCSACR-155
http://suprem.sec.samsung.net/jira/browse/TCSACR-156