### PR TITLE
[WiFi] Fix infinite recursion

### DIFF
--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -158,7 +158,11 @@ namespace Tizen.Network.WiFi
             int tid = Thread.CurrentThread.ManagedThreadId;
             Log.Info(Globals.LogTag, "PInvoke wifi_manager_initialize");
             int ret = Interop.WiFi.Initialize(tid, out handle);
-            CheckReturnValue(ret, "Initialize", PrivilegeNetworkGet);
+            if (ret != (int)WiFiError.None)
+            {
+                Log.Error(Globals.LogTag, "Initialize Fail, Error - " + (WiFiError)ret);
+                WiFiErrorFactory.ThrowWiFiException(ret, PrivilegeNetworkGet);
+            }
             handle.SetTID(tid);
             return handle;
         }


### PR DESCRIPTION
### Description of Change ###
When an exception in Initialize() happens, GetHandle() is called recursively because s_threadName is not initialized.