### PR TITLE
[Build] Suppress CS0618 warnings due to internal reference

### DIFF
--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/Folder.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/Folder.cs
@@ -28,6 +28,7 @@ namespace Tizen.Content.MediaContent
     /// <since_tizen> 4 </since_tizen>
     public class Folder
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         internal Folder(IntPtr handle)
         {
             Id = InteropHelper.GetString(handle, Interop.Folder.GetFolderId);
@@ -37,7 +38,7 @@ namespace Tizen.Content.MediaContent
             StorageType = InteropHelper.GetValue<StorageType>(handle, Interop.Folder.GetStorageType);
             StorageId = InteropHelper.GetString(handle, Interop.Folder.GetStorageId);
         }
-
+#pragma warning restore CS0618 // Type or member is obsolete
         internal static Folder FromHandle(IntPtr handle) => new Folder(handle);
 
         /// <summary>
@@ -77,6 +78,7 @@ namespace Tizen.Content.MediaContent
         [Obsolete("Please do not use! this will be deprecated in level 6")]
         public string StorageId { get; }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
         /// Returns a string representation of the folder.
         /// </summary>
@@ -84,5 +86,6 @@ namespace Tizen.Content.MediaContent
         /// <since_tizen> 4 </since_tizen>
         public override string ToString() =>
             $"Id={Id}, Name={Name}, Path={Path}, StorageType={StorageType}, StorageId={StorageType}";
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfo.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfo.cs
@@ -26,6 +26,7 @@ namespace Tizen.Content.MediaContent
     /// <since_tizen> 4 </since_tizen>
     public class MediaInfo
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         internal MediaInfo(Interop.MediaInfoHandle handle)
         {
             Id = InteropHelper.GetString(handle, Interop.MediaInfo.GetMediaId);
@@ -58,6 +59,7 @@ namespace Tizen.Content.MediaContent
 
             StorageType = InteropHelper.GetValue<StorageType>(handle, Interop.MediaInfo.GetStorageType);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Gets the ID of media.

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/QueryArguments.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/QueryArguments.cs
@@ -144,6 +144,7 @@ namespace Tizen.Content.MediaContent
             return handle;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         internal virtual bool IsEmpty()
         {
             return StorageId == null && FilterExpression == null;
@@ -163,6 +164,8 @@ namespace Tizen.Content.MediaContent
                     ThrowIfError("Failed to create filter handle(storage id)"); ;
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
+
     }
 
     /// <summary>

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/Storage.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/Storage.cs
@@ -43,7 +43,6 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The unique ID of the storage.</value>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Please do not use! this will be deprecated in level 6")]
         public string Id { get; }
 
         /// <summary>
@@ -51,7 +50,6 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The path of the storage.</value>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Please do not use! this will be deprecated in level 6")]
         public string Path { get; }
 
         /// <summary>
@@ -59,7 +57,6 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The type of the storage.</value>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Please do not use! this will be deprecated in level 6")]
         public StorageType Type { get; }
 
         /// <summary>
@@ -67,7 +64,6 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <returns>A string representation of the current storage.</returns>
         /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Please do not use! this will be deprecated in level 6")]
         public override string ToString() =>
             $"Id={Id}, Path={Path}, Type={Type}";
     }

--- a/src/Tizen.Multimedia.Metadata/MetadataExtractor/Metadata.cs
+++ b/src/Tizen.Multimedia.Metadata/MetadataExtractor/Metadata.cs
@@ -196,7 +196,9 @@ namespace Tizen.Multimedia
             Album = extractor.GetMetadata(MetadataExtractorAttr.Album);
             AlbumArtist = extractor.GetMetadata(MetadataExtractorAttr.AlbumArtist);
             Genre = extractor.GetMetadata(MetadataExtractorAttr.Genre);
+#pragma warning disable CS0618 // Type or member is obsolete
             Author = extractor.GetMetadata(MetadataExtractorAttr.Composer);
+#pragma warning restore CS0618 // Type or member is obsolete
             Composer = extractor.GetMetadata(MetadataExtractorAttr.Composer);
             Copyright = extractor.GetMetadata(MetadataExtractorAttr.Copyright);
             DateReleased = extractor.GetMetadata(MetadataExtractorAttr.ReleaseDate);

--- a/src/Tizen.Multimedia.Remoting/MediaController/MediaControlServer.Events.cs
+++ b/src/Tizen.Multimedia.Remoting/MediaController/MediaControlServer.Events.cs
@@ -95,7 +95,9 @@ namespace Tizen.Multimedia.Remoting
                 // SendPlaybackCommand doesn't use requestId. It'll be removed in Level 7.
                 if (requestId == null)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     PlaybackCommandReceived?.Invoke(null, new PlaybackCommandReceivedEventArgs(clientName, playbackCommand.ToPublic()));
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
                 else
                 {
@@ -182,7 +184,7 @@ namespace Tizen.Multimedia.Remoting
             Native.SetCustomCommandReceivedCb(Handle, _customCommandCallback).
                 ThrowIfError("Failed to init CustomCommandReceived event.");
         }
-        
+
         private static SearchCommand CreateSearchCommandReceivedEventArgs(IntPtr searchHandle)
         {
             var searchConditions = new List<MediaControlSearchCondition>();

--- a/src/Tizen.Multimedia/AudioManager/AudioManager.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioManager.cs
@@ -155,6 +155,8 @@ namespace Tizen.Multimedia
         #region DeviceStateChanged event
         private static int _deviceStateChangedCallbackId = -1;
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
         private static Interop.AudioDevice.StateChangedCallback _audioDeviceStateChangedCallback;
         private static EventHandler<AudioDeviceStateChangedEventArgs> _audioDeviceStateChanged;
         private static readonly object _audioDeviceStateLock = new object();
@@ -212,6 +214,8 @@ namespace Tizen.Multimedia
                 _audioDeviceStateChangedCallback, IntPtr.Zero, out _deviceStateChangedCallbackId).
                 ThrowIfError("Failed to add device state changed event");
         }
+
+#pragma warning restore CS0618 // Type or member is obsolete
 
         private static void UnregisterDeviceStateChangedEvent()
         {

--- a/src/Tizen.Multimedia/Interop/Interop.Device.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.Device.cs
@@ -26,8 +26,10 @@ namespace Tizen.Multimedia
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void ConnectionChangedCallback(IntPtr device, bool isConnected, IntPtr userData);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void StateChangedCallback(IntPtr device, AudioDeviceState changedState, IntPtr userData);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
             internal delegate void RunningChangedCallback(IntPtr device, bool isRunning, IntPtr userData);
@@ -54,8 +56,10 @@ namespace Tizen.Multimedia
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_name")]
             internal static extern int GetDeviceName(IntPtr device, out IntPtr name);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_device_state_by_id")]
             internal static extern AudioManagerError GetDeviceState(int deviceId, out AudioDeviceState state);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_is_device_running_by_id")]
             internal static extern AudioManagerError IsDeviceRunning(int deviceId, out bool isRunning);


### PR DESCRIPTION
### Description of Change ###
Suppress CS0618(Type or member is obsolete) warnings due to internal reference


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
