### PR TITLE
[AudioManager] Add new APIs for device running state

### DIFF
--- a/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
@@ -28,6 +28,7 @@ namespace Tizen.Multimedia
         private readonly int _id;
         private readonly AudioDeviceType _type;
         private readonly AudioDeviceIoDirection _ioDirection;
+        private readonly IntPtr _deviceHandle;
 
         internal AudioDevice(IntPtr deviceHandle)
         {
@@ -44,6 +45,8 @@ namespace Tizen.Multimedia
 
             ret = Interop.AudioDevice.GetDeviceIoDirection(deviceHandle, out _ioDirection);
             MultimediaDebug.AssertNoError(ret);
+
+            _deviceHandle = deviceHandle;
         }
 
         /// <summary>
@@ -79,6 +82,7 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <value>The <see cref="AudioDeviceState"/> of the device.</value>
         /// <since_tizen> 3 </since_tizen>
+        [Obsolete("Deprecated since API level 5. Please use the IsRunning property instead.")]
         public AudioDeviceState State
         {
             get
@@ -87,6 +91,22 @@ namespace Tizen.Multimedia
                     ThrowIfError("Failed to get the state of the device");
 
                 return state;
+            }
+        }
+
+        /// <summary>
+        /// Gets the running state of the device.
+        /// </summary>
+        /// <value>true if the audio stream of device is running actually; otherwise, false.</value>
+        /// <since_tizen> 5 </since_tizen>
+        public bool IsRunning
+        {
+            get
+            {
+                Interop.AudioDevice.GetDeviceRunningState(_deviceHandle, out bool isRunning).
+                    ThrowIfError("Failed to get the running state of the device");
+
+                return isRunning;
             }
         }
 

--- a/src/Tizen.Multimedia/AudioManager/AudioDeviceRunningStateChangedEventArgs.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDeviceRunningStateChangedEventArgs.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace Tizen.Multimedia
+{
+    /// <summary>
+    /// Provides data for the <see cref="AudioManager.DeviceRunningStateChanged"/> event.
+    /// </summary>
+    /// <since_tizen> 5 </since_tizen>
+    public class AudioDeviceRunningStateChangedEventArgs : EventArgs
+    {
+        internal AudioDeviceRunningStateChangedEventArgs(AudioDevice device, bool isRunning)
+        {
+            Device = device;
+            IsRunning = isRunning;
+        }
+
+        /// <summary>
+        /// Gets the device.
+        /// </summary>
+        /// <value>The <see cref="AudioDevice"/>.</value>
+        /// <since_tizen> 5 </since_tizen>
+        public AudioDevice Device { get; }
+
+        /// <summary>
+        /// Gets the running state of the device.
+        /// </summary>
+        /// <value>true if the audio stream of device is running actually; otherwise, false.</value>
+        /// <since_tizen> 5 </since_tizen>
+        public bool IsRunning { get; }
+    }
+}

--- a/src/Tizen.Multimedia/Interop/Interop.Device.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Device.cs
@@ -29,6 +29,9 @@ namespace Tizen.Multimedia
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void StateChangedCallback(IntPtr device, AudioDeviceState changedState, IntPtr userData);
 
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            internal delegate void RunningStateChangedCallback(IntPtr device, bool isRunning, IntPtr userData);
+
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_list")]
             internal static extern AudioManagerError GetDeviceList(AudioDeviceOptions deviceMask, out IntPtr deviceList);
 
@@ -53,6 +56,9 @@ namespace Tizen.Multimedia
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_state_by_id")]
             internal static extern AudioManagerError GetDeviceState(int deviceId, out AudioDeviceState state);
 
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_device_running")]
+            internal static extern AudioManagerError GetDeviceRunningState(IntPtr device, out bool isRunning);
+
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_connection_changed_cb")]
             internal static extern AudioManagerError AddDeviceConnectionChangedCallback(
                 AudioDeviceOptions deviceMask, ConnectionChangedCallback callback, IntPtr userData, out int id);
@@ -66,6 +72,13 @@ namespace Tizen.Multimedia
 
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_state_changed_cb")]
             internal static extern AudioManagerError RemoveDeviceStateChangedCallback(int id);
+
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_running_changed_cb")]
+            internal static extern AudioManagerError AddDeviceRunningStateChangedCallback(AudioDeviceOptions deviceMask,
+                RunningStateChangedCallback callback, IntPtr userData, out int id);
+
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_device_running_changed_cb")]
+            internal static extern AudioManagerError RemoveDeviceRunningStateChangedCallback(int id);
         }
     }
 }


### PR DESCRIPTION
### API Changes ###
It's related native ACR-1147.

Added:
 - public bool IsRunning
 - public static event EventHandler<AudioDeviceRunningStateChangedEventArgs> DeviceRunningStateChanged

Deprecated:
 - public AudioDeviceState State
 - public static event EventHandler<AudioDeviceStateChangedEventArgs> DeviceStateChanged
