### PR TITLE
[Packagemanager] Lock internal handle before set/unset event callback

### DIFF
--- a/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManager.cs
@@ -109,7 +109,7 @@ internal static partial class Interop
         internal static extern ErrorCode PackageManagerDestroy(IntPtr managerHandle);
 
         [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_set_event_status")]
-        internal static extern ErrorCode PackageManagerSetEvenStatus(SafePackageManagerHandle managerHandle, EventStatus eventStatus);
+        internal static extern ErrorCode PackageManagerSetEventStatus(SafePackageManagerHandle managerHandle, EventStatus eventStatus);
 
         [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_set_event_cb")]
         internal static extern ErrorCode PackageManagerSetEvent(SafePackageManagerHandle managerHandle, PackageManagerEventCallback callback, IntPtr userData);

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -1127,14 +1127,17 @@ namespace Tizen.Applications
 
             if (!Handle.IsInvalid)
             {
-                Log.Debug(LogTag, "Reset Package Event");
-                err = Interop.PackageManager.PackageManagerUnsetEvent(Handle);
-                if (err != Interop.PackageManager.ErrorCode.None)
+                lock (Handle)
                 {
-                    throw PackageManagerErrorFactory.GetException(err, "Failed to unregister package manager event event.");
-                }
+                    Log.Debug(LogTag, "Reset Package Event");
+                    err = Interop.PackageManager.PackageManagerUnsetEvent(Handle);
+                    if (err != Interop.PackageManager.ErrorCode.None)
+                    {
+                        throw PackageManagerErrorFactory.GetException(err, "Failed to unregister package manager event event.");
+                    }
 
-                err = Interop.PackageManager.PackageManagerSetEvent(Handle, s_packageManagerEventCallback, IntPtr.Zero);
+                    err = Interop.PackageManager.PackageManagerSetEvent(Handle, s_packageManagerEventCallback, IntPtr.Zero);
+                }
             }
             if (err != Interop.PackageManager.ErrorCode.None)
             {
@@ -1182,10 +1185,13 @@ namespace Tizen.Applications
 
             s_packageManagerEventCallback = null;
 
-            var err = Interop.PackageManager.PackageManagerUnsetEvent(Handle);
-            if (err != Interop.PackageManager.ErrorCode.None)
+            lock (Handle)
             {
-                throw PackageManagerErrorFactory.GetException(err, "Failed to unregister package manager event event.");
+                var err = Interop.PackageManager.PackageManagerUnsetEvent(Handle);
+                if (err != Interop.PackageManager.ErrorCode.None)
+                {
+                    throw PackageManagerErrorFactory.GetException(err, "Failed to unregister package manager event event.");
+                }
             }
         }
     }

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -1079,7 +1079,7 @@ namespace Tizen.Applications
             var err = Interop.PackageManager.ErrorCode.None;
             if (s_eventStatus != eventStatus)
             {
-                err = Interop.PackageManager.PackageManagerSetEvenStatus(Handle, eventStatus);
+                err = Interop.PackageManager.PackageManagerSetEventStatus(Handle, eventStatus);
                 if (err == Interop.PackageManager.ErrorCode.None)
                 {
                     s_eventStatus = eventStatus;
@@ -1106,7 +1106,7 @@ namespace Tizen.Applications
             var err = Interop.PackageManager.ErrorCode.None;
             if (s_eventStatus != eventStatus)
             {
-                err = Interop.PackageManager.PackageManagerSetEvenStatus(Handle, eventStatus);
+                err = Interop.PackageManager.PackageManagerSetEventStatus(Handle, eventStatus);
                 if (err == Interop.PackageManager.ErrorCode.None)
                 {
                     s_eventStatus = eventStatus;


### PR DESCRIPTION
### Description of Change ###
Since native API is not thread-safe, managed code should lock
SafePackageManager handle object before set/unset event callback.


### API Changes ###
N/A
