### PR TITLE
[Application] Fix SynchronizationContext issue

### DIFF
--- a/src/Tizen.Applications.WatchApplication/Tizen.Applications.CoreBackend/WatchCoreBackend.cs
+++ b/src/Tizen.Applications.WatchApplication/Tizen.Applications.CoreBackend/WatchCoreBackend.cs
@@ -116,6 +116,8 @@ namespace Tizen.Applications.CoreBackend
 
         public void Run(string[] args)
         {
+            TizenSynchronizationContext.Initialize();
+
             Interop.Watch.ErrorCode err = Interop.Watch.ErrorCode.None;
 
             err = Interop.Watch.AddEventHandler(out _lowMemoryEventHandle, Interop.Watch.AppEventType.LowMemory, _lowMemoryCallback, IntPtr.Zero);

--- a/src/Tizen.Applications.WidgetApplication/Tizen.Applications.CoreBackend/WidgetCoreBackend.cs
+++ b/src/Tizen.Applications.WidgetApplication/Tizen.Applications.CoreBackend/WidgetCoreBackend.cs
@@ -109,6 +109,8 @@ namespace Tizen.Applications.CoreBackend
 
         public void Run(string[] args)
         {
+            TizenSynchronizationContext.Initialize();
+
             Interop.Widget.ErrorCode err = Interop.Widget.ErrorCode.None;
             err = Interop.Widget.AddEventHandler(out _lowMemoryEventHandle, Interop.Widget.AppEventType.LowMemory, _lowMemoryCallback, IntPtr.Zero);
             if (err != Interop.Widget.ErrorCode.None)


### PR DESCRIPTION
### Description of Change ###
 - Set SynchronizationContext on WidgetCoreBackend.Run
 - Set SynchronizationContext on WatchCoreBackend.Run

 Fix https://github.com/Samsung/TizenFX/issues/628

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
