### PR TITLE
[WebView] Remove unused API

### DIFF
--- a/src/Tizen.WebView/Tizen.WebView/SmartCallbackArgs.cs
+++ b/src/Tizen.WebView/Tizen.WebView/SmartCallbackArgs.cs
@@ -33,50 +33,6 @@ namespace Tizen.WebView
         }
 
         /// <summary>
-        /// Gets the argument as an integer type.
-        /// </summary>
-        /// <returns>Argument as an integer type.</returns>
-        /// <since_tizen> 4 </since_tizen>
-        public int GetAsInteger()
-        {
-            if (_arg == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return Marshal.ReadInt32(_arg, 0);
-        }
-
-        /// <summary>
-        /// Gets the argument as a double type.
-        /// </summary>
-        /// <returns>Argument as a double type.</returns>
-        /// <since_tizen> 4 </since_tizen>
-        public double GetAsDouble()
-        {
-            if (_arg == IntPtr.Zero)
-            {
-                return 0d;
-            }
-            double[] ret = new double[1];
-            Marshal.Copy(_arg, ret, 0, 1);
-            return ret[0];
-        }
-
-        /// <summary>
-        /// Gets the argument as a boolean type.
-        /// </summary>
-        /// <returns>Argument as a boolean type.</returns>
-        /// <since_tizen> 4 </since_tizen>
-        public bool GetAsBoolean()
-        {
-            if (_arg == IntPtr.Zero)
-            {
-                return false;
-            }
-            return Marshal.ReadByte(_arg) != (byte)0;
-        }
-
-        /// <summary>
         /// Gets the argument as a string type.
         /// </summary>
         /// <returns>Argument as a string type.</returns>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This patch removes unused API from SmartCallbackArgs.
It will be re-landed when it is needed.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->

Removed:
 - int SmartCallbackArgs.GetAsInteger()
 - int SmartCallbackArgs.GetAsDouble()
 - int SmartCallbackArgs.GetAsBoolean()