### PR TITLE
[NUI] Avoid raising InputMethodContext reference count

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -922,6 +922,7 @@ namespace Tizen.NUI.BaseComponents
         private string textEditorTextSid = null;
         private string textEditorPlaceHolderTextSid = null;
         private bool systemlangTextFlag = false;
+        private InputMethodContext inputMethodContext = null;
 
         internal TextEditor(global::System.IntPtr cPtr, bool cMemoryOwn) : base(NDalicPINVOKE.TextEditor_SWIGUpcast(cPtr), cMemoryOwn)
         {
@@ -965,8 +966,7 @@ namespace Tizen.NUI.BaseComponents
                 if (swigCMemOwn)
                 {
                     swigCMemOwn = false;
-                    // In order to speed up IME hide, temporarily add
-                    GetInputMethodContext()?.DestroyContext();
+                    inputMethodContext?.Dispose();
                     NDalicPINVOKE.delete_TextEditor(swigCPtr);
                 }
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
@@ -1249,10 +1249,15 @@ namespace Tizen.NUI.BaseComponents
         /// Get the InputMethodContext instance.
         /// </summary>
         /// <returns>The InputMethodContext instance.</returns>
-        public InputMethodContext GetInputMethodContext() {
-            InputMethodContext ret = new InputMethodContext(NDalicPINVOKE.TextEditor_GetInputMethodContext(swigCPtr), true);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+        public InputMethodContext GetInputMethodContext()
+        {
+            if (inputMethodContext == null)
+            {
+                /*Avoid raising InputMethodContext reference count.*/
+                inputMethodContext = new InputMethodContext(NDalicPINVOKE.TextEditor_GetInputMethodContext(swigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return inputMethodContext;
         }
 
         internal TextEditorSignal TextChangedSignal()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -974,6 +974,7 @@ namespace Tizen.NUI.BaseComponents
         private string textFieldTextSid = null;
         private string textFieldPlaceHolderTextSid = null;
         private bool systemlangTextFlag = false;
+        private InputMethodContext inputMethodCotext = null;
 
         internal TextField(global::System.IntPtr cPtr, bool cMemoryOwn) : base(NDalicPINVOKE.TextField_SWIGUpcast(cPtr), cMemoryOwn)
         {
@@ -1025,8 +1026,7 @@ namespace Tizen.NUI.BaseComponents
                 if (swigCMemOwn)
                 {
                     swigCMemOwn = false;
-                    // In order to speed up IME hide, temporarily add
-                    GetInputMethodContext()?.DestroyContext();
+                    inputMethodCotext?.Dispose();
                     NDalicPINVOKE.delete_TextField(swigCPtr);
                 }
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
@@ -1288,10 +1288,15 @@ namespace Tizen.NUI.BaseComponents
         /// Get the InputMethodContext instance.
         /// </summary>
         /// <returns>The InputMethodContext instance.</returns>
-        public InputMethodContext GetInputMethodContext() {
-            InputMethodContext ret = new InputMethodContext(NDalicPINVOKE.TextField_GetInputMethodContext(swigCPtr), true);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+        public InputMethodContext GetInputMethodContext()
+        {
+            if (inputMethodCotext == null)
+            {
+                /*Avoid raising InputMethodContext reference count.*/
+                inputMethodCotext = new InputMethodContext(NDalicPINVOKE.TextField_GetInputMethodContext(swigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return inputMethodCotext;
         }
 
         internal TextFieldSignal TextChangedSignal()


### PR DESCRIPTION
### Description of Change ###
[NUI] Avoid raising InputMethodContext reference count
Change-Id: I25e89f41daa41008c81ae1b46fbb82c75a98a011

### Bugs Fixed ###
DF180814-00130

### API Changes ###
N/A

### Behavioral Changes ###
N/A
