### PR TITLE
[Applications.Common] Add an exception

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -174,7 +174,11 @@ namespace Tizen.Applications
         protected virtual void OnLowMemory(LowMemoryEventArgs e)
         {
             LowMemory?.Invoke(this, e);
-            sTimer = new Timer(new Random().Next(10 * 1000));
+            double interval = new Random().Next(10 * 1000);
+            if (interval <= 0)
+                interval = 10 * 1000;
+
+            sTimer = new Timer(interval);
             sTimer.Elapsed += OnTimedEvent;
             sTimer.AutoReset = false;
             sTimer.Enabled = true;


### PR DESCRIPTION
If the interval is less than or equal to zero, or greater than integer
maximum value, ArgumentException is occurred.

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
To avoid ArgumentException, we have to check whether the interval value is less than zero or NOT.
