### PR TITLE
[WebView] Replace eina_list_* with eina_iterator_*

### DIFF
--- a/src/Tizen.WebView/Interop/Interop.Eina.cs
+++ b/src/Tizen.WebView/Interop/Interop.Eina.cs
@@ -29,9 +29,16 @@ internal static partial class Interop
         internal static extern bool eina_hash_add(IntPtr hash, string Key, string Value);
 
         [DllImport(Libraries.Eina)]
-        internal static extern uint eina_list_count(IntPtr list);
+        internal static extern IntPtr eina_list_iterator_new(IntPtr list);
 
         [DllImport(Libraries.Eina)]
-        internal static extern IntPtr eina_list_nth(IntPtr list, uint n);
+        [return: MarshalAs(UnmanagedType.U1)]
+        internal static extern bool eina_iterator_next(IntPtr iterator, out IntPtr data);
+
+        [DllImport(Libraries.Eina)]
+        internal static extern void eina_iterator_free(IntPtr list);
+
+        [DllImport(Libraries.Eina)]
+        internal static extern IntPtr eina_list_free(IntPtr list);
     }
 }

--- a/src/Tizen.WebView/Tizen.WebView/BackForwardList.cs
+++ b/src/Tizen.WebView/Tizen.WebView/BackForwardList.cs
@@ -156,15 +156,17 @@ namespace Tizen.WebView
         /// <since_tizen> 6 </since_tizen>
         public IList<BackForwardListItem> BackItems(int limit)
         {
-            IntPtr backList = Interop.ChromiumEwk.ewk_back_forward_list_n_back_items_copy(_list_handle, limit);
+            IntPtr list = Interop.ChromiumEwk.ewk_back_forward_list_n_back_items_copy(_list_handle, limit);
             List<BackForwardListItem> backItemsList = new List<BackForwardListItem>();
 
-            uint count = Interop.Eina.eina_list_count(backList);
-
-            for(uint i=0; i < count; i++) {
-              IntPtr data = Interop.Eina.eina_list_nth(backList, i);
+            var iter = Interop.Eina.eina_list_iterator_new(list);
+            for (IntPtr data; Interop.Eina.eina_iterator_next(iter, out data);) {
               backItemsList.Add(new BackForwardListItem(data));
             }
+
+            Interop.Eina.eina_iterator_free(iter);
+            Interop.Eina.eina_list_free(list);
+
             return backItemsList;
         }
 
@@ -177,15 +179,17 @@ namespace Tizen.WebView
         /// <since_tizen> 6 </since_tizen>
         public IList<BackForwardListItem> ForwardItems(int limit)
         {
-            IntPtr forwardList = Interop.ChromiumEwk.ewk_back_forward_list_n_forward_items_copy(_list_handle, limit);
+            IntPtr list = Interop.ChromiumEwk.ewk_back_forward_list_n_forward_items_copy(_list_handle, limit);
             List<BackForwardListItem> forwardItemsList = new List<BackForwardListItem>();
 
-            uint count = Interop.Eina.eina_list_count(forwardList);
-
-            for(uint i = 0; i < count; i++) {
-              IntPtr data = Interop.Eina.eina_list_nth(forwardList, i);
+            var iter = Interop.Eina.eina_list_iterator_new(list);
+            for (IntPtr data; Interop.Eina.eina_iterator_next(iter, out data);) {
               forwardItemsList.Add(new BackForwardListItem(data));
             }
+
+            Interop.Eina.eina_iterator_free(iter);
+            Interop.Eina.eina_list_free(list);
+
             return forwardItemsList;
         }
     }


### PR DESCRIPTION
Signed-off-by: yh106.jung <yh106.jung@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
We cannot invoke eina_list_count because it is inline, so this patch replaces eina_list_* with eina_iterator_*.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
