### PR TITLE
[Tizen.Network.Bluetooth] Fix ValueChanged callback function bug

### DIFF
--- a/src/Tizen.Network.Bluetooth/Interop/Interop.Bluetooth.cs
+++ b/src/Tizen.Network.Bluetooth/Interop/Interop.Bluetooth.cs
@@ -478,7 +478,7 @@ internal static partial class Interop
         internal delegate void BtGattServerWriteValueRequestedCallback(string clientAddress, int requestId, IntPtr serverHandle, IntPtr gattHandle, int offset, bool response_needed, byte[] value, int len, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
-        internal delegate void BtClientCharacteristicValueChangedCallback(IntPtr characteristicHandle, byte[] value, int len, IntPtr userData);
+        internal delegate void BtClientCharacteristicValueChangedCallback(IntPtr characteristicHandle, IntPtr value, int len, IntPtr userData);
 
         [UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void BtGattServerNotificationStateChangeCallback(bool notify, IntPtr serverHandle, IntPtr characteristicHandle, IntPtr userData);

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothEventArgs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothEventArgs.cs
@@ -982,9 +982,16 @@ namespace Tizen.Network.Bluetooth
     /// <since_tizen> 3 </since_tizen>
     public class ValueChangedEventArgs : EventArgs
     {
-        internal ValueChangedEventArgs(byte[] value)
+        internal ValueChangedEventArgs(IntPtr value, int len)
         {
-            Value = value;
+            Value = new byte[len];
+            unsafe
+            {
+                for (int i = 0; i < len; i++)
+                {
+                    Value[i] = *((byte*)value.ToPointer() + i);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGatt.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGatt.cs
@@ -573,7 +573,7 @@ namespace Tizen.Network.Bluetooth
                     {
                         _characteristicValueChangedCallback = (gattHandle, characteristicValue, len, userData) =>
                         {
-                            _characteristicValueChanged?.Invoke(this, new ValueChangedEventArgs(characteristicValue));
+                            _characteristicValueChanged?.Invoke(this, new ValueChangedEventArgs(characteristicValue, len));
                         };
 
                         _impl.SetCharacteristicValueChangedEvent(_characteristicValueChangedCallback);


### PR DESCRIPTION
BluetoothGattCharacteristic.ValueChanged event always calls back
with a Byte array containing only the first byte of the actual
value. This problem is caused by marshaling the byte array from
the unmanaged C code.

Signed-off-by: Arumoy Biswas <arumoy.b@samsung.com>
Signed-off-by: DoHyun Pyun <dh79.pyun@samsung.com>

### Description of Change ###

Manual marshaling is done in the constructor of ValueChangedEventArgs.

### Bugs Fixed ###

N/A

### API Changes ###

If you have the ACR for changing APIs, put the link of the ACR:
 - ACR: N/A

### Behavioral Changes ###

N/A (Bug fix patchset)

