### PR TITLE
[AudioManager] Add HasStreamOnDevice method to AudioStreamPolicy

### DIFF
--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -314,7 +314,7 @@ namespace Tizen.Multimedia
         /// <exception cref="ObjectDisposedException">The <see cref="AudioStreamPolicy"/> has already been disposed of.</exception>
         /// <seealso cref="AudioManager.GetConnectedDevices()"/>
         /// <since_tizen> 6 </since_tizen>
-        public bool IsStreamOnDevice(AudioDevice device)
+        public bool HasStreamOnDevice(AudioDevice device)
         {
             if (device == null)
             {

--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -309,6 +309,14 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <returns>true if any audio stream from the current AudioStreamPolicy is using the device; otherwise, false.</returns>
         /// <param name="device">The device to be checked.</param>
+        /// <remarks>
+        /// The AudioStreamPolicy can be applied to each playback or recording stream via other API set.
+        /// (For example., <see cref="T:Tizen.Multimedia.Player"/>, <see cref="T:Tizen.Multimedia.WavPlayer"/>,
+        /// <see cref="T:Tizen.Multimedia.AudioPlayback"/>, <see cref="T:Tizen.Multimedia.AudioCapture"/>, etc.)
+        /// This method returns true only when the device is used for the stream which meets to the two conditions.
+        /// One is that the current AudioStreamPolicy sets a audio route path to the device and the other is that the playback
+        /// or recording stream from other API set should have already started to prepare or to play.(It depends on the API set.)
+        /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
         /// <exception cref="InvalidOperationException">An internal error occurs.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="AudioStreamPolicy"/> has already been disposed of.</exception>

--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -305,6 +305,29 @@ namespace Tizen.Multimedia
         }
 
         /// <summary>
+        /// Checks if any stream from the current AudioStreamPolicy is using the device.
+        /// </summary>
+        /// <returns>true if any audio stream from the current AudioStreamPolicy is using the device; otherwise, false.</returns>
+        /// <param name="device">The device to be checked.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">An internal error occurs.</exception>
+        /// <exception cref="ObjectDisposedException">The <see cref="AudioStreamPolicy"/> has already been disposed of.</exception>
+        /// <seealso cref="AudioManager.GetConnectedDevices()"/>
+        /// <since_tizen> 6 </since_tizen>
+        public bool IsStreamOnDevice(AudioDevice device)
+        {
+            if (device == null)
+            {
+                throw new ArgumentNullException(nameof(device));
+            }
+
+            var ret = Interop.AudioStreamPolicy.IsStreamOnDevice(Handle, device.Id, out var isOn);
+            ret.ThrowIfError("Failed to check stream on device");
+
+            return isOn;
+        }
+
+        /// <summary>
         /// Releases all resources used by the <see cref="AudioStreamPolicy"/>.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.Multimedia/Interop/Interop.StreamPolicy.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.StreamPolicy.cs
@@ -81,6 +81,10 @@ namespace Tizen.Multimedia
 
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_remove_focus_state_watch_cb")]
             internal static extern int RemoveFocusStateWatchCallback(int id);
+
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_stream_on_device_by_id")]
+            internal static extern AudioManagerError IsStreamOnDevice(AudioStreamPolicyHandle streamInfo, int deviceId,
+                out bool isOn);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Sangchul Lee <sc11.lee@samsung.com>

### Description of Change ###
Add **HasStreamOnDevice** method to AudioStreamPolicy class. This functionality has already exist in NativeAPI since Tizen 3.0.
It checks whether if any stream from the current AudioStreamPolicy is using the device.

### API Changes ###
 - ACR: TCSACR-220
