### PR TITLE
[Build] Remove retry command from build.sh (#572)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,11 +5,7 @@ SCRIPT_DIR=$(dirname $SCRIPT_FILE)
 
 OUTDIR=$SCRIPT_DIR/Artifacts
 
-RETRY_CMD="$SCRIPT_DIR/tools/scripts/retry.sh"
-TIMEOUT_CMD="$SCRIPT_DIR/tools/scripts/timeout.sh"
-DOTNET_CMD="$RETRY_CMD $TIMEOUT_CMD 600 dotnet"
-
-RUN_BUILD="$DOTNET_CMD msbuild $SCRIPT_DIR/build/build.proj /nologo"
+RUN_BUILD="dotnet msbuild $SCRIPT_DIR/build/build.proj /nologo"
 
 VERSION_PREFIX=5.0.0
 

--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -145,9 +145,11 @@ GetFileList wearable > wearable.filelist
 
 rm -fr %{_tizenfx_bin_path}
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
-./build.sh --full
-./build.sh --dummy
-./build.sh --pack %{TIZEN_NET_NUGET_VERSION}
+
+%define build_cmd ./tools/scripts/retry.sh ./tools/scripts/timeout.sh -t 600 ./build.sh
+%{build_cmd} --full
+%{build_cmd} --dummy
+%{build_cmd} --pack %{TIZEN_NET_NUGET_VERSION}
 
 %install
 mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_PATH}

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -144,9 +144,11 @@ GetFileList wearable > wearable.filelist
 
 rm -fr %{_tizenfx_bin_path}
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
-./build.sh --full
-./build.sh --dummy
-./build.sh --pack %{TIZEN_NET_NUGET_VERSION}
+
+%define build_cmd ./tools/scripts/retry.sh ./tools/scripts/timeout.sh -t 600 ./build.sh
+%{build_cmd} --full
+%{build_cmd} --dummy
+%{build_cmd} --pack %{TIZEN_NET_NUGET_VERSION}
 
 %install
 mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_PATH}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Remove retry and timeout command from build.sh.
This scripts are used in gbs build only.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
