### PR TITLE
[NUI] Change rotation APIs from internal to public

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -46,6 +46,18 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Activate")]
             public static extern void Window_Activate(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddAvailableOrientation")]
+            public static extern void Window_AddAvailableOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RemoveAvailableOrientation")]
+            public static extern void Window_RemoveAvailableOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPreferredOrientation")]
+            public static extern void Window_SetPreferredOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetPreferredOrientation")]
+            public static extern int Window_GetPreferredOrientation(global::System.Runtime.InteropServices.HandleRef jarg1);
             
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPositionSize")]
             public static extern void Window_SetPositionSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
@@ -192,14 +204,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetNativeWindowHandler")]
             public static extern System.IntPtr GetNativeWindowHandler(System.IntPtr Window);
 
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetParent")]
             public static extern void SetParent(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Unparent")]
             public static extern void Unparent(global::System.Runtime.InteropServices.HandleRef jarg1);
-
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetParent")]
             public static extern global::System.IntPtr GetParent(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
@@ -17,18 +17,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RotateIndicator")]
             public static extern void Window_RotateIndicator(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_AddAvailableOrientation")]
-            public static extern void Window_AddAvailableOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RemoveAvailableOrientation")]
-            public static extern void Window_RemoveAvailableOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPreferredOrientation")]
-            public static extern void Window_SetPreferredOrientation(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetPreferredOrientation")]
-            public static extern int Window_GetPreferredOrientation(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetNativeHandle")]
             public static extern global::System.IntPtr Window_GetNativeHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
         }

--- a/src/Tizen.NUI/src/public/Window.cs
+++ b/src/Tizen.NUI/src/public/Window.cs
@@ -1214,27 +1214,55 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal void AddAvailableOrientation(Window.WindowOrientation orientation)
+        /// <summary>
+        /// Adds an orientation to the list of available orientations.
+        /// </summary>
+        /// <param name="orientation">The available orientation to add</param>
+        /// <since_tizen> 6 </since_tizen>
+        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddAvailableOrientation(Window.WindowOrientation orientation)
         {
-            Interop.WindowInternal.Window_AddAvailableOrientation(swigCPtr, (int)orientation);
+            Interop.Window.Window_AddAvailableOrientation(swigCPtr, (int)orientation);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal void RemoveAvailableOrientation(Window.WindowOrientation orientation)
+        /// <summary>
+        /// Removes an orientation from the list of available orientations.
+        /// </summary>
+        /// <param name="orientation">The available orientation to remove.</param>
+        /// <since_tizen> 6 </since_tizen>
+        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void RemoveAvailableOrientation(Window.WindowOrientation orientation)
         {
-            Interop.WindowInternal.Window_RemoveAvailableOrientation(swigCPtr, (int)orientation);
+            Interop.Window.Window_RemoveAvailableOrientation(swigCPtr, (int)orientation);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal void SetPreferredOrientation(Window.WindowOrientation orientation)
+        /// <summary>
+        /// Sets a preferred orientation.
+        /// </summary>
+        /// <param name="orientation">The preferred orientation.</param>
+        /// <since_tizen> 6 </since_tizen>
+        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetPreferredOrientation(Window.WindowOrientation orientation)
         {
-            Interop.WindowInternal.Window_SetPreferredOrientation(swigCPtr, (int)orientation);
+            Interop.Window.Window_SetPreferredOrientation(swigCPtr, (int)orientation);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Window.WindowOrientation GetPreferredOrientation()
+        /// <summary>
+        /// Gets the preferred orientation.
+        /// </summary>
+        /// <param name="parent">The parent window.</param>
+        /// <since_tizen> 6 </since_tizen>
+        /// <returns>The preferred orientation if previously set, or none.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Window.WindowOrientation GetPreferredOrientation()
         {
-            Window.WindowOrientation ret = (Window.WindowOrientation)Interop.WindowInternal.Window_GetPreferredOrientation(swigCPtr);
+            Window.WindowOrientation ret = (Window.WindowOrientation)Interop.Window.Window_GetPreferredOrientation(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Change rotation APIs from internal to public.
- AddAvailableOrientation, RemoveAvailableOrientation, SetPreferredOrientation, GetPreferredOrientation
This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
