### PR TITLE
[IoTConnectivity] Fix wrong callback management

### DIFF
--- a/src/Tizen.Network.IoTConnectivity/Tizen.Network.IoTConnectivity/RemoteResource.cs
+++ b/src/Tizen.Network.IoTConnectivity/Tizen.Network.IoTConnectivity/RemoteResource.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -38,7 +39,7 @@ namespace Tizen.Network.IoTConnectivity
         private ResourceOptions _options;
 
         private int _responseCallbackId = 1;
-        private static Dictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback> _responseCallbacksMap = new Dictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback>();
+        private IDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback> _responseCallbacksMap;
 
         private Interop.IoTConnectivity.Client.RemoteResource.CachedRepresentationChangedCallback _cacheUpdatedCallback;
         private Interop.IoTConnectivity.Client.RemoteResource.StateChangedCallback _stateChangedCallback;
@@ -79,6 +80,7 @@ namespace Tizen.Network.IoTConnectivity
             Types = new List<string>(resourceTypes);
             Interfaces = new List<string>(resourceInterfaces);
             DeviceId = null;
+            _responseCallbacksMap = new ConcurrentDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback>();
 
             CreateRemoteResource(resourceTypes._resourceTypeHandle, resourceInterfaces.ResourceInterfacesHandle);
         }
@@ -92,6 +94,7 @@ namespace Tizen.Network.IoTConnectivity
                 throw IoTConnectivityErrorFactory.GetException(ret);
             }
             SetRemoteResource();
+            _responseCallbacksMap = new ConcurrentDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback>();
         }
 
         /// <summary>
@@ -404,10 +407,8 @@ namespace Tizen.Network.IoTConnectivity
             _responseCallbacksMap[id] = (IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData) =>
             {
                 IntPtr responseCallbackId = userData;
-                lock(_responseCallbacksMap)
-                {
-                    _responseCallbacksMap.Remove(responseCallbackId);
-                }
+
+                _responseCallbacksMap.Remove(responseCallbackId);
 
                 if (responseHandle != IntPtr.Zero)
                 {
@@ -459,10 +460,9 @@ namespace Tizen.Network.IoTConnectivity
             _responseCallbacksMap[id] = (IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData) =>
             {
                 IntPtr responseCallbackId = userData;
-                lock (_responseCallbacksMap)
-                {
-                    _responseCallbacksMap.Remove(responseCallbackId);
-                }
+
+                _responseCallbacksMap.Remove(responseCallbackId);
+
                 if (err == (int)(IoTConnectivityError.Iotivity))
                 {
                     RemoteResponse response = new RemoteResponse();
@@ -519,10 +519,9 @@ namespace Tizen.Network.IoTConnectivity
             _responseCallbacksMap[id] = (IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData) =>
             {
                 IntPtr responseCallbackId = userData;
-                lock (_responseCallbacksMap)
-                {
-                    _responseCallbacksMap.Remove(responseCallbackId);
-                }
+
+                _responseCallbacksMap.Remove(responseCallbackId);
+
                 if (responseHandle != IntPtr.Zero)
                 {
                     try
@@ -570,10 +569,9 @@ namespace Tizen.Network.IoTConnectivity
             _responseCallbacksMap[id] = (IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData) =>
             {
                 IntPtr responseCallbackId = userData;
-                lock (_responseCallbacksMap)
-                {
-                    _responseCallbacksMap.Remove(responseCallbackId);
-                }
+
+                _responseCallbacksMap.Remove(responseCallbackId);
+
                 if (err == (int)(IoTConnectivityError.Iotivity))
                 {
                     RemoteResponse response = new RemoteResponse();

--- a/src/Tizen.Network.IoTConnectivity/Tizen.Network.IoTConnectivity/RemoteResource.cs
+++ b/src/Tizen.Network.IoTConnectivity/Tizen.Network.IoTConnectivity/RemoteResource.cs
@@ -38,8 +38,8 @@ namespace Tizen.Network.IoTConnectivity
         private bool _cacheEnabled = false;
         private ResourceOptions _options;
 
-        private int _responseCallbackId = 1;
-        private IDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback> _responseCallbacksMap;
+        private static int _responseCallbackId = 1;
+        private static IDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback> _responseCallbacksMap = new ConcurrentDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback>();
 
         private Interop.IoTConnectivity.Client.RemoteResource.CachedRepresentationChangedCallback _cacheUpdatedCallback;
         private Interop.IoTConnectivity.Client.RemoteResource.StateChangedCallback _stateChangedCallback;
@@ -80,7 +80,6 @@ namespace Tizen.Network.IoTConnectivity
             Types = new List<string>(resourceTypes);
             Interfaces = new List<string>(resourceInterfaces);
             DeviceId = null;
-            _responseCallbacksMap = new ConcurrentDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback>();
 
             CreateRemoteResource(resourceTypes._resourceTypeHandle, resourceInterfaces.ResourceInterfacesHandle);
         }
@@ -94,7 +93,6 @@ namespace Tizen.Network.IoTConnectivity
                 throw IoTConnectivityErrorFactory.GetException(ret);
             }
             SetRemoteResource();
-            _responseCallbacksMap = new ConcurrentDictionary<IntPtr, Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback>();
         }
 
         /// <summary>


### PR DESCRIPTION
Change-Id: I5f9ba403661e32f2f6ed807318cc937b8137cfc9
Signed-off-by: Semun Lee <semun.lee@samsung.com>

### Description of Change ###
Dictionary for native callbacks was not properly managed. key of the dictionary was not static but dictionary was static. 
Changed to use ConcurrentDictionary instead of Dictionary and make the dictionary not to be static.


### API Changes ###
N/A