### PR TITLE
[Elmsharp.Wearable][Non-ACR] Add obsolete and remark for marker API

### DIFF
--- a/src/ElmSharp.Wearable/ElmSharp.Wearable/CircleDatetimeSelector.cs
+++ b/src/ElmSharp.Wearable/ElmSharp.Wearable/CircleDatetimeSelector.cs
@@ -98,7 +98,11 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Sets or gets the color of the marker.
         /// </summary>
+        /// <remarks>
+        /// MarkerColor is not supported on device or emulator which does not support marker in CircleDatetimeSelector and CircleSpinner.
+        /// </remarks>
         /// <since_tizen> preview </since_tizen>
+        [Obsolete("MarkerColor is obsolete as of version 6.0.0 and is no longer supported")]
         public Color MarkerColor
         {
             get
@@ -116,7 +120,11 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Sets or gets the line width of the marker.
         /// </summary>
+        /// <remarks>
+        /// MarkerLineWidth is not supported on device or emulator which does not support marker in CircleDatetimeSelector and CircleSpinner.
+        /// </remarks>
         /// <since_tizen> preview </since_tizen>
+        [Obsolete("MarkerLineWidth is obsolete as of version 6.0.0 and is no longer supported")]
         public int MarkerLineWidth
         {
             get
@@ -132,7 +140,11 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Sets or gets the radius at which the center of the marker lies.
         /// </summary>
+        /// <remarks>
+        /// MarkerRadius is not supported on device or emulator which does not support marker in CircleDatetimeSelector and CircleSpinner.
+        /// </remarks>
         /// <since_tizen> preview </since_tizen>
+        [Obsolete("MarkerRadius is obsolete as of version 6.0.0 and is no longer supported")]
         public double MarkerRadius
         {
             get

--- a/src/ElmSharp.Wearable/ElmSharp.Wearable/CircleSpinner.cs
+++ b/src/ElmSharp.Wearable/ElmSharp.Wearable/CircleSpinner.cs
@@ -137,7 +137,11 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Sets or gets the line width of the marker.
         /// </summary>
+        /// <remarks>
+        /// MarkerLineWidth is not supported on device or emulator which does not support marker in CircleDatetimeSelector and CircleSpinner.
+        /// </remarks>
         /// <since_tizen> preview </since_tizen>
+        [Obsolete("MarkerLineWidth is obsolete as of version 6.0.0 and is no longer supported")]
         public int MarkerLineWidth
         {
             get
@@ -153,7 +157,11 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Sets or gets the color of the marker.
         /// </summary>
+        /// <remarks>
+        /// MarkerColor is not supported on device or emulator which does not support marker in CircleDatetimeSelector and CircleSpinner.
+        /// </remarks>
         /// <since_tizen> preview </since_tizen>
+        [Obsolete("MarkerColor is obsolete as of version 6.0.0 and is no longer supported")]
         public Color MarkerColor
         {
             get
@@ -171,7 +179,11 @@ namespace ElmSharp.Wearable
         /// <summary>
         /// Sets or gets the radius at which the center of the marker lies.
         /// </summary>
+        /// <remarks>
+        /// MarkerRadius is not supported on device or emulator which does not support marker in CircleDatetimeSelector and CircleSpinner.
+        /// </remarks>
         /// <since_tizen> preview </since_tizen>
+        [Obsolete("MarkerRadius is obsolete as of version 6.0.0 and is no longer supported")]
         public double MarkerRadius
         {
             get


### PR DESCRIPTION
### Description of Change ###
I add obsolete and remark for marker API because efl will not support marker in CircleDateTime and CircleSpinner.


### API Changes ###
 - ACR: N/A
