### PR TITLE
[AudioManager] Add 'Network' audio device type

### DIFF
--- a/src/Tizen.Multimedia/AudioManager/AudioDeviceType.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDeviceType.cs
@@ -65,6 +65,11 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Bluetooth voice (SCO).
         /// </summary>
-        BluetoothVoice
+        BluetoothVoice,
+
+        /// <summary>
+        /// Network.
+        /// </summary>
+        Network
     }
 }

--- a/src/Tizen.Multimedia/AudioManager/AudioDeviceType.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDeviceType.cs
@@ -68,7 +68,7 @@ namespace Tizen.Multimedia
         BluetoothVoice,
 
         /// <summary>
-        /// Network.
+        /// Device for the transmission of audio data over a network
         /// </summary>
         Network
     }


### PR DESCRIPTION
Signed-off-by: Sangchul Lee <sc11.lee@samsung.com>

### Description of Change ###
Add Network type to Tizen.Multimedia.AudioDeviceType enumeration.


### API Changes ###
 - ACR: TCSACR-263
