### PR TITLE
[Build] Add GlobalSuppresions file for TizenFX global scope

### DIFF
--- a/build/GlobalSuppressions.cs
+++ b/build/GlobalSuppressions.cs
@@ -1,0 +1,11 @@
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2225:Operator overloads have named alternates")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1307:Specify StringComparison")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA2101:Specify marshaling for P/Invoke string arguments")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1033:Interface methods should be callable by child types")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1060:Move pinvokes to native methods class")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1030:Use events where appropriate")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Major Bug", "S3903:Types should be defined in named namespaces", Scope = "type", Target = "~T:Interop")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S125:Sections of code should not be commented out")]
+

--- a/build/analyzers.props
+++ b/build/analyzers.props
@@ -1,0 +1,17 @@
+<Project>
+
+  <ItemGroup >
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs">
+      <Link>_TizenFX_GlobalSuppressions.cs</Link>
+      <Visible>False</Visible>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/build/common.props
+++ b/build/common.props
@@ -6,7 +6,7 @@
     <GenerateDependencyFile>False</GenerateDependencyFile>
     <Deterministic>True</Deterministic>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
-    <NoWarn Condition="'$(IsDummyBuild)' == 'True'">CS0067;CS0169;CS0414;CS0649;CS1998</NoWarn>
+    <NoWarn Condition="'$(IsDummyBuild)' == 'True'">CS0067;CS0169;CS0414;CS0649;CS1998;CA2101</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -17,11 +17,6 @@
 
   <Import Project="$(MSBuildThisFileDirectory)version.props" />
 
-  <ItemGroup Condition="'$(BuildWithAnalyzer)' == 'True'">
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)analyzers.props" Condition="'$(BuildWithAnalyzer)' == 'True' Or '$(BuildingInsideVisualStudio)' == 'True'" />
 
 </Project>


### PR DESCRIPTION
### Description of Change ###

Add GlobalSuppresions.cs file to suppress analyzer warnings on global scope.
