### PR TITLE
[Tizen.Applications] Fix typo

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/LocaleChangedEventArgs.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/LocaleChangedEventArgs.cs
@@ -36,7 +36,7 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// The property to get the intformation of the Locale
+        /// The property to get the information of the Locale
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public string Locale { get; private set; }

--- a/src/Tizen.Applications.Common/Tizen.Applications/LowBatteryEventArgs.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/LowBatteryEventArgs.cs
@@ -35,7 +35,7 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// The property to get the intformation of the LowBatteryStatus
+        /// The property to get the information of the LowBatteryStatus
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public LowBatteryStatus LowBatteryStatus { get; private set; }

--- a/src/Tizen.Applications.Common/Tizen.Applications/LowMemoryEventArgs.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/LowMemoryEventArgs.cs
@@ -35,7 +35,7 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// The property to get the intformation of the LowMemoryStatus
+        /// The property to get the information of the LowMemoryStatus
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public LowMemoryStatus LowMemoryStatus { get; private set; }

--- a/src/Tizen.Applications.Common/Tizen.Applications/RegionFormatChangedEventArgs.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/RegionFormatChangedEventArgs.cs
@@ -36,7 +36,7 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// The property to get the intformation of the Region
+        /// The property to get the information of the Region
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public string Region { get; private set; }


### PR DESCRIPTION
### Description of Change ###

Fix typo at property description.
`intformation` -> `information`

### Bugs Fixed ###

- N/A

### API Changes ###
- N/A

### Behavioral Changes ###

- N/A

