### PR TITLE
[Tools] Fix code checker

### DIFF
--- a/tools/scripts/CodeChecker/main.py
+++ b/tools/scripts/CodeChecker/main.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
 
         for diffLine in pr.fileDiffHunkPairs[file]:
             for warning in warningsInFile:
-                if (diffLine[0]) <= warning[BuildLog.LINE_NUMBER] and warning[BuildLog.LINE_NUMBER] <= (diffLine[0] + diffLine[1]):
+                if (diffLine[0]) <= warning[BuildLog.LINE_NUMBER] and warning[BuildLog.LINE_NUMBER] < (diffLine[0] + diffLine[1]):
                     print("{}, Warning on line {}! -> ".format(file.filename, warning[BuildLog.LINE_NUMBER]) + warning[BuildLog.MESSAGE])
                     _warningMessage = warning[BuildLog.WARNING_CODE] + ":" +warning[BuildLog.MESSAGE]
                     pr.CreateReviewComment(file, warning[BuildLog.LINE_NUMBER], _warningMessage)


### PR DESCRIPTION
### Description of Change ###

Fix code checker to add warnings only between diff hunk lines.
The code checker used to take one more line as the range of diff hunk lines.

### Bugs Fixed ###

- Fix coner case that adds warning at the out of range.

### API Changes ###
- N/A

### Behavioral Changes ###
- N/A

