### PR TITLE
Add Tizen.Environment.SetEnvironmentVariable wrapper to setup environment variables

### DIFF
--- a/packaging/PlatformFileList.txt
+++ b/packaging/PlatformFileList.txt
@@ -32,6 +32,7 @@ Tizen.Content.Download.dll                         #common #mobile #mobile-emul 
 Tizen.Content.MediaContent.dll                     #common #mobile #mobile-emul #tv #wearable
 Tizen.Content.MimeType.dll                         #common #mobile #mobile-emul #tv #wearable
 Tizen.Context.dll                                  #mobile #mobile-emul #wearable
+Tizen.Environment                                  #common #mobile #mobile-emul #tv #wearable
 Tizen.dll                                          #common #mobile #mobile-emul #tv #wearable
 Tizen.Location.dll                                 #mobile #mobile-emul #tv #wearable
 Tizen.Location.Geofence.dll                        #mobile #mobile-emul

--- a/src/Tizen.Environment/Tizen.Environment.csproj
+++ b/src/Tizen.Environment/Tizen.Environment.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Tizen.Environment/Tizen.Environment.sln
+++ b/src/Tizen.Environment/Tizen.Environment.sln
@@ -1,0 +1,22 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tizen.Environment", "Tizen.Environment.csproj", "{2389117A-0FE7-43CE-8075-5775C3CCAAB0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2389117A-0FE7-43CE-8075-5775C3CCAAB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2389117A-0FE7-43CE-8075-5775C3CCAAB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2389117A-0FE7-43CE-8075-5775C3CCAAB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2389117A-0FE7-43CE-8075-5775C3CCAAB0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Tizen.Environment/Tizen/Environment.cs
+++ b/src/Tizen.Environment/Tizen/Environment.cs
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace Tizen
+{
+    /// <summary>
+    /// The Environment class provides the method to set environment variables through delegate.
+    /// Delegate for System.Environment.SetEnvironmentVariable can't be created because it is overloaded, so
+    /// Tizen.Environment.SetEnvironmentVariable wrapper is added.
+    /// </summary>
+    /// <since_tizen> 5.5 </since_tizen>
+    public class Environment
+    {
+        /// <summary>
+        /// Sets environment variable
+        /// </summary>
+        /// <returns></returns>
+        /// <since_tizen> 5.5 </since_tizen>
+        public static void SetEnvironmentVariable(string variable, string value)
+        {
+            System.Environment.SetEnvironmentVariable(variable, value);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Dotnet-launcher sets app specific environment variable after `coreclr_initialize`. On older versions of CoreCLR, `SetEnvironmentVariableW` function was used for this, but on the newest master it is removed from unix exports. 

Now `Tizen.Environment.SetEnvironmentVariable` could be used instead, when delegate is created for this method. Delegate can't be created for `System.Environment.SetEnvironmentVariable` directly, because it is overloaded. 

Related issue: https://github.com/dotnet/coreclr/issues/23683

### API Changes ###

`Tizen.Environment.dll` is added. It contains `Tizen.Environment.SetEnvironmentVariable`.

cc @alpencolt
