### PR TITLE
[Applications] Modify args handling

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -112,18 +112,13 @@ namespace Tizen.Applications
             _backend.AddEventHandler<RegionFormatChangedEventArgs>(EventType.RegionFormatChanged, OnRegionFormatChanged);
             _backend.AddEventHandler<DeviceOrientationEventArgs>(EventType.DeviceOrientationChanged, OnDeviceOrientationChanged);
 
-            string[] argsClone = null;
-
-            if (args == null)
+            string[] argsClone = new string[args.Length + 1];
+            if (args.Length > 1)
             {
-                argsClone = new string[1];
-            }
-            else
-            {
-                argsClone = new string[args.Length + 1];
                 args.CopyTo(argsClone, 1);
             }
             argsClone[0] = string.Empty;
+
             _backend.Run(argsClone);
         }
 


### PR DESCRIPTION
If args is null, throwing ArgumentNullException is occurred.
The null check logic is unnecessary. It's removed.
This patch checks the length of args before copying args.

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
Checking the length of args is added instead of unnecessary check null logic.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:Not required

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
