### PR TITLE
Revert "[Applications] Fix static analysis issue"

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -101,6 +101,17 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public override void Run(string[] args)
         {
+            base.Run(args);
+
+            _backend.AddEventHandler(EventType.Created, OnCreate);
+            _backend.AddEventHandler(EventType.Terminated, OnTerminate);
+            _backend.AddEventHandler<AppControlReceivedEventArgs>(EventType.AppControlReceived, OnAppControlReceived);
+            _backend.AddEventHandler<LowMemoryEventArgs>(EventType.LowMemory, OnLowMemory);
+            _backend.AddEventHandler<LowBatteryEventArgs>(EventType.LowBattery, OnLowBattery);
+            _backend.AddEventHandler<LocaleChangedEventArgs>(EventType.LocaleChanged, OnLocaleChanged);
+            _backend.AddEventHandler<RegionFormatChangedEventArgs>(EventType.RegionFormatChanged, OnRegionFormatChanged);
+            _backend.AddEventHandler<DeviceOrientationEventArgs>(EventType.DeviceOrientationChanged, OnDeviceOrientationChanged);
+
             string[] argsClone = null;
 
             if (args == null)
@@ -113,18 +124,6 @@ namespace Tizen.Applications
                 args.CopyTo(argsClone, 1);
             }
             argsClone[0] = string.Empty;
-
-            base.Run(argsClone);
-
-            _backend.AddEventHandler(EventType.Created, OnCreate);
-            _backend.AddEventHandler(EventType.Terminated, OnTerminate);
-            _backend.AddEventHandler<AppControlReceivedEventArgs>(EventType.AppControlReceived, OnAppControlReceived);
-            _backend.AddEventHandler<LowMemoryEventArgs>(EventType.LowMemory, OnLowMemory);
-            _backend.AddEventHandler<LowBatteryEventArgs>(EventType.LowBattery, OnLowBattery);
-            _backend.AddEventHandler<LocaleChangedEventArgs>(EventType.LocaleChanged, OnLocaleChanged);
-            _backend.AddEventHandler<RegionFormatChangedEventArgs>(EventType.RegionFormatChanged, OnRegionFormatChanged);
-            _backend.AddEventHandler<DeviceOrientationEventArgs>(EventType.DeviceOrientationChanged, OnDeviceOrientationChanged);
-
             _backend.Run(argsClone);
         }
 


### PR DESCRIPTION
Reverts Samsung/TizenFX#659

It cause behavior change
and It is **NOT** issue throwing exception when args was null
If you want to allow null reference on args, 
please fix below code
https://github.com/Samsung/TizenFX/blob/e3ef2c83139d7f3985809aa2ac5be8a740b520dd/src/Tizen.Applications.Common/Tizen.Applications/Application.cs#L121-L124