### PR TITLE
[AudioManager] Add properties for the preferred device

### DIFF
--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -344,18 +344,7 @@ namespace Tizen.Multimedia
             }
             set
             {
-                int deviceId;
-
-                if (value == null)
-                {
-                    deviceId = 0;
-                }
-                else
-                {
-                    deviceId = value.Id;
-                }
-
-                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Input, deviceId).
+                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Input, value?.Id ?? 0).
                     ThrowIfError("Failed to set preferred input device");
 
                 _inputDevice = value;
@@ -400,18 +389,7 @@ namespace Tizen.Multimedia
             }
             set
             {
-                int deviceId;
-
-                if (value == null)
-                {
-                    deviceId = 0;
-                }
-                else
-                {
-                    deviceId = value.Id;
-                }
-
-                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Output, deviceId).
+                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Output, value?.Id ?? 0).
                     ThrowIfError("Failed to set preferred output device");
 
                 _outputDevice = value;

--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -30,6 +30,7 @@ namespace Tizen.Multimedia
         private Interop.AudioStreamPolicy.FocusStateChangedCallback _focusStateChangedCallback;
         private static AudioDevice _inputDevice = null;
         private static AudioDevice _outputDevice = null;
+        private const string Tag = "Tizen.Multimedia.AudioStreamPolicy";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioStreamPolicy"/> class with <see cref="AudioStreamType"/>.
@@ -327,8 +328,12 @@ namespace Tizen.Multimedia
         {
             get
             {
+                /* This P/Invoke intends to validate if the core audio system
+                 * is normal. Otherwise, it'll throw an error here. */
                 Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out var inDeviceId, out _).
                     ThrowIfError("Failed to get preferred input device");
+
+                Log.Debug(Tag, $"preferred input device id:{inDeviceId}");
 
                 return _inputDevice;
             }
@@ -362,8 +367,12 @@ namespace Tizen.Multimedia
         {
             get
             {
+                /* This P/Invoke intends to validate if the core audio system
+                 * is normal. Otherwise, it'll throw an error here. */
                 Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out _, out var outDeviceId).
                     ThrowIfError("Failed to get preferred output device");
+
+                Log.Debug(Tag, $"preferred output device id:{outDeviceId}");
 
                 return _outputDevice;
             }

--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -305,6 +305,72 @@ namespace Tizen.Multimedia
         }
 
         /// <summary>
+        /// Gets or sets the preferred input device id.
+        /// </summary>
+        /// <value>
+        /// A device id which is greater than or equal to 0.<br/>
+        /// The default is 0 which means any device is not set on this property.
+        /// </value>
+        /// <remarks>
+        /// This property is to set a specific built-in device when the system has multiple devices of the same built-in device type.
+        /// When there's only one device for a built-in device type in the system, nothing will happen even if this property is set successfully.
+        /// </remarks>
+        /// <exception cref="ArgumentException">A device is not for input.</exception>
+        /// <exception cref="InvalidOperationException">An internal error occurs.</exception>
+        /// <exception cref="AudioPolicyException">A device is not supported by this <see cref="AudioStreamPolicy"/> instance.</exception>
+        /// <exception cref="ObjectDisposedException">The <see cref="AudioStreamPolicy"/> has already been disposed of.</exception>
+        /// <seealso cref="AudioManager.GetConnectedDevices()"/>
+        /// <since_tizen> 6 </since_tizen>
+        public int PreferredInputDeviceId
+        {
+            get
+            {
+                Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out var inDeviceId, out _).
+                    ThrowIfError("Failed to get preferred input device");
+
+                return inDeviceId;
+            }
+            set
+            {
+                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Input, value).
+                    ThrowIfError("Failed to set preferred input device");
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the preferred output device id.
+        /// </summary>
+        /// <value>
+        /// A device id which is greater than or equal to 0.<br/>
+        /// The default is 0 which means any device is not set on this property.
+        /// </value>
+        /// <remarks>
+        /// This property is to set a specific built-in device when the system has multiple devices of the same built-in device type.
+        /// When there's only one device for a built-in device type in the system, nothing will happen even if this property is set successfully.
+        /// </remarks>
+        /// <exception cref="ArgumentException">A device is not for output.</exception>
+        /// <exception cref="InvalidOperationException">An internal error occurs.</exception>
+        /// <exception cref="AudioPolicyException">A device is not supported by this <see cref="AudioStreamPolicy"/> instance.</exception>
+        /// <exception cref="ObjectDisposedException">The <see cref="AudioStreamPolicy"/> has already been disposed of.</exception>
+        /// <seealso cref="AudioManager.GetConnectedDevices()"/>
+        /// <since_tizen> 6 </since_tizen>
+        public int PreferredOutputDeviceId
+        {
+            get
+            {
+                Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out _, out var outDeviceId).
+                    ThrowIfError("Failed to get preferred output device");
+
+                return outDeviceId;
+            }
+            set
+            {
+                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Output, value).
+                    ThrowIfError("Failed to set preferred output device");
+            }
+        }
+
+        /// <summary>
         /// Checks if any stream from the current AudioStreamPolicy is using the device.
         /// </summary>
         /// <returns>true if any audio stream from the current AudioStreamPolicy is using the device; otherwise, false.</returns>

--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -28,6 +28,8 @@ namespace Tizen.Multimedia
         private AudioStreamPolicyHandle _handle;
         private bool _disposed = false;
         private Interop.AudioStreamPolicy.FocusStateChangedCallback _focusStateChangedCallback;
+        private static AudioDevice _inputDevice = null;
+        private static AudioDevice _outputDevice = null;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AudioStreamPolicy"/> class with <see cref="AudioStreamType"/>.
@@ -305,11 +307,11 @@ namespace Tizen.Multimedia
         }
 
         /// <summary>
-        /// Gets or sets the preferred input device id.
+        /// Gets or sets the preferred device.
         /// </summary>
         /// <value>
-        /// A device id which is greater than or equal to 0.<br/>
-        /// The default is 0 which means any device is not set on this property.
+        /// The <see cref="AudioDevice"/> instance.<br/>
+        /// The default is null which means any device is not set on this property.
         /// </value>
         /// <remarks>
         /// This property is to set a specific built-in device when the system has multiple devices of the same built-in device type.
@@ -321,28 +323,51 @@ namespace Tizen.Multimedia
         /// <exception cref="ObjectDisposedException">The <see cref="AudioStreamPolicy"/> has already been disposed of.</exception>
         /// <seealso cref="AudioManager.GetConnectedDevices()"/>
         /// <since_tizen> 6 </since_tizen>
-        public int PreferredInputDeviceId
+        public AudioDevice PreferredInputDevice
         {
             get
             {
+                if (_inputDevice == null)
+                {
+                    return null;
+                }
+
                 Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out var inDeviceId, out _).
                     ThrowIfError("Failed to get preferred input device");
 
-                return inDeviceId;
+                if (inDeviceId != _inputDevice.Id)
+                {
+                    throw new InvalidOperationException("output device id does not match");
+                }
+
+                return _inputDevice;
             }
             set
             {
-                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Input, value).
+                int deviceId;
+
+                if (value == null)
+                {
+                    deviceId = 0;
+                }
+                else
+                {
+                    deviceId = value.Id;
+                }
+
+                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Input, deviceId).
                     ThrowIfError("Failed to set preferred input device");
+
+                _inputDevice = value;
             }
         }
 
         /// <summary>
-        /// Gets or sets the preferred output device id.
+        /// Gets or sets the preferred output device.
         /// </summary>
         /// <value>
-        /// A device id which is greater than or equal to 0.<br/>
-        /// The default is 0 which means any device is not set on this property.
+        /// The <see cref="AudioDevice"/> instance.<br/>
+        /// The default is null which means any device is not set on this property.
         /// </value>
         /// <remarks>
         /// This property is to set a specific built-in device when the system has multiple devices of the same built-in device type.
@@ -354,19 +379,42 @@ namespace Tizen.Multimedia
         /// <exception cref="ObjectDisposedException">The <see cref="AudioStreamPolicy"/> has already been disposed of.</exception>
         /// <seealso cref="AudioManager.GetConnectedDevices()"/>
         /// <since_tizen> 6 </since_tizen>
-        public int PreferredOutputDeviceId
+        public AudioDevice PreferredOutputDevice
         {
             get
             {
+                if (_outputDevice == null)
+                {
+                    return null;
+                }
+
                 Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out _, out var outDeviceId).
                     ThrowIfError("Failed to get preferred output device");
 
-                return outDeviceId;
+                if (outDeviceId != _outputDevice.Id)
+                {
+                    throw new InvalidOperationException("output device id does not match");
+                }
+
+                return _outputDevice;
             }
             set
             {
-                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Output, value).
+                int deviceId;
+
+                if (value == null)
+                {
+                    deviceId = 0;
+                }
+                else
+                {
+                    deviceId = value.Id;
+                }
+
+                Interop.AudioStreamPolicy.SetPreferredDevice(Handle, AudioDeviceIoDirection.Output, deviceId).
                     ThrowIfError("Failed to set preferred output device");
+
+                _outputDevice = value;
             }
         }
 

--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -327,18 +327,8 @@ namespace Tizen.Multimedia
         {
             get
             {
-                if (_inputDevice == null)
-                {
-                    return null;
-                }
-
                 Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out var inDeviceId, out _).
                     ThrowIfError("Failed to get preferred input device");
-
-                if (inDeviceId != _inputDevice.Id)
-                {
-                    throw new InvalidOperationException("output device id does not match");
-                }
 
                 return _inputDevice;
             }
@@ -372,18 +362,8 @@ namespace Tizen.Multimedia
         {
             get
             {
-                if (_outputDevice == null)
-                {
-                    return null;
-                }
-
                 Interop.AudioStreamPolicy.GetPreferredDevice(Handle, out _, out var outDeviceId).
                     ThrowIfError("Failed to get preferred output device");
-
-                if (outDeviceId != _outputDevice.Id)
-                {
-                    throw new InvalidOperationException("output device id does not match");
-                }
 
                 return _outputDevice;
             }

--- a/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioStreamPolicy.cs
@@ -307,7 +307,7 @@ namespace Tizen.Multimedia
         }
 
         /// <summary>
-        /// Gets or sets the preferred device.
+        /// Gets or sets the preferred input device.
         /// </summary>
         /// <value>
         /// The <see cref="AudioDevice"/> instance.<br/>

--- a/src/Tizen.Multimedia/Interop/Interop.StreamPolicy.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.StreamPolicy.cs
@@ -51,6 +51,12 @@ namespace Tizen.Multimedia
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_apply_stream_routing")]
             internal static extern AudioManagerError ApplyStreamRouting(AudioStreamPolicyHandle streamInfo);
 
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_set_stream_preferred_device_id")]
+            internal static extern AudioManagerError SetPreferredDevice(AudioStreamPolicyHandle streamInfo, AudioDeviceIoDirection direction, int deviceId);
+
+            [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_get_stream_preferred_device")]
+            internal static extern AudioManagerError GetPreferredDevice(AudioStreamPolicyHandle streamInfo, out int inDeviceId, out int outDeviceId);
+
             [DllImport(Libraries.SoundManager, EntryPoint = "sound_manager_acquire_focus")]
             internal static extern AudioManagerError AcquireFocus(AudioStreamPolicyHandle streamInfo,
                 AudioStreamFocusOptions focusMask, AudioStreamBehaviors audioStreamBehavior, string extraInfo);


### PR DESCRIPTION
### Description of Change ###
Add two properties to AudioStreamPolicy.
These properties are to set a specific built-in device when the system has multiple devices of the same built-in device type.

### API Changes ###
 - ACR: TCSACR-269
