### PR TITLE
[Applications] Fix static analysis issue

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -101,17 +101,6 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public override void Run(string[] args)
         {
-            base.Run(args);
-
-            _backend.AddEventHandler(EventType.Created, OnCreate);
-            _backend.AddEventHandler(EventType.Terminated, OnTerminate);
-            _backend.AddEventHandler<AppControlReceivedEventArgs>(EventType.AppControlReceived, OnAppControlReceived);
-            _backend.AddEventHandler<LowMemoryEventArgs>(EventType.LowMemory, OnLowMemory);
-            _backend.AddEventHandler<LowBatteryEventArgs>(EventType.LowBattery, OnLowBattery);
-            _backend.AddEventHandler<LocaleChangedEventArgs>(EventType.LocaleChanged, OnLocaleChanged);
-            _backend.AddEventHandler<RegionFormatChangedEventArgs>(EventType.RegionFormatChanged, OnRegionFormatChanged);
-            _backend.AddEventHandler<DeviceOrientationEventArgs>(EventType.DeviceOrientationChanged, OnDeviceOrientationChanged);
-
             string[] argsClone = null;
 
             if (args == null)
@@ -124,6 +113,18 @@ namespace Tizen.Applications
                 args.CopyTo(argsClone, 1);
             }
             argsClone[0] = string.Empty;
+
+            base.Run(argsClone);
+
+            _backend.AddEventHandler(EventType.Created, OnCreate);
+            _backend.AddEventHandler(EventType.Terminated, OnTerminate);
+            _backend.AddEventHandler<AppControlReceivedEventArgs>(EventType.AppControlReceived, OnAppControlReceived);
+            _backend.AddEventHandler<LowMemoryEventArgs>(EventType.LowMemory, OnLowMemory);
+            _backend.AddEventHandler<LowBatteryEventArgs>(EventType.LowBattery, OnLowBattery);
+            _backend.AddEventHandler<LocaleChangedEventArgs>(EventType.LocaleChanged, OnLocaleChanged);
+            _backend.AddEventHandler<RegionFormatChangedEventArgs>(EventType.RegionFormatChanged, OnRegionFormatChanged);
+            _backend.AddEventHandler<DeviceOrientationEventArgs>(EventType.DeviceOrientationChanged, OnDeviceOrientationChanged);
+
             _backend.Run(argsClone);
         }
 


### PR DESCRIPTION
To avoid ArgumentNullException, we have to check the args before calling
base.Run().

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
This patch is for checking args parameter before calling base.run().
Currently, if args is null, ArgumentNullException can be occurred.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: Not Required

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
