### PR TITLE
[AudioManager] Fix to use sound_manager_is_device_running_by_id() for…

### DIFF
--- a/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
@@ -103,7 +103,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                Interop.AudioDevice.IsDeviceRunning(_deviceHandle, out bool isRunning).
+                Interop.AudioDevice.IsDeviceRunning(_id, out bool isRunning).
                     ThrowIfError("Failed to get the running state of the device");
 
                 return isRunning;

--- a/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
@@ -28,7 +28,6 @@ namespace Tizen.Multimedia
         private readonly int _id;
         private readonly AudioDeviceType _type;
         private readonly AudioDeviceIoDirection _ioDirection;
-        private readonly IntPtr _deviceHandle;
 
         internal AudioDevice(IntPtr deviceHandle)
         {
@@ -45,8 +44,6 @@ namespace Tizen.Multimedia
 
             ret = Interop.AudioDevice.GetDeviceIoDirection(deviceHandle, out _ioDirection);
             MultimediaDebug.AssertNoError(ret);
-
-            _deviceHandle = deviceHandle;
         }
 
         /// <summary>

--- a/src/Tizen.Multimedia/Interop/Interop.Device.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Device.cs
@@ -57,8 +57,8 @@ namespace Tizen.Multimedia
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_state_by_id")]
             internal static extern AudioManagerError GetDeviceState(int deviceId, out AudioDeviceState state);
 
-            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_device_running")]
-            internal static extern AudioManagerError IsDeviceRunning(IntPtr device, out bool isRunning);
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_device_running_by_id")]
+            internal static extern AudioManagerError IsDeviceRunning(int deviceId, out bool isRunning);
 
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_add_device_connection_changed_cb")]
             internal static extern AudioManagerError AddDeviceConnectionChangedCallback(


### PR DESCRIPTION
… Interop.AudioDevice.IsDeviceRunning

Signed-off-by: Sangchul Lee <sc11.lee@samsung.com>

### Description of Change ###
Since device state is mutable variable, it needs to get the value from server on the fly.

### Bugs Fixed ###
- AudioDevice does not include the running state. So it should be obtained by checking with id. (Use the id instead of the ptr of new copied AudioDevice object)