### PR TITLE
[ElmSharp] Fix Focus Clearing issue

### DIFF
--- a/src/ElmSharp/ElmSharp/Widget.cs
+++ b/src/ElmSharp/ElmSharp/Widget.cs
@@ -293,7 +293,14 @@ namespace ElmSharp
         /// <since_tizen> preview </since_tizen>
         public void SetFocus(bool isFocus)
         {
-            Interop.Elementary.elm_object_focus_set(RealHandle, isFocus);
+            if (isFocus)
+            {
+                Interop.Elementary.elm_object_focus_set(RealHandle, isFocus);
+            }
+            else
+            {
+                Interop.Elementary.elm_object_focused_clear(RealHandle);
+            }
         }
 
         /// <summary>

--- a/src/ElmSharp/Interop/Interop.Elementary.cs
+++ b/src/ElmSharp/Interop/Interop.Elementary.cs
@@ -91,6 +91,33 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(_elm_config_profile_get());
         }
 
+        internal static void elm_object_focused_clear(IntPtr handle)
+        {
+            if (elm_widget_is(handle))
+            {
+                efl_ui_widget_focused_object_clear(handle);
+            }
+            else
+            {
+                Evas.evas_object_focus_set(handle, false);
+            }
+
+            IntPtr win = elm_widget_top_get(handle);
+            if (win != IntPtr.Zero && Eo.efl_class_name_get(Eo.efl_class_get(win)) == "Efl.Ui.Win")
+            {
+                Evas.evas_object_focus_set(win, true);
+            }
+        }
+
+        [DllImport(Libraries.Elementary)]
+        internal static extern IntPtr elm_widget_top_get(IntPtr handle);
+
+        [DllImport(Libraries.Elementary)]
+        internal static extern bool elm_widget_is(IntPtr handle);
+
+        [DllImport(Libraries.Elementary)]
+        internal static extern void efl_ui_widget_focused_object_clear(IntPtr handle);
+
         [DllImport(Libraries.Elementary)]
         internal static extern void elm_config_preferred_engine_set(string name);
 


### PR DESCRIPTION
### Description of Change ###

Focus is missing when `ElmSharp.SetFocus(false)` is set to an object.
This change applies the work around for clearing focus.

### Bugs Fixed ###

- N/A

### API Changes ###

- N/A

### Behavioral Changes ###

- When `ElmSharp.SetFocus(false)` is called, the focus is reset to the Window.

