### PR TITLE
[OAuth2] Remove references to AuthorizeAsync method from documentation

### DIFF
--- a/src/Tizen.Account.OAuth2/Tizen.Account.OAuth2/CodeGrantAuthorizer.cs
+++ b/src/Tizen.Account.OAuth2/Tizen.Account.OAuth2/CodeGrantAuthorizer.cs
@@ -52,7 +52,7 @@ namespace Tizen.Account.OAuth2
         }
 
         /// <summary>
-        /// Retrieves access token by exchanging authorization code received using <see cref="AuthorizeAsync(AuthorizationRequest)"/>.
+        /// Retrieves access token by exchanging authorization code received using AuthorizeAsync(AuthorizationRequest/>.
         /// The authroization request parameters should be as defined in https://tools.ietf.org/html/rfc6749#section-4.1.3
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.Account.OAuth2/Tizen.Account.OAuth2/ImplicitGrantAuthorizer.cs
+++ b/src/Tizen.Account.OAuth2/Tizen.Account.OAuth2/ImplicitGrantAuthorizer.cs
@@ -52,7 +52,7 @@ namespace Tizen.Account.OAuth2
         }
 
         /// <summary>
-        /// Access token can be retreived implicitly using <see cref="AuthorizeAsync"/> in this flow.
+        /// Access token can be retreived implicitly using AuthorizeAsync in this flow.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when the operation is not supported</exception>


### PR DESCRIPTION
### Description of Change ###
This commit fixes documentation issues found in PR #849


