### PR TITLE
[NUI] Fix NUI.WebView concerned with GC

### DIFF
--- a/src/Tizen.NUI/src/internal/WebView.cs
+++ b/src/Tizen.NUI/src/internal/WebView.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Tizen.NUI.BaseComponents;
 
@@ -418,6 +419,10 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void JavaScriptMessageHandler(string message);
 
+
+        // For rooting handlers
+        internal Dictionary<string, JavaScriptMessageHandler> handlerRootMap = new Dictionary<string, JavaScriptMessageHandler>();
+
         /// <summary>
         /// Add a message handler into the WebView.
         /// <param name="objectName">The name of exposed object</param>
@@ -426,8 +431,16 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddJavaScriptMessageHandler(string objectName, JavaScriptMessageHandler handler)
         {
+            if (handlerRootMap.ContainsKey(objectName))
+            {
+                return;
+            }
+
+            handlerRootMap.Add(objectName, handler);
+
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(handler);
             NDalicPINVOKE.WebView_AddJavaScriptMessageHandler(swigCPtr, objectName, new System.Runtime.InteropServices.HandleRef(this, ip));
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
JavaScriptMessageHandler delegate instances are collectable by GC,
so the concrete root for those instants are needed.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
