### PR TITLE
[ElmSharp] Fix memory leak on Image.LoadAsync method

### DIFF
--- a/src/ElmSharp/ElmSharp/EvasObject.cs
+++ b/src/ElmSharp/ElmSharp/EvasObject.cs
@@ -1219,7 +1219,8 @@ namespace ElmSharp
 
         private void DisposeEvent()
         {
-            foreach (var evt in _eventStore)
+            var events = new List<IInvalidatable>(_eventStore);
+            foreach (var evt in events)
             {
                 evt.Dispose();
             }
@@ -1238,6 +1239,11 @@ namespace ElmSharp
         internal void AddToEventLifeTracker(IInvalidatable item)
         {
             _eventStore.Add(item);
+        }
+
+        internal void RemoveFromEventLifeTracker(IInvalidatable item)
+        {
+            _eventStore.Remove(item);
         }
     }
 }

--- a/src/ElmSharp/ElmSharp/EvasObjectEvent.cs
+++ b/src/ElmSharp/ElmSharp/EvasObjectEvent.cs
@@ -351,7 +351,7 @@ namespace ElmSharp
             {
                 if (disposing)
                 {
-                    // Place holder to dispose managed state (managed objects).
+                    _sender.RemoveFromEventLifeTracker(this);
                 }
                 if (_handle != IntPtr.Zero)
                 {

--- a/src/ElmSharp/ElmSharp/Image.cs
+++ b/src/ElmSharp/ElmSharp/Image.cs
@@ -431,7 +431,7 @@ namespace ElmSharp
         public bool Load(string file)
         {
             if (file == null)
-                throw new ArgumentNullException("file");
+                throw new ArgumentNullException(nameof(file));
 
             Interop.Elementary.elm_image_async_open_set(RealHandle, false);
             Interop.Elementary.elm_image_preload_disabled_set(RealHandle, true);
@@ -447,7 +447,7 @@ namespace ElmSharp
         public bool Load(Uri uri)
         {
             if (uri == null)
-                throw new ArgumentNullException("uri");
+                throw new ArgumentNullException(nameof(uri));
 
             return Load(uri.IsFile ? uri.LocalPath : uri.AbsoluteUri);
         }
@@ -468,7 +468,7 @@ namespace ElmSharp
         public unsafe bool Load(byte* img, long size)
         {
             if (img == null)
-                throw new ArgumentNullException("img");
+                throw new ArgumentNullException(nameof(img));
 
             Interop.Elementary.elm_image_async_open_set(RealHandle, false);
             Interop.Elementary.elm_image_preload_disabled_set(RealHandle, true);
@@ -484,7 +484,7 @@ namespace ElmSharp
         public bool Load(Stream stream)
         {
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             Interop.Elementary.elm_image_async_open_set(RealHandle, false);
             Interop.Elementary.elm_image_preload_disabled_set(RealHandle, true);
@@ -507,10 +507,10 @@ namespace ElmSharp
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>(true = success, false = error)</returns>
         /// <since_tizen> preview </since_tizen>
-        public Task<bool> LoadAsync(string file, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<bool> LoadAsync(string file, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (file == null)
-                throw new ArgumentNullException("file");
+                throw new ArgumentNullException(nameof(file));
 
             Interop.Elementary.elm_image_async_open_set(RealHandle, true);
             Interop.Elementary.elm_image_preload_disabled_set(RealHandle, false);
@@ -528,7 +528,6 @@ namespace ElmSharp
             SmartEvent loadReady = new SmartEvent(this, RealHandle, "load,ready");
             loadReady.On += (s, e) =>
             {
-                loadReady.Dispose();
                 LoadingCompleted?.Invoke(this, EventArgs.Empty);
                 if (tcs != null && !tcs.Task.IsCompleted)
                 {
@@ -539,7 +538,6 @@ namespace ElmSharp
             SmartEvent loadError = new SmartEvent(this, RealHandle, "load,error");
             loadError.On += (s, e) =>
             {
-                loadError.Dispose();
                 LoadingFailed?.Invoke(this, EventArgs.Empty);
                 if (tcs != null && !tcs.Task.IsCompleted)
                 {
@@ -547,13 +545,17 @@ namespace ElmSharp
                 }
             };
 
-            bool ret = Interop.Elementary.elm_image_file_set(RealHandle, file, null);
-            if (!ret)
+            using (loadReady)
+            using (loadError)
             {
-                throw new InvalidOperationException("Failed to set file to Image");
+                bool ret = Interop.Elementary.elm_image_file_set(RealHandle, file, null);
+                if (!ret)
+                {
+                    throw new InvalidOperationException("Failed to set file to Image");
+                }
+                // it should be return on main thread, because SmartEvent should be disposed on main thread
+                return await tcs.Task.ConfigureAwait(true); 
             }
-
-            return tcs.Task;
         }
 
         /// <summary>
@@ -566,7 +568,7 @@ namespace ElmSharp
         public Task<bool> LoadAsync(Uri uri, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (uri == null)
-                throw new ArgumentNullException("uri");
+                throw new ArgumentNullException(nameof(uri));
 
             return LoadAsync(uri.IsFile ? uri.LocalPath : uri.AbsoluteUri, cancellationToken);
         }
@@ -581,7 +583,7 @@ namespace ElmSharp
         public async Task<bool> LoadAsync(Stream stream, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (stream == null)
-                throw new ArgumentNullException("stream");
+                throw new ArgumentNullException(nameof(stream));
 
             Interop.Elementary.elm_image_async_open_set(RealHandle, true);
             Interop.Elementary.elm_image_preload_disabled_set(RealHandle, false);
@@ -599,7 +601,6 @@ namespace ElmSharp
             SmartEvent loadReady = new SmartEvent(this, RealHandle, "load,ready");
             loadReady.On += (s, e) =>
             {
-                loadReady.Dispose();
                 LoadingCompleted?.Invoke(this, EventArgs.Empty);
                 if (tcs != null && !tcs.Task.IsCompleted)
                 {
@@ -610,7 +611,6 @@ namespace ElmSharp
             SmartEvent loadError = new SmartEvent(this, RealHandle, "load,error");
             loadError.On += (s, e) =>
             {
-                loadError.Dispose();
                 LoadingFailed?.Invoke(this, EventArgs.Empty);
                 if (tcs != null && !tcs.Task.IsCompleted)
                 {
@@ -619,8 +619,10 @@ namespace ElmSharp
             };
 
             using (MemoryStream memstream = new MemoryStream())
+            using (loadReady)
+            using (loadError)
             {
-                await stream.CopyToAsync(memstream);
+                await stream.CopyToAsync(memstream).ConfigureAwait(true);
 
                 unsafe
                 {
@@ -634,9 +636,9 @@ namespace ElmSharp
                         }
                     }
                 }
+                // it should be return on main thread, because SmartEvent should be disposed on main thread
+                return await tcs.Task.ConfigureAwait(true);
             }
-
-            return await tcs.Task;
         }
 
         /// <summary>

--- a/src/ElmSharp/ElmSharp/SmartEvent.cs
+++ b/src/ElmSharp/ElmSharp/SmartEvent.cs
@@ -171,7 +171,7 @@ namespace ElmSharp
         {
             if (disposing)
             {
-                // Place holder to dispose managed state (managed objects).
+                _sender.RemoveFromEventLifeTracker(this);
             }
             if (_handle != IntPtr.Zero)
             {


### PR DESCRIPTION
### Description of Change ###
 * Dispose SmartEvent object on LoadAsync method with using block
 * When SmartEvent was disposed, remove from EventLifeTracker to quickly released by GC

 * Fix https://github.com/Samsung/TizenFX/issues/719


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
