### PR TITLE
[Applications] Fix a bug when getting application metadata info

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationInfo.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationInfo.cs
@@ -207,7 +207,8 @@ namespace Tizen.Applications
                 {
                     if (key.Length != 0)
                     {
-                        metadata.Add(key, value);
+                        if (!metadata.ContainsKey(key))
+                            metadata.Add(key, value);
                     }
                     return true;
                 };


### PR DESCRIPTION
### Description of Change ###

Some applications may have multiple value for one key.
We use dictionary for application metadata, this can cause an exception.
This fix prevents above exception, but this will cause different
behavior with native API.

### Bugs Fixed ###

N/A

### API Changes ###

N/A

### Behavioral Changes ###

N/A
