### PR TITLE
[NUI] Add to get LogicalKey and KeyPressed

### DIFF
--- a/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/NDalicPINVOKE.cs
@@ -4139,6 +4139,8 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_Key_state_get")]
         public static extern int Key_state_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+        [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_Key_logicalKey_get")]
+        public static extern string Key_logicalKey_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
         [global::System.Runtime.InteropServices.DllImport("libdali-csharp-binder.so", EntryPoint = "CSharp_Dali_new_LongPressGestureDetector__SWIG_0")]
         public static extern global::System.IntPtr new_LongPressGestureDetector__SWIG_0();

--- a/src/Tizen.NUI/src/public/Key.cs
+++ b/src/Tizen.NUI/src/public/Key.cs
@@ -159,7 +159,28 @@ namespace Tizen.NUI
             }
         }
 
-        /* duplicated with KeyPressedName : removed
+        /// <summary>
+        /// Get the logical key string. (eg. shift + 1 == "exclamation")
+        /// </summary>
+        /// <returns>The logical key symbol</returns>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string LogicalKey
+        {
+            get
+            {
+                return logicalKey;
+            }
+        }
+
+        /// <summary>
+        /// Get the actual string returned that should be used for input editors.
+        /// </summary>
+        /// <returns>The key string</returns>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string KeyPressed
         {
             get
@@ -167,7 +188,6 @@ namespace Tizen.NUI
                 return keyPressed;
             }
         }
-        */
 
         /// <summary>
         /// Keycode for the key pressed.
@@ -405,6 +425,16 @@ namespace Tizen.NUI
             get
             {
                 Key.StateType ret = (Key.StateType)NDalicPINVOKE.Key_state_get(swigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private string logicalKey
+        {
+            get
+            {
+                string ret = NDalicPINVOKE.Key_logicalKey_get(swigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }

--- a/src/Tizen.NUI/src/public/Key.cs
+++ b/src/Tizen.NUI/src/public/Key.cs
@@ -15,6 +15,8 @@
  *
  */
 
+using System.ComponentModel;
+
 namespace Tizen.NUI
 {
 


### PR DESCRIPTION
Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
The  user can get 'LogicalKey' and 'KeyPressed' information of Key Event.
These will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.

### API Changes ###
Added:
 - public string LogicalKey
 - public string KeyPressed


