### PR TITLE
[Build] Use regexp in CodeChecker for parsing the unified diff lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.suo
 *.user
 *.sln.docstates
+*.pyc
 
 # Build results
 


### PR DESCRIPTION
### Description of Change ###
Use regexp in CodeChecker for parsing the unified diff lines


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
