### PR TITLE
[Multimedia.MediaTool] Add APIs for rotation and flip

### DIFF
--- a/src/Tizen.Multimedia/Common.Internal/RotationFlip.cs
+++ b/src/Tizen.Multimedia/Common.Internal/RotationFlip.cs
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Tizen.Multimedia
+{
+    /// <summary>
+    /// Represents a rotation and flip for mediatool.
+    /// </summary>
+    internal enum RotationFlip
+    {
+        Rotate0,
+        Rotate90,
+        Rotate180,
+        Rotate270,
+        HorizontalFlip,
+        VerticalFlip
+    }
+}

--- a/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
@@ -88,6 +88,12 @@ namespace Tizen.Multimedia
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_extra")]
             internal static extern int GetExtra(IntPtr handle, out IntPtr value);
+
+            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_set_rotate_method")]
+            internal static extern int SetRotation(IntPtr handle, RotationFlip rotationFlip);
+
+            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_rotate_method")]
+            internal static extern int GetRotation(IntPtr handle, out RotationFlip rotationFlip);
         }
 
         internal static class MediaFormat

--- a/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
@@ -216,7 +216,6 @@ namespace Tizen.Multimedia
                 ValidateNotDisposed();
 
                 int ret = Interop.MediaPacket.GetDts(_handle, out var value);
-
                 MultimediaDebug.AssertNoError(ret);
 
                 return value;
@@ -227,7 +226,6 @@ namespace Tizen.Multimedia
                 ValidateNotLocked();
 
                 int ret = Interop.MediaPacket.SetDts(_handle, value);
-
                 MultimediaDebug.AssertNoError(ret);
             }
         }
@@ -245,7 +243,6 @@ namespace Tizen.Multimedia
                 ValidateNotDisposed();
 
                 int ret = Interop.MediaPacket.IsEncoded(_handle, out var value);
-
                 MultimediaDebug.AssertNoError(ret);
 
                 return value;
@@ -257,6 +254,9 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <exception cref="ArgumentException">The specified value to set is invalid.</exception>
         /// <exception cref="ObjectDisposedException">The MediaPacket has already been disposed of.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     The MediaPacket is not in the writable state, which means it is being used by another module.
+        /// </exception>
         /// <since_tizen> 5 </since_tizen>
         public Rotation Rotation
         {
@@ -265,10 +265,11 @@ namespace Tizen.Multimedia
                 ValidateNotDisposed();
 
                 int ret = Interop.MediaPacket.GetRotation(_handle, out var value);
-
                 MultimediaDebug.AssertNoError(ret);
 
-                return (value < RotationFlip.HorizontalFlip) ? (Rotation)value : Rotation.Rotate0;
+                var rotation = value < RotationFlip.HorizontalFlip ? (Rotation)value : Rotation.Rotate0;
+
+                return rotation;
             }
             set
             {
@@ -277,7 +278,6 @@ namespace Tizen.Multimedia
                 ValidationUtil.ValidateEnum(typeof(Rotation), value, nameof(value));
 
                 int ret = Interop.MediaPacket.SetRotation(_handle, (RotationFlip)value);
-
                 MultimediaDebug.AssertNoError(ret);
             }
         }
@@ -290,6 +290,9 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <exception cref="ArgumentException">The specified value to set is invalid.</exception>
         /// <exception cref="ObjectDisposedException">The MediaPacket has already been disposed of.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     The MediaPacket is not in the writable state, which means it is being used by another module.
+        /// </exception>
         /// <since_tizen> 5 </since_tizen>
         public Flips Flip
         {
@@ -298,7 +301,6 @@ namespace Tizen.Multimedia
                 ValidateNotDisposed();
 
                 int ret = Interop.MediaPacket.GetRotation(_handle, out var value);
-
                 MultimediaDebug.AssertNoError(ret);
 
                 var flip = (value < RotationFlip.HorizontalFlip) ? Flips.None :
@@ -320,7 +322,6 @@ namespace Tizen.Multimedia
                 var flip = value == Flips.Horizontal ? RotationFlip.HorizontalFlip : RotationFlip.VerticalFlip;
 
                 int ret = Interop.MediaPacket.SetRotation(_handle, flip);
-
                 MultimediaDebug.AssertNoError(ret);
             }
         }

--- a/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
@@ -252,6 +252,79 @@ namespace Tizen.Multimedia
             }
         }
 
+        /// <summary>
+        /// Gets or sets the rotation value of the current packet.
+        /// </summary>
+        /// <exception cref="ArgumentException">The specified value to set is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The MediaPacket has already been disposed of.</exception>
+        /// <since_tizen> 5 </since_tizen>
+        public Rotation Rotation
+        {
+            get
+            {
+                ValidateNotDisposed();
+
+                int ret = Interop.MediaPacket.GetRotation(_handle, out var value);
+
+                MultimediaDebug.AssertNoError(ret);
+
+                return (value < RotationFlip.HorizontalFlip) ? (Rotation)value : Rotation.Rotate0;
+            }
+            set
+            {
+                ValidateNotDisposed();
+                ValidateNotLocked();
+                ValidationUtil.ValidateEnum(typeof(Rotation), value, nameof(value));
+
+                int ret = Interop.MediaPacket.SetRotation(_handle, (RotationFlip)value);
+
+                MultimediaDebug.AssertNoError(ret);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the flip value of the current packet.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Flips.None"/> will be ignored in set case. It's not supported in Native FW.
+        /// </remarks>
+        /// <exception cref="ArgumentException">The specified value to set is invalid.</exception>
+        /// <exception cref="ObjectDisposedException">The MediaPacket has already been disposed of.</exception>
+        /// <since_tizen> 5 </since_tizen>
+        public Flips Flip
+        {
+            get
+            {
+                ValidateNotDisposed();
+
+                int ret = Interop.MediaPacket.GetRotation(_handle, out var value);
+
+                MultimediaDebug.AssertNoError(ret);
+
+                var flip = (value < RotationFlip.HorizontalFlip) ? Flips.None :
+                    (value == RotationFlip.HorizontalFlip ? Flips.Horizontal : Flips.Vertical);
+
+                return flip;
+            }
+            set
+            {
+                ValidateNotDisposed();
+                ValidateNotLocked();
+                ValidationUtil.ValidateEnum(typeof(Flips), value, nameof(value));
+
+                if (value == Flips.None)
+                {
+                    return;
+                }
+
+                var flip = value == Flips.Horizontal ? RotationFlip.HorizontalFlip : RotationFlip.VerticalFlip;
+
+                int ret = Interop.MediaPacket.SetRotation(_handle, flip);
+
+                MultimediaDebug.AssertNoError(ret);
+            }
+        }
+
         private Lazy<IMediaBuffer> _buffer;
 
         /// <summary>
@@ -396,6 +469,7 @@ namespace Tizen.Multimedia
             }
         }
 
+        #region Dispose support
         /// <summary>
         /// Gets a value indicating whether the packet has been disposed of.
         /// </summary>
@@ -404,7 +478,6 @@ namespace Tizen.Multimedia
         public bool IsDisposed => _isDisposed;
 
         private bool _isDisposed = false;
-
 
         /// <summary>
         /// Releases all resources used by the <see cref="MediaPacket"/> object.
@@ -448,15 +521,6 @@ namespace Tizen.Multimedia
             _isDisposed = true;
         }
 
-        internal IntPtr GetHandle()
-        {
-            ValidateNotDisposed();
-
-            Debug.Assert(_handle != IntPtr.Zero, "The handle is invalid!");
-
-            return _handle;
-        }
-
         /// <summary>
         /// Validates the current object has not been disposed of.
         /// </summary>
@@ -467,6 +531,16 @@ namespace Tizen.Multimedia
             {
                 throw new ObjectDisposedException("This packet has already been disposed of.");
             }
+        }
+        #endregion
+
+        internal IntPtr GetHandle()
+        {
+            ValidateNotDisposed();
+
+            Debug.Assert(_handle != IntPtr.Zero, "The handle is invalid!");
+
+            return _handle;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###

Add APIs for rotation and flip. 
Rotation and flip are in same enum at native fw. But, Rotation and Flips enums are already used in Multimedia so we use it.

### API Changes ###

 - TCSACR-174
   ( It's related with Native ACR-1214.)

Added:
 - Rotation { get; set; } // Property
 - Flip { get; set; } // Property
