### PR TITLE
[MediaVision] Fix an issue that callback was made on a garbage collected delegate

### DIFF
--- a/src/Tizen.Multimedia.Vision/MediaVision/MovementDetector.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/MovementDetector.cs
@@ -49,17 +49,12 @@ namespace Tizen.Multimedia.Vision
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<MovementDetectedEventArgs> Detected;
 
-        internal override void OnEventDetected(IntPtr trigger, IntPtr source, int streamId,
-            IntPtr result, IntPtr _)
+        private void RegisterEvent()
         {
-            try
+            _eventDetectedCallback = (IntPtr trigger, IntPtr source, int streamId, IntPtr result, IntPtr _) =>
             {
                 Detected?.Invoke(this, CreateMovementDetectedEventArgs(result));
-            }
-            catch (Exception e)
-            {
-                MultimediaLog.Error(MediaVisionLog.Tag, "Failed to invoke Recognized event.", e);
-            }
+            };
         }
 
         private static Rectangle[] RetrieveAreas(IntPtr result)
@@ -113,6 +108,7 @@ namespace Tizen.Multimedia.Vision
         /// <since_tizen> 4 </since_tizen>
         public void AddSource(SurveillanceSource source, MovementDetectionConfiguration config)
         {
+            RegisterEvent();
             InvokeAddSource(source, config);
         }
 

--- a/src/Tizen.Multimedia.Vision/MediaVision/PersonAppearanceDetector.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/PersonAppearanceDetector.cs
@@ -53,17 +53,12 @@ namespace Tizen.Multimedia.Vision
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<PersonAppearanceDetectedEventArgs> Detected;
 
-        internal override void OnEventDetected(IntPtr trigger, IntPtr source, int streamId,
-            IntPtr result, IntPtr _)
+        private void RegisterEvent()
         {
-            try
+            _eventDetectedCallback = (IntPtr trigger, IntPtr source, int streamId, IntPtr result, IntPtr _) =>
             {
                 Detected?.Invoke(this, CreatePersonAppearanceChangedEventArgs(result));
-            }
-            catch (Exception e)
-            {
-                MultimediaLog.Error(MediaVisionLog.Tag, "Failed to invoke Recognized event.", e);
-            }
+            };
         }
 
 
@@ -118,6 +113,7 @@ namespace Tizen.Multimedia.Vision
         /// <since_tizen> 4 </since_tizen>
         public void AddSource(SurveillanceSource source, PersonAppearanceDetectionConfiguration config)
         {
+            RegisterEvent();
             InvokeAddSource(source, config);
         }
     }

--- a/src/Tizen.Multimedia.Vision/MediaVision/PersonRecognizer.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/PersonRecognizer.cs
@@ -42,6 +42,7 @@ namespace Tizen.Multimedia.Vision
         /// <since_tizen> 4 </since_tizen>
         public PersonRecognizer() : base(PersonRecognizedEventType)
         {
+
         }
 
         /// <summary>
@@ -52,17 +53,12 @@ namespace Tizen.Multimedia.Vision
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<PersonRecognizedEventArgs> Recognized;
 
-        internal override void OnEventDetected(IntPtr trigger, IntPtr source, int streamId,
-            IntPtr result, IntPtr _)
+        private void RegisterEvent()
         {
-            try
+            _eventDetectedCallback = (IntPtr trigger, IntPtr source, int streamId, IntPtr result, IntPtr _) =>
             {
                 Recognized?.Invoke(this, CreatePersonRecognizedEventArgs(result));
-            }
-            catch (Exception e)
-            {
-                MultimediaLog.Error(MediaVisionLog.Tag, "Failed to invoke Recognized event.", e);
-            }
+            };
         }
 
         private PersonRecognizedEventArgs CreatePersonRecognizedEventArgs(IntPtr result)
@@ -124,6 +120,8 @@ namespace Tizen.Multimedia.Vision
             {
                 throw new ArgumentNullException(nameof(config));
             }
+
+            RegisterEvent();
             InvokeAddSource(source, config);
         }
     }

--- a/src/Tizen.Multimedia.Vision/MediaVision/SurveillanceEngine.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/SurveillanceEngine.cs
@@ -35,6 +35,7 @@ namespace Tizen.Multimedia.Vision
         private IntPtr _handle = IntPtr.Zero;
         private bool _disposed = false;
 
+        internal EventOccurredCallback _eventDetectedCallback;
         /// <summary>
         /// Initializes a new instance of the <see cref="SurveillanceEngine"/> class.
         /// </summary>
@@ -105,9 +106,6 @@ namespace Tizen.Multimedia.Vision
             }
         }
 
-        internal abstract void OnEventDetected(IntPtr trigger, IntPtr source,
-            int streamId, IntPtr eventResult, IntPtr userData);
-
         internal void InvokeAddSource(SurveillanceSource source, SurveillanceEngineConfiguration config)
         {
             if (source == null)
@@ -115,7 +113,7 @@ namespace Tizen.Multimedia.Vision
                 throw new ArgumentNullException(nameof(source));
             }
             SubscribeEventTrigger(Handle, source.StreamId, EngineConfiguration.GetHandle(config),
-                OnEventDetected).Validate("Failed to subscribe trigger");
+                _eventDetectedCallback).Validate("Failed to subscribe trigger");
         }
 
         /// <summary>


### PR DESCRIPTION

Signed-off-by: Tae-Young Chung <ty83.chung@samsung.com>

### Bugs Fixed ###
- TC is sometimes block because of issue that callback was made on a garbage collected delegate.
- To fix it, declare the member variable for callback.

