### PR TITLE
[ImageUtil] Deprecate useless CalculateBufferSize

### DIFF
--- a/src/Tizen.Multimedia.Util/ImageUtil/ImageUtil.cs
+++ b/src/Tizen.Multimedia.Util/ImageUtil/ImageUtil.cs
@@ -60,6 +60,7 @@ namespace Tizen.Multimedia.Util
         /// </exception>
         /// <exception cref="ArgumentException"><paramref name="colorSpace"/> is invalid.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Please do not use! This will be deprecated.")]
         public static int CalculateBufferSize(Size resolution, ColorSpace colorSpace)
         {
             if (resolution.Width <= 0)

--- a/src/Tizen.Multimedia.Util/ImageUtil/ImageUtil.cs
+++ b/src/Tizen.Multimedia.Util/ImageUtil/ImageUtil.cs
@@ -60,7 +60,7 @@ namespace Tizen.Multimedia.Util
         /// </exception>
         /// <exception cref="ArgumentException"><paramref name="colorSpace"/> is invalid.</exception>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Please do not use! This will be deprecated.")]
+        [Obsolete("Please do not use! This will be deprecated in level 6.")]
         public static int CalculateBufferSize(Size resolution, ColorSpace colorSpace)
         {
             if (resolution.Width <= 0)


### PR DESCRIPTION
### Description of Change ###
Deprecate useless `CalculateBufferSize` method.
C# API allocate buffer in managed memory with the size returning in native.

### API Changes ###
- TCSACR-241
