### PR TITLE
[ElmSharp] Obsolete ContextPopup.IsAvailableDirection

### DIFF
--- a/src/ElmSharp/ElmSharp/ContextPopup.cs
+++ b/src/ElmSharp/ElmSharp/ContextPopup.cs
@@ -224,9 +224,11 @@ namespace ElmSharp
         /// Get false if you cannot put it in the direction. Get true if it's possible.
         /// </returns>
         /// <since_tizen> preview </since_tizen>
+        /// [Obsolete("IsAvailableDirection is obsolete as of API6 and is no longer supported.")]
         public bool IsAvailableDirection(ContextPopupDirection direction)
         {
-            return Interop.Elementary.elm_ctxpopup_direction_available_get(RealHandle, (int)direction);
+            Console.WriteLine("ContextPopup.IsAvailableDirection is obsolete as of API6 and is no longer supported.");
+            return false;
         }
 
         /// <summary>

--- a/src/ElmSharp/Interop/Interop.Elementary.CtxPopup.cs
+++ b/src/ElmSharp/Interop/Interop.Elementary.CtxPopup.cs
@@ -43,9 +43,6 @@ internal static partial class Interop
         internal static extern void elm_ctxpopup_hover_parent_set(IntPtr obj, IntPtr parent);
 
         [DllImport(Libraries.Elementary)]
-        internal static extern bool elm_ctxpopup_direction_available_get(IntPtr obj, int direction);
-
-        [DllImport(Libraries.Elementary)]
         internal static extern void elm_ctxpopup_direction_priority_set(IntPtr obj, int first, int second, int third, int fourth);
 
         [DllImport(Libraries.Elementary)]


### PR DESCRIPTION
### Description of Change ###
According to native API changes, `ElmSharp.ContextPopup.IsAvailableDirection` has been obsoleted.

### API Changes ###
 - ACR: ACR-319
```
elementary: remove deprecated API
           Following API was deprecated from 2.4.
           - elm_ctxpopup_direction_available_get (ACR-319)
```

Obsoleted:
 - bool ElmSharp.ContextPopup.IsAvailableDirection