### PR TITLE
[NUI] Change Parameter type of KeyboardRepeatInfo APIs

### DIFF
--- a/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
@@ -303,10 +303,10 @@ namespace Tizen.NUI
         public static extern bool UngrabKey(System.IntPtr Window, int DaliKey);
 
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_SetKeyboardRepeatInfo")]
-        public static extern bool SetKeyboardRepeatInfo(double rate, double delay);
+        public static extern bool SetKeyboardRepeatInfo(float rate, float delay);
 
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_GetKeyboardRepeatInfo")]
-        public static extern bool GetKeyboardRepeatInfo(out double rate, out double delay);
+        public static extern bool GetKeyboardRepeatInfo(out float rate, out float delay);
 
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_GetNativeWindowHandler")]
         public static extern System.IntPtr GetNativeWindowHandler(System.IntPtr Window);

--- a/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/ManualPINVOKE.cs
@@ -302,10 +302,10 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_UngrabKey")]
         public static extern bool UngrabKey(System.IntPtr Window, int DaliKey);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_SetKeyboardRepeatInfo")]
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_Keyboard_SetRepeatInfo")]
         public static extern bool SetKeyboardRepeatInfo(float rate, float delay);
 
-        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_GetKeyboardRepeatInfo")]
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_Keyboard_GetRepeatInfo")]
         public static extern bool GetKeyboardRepeatInfo(out float rate, out float delay);
 
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_GetNativeWindowHandler")]

--- a/src/Tizen.NUI/src/public/Window.cs
+++ b/src/Tizen.NUI/src/public/Window.cs
@@ -900,7 +900,7 @@ namespace Tizen.NUI
         /// <param name="delay">The key repeat delay value in seconds</param>
         /// <returns>True if setting the keyboard repeat succeeds.</returns>
         /// <since_tizen> 5 </since_tizen>
-        public bool SetKeyboardRepeatInfo(double rate, double delay)
+        public bool SetKeyboardRepeatInfo(float rate, float delay)
         {
             bool ret = NDalicManualPINVOKE.SetKeyboardRepeatInfo(rate, delay);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -914,7 +914,7 @@ namespace Tizen.NUI
         /// <param name="delay">The key repeat delay value in seconds</param>
         /// <returns>True if setting the keyboard repeat succeeds.</returns>
         /// <since_tizen> 5 </since_tizen>
-        public bool GetKeyboardRepeatInfo(out double rate, out double delay)
+        public bool GetKeyboardRepeatInfo(out float rate, out float delay)
         {
             bool ret = NDalicManualPINVOKE.GetKeyboardRepeatInfo(out rate, out delay);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();


### PR DESCRIPTION
Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
Changed the parameters' type of KeyboardRepeatInfo APIs
- 'double' type -> 'float' type

### Bugs Fixed ###

- N/A

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-152

Changed:
 - bool SetKeyboardRepeatInfo(double rate, double delay) => bool SetKeyboardRepeatInfo(float rate, float delay)
 - bool GetKeyboardRepeatInfo(out double rate, out double delay) => bool GetKeyboardRepeatInfo(out float rate, out float delay)

### Behavioral Changes ###
Changed the parameters' type of SetKeyboardRepeatInfo / GetKeyboardRepeatInfo in Window.cs
- 'double' type -> 'float' type

