### PR TITLE
[EflSharp] Fix constructor of MoreOption and RotarySelector

### DIFF
--- a/internals/src/EflSharp/EflSharp/Circle/MoreOption.cs
+++ b/internals/src/EflSharp/EflSharp/Circle/MoreOption.cs
@@ -48,7 +48,7 @@ namespace Efl
                 /// </summary>
                 /// <param name="parent">The Efl.Ui.Widget to which the new MoreOption will be attached as a child.</param>
                 /// <since_tizen> 6 </since_tizen>
-                public MoreOption(Efl.Ui.Widget parent) : base(new ConstructingHandle(Interop.Eext.eext_more_option_add(parent.NativeHandle)))
+                public MoreOption(Efl.Ui.Widget parent) : base(new Efl.Eo.Globals.WrappingHandle(Interop.Eext.eext_more_option_add(parent.NativeHandle)))
                 {
                     smartClicked = new Interop.Evas.SmartCallback((d, o, e) =>
                     {

--- a/internals/src/EflSharp/EflSharp/Circle/RotarySelector.cs
+++ b/internals/src/EflSharp/EflSharp/Circle/RotarySelector.cs
@@ -102,7 +102,7 @@ namespace Efl
                 /// </summary>
                 /// <param name="parent">The Efl.Ui.Widget to which the new RotarySelector will be attached as a child.</param>
                 /// <since_tizen> 6 </since_tizen>
-                public RotarySelector(Efl.Ui.Widget parent) : base(new ConstructingHandle(Interop.Eext.eext_rotary_selector_add(parent.NativeHandle)))
+                public RotarySelector(Efl.Ui.Widget parent) : base(new Efl.Eo.Globals.WrappingHandle(Interop.Eext.eext_rotary_selector_add(parent.NativeHandle)))
                 {
                     smartClicked = new Interop.Evas.SmartCallback((d, o, e) =>
                     {


### PR DESCRIPTION
Now, EoWrapper does not have constructor with parameter IntPtr.
Instead, EoWrapper has constructors with paramater ConstructingHandle
and WrappingHandle.

Since ConstructingHandle is created internally, the constructor with
parameter ConstructingHandle should be used for internal usage.
Instead, constructor with parameter WrappingHandle should be used to use
C native handle (i.e. eo pointer in C).

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
