### PR TITLE
[NFC] Fix logical error for get NDEF message

### DIFF
--- a/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcManager.cs
+++ b/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcManager.cs
@@ -149,7 +149,7 @@ namespace Tizen.Network.Nfc
                 bool isCeSupported = false;
 
                 Information.TryGetValue("http://tizen.org/feature/network.nfc", out isNfcSupported);
-                Information.TryGetValue("http://tizen.org/feature/network.nfc.cardemulation", out isCeSupported);
+                Information.TryGetValue("http://tizen.org/feature/network.nfc.card_emulation", out isCeSupported);
 
                 if (!isNfcSupported || !isCeSupported)
                 {
@@ -171,7 +171,7 @@ namespace Tizen.Network.Nfc
                 bool isCeSupported = false;
 
                 Information.TryGetValue("http://tizen.org/feature/network.nfc", out isNfcSupported);
-                Information.TryGetValue("http://tizen.org/feature/network.nfc.cardemulation", out isCeSupported);
+                Information.TryGetValue("http://tizen.org/feature/network.nfc.card_emulation", out isCeSupported);
 
                 if (!isNfcSupported || !isCeSupported)
                 {
@@ -330,7 +330,7 @@ namespace Tizen.Network.Nfc
             bool isCeSupported = false;
 
             Information.TryGetValue("http://tizen.org/feature/network.nfc", out isNfcSupported);
-            Information.TryGetValue("http://tizen.org/feature/network.nfc.cardemulation", out isCeSupported);
+            Information.TryGetValue("http://tizen.org/feature/network.nfc.card_emulation", out isCeSupported);
 
             if (!isNfcSupported || !isCeSupported)
             {

--- a/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcNdefMessage.cs
+++ b/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcNdefMessage.cs
@@ -68,6 +68,29 @@ namespace Tizen.Network.Nfc
         internal NfcNdefMessage(IntPtr messageHandle)
         {
             _messageHandle = messageHandle;
+
+            int recordCount;
+            int ret = Interop.Nfc.NdefMessage.GetRecordCount(_messageHandle, out recordCount);
+            if (ret != (int)NfcError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to GetRecordCount, Error - " + (NfcError)ret);
+                NfcErrorFactory.ThrowNfcException(ret);
+            }
+
+            for (int i = 0; i < recordCount; i++) {
+                IntPtr recordHandle;
+                ret = Interop.Nfc.NdefMessage.GetRecord(_messageHandle, i, out recordHandle);
+                if (ret != (int)NfcError.None)
+                {
+                    Log.Error(Globals.LogTag, "Failed to get record, Error - " + (NfcError)ret);
+                    NfcErrorFactory.ThrowNfcException(ret);
+                }
+
+                NfcNdefRecord record = new NfcNdefRecord(recordHandle);
+                
+                _recordList.Add(record);
+                Log.Error(Globals.LogTag, "Record Added");
+            }
         }
 
         /// <summary>

--- a/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcNdefRecord.cs
+++ b/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcNdefRecord.cs
@@ -284,6 +284,11 @@ namespace Tizen.Network.Nfc
             }
         }
 
+        internal NfcNdefRecord(IntPtr recordHandle)
+        {
+            _recordHandle = recordHandle;
+        }
+
         /// <summary>
         /// NfcNdefRecord destructor.
         /// </summary>


### PR DESCRIPTION
Signed-off-by: Jung Jihoon <jh8801.jung@samsung.com>

### Description of Change ###
Fix for logical error when store & get the NDEF message.
(http://suprem.sec.samsung.net/jira/browse/TNEXT-17352?filter=-1)
(It is not needed ACR. It just bug fix)
