### PR TITLE
[MediaPlayer] Modify the pre-condition of streaming function

### DIFF
--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
@@ -192,7 +192,8 @@ namespace Tizen.Multimedia
         /// Gets the streaming download progress.
         /// </summary>
         /// <returns>The <see cref="DownloadProgress"/> containing current download progress.</returns>
-        /// <remarks>The player must be in the <see cref="PlayerState.Playing"/> or <see cref="PlayerState.Paused"/> state.</remarks>
+        /// <remarks>The player must be in the <see cref="PlayerState.Ready"/>, <see cref="PlayerState.Playing"/>,
+        /// or <see cref="PlayerState.Paused"/> state.</remarks>
         /// <exception cref="InvalidOperationException">
         ///     The player is not streaming.<br/>
         ///     -or-<br/>
@@ -202,7 +203,7 @@ namespace Tizen.Multimedia
         /// <since_tizen> 3 </since_tizen>
         public DownloadProgress GetDownloadProgress()
         {
-            ValidatePlayerState(PlayerState.Playing, PlayerState.Paused);
+            ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
             int start = 0;
             int current = 0;


### PR DESCRIPTION
### Description of Change ###
[MediaPlayer] Modify the pre-condition of streaming function

Extend pre-condition include READY state so that the application could get buffering progress more earlier just right after calling Prepare.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-242

Changed :
Added PlayerState.Ready State
public DownloadProgress GetDownloadProgress()