### PR TITLE
[Tizen.Multimedia.Util] Fix callback function lifecycle bug

### DIFF
--- a/src/Tizen.Multimedia.Util/ThumbnailExtractor/ThumbnailExtractor.cs
+++ b/src/Tizen.Multimedia.Util/ThumbnailExtractor/ThumbnailExtractor.cs
@@ -190,9 +190,10 @@ namespace Tizen.Multimedia.Util
             }
         }
 
+        private static Native.ThumbnailExtractCallback thumbnailExtractCallback;
         private static Native.ThumbnailExtractCallback GetCallback(TaskCompletionSource<ThumbnailExtractionResult> tcs)
         {
-            return (error, requestId, thumbWidth, thumbHeight, thumbData, dataSize, _) =>
+            return thumbnailExtractCallback = (error, requestId, thumbWidth, thumbHeight, thumbData, dataSize, _) =>
             {
                 if (error == ThumbnailExtractorError.None)
                 {


### PR DESCRIPTION
### Bugs Fixed ###

- Crash was occured because callback handler was invoked after garbage colleciton.

