### PR TITLE
[MediaPlayer] add APIs to use AudioOffload

### DIFF
--- a/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Interop/Interop.Player.cs
@@ -66,6 +66,9 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate bool AdaptiveVariantCallback(int bandwidth, int width, int height, IntPtr userData);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate bool SupportedMediaFormatCallback(int format, IntPtr userData);
+
         [DllImport(Libraries.Player, EntryPoint = "player_create")]
         internal static extern PlayerErrorCode Create(out PlayerHandle player);
 
@@ -363,6 +366,18 @@ internal static partial class Interop
 
         [DllImport(Libraries.Player, EntryPoint = "player_audio_pitch_get_value")]
         internal static extern PlayerErrorCode GetAudioPitch(IntPtr player, out float level);
+
+        [DllImport(Libraries.Player, EntryPoint = "player_audio_offload_set_enabled")]
+        internal static extern PlayerErrorCode SetAudioOffloadEnabled(IntPtr player, bool value);
+
+        [DllImport(Libraries.Player, EntryPoint = "player_audio_offload_is_enabled")]
+        internal static extern PlayerErrorCode IsAudioOffloadEnabled(IntPtr player, out bool value);
+
+        [DllImport(Libraries.Player, EntryPoint = "player_audio_offload_is_activated")]
+        internal static extern PlayerErrorCode IsAudioOffloadActivated(IntPtr player, out bool value);
+
+        [DllImport(Libraries.Player, EntryPoint = "player_audio_offload_foreach_supported_format")]
+        internal static extern PlayerErrorCode SupportedAudioOffloadFormat(IntPtr player, SupportedMediaFormatCallback callback, IntPtr userData);
     }
 
     internal class PlayerHandle : SafeHandle

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
@@ -42,7 +42,7 @@ namespace Tizen.Multimedia
 
             _count = Count;
             _bandLevelRange = BandLevelRange;
-            _bands = new EqualizerBand[_count];
+            _bands = new EqualizerBand[Count];
         }
 
         /// <summary>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
@@ -35,7 +35,7 @@ namespace Tizen.Multimedia
             Player = owner;
 
             _isAvailable = IsAvailable;
-            if (_isAvailable == false)
+            if (IsAvailable== false)
             {
                 return;
             }

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
@@ -26,22 +26,16 @@ namespace Tizen.Multimedia
     public class AudioEffect
     {
         private readonly EqualizerBand[] _bands;
-        private readonly int _count;
-        private readonly bool _isAvailable;
-        private readonly Range _bandLevelRange;
 
         internal AudioEffect(Player owner)
         {
             Player = owner;
 
-            _isAvailable = IsAvailable;
             if (IsAvailable== false)
             {
                 return;
             }
 
-            _count = Count;
-            _bandLevelRange = BandLevelRange;
             _bands = new EqualizerBand[Count];
         }
 
@@ -64,7 +58,7 @@ namespace Tizen.Multimedia
             get
             {
                 Player.ValidateNotDisposed();
-                Player.AudioOffload.CheckEnabled();
+                Player.AudioOffload.CheckDisabled();
 
                 if (index < 0 || Count <= index)
                 {
@@ -92,7 +86,7 @@ namespace Tizen.Multimedia
         public void Clear()
         {
             Player.ValidateNotDisposed();
-            Player.AudioOffload.CheckEnabled();
+            Player.AudioOffload.CheckDisabled();
 
             Native.EqualizerClear(Player.Handle).
                 ThrowIfFailed(Player, "Failed to clear equalizer effect");
@@ -109,7 +103,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                Player.AudioOffload.CheckEnabled();
+                Player.AudioOffload.CheckDisabled();
 
                 Native.GetEqualizerBandsCount(Player.Handle, out var count).
                     ThrowIfFailed(Player, "Failed to initialize the AudioEffect");
@@ -129,7 +123,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                Player.AudioOffload.CheckEnabled();
+                Player.AudioOffload.CheckDisabled();
 
                 Native.GetEqualizerLevelRange(Player.Handle, out var min, out var max).
                     ThrowIfFailed(Player, "Failed to initialize the AudioEffect");
@@ -149,7 +143,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                Player.AudioOffload.CheckEnabled();
+                Player.AudioOffload.CheckDisabled();
 
                 Native.EqualizerIsAvailable(Player.Handle, out var available).
                     ThrowIfFailed(Player, "Failed to initialize the AudioEffect");

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
@@ -1,0 +1,161 @@
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using static Interop;
+
+namespace Tizen.Multimedia
+{
+    /// <summary>
+    /// Provides the ability to control the audio offload for <see cref="Multimedia.Player"/>.
+    /// </summary>
+    /// <since_tizen> 6 </since_tizen>
+    public class AudioOffload
+    {
+        private IList<MediaFormatAudioMimeType> _supportedFormat;
+
+        /// <summary>
+        /// Gets the <see cref="Multimedia.Player"/> that owns this instance.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        public Player Player { get; }
+
+        /// <summary>
+        /// Provides a means to retrieve audio offload information.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        internal AudioOffload(Player player)
+        {
+            Debug.Assert(player != null);
+            Player = player;
+        }
+
+        internal void CheckEnabled()
+        {
+            if (Player.AudioOffload.IsEnabled)
+            {
+                throw new InvalidOperationException("the audio offload is enabled.");
+            }
+        }
+
+        /// <summary>
+        /// Enables or disables the audio offload.
+        /// </summary>
+        /// <feature>http://tizen.org/feature/multimedia.player.audio_offload</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Operation failed; internal error.
+        /// </exception>
+        /// <since_tizen> 6 </since_tizen>
+        public bool IsEnabled
+        {
+            get
+            {
+                ValidationUtil.ValidateFeatureSupported(PlayerFeatures.AudioOffload);
+                Player.ValidateNotDisposed();
+
+                NativePlayer.IsAudioOffloadEnabled(Player.Handle, out var value).
+                    ThrowIfFailed(Player, "Failed to get whether the audio offload of the player is enabled or not");
+                return value;
+            }
+
+            set
+            {
+                ValidationUtil.ValidateFeatureSupported(PlayerFeatures.AudioOffload);
+                Player.ValidateNotDisposed();
+
+                NativePlayer.SetAudioOffloadEnabled(Player.Handle, value).
+                    ThrowIfFailed(Player, "Failed to set the audio offload of the player");
+            }
+        }
+
+        /// <summary>
+        /// Get a state whether or not the audio offload is activated.
+        /// </summary>
+        /// <feature>http://tizen.org/feature/multimedia.player.audio_offload</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Operation failed; internal error.
+        /// </exception>
+        /// <since_tizen> 6 </since_tizen>
+        public bool IsActivated
+        {
+            get
+            {
+                ValidationUtil.ValidateFeatureSupported(PlayerFeatures.AudioOffload);
+                Player.ValidateNotDisposed();
+
+                NativePlayer.IsAudioOffloadActivated(Player.Handle, out var value).
+                    ThrowIfFailed(Player, "Failed to get whether the audio offload of the player is enabled or not");
+                return value;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves all formats for audio offload.
+        /// </summary>
+        /// <returns>
+        /// It returns a list contained all formats for audio offload.
+        /// </returns>
+        /// <feature>http://tizen.org/feature/multimedia.player.audio_offload</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ObjectDisposedException">The <see cref="Player"/> has already been disposed of.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Operation failed; internal error.
+        /// </exception>
+        /// <seealso cref="MediaFormatAudioMimeType"/>
+        /// <since_tizen> 6 </since_tizen>
+        public IEnumerable<MediaFormatAudioMimeType> SupportedFormats
+        {
+            get
+            {
+                if (_supportedFormat == null)
+                {
+                    _supportedFormat = GetSupportedFormats();
+                }
+
+                return _supportedFormat;
+            }
+        }
+
+        private IList<MediaFormatAudioMimeType> GetSupportedFormats()
+        {
+            List<MediaFormatAudioMimeType> audioFormats = new List<MediaFormatAudioMimeType>();
+
+            NativePlayer.SupportedMediaFormatCallback callback = (int format, IntPtr userData) =>
+            {
+                if (!Enum.IsDefined(typeof(MediaFormatAudioMimeType), format))
+                {
+                    Log.Warn(PlayerLog.Tag, "not supported : " + format.ToString());
+                    return false;
+                }
+
+                Log.Debug(PlayerLog.Tag, "supported : " + ((MediaFormatAudioMimeType)format).ToString());
+                audioFormats.Add((MediaFormatAudioMimeType)format);
+                return true;
+            };
+
+            NativePlayer.SupportedAudioOffloadFormat(Player.Handle, callback, IntPtr.Zero).
+                ThrowIfFailed(Player, "Failed to get the supported formats for audio offload");
+
+            return audioFormats.AsReadOnly();
+        }
+    }
+}

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
@@ -28,12 +28,7 @@ namespace Tizen.Multimedia
     public class AudioOffload
     {
         private IList<MediaFormatAudioMimeType> _supportedFormat;
-
-        /// <summary>
-        /// Gets the <see cref="Multimedia.Player"/> that owns this instance.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        internal Player Player { get; }
+        private Player _player { get; }
 
         /// <summary>
         /// Provides a means to retrieve audio offload information.
@@ -42,7 +37,7 @@ namespace Tizen.Multimedia
         internal AudioOffload(Player player)
         {
             Debug.Assert(player != null);
-            Player = player;
+            _player = player;
         }
 
         private bool _enabled;
@@ -88,21 +83,21 @@ namespace Tizen.Multimedia
             get
             {
                 ValidationUtil.ValidateFeatureSupported(PlayerFeatures.AudioOffload);
-                Player.ValidateNotDisposed();
+                _player.ValidateNotDisposed();
 
-                NativePlayer.IsAudioOffloadEnabled(Player.Handle, out var value).
-                    ThrowIfFailed(Player, "Failed to get whether the audio offload of the player is enabled or not");
+                NativePlayer.IsAudioOffloadEnabled(_player.Handle, out var value).
+                    ThrowIfFailed(_player, "Failed to get whether the audio offload of the player is enabled or not");
                 return value;
             }
 
             set
             {
                 ValidationUtil.ValidateFeatureSupported(PlayerFeatures.AudioOffload);
-                Player.ValidateNotDisposed();
-                Player.ValidatePlayerState(PlayerState.Idle);
+                _player.ValidateNotDisposed();
+                _player.ValidatePlayerState(PlayerState.Idle);
 
-                NativePlayer.SetAudioOffloadEnabled(Player.Handle, value).
-                    ThrowIfFailed(Player, "Failed to set the audio offload of the player");
+                NativePlayer.SetAudioOffloadEnabled(_player.Handle, value).
+                    ThrowIfFailed(_player, "Failed to set the audio offload of the player");
                 _enabled = value;
             }
         }
@@ -130,11 +125,11 @@ namespace Tizen.Multimedia
             get
             {
                 ValidationUtil.ValidateFeatureSupported(PlayerFeatures.AudioOffload);
-                Player.ValidateNotDisposed();
-                Player.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
+                _player.ValidateNotDisposed();
+                _player.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
-                NativePlayer.IsAudioOffloadActivated(Player.Handle, out var value).
-                    ThrowIfFailed(Player, "Failed to get whether the audio offload of the player is enabled or not");
+                NativePlayer.IsAudioOffloadActivated(_player.Handle, out var value).
+                    ThrowIfFailed(_player, "Failed to get whether the audio offload of the player is enabled or not");
                 return value;
             }
         }
@@ -184,8 +179,8 @@ namespace Tizen.Multimedia
                 return true;
             };
 
-            NativePlayer.SupportedAudioOffloadFormat(Player.Handle, callback, IntPtr.Zero).
-                ThrowIfFailed(Player, "Failed to get the supported formats for audio offload");
+            NativePlayer.SupportedAudioOffloadFormat(_player.Handle, callback, IntPtr.Zero).
+                ThrowIfFailed(_player, "Failed to get the supported formats for audio offload");
 
             return audioFormats.AsReadOnly();
         }

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
@@ -47,7 +47,7 @@ namespace Tizen.Multimedia
 
         internal void CheckDisabled()
         {
-            if (Player.AudioOffload.IsEnabled)
+            if (Features.IsSupported(PlayerFeatures.AudioOffload) && Player.AudioOffload.IsEnabled)
             {
                 throw new InvalidOperationException("the audio offload is enabled.");
             }

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
@@ -45,7 +45,7 @@ namespace Tizen.Multimedia
             Player = player;
         }
 
-        internal void CheckEnabled()
+        internal void CheckDisabled()
         {
             if (Player.AudioOffload.IsEnabled)
             {

--- a/src/Tizen.Multimedia.MediaPlayer/Player/EqualizerBand.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/EqualizerBand.cs
@@ -29,6 +29,8 @@ namespace Tizen.Multimedia
     {
         private readonly AudioEffect _owner;
         private readonly int _index;
+        private readonly int _frequency;
+        private readonly int _frequencyRange;
 
         internal EqualizerBand(AudioEffect owner, int index)
         {
@@ -36,16 +38,10 @@ namespace Tizen.Multimedia
 
             _owner = owner;
             _index = index;
+            _frequency = Frequency;
+            _frequencyRange = FrequencyRange;
 
-            Native.GetEqualizerBandFrequency(_owner.Player.Handle, _index, out var frequency).
-                ThrowIfFailed(_owner.Player, "Failed to initialize equalizer band");
-
-            Native.GetEqualizerBandFrequencyRange(_owner.Player.Handle, _index, out var range).
-                ThrowIfFailed(_owner.Player, "Failed to initialize equalizer band");
-
-            Frequency = frequency;
-            FrequencyRange = range;
-            Log.Debug(PlayerLog.Tag, "frequency : " + frequency + ", range : " + range);
+            Log.Debug(PlayerLog.Tag, "frequency : " + _frequency + ", range : " + _frequencyRange);
         }
 
         /// <summary>
@@ -56,12 +52,16 @@ namespace Tizen.Multimedia
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="value"/> is not inside of <see cref="AudioEffect.BandLevelRange"/>.
         /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <since_tizen> 3 </since_tizen>
         public int Level
         {
             get
             {
                 _owner.Player.ValidateNotDisposed();
+                _owner.Player.AudioOffload.CheckEnabled();
 
                 Native.GetEqualizerBandLevel(_owner.Player.Handle, _index, out var value).
                     ThrowIfFailed(_owner.Player, "Failed to get the level of the equalizer band");
@@ -72,6 +72,7 @@ namespace Tizen.Multimedia
             set
             {
                 _owner.Player.ValidateNotDisposed();
+                _owner.Player.AudioOffload.CheckEnabled();
 
                 if (value < _owner.BandLevelRange.Min || _owner.BandLevelRange.Max < value)
                 {
@@ -90,14 +91,42 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets the frequency in the dB.
         /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <since_tizen> 3 </since_tizen>
-        public int Frequency { get; }
+        public int Frequency
+        {
+            get
+            {
+                _owner.Player.AudioOffload.CheckEnabled();
+
+                Native.GetEqualizerBandFrequency(_owner.Player.Handle, _index, out var frequency).
+                ThrowIfFailed(_owner.Player, "Failed to initialize equalizer band");
+
+                return frequency;
+            }
+        }
 
         /// <summary>
         /// Gets the frequency range in the dB.
         /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <since_tizen> 3 </since_tizen>
-        public int FrequencyRange { get; }
+        public int FrequencyRange
+        {
+            get
+            {
+                _owner.Player.AudioOffload.CheckEnabled();
+
+                Native.GetEqualizerBandFrequencyRange(_owner.Player.Handle, _index, out var frequencyRange).
+                ThrowIfFailed(_owner.Player, "Failed to initialize equalizer band");
+
+                return frequencyRange;
+            }
+        }
 
     }
 }

--- a/src/Tizen.Multimedia.MediaPlayer/Player/EqualizerBand.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/EqualizerBand.cs
@@ -29,8 +29,6 @@ namespace Tizen.Multimedia
     {
         private readonly AudioEffect _owner;
         private readonly int _index;
-        private readonly int _frequency;
-        private readonly int _frequencyRange;
 
         internal EqualizerBand(AudioEffect owner, int index)
         {
@@ -38,10 +36,8 @@ namespace Tizen.Multimedia
 
             _owner = owner;
             _index = index;
-            _frequency = Frequency;
-            _frequencyRange = FrequencyRange;
 
-            Log.Debug(PlayerLog.Tag, "frequency : " + _frequency + ", range : " + _frequencyRange);
+            Log.Debug(PlayerLog.Tag, "frequency : " + Frequency + ", range : " + FrequencyRange);
         }
 
         /// <summary>
@@ -61,7 +57,7 @@ namespace Tizen.Multimedia
             get
             {
                 _owner.Player.ValidateNotDisposed();
-                _owner.Player.AudioOffload.CheckEnabled();
+                _owner.Player.AudioOffload.CheckDisabled();
 
                 Native.GetEqualizerBandLevel(_owner.Player.Handle, _index, out var value).
                     ThrowIfFailed(_owner.Player, "Failed to get the level of the equalizer band");
@@ -72,7 +68,7 @@ namespace Tizen.Multimedia
             set
             {
                 _owner.Player.ValidateNotDisposed();
-                _owner.Player.AudioOffload.CheckEnabled();
+                _owner.Player.AudioOffload.CheckDisabled();
 
                 if (value < _owner.BandLevelRange.Min || _owner.BandLevelRange.Max < value)
                 {
@@ -99,7 +95,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                _owner.Player.AudioOffload.CheckEnabled();
+                _owner.Player.AudioOffload.CheckDisabled();
 
                 Native.GetEqualizerBandFrequency(_owner.Player.Handle, _index, out var frequency).
                 ThrowIfFailed(_owner.Player, "Failed to initialize equalizer band");
@@ -119,7 +115,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                _owner.Player.AudioOffload.CheckEnabled();
+                _owner.Player.AudioOffload.CheckDisabled();
 
                 Native.GetEqualizerBandFrequencyRange(_owner.Player.Handle, _index, out var frequencyRange).
                 ThrowIfFailed(_owner.Player, "Failed to initialize equalizer band");

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
@@ -241,7 +241,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
 
                 NativePlayer.GetAudioLatencyMode(Handle, out var value).
                     ThrowIfFailed(this, "Failed to get the audio latency mode of the player");
@@ -251,7 +251,7 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
 
                 ValidationUtil.ValidateEnum(typeof(AudioLatencyMode), value, nameof(value));
 
@@ -557,7 +557,7 @@ namespace Tizen.Multimedia
             get
             {
                 ValidateNotDisposed();
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
 
                 NativePlayer.IsReplayGain(Handle, out var value).
                     ThrowIfFailed(this, "Failed to get the replaygain of the player");
@@ -566,7 +566,7 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
 
                 NativePlayer.SetReplayGain(Handle, value).
                     ThrowIfFailed(this, "Failed to set the replaygain of the player");
@@ -593,7 +593,7 @@ namespace Tizen.Multimedia
             get
             {
                 ValidateNotDisposed();
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
 
                 NativePlayer.IsAudioPitchEnabled(Handle, out var value).
                     ThrowIfFailed(this, "Failed to get whether the audio pitch is enabled or not");
@@ -603,7 +603,7 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
                 ValidatePlayerState(PlayerState.Idle);
 
                 NativePlayer.SetAudioPitchEnabled(Handle, value).
@@ -635,7 +635,7 @@ namespace Tizen.Multimedia
             get
             {
                 ValidateNotDisposed();
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
 
                 if (AudioPitchEnabled == false)
                 {
@@ -651,7 +651,7 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
-                AudioOffload.CheckEnabled();
+                AudioOffload.CheckDisabled();
 
                 if (AudioPitchEnabled == false)
                 {

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
@@ -233,11 +233,16 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
         /// <exception cref="ArgumentException">The value is not valid.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <since_tizen> 3 </since_tizen>
         public AudioLatencyMode AudioLatencyMode
         {
             get
             {
+                AudioOffload.CheckEnabled();
+
                 NativePlayer.GetAudioLatencyMode(Handle, out var value).
                     ThrowIfFailed(this, "Failed to get the audio latency mode of the player");
 
@@ -246,6 +251,7 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
+                AudioOffload.CheckEnabled();
 
                 ValidationUtil.ValidateEnum(typeof(AudioLatencyMode), value, nameof(value));
 
@@ -540,13 +546,19 @@ namespace Tizen.Multimedia
         /// <value>If the replaygain status is true, replaygain is applied (if contents has a replaygain tag);
         /// otherwise, the replaygain is not affected by tag and properties.</value>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
-        /// <exception cref="InvalidOperationException">The player is not in the valid state.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     The player is not in the valid state.
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <since_tizen> 5 </since_tizen>
         public bool ReplayGain
         {
             get
             {
                 ValidateNotDisposed();
+                AudioOffload.CheckEnabled();
+
                 NativePlayer.IsReplayGain(Handle, out var value).
                     ThrowIfFailed(this, "Failed to get the replaygain of the player");
                 return value;
@@ -554,6 +566,8 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
+                AudioOffload.CheckEnabled();
+
                 NativePlayer.SetReplayGain(Handle, value).
                     ThrowIfFailed(this, "Failed to set the replaygain of the player");
             }
@@ -566,7 +580,11 @@ namespace Tizen.Multimedia
         /// <value>The value indicating whether or not AudioPitch is enabled. The default is false.</value>
         /// <remarks>This function is used for audio content only.
         /// To set, the player must be in the <see cref="PlayerState.Idle"/> state.</remarks>
-        /// <exception cref="InvalidOperationException">The player is not in the valid state.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     The player is not in the valid state.
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
         /// <seealso cref="AudioPitch"/>
         /// <since_tizen> 6 </since_tizen>
@@ -575,6 +593,8 @@ namespace Tizen.Multimedia
             get
             {
                 ValidateNotDisposed();
+                AudioOffload.CheckEnabled();
+
                 NativePlayer.IsAudioPitchEnabled(Handle, out var value).
                     ThrowIfFailed(this, "Failed to get whether the audio pitch is enabled or not");
                 return value;
@@ -583,6 +603,7 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
+                AudioOffload.CheckEnabled();
                 ValidatePlayerState(PlayerState.Idle);
 
                 NativePlayer.SetAudioPitchEnabled(Handle, value).
@@ -596,7 +617,11 @@ namespace Tizen.Multimedia
         /// <value>The audio stream pitch value. The default is 1.</value>
         /// <remarks>Enabling pitch control could increase the CPU usage on some devices.
         /// This function is used for audio content only.</remarks>
-        /// <exception cref="InvalidOperationException">A pitch is not enabled.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     A pitch is not enabled.
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     value is less than 0.5.
@@ -610,6 +635,7 @@ namespace Tizen.Multimedia
             get
             {
                 ValidateNotDisposed();
+                AudioOffload.CheckEnabled();
 
                 if (AudioPitchEnabled == false)
                 {
@@ -625,6 +651,7 @@ namespace Tizen.Multimedia
             set
             {
                 ValidateNotDisposed();
+                AudioOffload.CheckEnabled();
 
                 if (AudioPitchEnabled == false)
                 {
@@ -675,6 +702,25 @@ namespace Tizen.Multimedia
                 }
 
                 return _adaptiveVariants;
+            }
+        }
+
+        private AudioOffload _audioOffload;
+
+        /// <summary>
+        /// Gets the setting for audio offload.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        public AudioOffload AudioOffload
+        {
+            get
+            {
+                if (_audioOffload == null)
+                {
+                    _audioOffload = new AudioOffload(this);
+                }
+
+                return _audioOffload;
             }
         }
     }

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
@@ -785,7 +785,7 @@ namespace Tizen.Multimedia
                 throw new ArgumentOutOfRangeException(nameof(rate), rate, "Valid range is -5.0 to 5.0 (except 0.0)");
             }
 
-            AudioOffload.CheckEnabled();
+            AudioOffload.CheckDisabled();
             ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
             NativePlayer.SetPlaybackRate(Handle, rate).ThrowIfFailed(this, "Failed to set the playback rate.");
@@ -987,7 +987,7 @@ namespace Tizen.Multimedia
         public void EnableExportingAudioData(AudioMediaFormat format, PlayerAudioExtractOption option)
         {
             ValidationUtil.ValidateEnum(typeof(PlayerAudioExtractOption), option, nameof(option));
-            AudioOffload.CheckEnabled();
+            AudioOffload.CheckDisabled();
             ValidatePlayerState(PlayerState.Idle);
 
             _audioFrameDecodedCallback = (IntPtr packetHandle, IntPtr userData) =>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
@@ -767,6 +767,8 @@ namespace Tizen.Multimedia
         ///     The player is not in the valid state.<br/>
         ///     -or-<br/>
         ///     Streaming playback.
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="rate"/> is less than -5.0.<br/>
@@ -783,6 +785,7 @@ namespace Tizen.Multimedia
                 throw new ArgumentOutOfRangeException(nameof(rate), rate, "Valid range is -5.0 to 5.0 (except 0.0)");
             }
 
+            AudioOffload.CheckEnabled();
             ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
             NativePlayer.SetPlaybackRate(Handle, rate).ThrowIfFailed(this, "Failed to set the playback rate.");
@@ -975,14 +978,17 @@ namespace Tizen.Multimedia
         ///     Operation failed; internal error.
         ///     -or-<br/>
         ///     The player is not in the valid state.
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         ///     </exception>
         /// <seealso cref="PlayerAudioExtractOption"/>
         /// <seealso cref="DisableExportingAudioData"/>
         /// <since_tizen> 6 </since_tizen>
         public void EnableExportingAudioData(AudioMediaFormat format, PlayerAudioExtractOption option)
         {
-            ValidatePlayerState(PlayerState.Idle);
             ValidationUtil.ValidateEnum(typeof(PlayerAudioExtractOption), option, nameof(option));
+            AudioOffload.CheckEnabled();
+            ValidatePlayerState(PlayerState.Idle);
 
             _audioFrameDecodedCallback = (IntPtr packetHandle, IntPtr userData) =>
             {

--- a/src/Tizen.Multimedia.MediaPlayer/Player/PlayerFeatures.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/PlayerFeatures.cs
@@ -22,5 +22,6 @@ namespace Tizen.Multimedia
         internal const string RawVideo = "http://tizen.org/feature/multimedia.raw_video";
         internal const string OpenGl = "http://tizen.org/feature/opengles.version.2_0";
         internal const string SphericalVideo = "http://tizen.org/feature/multimedia.player.spherical_video";
+        internal const string AudioOffload = "http://tizen.org/feature/multimedia.player.audio_offload";
     }
 }

--- a/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
@@ -55,7 +55,7 @@ namespace Tizen.Multimedia
         /// <since_tizen> 3 </since_tizen>
         public int GetCount()
         {
-            _owner.AudioOffload.CheckEnabled();
+            _owner.AudioOffload.CheckDisabled();
             _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
             NativePlayer.GetTrackCount(_owner.Handle, _streamType, out var count).
@@ -95,7 +95,7 @@ namespace Tizen.Multimedia
                     $"Valid index range is 0 <= x < {nameof(GetCount)}(), but got { index }.");
             }
 
-            _owner.AudioOffload.CheckEnabled();
+            _owner.AudioOffload.CheckDisabled();
             _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
             IntPtr code = IntPtr.Zero;
@@ -145,7 +145,7 @@ namespace Tizen.Multimedia
         {
             get
             {
-                _owner.AudioOffload.CheckEnabled();
+                _owner.AudioOffload.CheckDisabled();
                 _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
                 NativePlayer.GetCurrentTrack(_owner.Handle, _streamType, out var value).
@@ -161,7 +161,7 @@ namespace Tizen.Multimedia
                         $"Valid index range is 0 <= x < {nameof(GetCount)}(), but got { value }.");
                 }
 
-                _owner.AudioOffload.CheckEnabled();
+                _owner.AudioOffload.CheckDisabled();
                 _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
                 NativePlayer.SelectTrack(_owner.Handle, _streamType, value).

--- a/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
@@ -48,7 +48,7 @@ namespace Tizen.Multimedia
         /// <see cref="PlayerState.Playing"/>, or <see cref="PlayerState.Paused"/> state.
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> that this instance belongs to has been disposed of.</exception>
-        /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.</exception>
+        /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.
         ///     -or-<br/>
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
@@ -55,6 +55,7 @@ namespace Tizen.Multimedia
         /// <since_tizen> 3 </since_tizen>
         public int GetCount()
         {
+            _owner.ValidateNotDisposed();
             _owner.AudioOffload.CheckDisabled();
             _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
@@ -89,6 +90,8 @@ namespace Tizen.Multimedia
         /// <since_tizen> 3 </since_tizen>
         public string GetLanguageCode(int index)
         {
+            _owner.ValidateNotDisposed();
+
             if (index < 0 || GetCount() <= index)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index,
@@ -145,6 +148,7 @@ namespace Tizen.Multimedia
         {
             get
             {
+                _owner.ValidateNotDisposed();
                 _owner.AudioOffload.CheckDisabled();
                 _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
@@ -155,6 +159,8 @@ namespace Tizen.Multimedia
             }
             set
             {
+                _owner.ValidateNotDisposed();
+
                 if (value < 0 || GetCount() <= value)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value,

--- a/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
@@ -49,9 +49,13 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> that this instance belongs to has been disposed of.</exception>
         /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.</exception>
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <since_tizen> 3 </since_tizen>
         public int GetCount()
         {
+            _owner.AudioOffload.CheckEnabled();
             _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
             NativePlayer.GetTrackCount(_owner.Handle, _streamType, out var count).
@@ -73,7 +77,10 @@ namespace Tizen.Multimedia
         ///     <para>The language codes are defined in ISO 639-1.</para>
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> that this instance belongs to has been disposed of.</exception>
-        /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.</exception>
+        /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="index"/> is less than zero.<br/>
         ///     -or-<br/>
@@ -82,13 +89,14 @@ namespace Tizen.Multimedia
         /// <since_tizen> 3 </since_tizen>
         public string GetLanguageCode(int index)
         {
-            _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
-
             if (index < 0 || GetCount() <= index)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index,
                     $"Valid index range is 0 <= x < {nameof(GetCount)}(), but got { index }.");
             }
+
+            _owner.AudioOffload.CheckEnabled();
+            _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
             IntPtr code = IntPtr.Zero;
 
@@ -122,7 +130,11 @@ namespace Tizen.Multimedia
         /// <see cref="PlayerState.Playing"/>, or <see cref="PlayerState.Paused"/> state.
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> that this instance belongs to has been disposed of.</exception>
-        /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.</exception>
+        /// <exception cref="InvalidOperationException">
+        ///     The <see cref="Player"/> that this instance belongs to is not in the valid state.<br/>
+        ///     -or-<br/>
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="value"/> is less than zero.<br/>
         ///     -or-<br/>
@@ -133,6 +145,7 @@ namespace Tizen.Multimedia
         {
             get
             {
+                _owner.AudioOffload.CheckEnabled();
                 _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
                 NativePlayer.GetCurrentTrack(_owner.Handle, _streamType, out var value).
@@ -148,6 +161,7 @@ namespace Tizen.Multimedia
                         $"Valid index range is 0 <= x < {nameof(GetCount)}(), but got { value }.");
                 }
 
+                _owner.AudioOffload.CheckEnabled();
                 _owner.ValidatePlayerState(PlayerState.Ready, PlayerState.Playing, PlayerState.Paused);
 
                 NativePlayer.SelectTrack(_owner.Handle, _streamType, value).


### PR DESCRIPTION
### API Changes ###
 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-262

If you can't make the ACR, List all API changes here (or just put None), example:
Added:
- public class AudioOffload
- public bool IsEnabled
- public bool IsActivated
- public IEnumerable<MediaFormatAudioMimeType> SupportedFormats
- public AudioOffload AudioOffload



Changed:  : the error case is added. when audio offload is set, invalid operation occurs for the below APIs
(AudioEffect.cs)
public EqualizerBand this[int index]
public void Clear()
public int Count
public Range BandLevelRange
public bool IsAvailable

(EqualizerBand.cs)
public int Level
public int Frequency
public int FrequencyRange

(Player.Properties.cs)
public AudioLatencyMode AudioLatencyMode
public bool ReplayGain
public bool AudioPitchEnabled
public float AudioPitch

(Player.cs)
public void SetPlaybackRate(float rate)
public void EnableExportingAudioData(AudioMediaFormat format, PlayerAudioExtractOption option)

(PlayerTrackInfo.cs)
public int GetCount()
public string GetLanguageCode(int index)
public int Selected