### PR TITLE
[MediaController] Remove useless method call and fix the bug of foreach method

### DIFF
--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerPlaylist.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.MediaControllerPlaylist.cs
@@ -31,7 +31,7 @@ internal static partial class Interop
             IntPtr handle, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void PlaylistCallback(IntPtr handle, IntPtr userData);
+        internal delegate bool PlaylistCallback(IntPtr handle, IntPtr userData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool PlaylistItemCallback(string index, IntPtr handle, IntPtr userData);

--- a/src/Tizen.Multimedia.Remoting/MediaController/MediaControlPlaylist.cs
+++ b/src/Tizen.Multimedia.Remoting/MediaController/MediaControlPlaylist.cs
@@ -190,8 +190,6 @@ namespace Tizen.Multimedia.Remoting
             {
                 AddMetadata(data.Key, data.Value);
             }
-
-            MediaControlServer.SavePlaylist(Handle);
         }
 
         /// <summary>

--- a/src/Tizen.Multimedia.Remoting/MediaController/MediaController.cs
+++ b/src/Tizen.Multimedia.Remoting/MediaController/MediaController.cs
@@ -189,12 +189,28 @@ namespace Tizen.Multimedia.Remoting
 
             var playlists = new List<MediaControlPlaylist>();
 
+            Exception caught = null;
+
             NativePlaylist.PlaylistCallback playlistCallback = (handle, _) =>
             {
-                playlists.Add(new MediaControlPlaylist(handle));
+                try
+                {
+                    playlists.Add(new MediaControlPlaylist(handle));
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    caught = e;
+                    return false;
+                }
             };
             NativePlaylist.ForeachServerPlaylist(Manager.Handle, ServerAppId, playlistCallback, IntPtr.Zero)
                 .ThrowIfError("Failed to get playlist.");
+
+            if (caught != null)
+            {
+                throw caught;
+            }
 
             return playlists.AsReadOnly();
         }


### PR DESCRIPTION
### Bug fix ###
1. Remove useless SavePlaylist() method call.
2. Fix return type of foreach callback function and its behavior.

* It's merged in master branch already.