### PR TITLE
[Applications.Common] Add a new property of AppControl

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
@@ -145,5 +145,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request_async")]
         internal static extern ErrorCode SendLaunchRequestAsync(SafeAppControlHandle handle, ResultCallback resultCallback, ReplyCallback replyCallback, IntPtr userData);
+
+        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_component_id")]
+        internal static extern ErrorCode SetComponentId(SafeAppControlHandle handle, string componentId);
+
+        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_component_id")]
+        internal static extern ErrorCode GetComponentId(SafeAppControlHandle handle, out string componentId);
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -58,6 +58,7 @@ namespace Tizen.Applications
         private string _category = null;
         private string _applicationId = null;
         private ExtraDataCollection _extraData = null;
+        private string _componentId = null;
 
         /// <summary>
         /// Initializes the instance of the AppControl class.
@@ -441,6 +442,48 @@ namespace Tizen.Applications
                 if (_extraData == null)
                     _extraData = new ExtraDataCollection(_handle);
                 return _extraData;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the component ID.
+        /// </summary>
+        /// <value>
+        /// (if the component ID is null for setter, it clears the previous value.)
+        /// </value>
+        /// <example>
+        /// <code>
+        /// AppControl appControl = new AppControl();
+        /// appControl.ComponentId = "org.tizen.frame-component";
+        /// Log.Debug(LogTag, "ComponentId: " + appControl.ComponentId);
+        /// </code>
+        /// </example>
+        /// <since_tizen> 6 </since_tizen>
+        public string ComponentId
+        {
+            get
+            {
+                if (String.IsNullOrEmpty(_componentId))
+                {
+                    Interop.AppControl.ErrorCode err = Interop.AppControl.GetComponentId(_handle, out _componentId);
+                    if (err != Interop.AppControl.ErrorCode.None)
+                    {
+                        Log.Warn(LogTag, "Failed to get the component id from the AppControl. Err = " + err);
+                    }
+                }
+                return _componentId;
+            }
+            set
+            {
+                Interop.AppControl.ErrorCode err = Interop.AppControl.SetComponentId(_handle, value);
+                if (err == Interop.AppControl.ErrorCode.None)
+                {
+                    _componentId = value;
+                }
+                else
+                {
+                    Log.Warn(LogTag, "Failed to set the component id to the AppControl. Err = " + err);
+                }
             }
         }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -450,12 +450,15 @@ namespace Tizen.Applications
         /// </summary>
         /// <value>
         /// (if the component ID is null for setter, it clears the previous value.)
+        /// From Tizen 5.5, a new application model is supported that is component-based application.
+        /// This property is for launching component-based application. If it's not set, the main component of component-based application will be launched.
         /// </value>
         /// <example>
         /// <code>
         /// AppControl appControl = new AppControl();
+        /// appControl.ApplicationId = "org.tizen.component-based-app"; // component-based application
         /// appControl.ComponentId = "org.tizen.frame-component";
-        /// Log.Debug(LogTag, "ComponentId: " + appControl.ComponentId);
+        /// SendLaunchRequest(appControl);
         /// </code>
         /// </example>
         /// <since_tizen> 6 </since_tizen>

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -458,7 +458,7 @@ namespace Tizen.Applications
         /// AppControl appControl = new AppControl();
         /// appControl.ApplicationId = "org.tizen.component-based-app"; // component-based application
         /// appControl.ComponentId = "org.tizen.frame-component";
-        /// SendLaunchRequest(appControl);
+        /// AppControl.SendLaunchRequest(appControl);
         /// </code>
         /// </example>
         /// <since_tizen> 6 </since_tizen>

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -452,6 +452,7 @@ namespace Tizen.Applications
         /// (if the component ID is null for setter, it clears the previous value.)
         /// From Tizen 5.5, a new application model is supported that is component-based application.
         /// This property is for launching component-based application. If it's not set, the main component of component-based application will be launched.
+        /// If the target app is not component-based application, setting property is meaningless.
         /// </value>
         /// <example>
         /// <code>

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -446,7 +446,7 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// Gets and sets the component ID.
+        /// Gets and sets the component ID of the component-based application.
         /// </summary>
         /// <value>
         /// (if the component ID is null for setter, it clears the previous value.)

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -446,7 +446,7 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// Gets and sets the component ID of the component-based application.
+        /// Gets and sets the component ID to explicitly launch a component.
         /// </summary>
         /// <value>
         /// (if the component ID is null for setter, it clears the previous value.)


### PR DESCRIPTION
Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
This property is for getting and setting a component ID.

<class>
AppControl
<property>
+ string ComponentID { get; set; }

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: TCSACR-277

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
