### PR TITLE
[NUI] Support constructor with default parameter

### DIFF
--- a/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
@@ -88,7 +88,16 @@ namespace Tizen.NUI.Xaml
                     }
                     if (value == null)
                     {
-                        value = Activator.CreateInstance(type);
+                        if (type.GetTypeInfo().DeclaredConstructors.Any(ci => ci.IsPublic && ci.GetParameters().Length == 0))
+                        {
+                            //default constructor
+                            value = Activator.CreateInstance(type);
+                        }
+                        else
+                        {
+                            //constructor with all default parameters
+                            value = Activator.CreateInstance(type, BindingFlags.CreateInstance | BindingFlags.Public | BindingFlags.Instance | BindingFlags.OptionalParamBinding, null, new object[] { Type.Missing }, CultureInfo.CurrentCulture);
+                        }
                         if (value is Element)
                         {
                             if (null != Application.Current)
@@ -216,7 +225,7 @@ namespace Tizen.NUI.Xaml
             if (!node.Properties.ContainsKey(XmlName.xFactoryMethod))
             {
                 //non-default ctor
-                object ret = Activator.CreateInstance(nodeType, arguments);
+                object ret = Activator.CreateInstance(nodeType, BindingFlags.CreateInstance | BindingFlags.Public | BindingFlags.Instance | BindingFlags.OptionalParamBinding, null, arguments, CultureInfo.CurrentCulture); ;
                 if (ret is Element)
                 {
                     if (null != Application.Current)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

| Code | XAML |
| -- | -- |
| public MyClass() | \<MyClass \/\> |
| public MyClass(MyType1 para1 = "para1") | \<MyClass \/\>or\<MyClass\>\<x:Arguments\>\<MyType1\>para1\<MyType1\/\>\<\/x:Arguments\>\<MyClass\/\> |
| public MyClass(MyType1 para1, MyType2 para2 = "para2") | \<MyClass\>    \<x:Arguments\>\<MyType1\>para1\<\/MyType1\>\<\/x:Arguments\>\<\/MyClass\>or\<MyClass\>    \<x:Arguments\>        \<MyType1\>para1\<\/MyType1\>        \<MyType2\>para2\<\/MyType2\>    \<\/x:Arguments\>\<\/MyClass\> |
| public MyClass(MyType1 para1 = "para1", MyType2 para2 = "para2") | \<MyClass \/\>or\<MyClass\>    \<x:Arguments\>        \<MyType1\>para1\<\/MyType1\>    \<\/x:Arguments\>\<MyClass\/\>or\<MyClass\>    \<x:Arguments\>        \<MyType1\>para1\<\/MyType1\>        \<MyType2\>para2\<\/MyType2\>    \<\/x:Arguments\>\<MyClass\/\> |



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
