### PR TITLE
[ElmSharp] Fix SetNextFocusObject issue

### DIFF
--- a/src/ElmSharp/ElmSharp/Widget.cs
+++ b/src/ElmSharp/ElmSharp/Widget.cs
@@ -328,7 +328,7 @@ namespace ElmSharp
         /// <since_tizen> preview </since_tizen>
         public void SetNextFocusObject(EvasObject next, FocusDirection direction)
         {
-            Interop.Elementary.elm_object_focus_next_object_set(RealHandle, next.RealHandle, (int)direction);
+            Interop.Elementary.elm_object_focus_next_object_set(RealHandle, next?.RealHandle ?? IntPtr.Zero, (int)direction);
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
``` c#
public void SetNextFocusObject(EvasObject next, FocusDirection direction)
```
 To allow null value on next parameter, `null` means reset to default

### Bugs Fixed ###
None

### API Changes ###
None

### Behavioral Changes ###
None