### PR TITLE
[Network.Stc] Fix Build issue and Update PlatformFileList

### DIFF
--- a/packaging/PlatformFileList.txt
+++ b/packaging/PlatformFileList.txt
@@ -62,6 +62,7 @@ Tizen.Network.Mtp.dll
 Tizen.Network.Nfc.dll                              #mobile #mobile-emul #wearable
 Tizen.Network.Nsd.dll                              #common #mobile #mobile-emul #tv #wearable
 Tizen.Network.Smartcard.dll                        #mobile #mobile-emul #wearable
+Tizen.Network.Stc.dll                              #common #mobile #tv #wearable
 Tizen.Network.WiFi.dll                             #common #mobile #mobile-emul #tv #wearable
 Tizen.Network.WiFiDirect.dll                       #common #mobile #tv #ivi
 Tizen.Nlp.dll                                      #mobile #mobile-emul

--- a/src/Tizen.Network.Stc/Tizen.Network.Stc.sln
+++ b/src/Tizen.Network.Stc/Tizen.Network.Stc.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 15.0.26228.64
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Network.Stc", "Tizen.Network.Stc.csproj", "{7DB9ED96-A996-4527-AE60-6B97E1E27A57}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen", "..\Tizen\Tizen.csproj", "{4B7B60E2-BACB-4A68-A7A4-1D7827B38610}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Log", "..\Tizen.Log\Tizen.Log.csproj", "{D6CDDA7F-65D0-46CF-9E94-450ABFD8C729}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +19,14 @@ Global
 		{7DB9ED96-A996-4527-AE60-6B97E1E27A57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DB9ED96-A996-4527-AE60-6B97E1E27A57}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DB9ED96-A996-4527-AE60-6B97E1E27A57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B7B60E2-BACB-4A68-A7A4-1D7827B38610}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B7B60E2-BACB-4A68-A7A4-1D7827B38610}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B7B60E2-BACB-4A68-A7A4-1D7827B38610}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B7B60E2-BACB-4A68-A7A4-1D7827B38610}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6CDDA7F-65D0-46CF-9E94-450ABFD8C729}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6CDDA7F-65D0-46CF-9E94-450ABFD8C729}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6CDDA7F-65D0-46CF-9E94-450ABFD8C729}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6CDDA7F-65D0-46CF-9E94-450ABFD8C729}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Description of Changes

1. [Network.Stc] Add project dependencies in Solution file
This patch adds dependencies of Tizen and Tizen.log project so that Tizen.Network.Stc can build standalone.

2. [Network.Stc] Update PlatformFileList
This patch adds "Tizen.Network.Stc.dll" in PlatformFileList.txt.
