### PR TITLE
[Connection] Remove deprecated API

### DIFF
--- a/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
+++ b/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
@@ -87,7 +87,7 @@ internal static partial class Interop
         [DllImport(Libraries.Connection, EntryPoint = "connection_set_ip_address_changed_cb")]
         public static extern int SetIPAddressChangedCallback(IntPtr handle, ConnectionAddressChangedCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_set_ethernet_cable_state_chaged_cb")]
+        [DllImport(Libraries.Connection, EntryPoint = "connection_set_ethernet_cable_state_changed_cb")]
         public static extern int SetEthernetCableStateChagedCallback(IntPtr handle, EthernetCableStateChangedCallback callback, IntPtr userData);
 
         [DllImport(Libraries.Connection, EntryPoint = "connection_set_proxy_address_changed_cb")]
@@ -99,7 +99,7 @@ internal static partial class Interop
         [DllImport(Libraries.Connection, EntryPoint = "connection_unset_ip_address_changed_cb")]
         public static extern int UnsetIPAddressChangedCallback(IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_unset_ethernet_cable_state_chaged_cb")]
+        [DllImport(Libraries.Connection, EntryPoint = "connection_unset_ethernet_cable_state_changed_cb")]
         public static extern int UnsetEthernetCableStateChagedCallback(IntPtr handle);
 
         [DllImport(Libraries.Connection, EntryPoint = "connection_unset_proxy_address_changed_cb")]


### PR DESCRIPTION
### Description of Change ###

Some APIs which has typo has been deprecated since tizen 4.0.
This patch replaces thease APIs with proper APIs.
- deprecated API: connection_set_ethernet_cable_state_chaged_cb
                             connection_unset_ethernet_cable_state_chaged_cb
- New API: connection_set_ethernet_cable_state_changed_cb
                  connection_unset_ethernet_cable_state_changed_cb


### Bugs Fixed ###

- N/A

### API Changes ###

- N/A

### Behavioral Changes ###

- N/A

