### PR TITLE
typo correction

### DIFF
--- a/src/Tizen.System/Device/Haptic.cs
+++ b/src/Tizen.System/Device/Haptic.cs
@@ -138,7 +138,7 @@ namespace Tizen.System
         ///     {
         ///         vibrator.Vibrate(2000, 70);
         ///     }
-        ///     Catch(Exception e)
+        ///     catch(Exception e)
         ///     {
         ///     }
         /// </code>
@@ -182,7 +182,7 @@ namespace Tizen.System
         ///     {
         ///         vibrator.Stop();
         ///     }
-        ///     Catch(Exception e)
+        ///     catch(Exception e)
         ///     {
         ///     }
         /// </code>


### PR DESCRIPTION
### Description of Change ###
there is a minor typo in the docs, catch (c# keyword) is spelled with a capital C

### Bugs Fixed ###
no bug listed for that 

### API Changes ###
no api changes

### Behavioral Changes ###
no behavioral changes
