### PR TITLE
[MediaPlayer] change the error code related with AudioOffload

### DIFF
--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
@@ -157,6 +157,7 @@ namespace Tizen.Multimedia
         /// <exception cref="NotAvailableException">
         ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
         /// </exception>
+        /// <seealso cref="Player.AudioOffload"/>
         /// <seealso cref="Player.AudioCodecType"/>
         /// <since_tizen> 3 </since_tizen>
         public bool IsAvailable

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
@@ -49,7 +49,7 @@ namespace Tizen.Multimedia
         ///     -or-<br/>
         ///     <paramref name="index"/> is equal to or greater than <see cref="Count"/>.
         /// </exception>
-        /// <exception cref="InvalidOperationException">
+        /// <exception cref="NotAvailableException">
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>
@@ -79,10 +79,10 @@ namespace Tizen.Multimedia
         /// Clears the equalizer effect.
         /// </summary>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> has already been disposed of.</exception>
-        /// <exception cref="InvalidOperationException">
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     <see cref="IsAvailable"/> returns false. (Since tizen 6.0)
         /// </exception>
-        /// <exception cref="NotAvailableException"><see cref="IsAvailable"/> returns false. (Since tizen 6.0)</exception>
         /// <seealso cref="IsAvailable"/>
         /// <since_tizen> 3 </since_tizen>
         public void Clear()
@@ -100,10 +100,10 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets the number of items.
         /// </summary>
-        /// <exception cref="InvalidOperationException">
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     <see cref="IsAvailable"/> returns false. (Since tizen 6.0)
         /// </exception>
-        /// <exception cref="NotAvailableException"><see cref="IsAvailable"/> returns false. (Since tizen 6.0)</exception>
         /// <seealso cref="IsAvailable"/>
         /// <since_tizen> 3 </since_tizen>
         public int Count
@@ -125,10 +125,10 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets the range of band level in dB.
         /// </summary>
-        /// <exception cref="InvalidOperationException">
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     <see cref="IsAvailable"/> returns false. (Since tizen 6.0)
         /// </exception>
-        /// <exception cref="NotAvailableException"><seealso cref="IsAvailable"/> returns false. (Since tizen 6.0)</exception>
         /// <seealso cref="IsAvailable"/>
         /// <since_tizen> 3 </since_tizen>
         public Range BandLevelRange
@@ -152,10 +152,10 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <remarks>This function returns the availability of the audio effect function group and
         /// it could be unavailable depending on the platform capabilities.</remarks>
-        /// <exception cref="InvalidOperationException">
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
         /// </exception>
-        /// <exception cref="NotAvailableException">The function is not available depending on the audio codec type. (Since tizen 6.0)</exception>
         /// <seealso cref="Player.AudioCodecType"/>
         /// <since_tizen> 3 </since_tizen>
         public bool IsAvailable

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioEffect.cs
@@ -151,9 +151,10 @@ namespace Tizen.Multimedia
         /// Gets the value whether the AudioEffect is available or not.
         /// </summary>
         /// <remarks>This function returns the availability of the audio effect function group and
-        /// it could be unavailable depending on the platform capabilities.</remarks>
-        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
-        ///     -or-<br/>
+        /// it could be unavailable depending on the platform capabilities.<br/>
+        /// If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>,
+        /// the <see cref="IsAvailable"/> returns false.(Since tizen 6.0)</remarks>
+        /// <exception cref="NotAvailableException">
         ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
         /// </exception>
         /// <seealso cref="Player.AudioCodecType"/>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/AudioOffload.cs
@@ -56,7 +56,7 @@ namespace Tizen.Multimedia
         /// <remarks><para>The player lets the hardware decode and render the sound if the audio offload is enabled.
         /// Audio offload can reduce the power consumption, but disable the ability to handle output PCM.
         /// Please check the below list of functions which will not work if offloading is enabled.</para>
-        /// <para>If audio offload is enabled, the following functions will return <see cref="InvalidOperationException"/>: <br/>
+        /// <para>If audio offload is enabled, the following functions will return <see cref="NotAvailableException"/>: <br/>
         /// <see cref="AudioEffect"/><br/>
         /// <see cref="EqualizerBand"/><br/>
         /// <see cref="PlayerTrackInfo"/><br/>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/EqualizerBand.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/EqualizerBand.cs
@@ -48,7 +48,7 @@ namespace Tizen.Multimedia
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="value"/> is not inside of <see cref="AudioEffect.BandLevelRange"/>.
         /// </exception>
-        /// <exception cref="InvalidOperationException">
+        /// <exception cref="NotAvailableException">
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>
@@ -87,7 +87,7 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets the frequency in dB.
         /// </summary>
-        /// <exception cref="InvalidOperationException">
+        /// <exception cref="NotAvailableException">
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>
@@ -107,7 +107,7 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Gets the frequency range in dB.
         /// </summary>
-        /// <exception cref="InvalidOperationException">
+        /// <exception cref="NotAvailableException">
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
@@ -236,6 +236,7 @@ namespace Tizen.Multimedia
         /// <exception cref="NotAvailableException">
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
+        /// <seealso cref="AudioOffload"/>
         /// <since_tizen> 3 </since_tizen>
         public AudioLatencyMode AudioLatencyMode
         {
@@ -554,6 +555,7 @@ namespace Tizen.Multimedia
         ///     -or-<br/>
         ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
         /// </exception>
+        /// <seealso cref="AudioOffload"/>
         /// <seealso cref="AudioCodecType"/>
         /// <since_tizen> 5 </since_tizen>
         public bool ReplayGain
@@ -594,6 +596,7 @@ namespace Tizen.Multimedia
         ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
         /// </exception>
         /// <seealso cref="AudioPitch"/>
+        /// <seealso cref="AudioOffload"/>
         /// <seealso cref="AudioCodecType"/>
         /// <since_tizen> 6 </since_tizen>
         public bool AudioPitchEnabled
@@ -640,6 +643,7 @@ namespace Tizen.Multimedia
         ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
         /// </exception>
         /// <seealso cref="AudioPitchEnabled"/>
+        /// <seealso cref="AudioOffload"/>
         /// <seealso cref="AudioCodecType"/>
         /// <since_tizen> 6 </since_tizen>
         public float AudioPitch

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.Properties.cs
@@ -233,7 +233,7 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
         /// <exception cref="ArgumentException">The value is not valid.</exception>
-        /// <exception cref="InvalidOperationException">
+        /// <exception cref="NotAvailableException">
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>
@@ -549,10 +549,11 @@ namespace Tizen.Multimedia
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
         /// <exception cref="InvalidOperationException">
         ///     The player is not in the valid state.
-        ///     -or-<br/>
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
-        /// <exception cref="NotAvailableException">The function is not available depending on the audio codec type. (Since tizen 6.0)</exception>
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
+        /// </exception>
         /// <seealso cref="AudioCodecType"/>
         /// <since_tizen> 5 </since_tizen>
         public bool ReplayGain
@@ -586,11 +587,12 @@ namespace Tizen.Multimedia
         /// This function could be unavailable depending on the audio codec type.</remarks>
         /// <exception cref="InvalidOperationException">
         ///     The player is not in the valid state.
-        ///     -or-<br/>
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
-        /// <exception cref="NotAvailableException">The function is not available depending on the audio codec type. (Since tizen 6.0)</exception>
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
+        /// </exception>
         /// <seealso cref="AudioPitch"/>
         /// <seealso cref="AudioCodecType"/>
         /// <since_tizen> 6 </since_tizen>
@@ -626,16 +628,17 @@ namespace Tizen.Multimedia
         /// This function could be unavailable depending on the audio codec type.</remarks>
         /// <exception cref="InvalidOperationException">
         ///     A pitch is not enabled.
-        ///     -or-<br/>
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <exception cref="ObjectDisposedException">The player has already been disposed of.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     value is less than 0.5.
         ///     -or-<br/>
-        ///     value is greater than 2.0.<br/>
+        ///     value is greater than 2.0.
         /// </exception>
-        /// <exception cref="NotAvailableException">The function is not available depending on the audio codec type. (Since tizen 6.0)</exception>
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
+        /// </exception>
         /// <seealso cref="AudioPitchEnabled"/>
         /// <seealso cref="AudioCodecType"/>
         /// <since_tizen> 6 </since_tizen>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
@@ -762,8 +762,6 @@ namespace Tizen.Multimedia
         ///     The player is not in the valid state.<br/>
         ///     -or-<br/>
         ///     Streaming playback.
-        ///     -or-<br/>
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="rate"/> is less than -5.0.<br/>
@@ -771,6 +769,9 @@ namespace Tizen.Multimedia
         ///     <paramref name="rate"/> is greater than 5.0.<br/>
         ///     -or-<br/>
         ///     <paramref name="rate"/> is zero.
+        /// </exception>
+        /// <exception cref="NotAvailableException">
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>
         public void SetPlaybackRate(float rate)
@@ -974,10 +975,11 @@ namespace Tizen.Multimedia
         ///     Operation failed; internal error.
         ///     -or-<br/>
         ///     The player is not in the valid state.
-        ///     -or-<br/>
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         ///     </exception>
-        /// <exception cref="NotAvailableException">The function is not available depending on the audio codec type. (Since tizen 6.0)</exception>
+        /// <exception cref="NotAvailableException">If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     -or-<br/>
+        ///     The function is not available depending on the audio codec type. (Since tizen 6.0)
+        /// </exception>
         /// <seealso cref="PlayerAudioExtractOption"/>
         /// <seealso cref="DisableExportingAudioData"/>
         /// <seealso cref="AudioCodecType"/>

--- a/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/Player.cs
@@ -773,6 +773,7 @@ namespace Tizen.Multimedia
         /// <exception cref="NotAvailableException">
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
+        /// <seealso cref="AudioOffload"/>
         /// <since_tizen> 3 </since_tizen>
         public void SetPlaybackRate(float rate)
         {
@@ -982,6 +983,7 @@ namespace Tizen.Multimedia
         /// </exception>
         /// <seealso cref="PlayerAudioExtractOption"/>
         /// <seealso cref="DisableExportingAudioData"/>
+        /// <seealso cref="AudioOffload"/>
         /// <seealso cref="AudioCodecType"/>
         /// <since_tizen> 6 </since_tizen>
         public void EnableExportingAudioData(AudioMediaFormat format, PlayerAudioExtractOption option)

--- a/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
+++ b/src/Tizen.Multimedia.MediaPlayer/Player/PlayerTrackInfo.cs
@@ -48,7 +48,7 @@ namespace Tizen.Multimedia
         /// <see cref="PlayerState.Playing"/>, or <see cref="PlayerState.Paused"/> state.
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> that this instance belongs to has been disposed of.</exception>
-        /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.
+        /// <exception cref="NotAvailableException">The <see cref="Player"/> that this instance belongs to is not in the valid state.
         ///     -or-<br/>
         ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
@@ -79,13 +79,14 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> that this instance belongs to has been disposed of.</exception>
         /// <exception cref="InvalidOperationException">The <see cref="Player"/> that this instance belongs to is not in the valid state.
-        ///     -or-<br/>
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="index"/> is less than zero.<br/>
         ///     -or-<br/>
         ///     <paramref name="index"/> is equal to or greater than <see cref="GetCount()"/>.
+        /// </exception>
+        /// <exception cref="NotAvailableException">
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>
         public string GetLanguageCode(int index)
@@ -134,14 +135,15 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The <see cref="Player"/> that this instance belongs to has been disposed of.</exception>
         /// <exception cref="InvalidOperationException">
-        ///     The <see cref="Player"/> that this instance belongs to is not in the valid state.<br/>
-        ///     -or-<br/>
-        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
+        ///     The <see cref="Player"/> that this instance belongs to is not in the valid state.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///     <paramref name="value"/> is less than zero.<br/>
         ///     -or-<br/>
         ///     <paramref name="value"/> is equal to or greater than <see cref="GetCount()"/>.
+        /// </exception>
+        /// <exception cref="NotAvailableException">
+        ///     If audio offload is enabled by calling <see cref="AudioOffload.IsEnabled"/>. (Since tizen 6.0)
         /// </exception>
         /// <since_tizen> 3 </since_tizen>
         public int Selected


### PR DESCRIPTION
### API Changes ###
 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-284


▶Change
It works even though AudioOffload is enabled.

(AudioEffect.cs)
public bool IsAvailable

-----------------

▶Change
InvalidOperation will be removed and NotAvailableException will be returned instead of it.

(AudioEffect.cs)
public EqualizerBand this[int index]

(EqualizerBand.cs)
public int Level
public int Frequency
public int FrequencyRange

(Player.Properties.cs)
public AudioLatencyMode AudioLatencyMode

(PlayerTrackInfo.cs)
public int GetCount()

-----------------

▶Change
if AudioOffload is enabled, NotAvailableException is returned instead of InvalidOperation exception.

(AudioEffect.cs)
public void Clear()
public int Count
public Range BandLevelRange


(Player.Properties.cs)
public bool ReplayGain
public bool AudioPitchEnabled
public float AudioPitch

(Player.cs)
public void SetPlaybackRate(float rate)
public void EnableExportingAudioData(AudioMediaFormat format, PlayerAudioExtractOption option)

(PlayerTrackInfo.cs)
public string GetLanguageCode(int index)
public int Selected