### PR TITLE
[PrivacyPrivilegeManager] Add new API for checking & requesting multiple privileges

### DIFF
--- a/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Interop/Interop.PrivacyPrivilegeManager.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
+ * Copyright (c) 2017 - 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.
@@ -53,10 +53,27 @@ internal static partial class Interop
         //[UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
         internal delegate void RequestResponseCallback(CallCause cause, RequestResult result, string privilege, IntPtr userData);
 
+        //[UnmanagedFunctionPointerAttribute(CallingConvention.Cdecl)]
+        internal delegate void RequestMultipleResponseCallback(CallCause cause,
+                                                               [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] RequestResult[] results,
+                                                               [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] string[] privileges,
+                                                               uint privilegesCount, IntPtr userData);
+
         [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_check_permission")]
         internal static extern ErrorCode CheckPermission(string privilege, out CheckResult result);
 
+        [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_check_permissions")]
+        internal static extern ErrorCode CheckPermissions([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)]string[] privileges,
+                                                          uint privilegesCount,
+                                                          [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] CheckResult[] results);
+
+
         [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_request_permission")]
         internal static extern ErrorCode RequestPermission(string privilege, RequestResponseCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.PrivacyPrivilegeManager, EntryPoint = "ppm_request_permissions")]
+        internal static extern ErrorCode RequestPermissions([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] string[] privileges,
+                                                            uint privilegesCount, RequestMultipleResponseCallback callback, IntPtr userData);
+
     }
 }

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security.PrivacyPrivilegeManager.sln
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security.PrivacyPrivilegeManager.sln
@@ -1,9 +1,8 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tizen.Security.PrivacyPrivilegeManager", "Tizen.Security.PrivacyPrivilegeManager.csproj", "{588EBECE-A11C-4837-80F3-5EDECFC17E5E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Security.PrivacyPrivilegeManager", "Tizen.Security.PrivacyPrivilegeManager.csproj", "{588EBECE-A11C-4837-80F3-5EDECFC17E5E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,21 +13,24 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x64.ActiveCfg = Debug|x64
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x64.Build.0 = Debug|x64
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x86.ActiveCfg = Debug|x86
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x86.Build.0 = Debug|x86
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x64.Build.0 = Debug|Any CPU
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Debug|x86.Build.0 = Debug|Any CPU
 		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x64.ActiveCfg = Release|x64
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x64.Build.0 = Release|x64
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x86.ActiveCfg = Release|x86
-		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x86.Build.0 = Release|x86
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x64.ActiveCfg = Release|Any CPU
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x64.Build.0 = Release|Any CPU
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x86.ActiveCfg = Release|Any CPU
+		{588EBECE-A11C-4837-80F3-5EDECFC17E5E}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {938329CD-8EF9-430F-A061-0AE8567C0F87}
 	EndGlobalSection
 EndGlobal

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionRequestResponse.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/PermissionRequestResponse.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Tizen.Security
+{
+    /// <summary>
+    /// Holds information about privilege request result.
+    /// </summary>
+    public class PermissionRequestResponse
+    {
+        /// <summary>
+        /// The result of a permission request.
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        public RequestResult Result { get; internal set; }
+
+        /// <summary>
+        /// The privilege for which a permission was requested for.
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        public string Privilege { get; internal set; }
+    }
+}

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResponseEventArgs.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResponseEventArgs.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Samsung Electronics Co., Ltd All Rights Reserved
+ * Copyright (c) 2017 - 2018 Samsung Electronics Co., Ltd All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.
@@ -42,5 +42,21 @@ namespace Tizen.Security
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
         public string privilege { get; internal set; }
+
+        /// <summary>
+        /// The response for privilege request
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        public PermissionRequestResponse Response
+        {
+            get
+            {
+                return new PermissionRequestResponse
+                {
+                    Result = result,
+                    Privilege = privilege,
+                };
+            }
+        }
     }
 }

--- a/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResponseMultipleEventArgs.cs
+++ b/src/Tizen.Security.PrivacyPrivilegeManager/Tizen.Security/RequestResponseMultipleEventArgs.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace Tizen.Security
+{
+    /// <summary>
+    /// This class is an event argument of the RequestResponse event.
+    /// </summary>
+    /// <since_tizen> 5 </since_tizen>
+
+    public class RequestMultipleResponseEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The cause of a triggered response.
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        public CallCause Cause { get; internal set; }
+
+        /// <summary>
+        /// The response for privilege request
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        public IEnumerable<PermissionRequestResponse> Responses { get; internal set; }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

C# bindings for checking & requesting multiple privileges using single API call

### API Changes ###
 - TCSACR-184
(It's related Native ACR-1253.)

### Added: ###
#### Class PrivacyPrivilegeManager: ####
Method:
```csharp
public static IEnumerable<CheckResult> CheckPermissions(IEnumerable<string> privileges);
public static Task<RequestMultipleResponseEventArgs> RequestPermissions(IEnumerable<string> privileges);
```
#### Class PermissionRequestResponse: ####
Event:
```csharp
public RequestResult Result { get; internal set; }
public string Privilege { get; internal set; }
```
#### Class RequestResponseEventArgs : EventArgs ####
Property:
```csharp
public PermissionRequestResponse Response { get; }
```
#### Class RequestMultipleResponseEventArgs : EventArgs ####
Property:
```csharp
public CallCause Cause { get; internal set; }
public IEnumerable<PermissionRequestResponse> Responses { get; internal set; }
```