### PR TITLE
[MediaContent] Added exception handling to catch p/invoke error return

### DIFF
--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/PlaylistCommand.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/PlaylistCommand.cs
@@ -239,12 +239,12 @@ namespace Tizen.Content.MediaContent
             {
                 Interop.Playlist.GetPlaylistFromDb(playlistId, out handle).ThrowIfError("Failed to query");
 
-                if (handle == IntPtr.Zero)
-                {
-                    throw new RecordNotFoundException("No matching playlist exists.");
-                }
-
                 Interop.Playlist.ExportToFile(handle, path).ThrowIfError("Failed to export");
+            }
+            catch (ArgumentException)
+            {
+                // Native FW returns ArgumentException when there's no matched record.
+                throw new RecordNotFoundException("No matching playlist exists.");
             }
             finally
             {
@@ -381,12 +381,12 @@ namespace Tizen.Content.MediaContent
             {
                 Interop.Playlist.GetPlaylistFromDb(playlistId, out handle).ThrowIfError("Failed to query");
 
-                if (handle == IntPtr.Zero)
-                {
-                    return null;
-                }
-
                 return new Playlist(handle);
+            }
+            catch (ArgumentException)
+            {
+                // Native FW returns ArgumentException when there's no matched record.
+                return null;
             }
             finally
             {

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/StorageCommand.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/StorageCommand.cs
@@ -88,7 +88,12 @@ namespace Tizen.Content.MediaContent
             {
                 Interop.Storage.GetStorageInfoFromDb(storageId, out handle).ThrowIfError("Failed to query");
 
-                return handle == IntPtr.Zero ? null : new Storage(handle);
+                return new Storage(handle);
+            }
+            catch (ArgumentException)
+            {
+                // Native FW returns ArgumentException when there's no matched record.
+                return null;
             }
             finally
             {

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/TagCommand.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/TagCommand.cs
@@ -213,11 +213,12 @@ namespace Tizen.Content.MediaContent
             {
                 Interop.Tag.GetTagFromDb(tagId, out handle).ThrowIfError("Failed to query");
 
-                if (handle == IntPtr.Zero)
-                {
-                    return null;
-                }
                 return new Tag(handle);
+            }
+            catch (ArgumentException)
+            {
+                // Native FW returns ArgumentException when there's no matched record.
+                return null;
             }
             finally
             {


### PR DESCRIPTION
### Bugs Fixed ###

- Native FW was changed to return error when there's no matched record with playlistId.
  So, C# layer should catch the exception to handle it correctly.

