### PR TITLE
Revert "[NUI] Avoid raising InputMethodContext reference count (#459)"

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -922,7 +922,6 @@ namespace Tizen.NUI.BaseComponents
         private string textEditorTextSid = null;
         private string textEditorPlaceHolderTextSid = null;
         private bool systemlangTextFlag = false;
-        private InputMethodContext inputMethodContext = null;
 
         internal TextEditor(global::System.IntPtr cPtr, bool cMemoryOwn) : base(NDalicPINVOKE.TextEditor_SWIGUpcast(cPtr), cMemoryOwn)
         {
@@ -966,7 +965,8 @@ namespace Tizen.NUI.BaseComponents
                 if (swigCMemOwn)
                 {
                     swigCMemOwn = false;
-                    inputMethodContext?.Dispose();
+                    // In order to speed up IME hide, temporarily add
+                    GetInputMethodContext()?.DestroyContext();
                     NDalicPINVOKE.delete_TextEditor(swigCPtr);
                 }
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
@@ -1249,15 +1249,10 @@ namespace Tizen.NUI.BaseComponents
         /// Get the InputMethodContext instance.
         /// </summary>
         /// <returns>The InputMethodContext instance.</returns>
-        public InputMethodContext GetInputMethodContext()
-        {
-            if (inputMethodContext == null)
-            {
-                /*Avoid raising InputMethodContext reference count.*/
-                inputMethodContext = new InputMethodContext(NDalicPINVOKE.TextEditor_GetInputMethodContext(swigCPtr), true);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-            return inputMethodContext;
+        public InputMethodContext GetInputMethodContext() {
+            InputMethodContext ret = new InputMethodContext(NDalicPINVOKE.TextEditor_GetInputMethodContext(swigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
         }
 
         internal TextEditorSignal TextChangedSignal()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -974,7 +974,6 @@ namespace Tizen.NUI.BaseComponents
         private string textFieldTextSid = null;
         private string textFieldPlaceHolderTextSid = null;
         private bool systemlangTextFlag = false;
-        private InputMethodContext inputMethodCotext = null;
 
         internal TextField(global::System.IntPtr cPtr, bool cMemoryOwn) : base(NDalicPINVOKE.TextField_SWIGUpcast(cPtr), cMemoryOwn)
         {
@@ -1026,7 +1025,8 @@ namespace Tizen.NUI.BaseComponents
                 if (swigCMemOwn)
                 {
                     swigCMemOwn = false;
-                    inputMethodCotext?.Dispose();
+                    // In order to speed up IME hide, temporarily add
+                    GetInputMethodContext()?.DestroyContext();
                     NDalicPINVOKE.delete_TextField(swigCPtr);
                 }
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
@@ -1288,15 +1288,10 @@ namespace Tizen.NUI.BaseComponents
         /// Get the InputMethodContext instance.
         /// </summary>
         /// <returns>The InputMethodContext instance.</returns>
-        public InputMethodContext GetInputMethodContext()
-        {
-            if (inputMethodCotext == null)
-            {
-                /*Avoid raising InputMethodContext reference count.*/
-                inputMethodCotext = new InputMethodContext(NDalicPINVOKE.TextField_GetInputMethodContext(swigCPtr), true);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-            return inputMethodCotext;
+        public InputMethodContext GetInputMethodContext() {
+            InputMethodContext ret = new InputMethodContext(NDalicPINVOKE.TextField_GetInputMethodContext(swigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
         }
 
         internal TextFieldSignal TextChangedSignal()


### PR DESCRIPTION
### Description of Change ###
Revert "[NUI] Avoid raising InputMethodContext reference count (#459)"
This reverts commit 12a3196fd3f43186573416bf818acaea2254a44c.

the patch makes 100% crash when the SearchAll app ends. 
need to investigate root cause. (now reverting for VD release)

### Bugs Fixed ###
the patch makes 100% crash when the SearchAll app ends. 
need to investigate root cause. (now reverting for VD release)

### API Changes ###
N/A

### Behavioral Changes ###
N/A
