### PR TITLE
[NUI] Disconnect all native signals of Window class when application …

### DIFF
--- a/src/Tizen.NUI/src/internal/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application.cs
@@ -1002,6 +1002,8 @@ namespace Tizen.NUI
                 e.Application = this;
                 _applicationTerminateEventHandler.Invoke(this, e);
             }
+
+            Window.Instance.DisconnectNativeSignals();
         }
 
         /**

--- a/src/Tizen.NUI/src/public/Window.cs
+++ b/src/Tizen.NUI/src/public/Window.cs
@@ -1789,5 +1789,63 @@ namespace Tizen.NUI
             }
         }
 
+        /// <summary>
+        /// Disconnect all native signals
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        internal void DisconnectNativeSignals() 
+        {
+            if( _windowFocusChangedEventCallback != null )
+            {
+                WindowFocusChangedSignal().Disconnect(_windowFocusChangedEventCallback);
+            }
+
+            if( _rootLayerTouchDataCallback != null )
+            {
+                TouchDataSignal().Disconnect(_rootLayerTouchDataCallback);
+            }
+
+            if( _wheelEventCallback != null )
+            {
+                StageWheelEventSignal().Disconnect(_wheelEventCallback);
+            }
+
+            if( _stageKeyCallbackDelegate != null )
+            {
+                KeyEventSignal().Disconnect(_stageKeyCallbackDelegate);
+            }
+
+            if( _stageEventProcessingFinishedEventCallbackDelegate != null )
+            {
+                EventProcessingFinishedSignal().Disconnect(_stageEventProcessingFinishedEventCallbackDelegate);
+            }
+
+            if( _stageContextLostEventCallbackDelegate != null )
+            {
+                ContextLostSignal().Disconnect(_stageContextLostEventCallbackDelegate);
+            }
+
+            if( _stageContextRegainedEventCallbackDelegate != null )
+            {
+                ContextRegainedSignal().Disconnect(_stageContextRegainedEventCallbackDelegate);
+            }
+
+            if( _stageSceneCreatedEventCallbackDelegate != null )
+            {
+                SceneCreatedSignal().Disconnect(_stageSceneCreatedEventCallbackDelegate);
+            }
+
+            if( _windowResizedEventCallback != null )
+            {
+                ResizedSignal().Disconnect(_windowResizedEventCallback);
+            }
+
+            if( _windowFocusChangedEventCallback2 != null )
+            {
+                WindowFocusChangedSignal().Disconnect(_windowFocusChangedEventCallback2);
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
### Description of Change ###
[NUI] Disconnect all native signals of Window class when application is terminated
  - defensive code for timing critical issue (application is terminating and CLR is disposing)

### API Changes ###
None