### PR TITLE
[Bluetooth] Fix the re-register GATT server issue (#688)

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGattImpl.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGattImpl.cs
@@ -640,7 +640,6 @@ namespace Tizen.Network.Bluetooth
                 int err;
 
                 err = Interop.Bluetooth.BtGattServerDestroy(handle);
-
                 if (err.IsFailed())
                 {
                     Log.Error(Globals.LogTag, "Failed to destroy the server instance");


### PR DESCRIPTION
### Description of Change ###
Fix the bug to re-register GATT server. The API calling sequence was wrong.
After destroying server, we should call the bt_gatt_server_deinitialize API

### API Changes ###
 - ACR: No ACR