### PR TITLE
Apply TCSACR-288 Tizen.Telephony

### DIFF
--- a/src/Tizen.Telephony/Tizen.Telephony/Modem.cs
+++ b/src/Tizen.Telephony/Tizen.Telephony/Modem.cs
@@ -80,8 +80,14 @@ namespace Tizen.Telephony
         /// Gets the IMEI (International Mobile Station Equipment Identity) of a mobile phone.
         /// The IMEI number is used by a GSM network to identify valid devices and therefore, can be used for stopping a stolen phone from accessing that network.
         /// </summary>
+        /// <remarks>
+        /// For avoding the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
+        /// For an application with API version 6 or higer, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
+        /// For an application with API version lower than 6. if an application has http://tizen.org/privilege/telephony privilege, it sets with a pseudo value.
+        /// </remarks>
         /// <since_tizen> 3 </since_tizen>
-        /// <privilege>http://tizen.org/privilege/telephony</privilege>
+        /// <privilege>http://tizen.org/privilege/securesysteminfo</privilege>
+        /// <privlevel>partner</privlevel>
         /// <value>
         /// The International Mobile Station Equipment Identity.
         /// Empty string if unable to complete the operation.
@@ -130,8 +136,14 @@ namespace Tizen.Telephony
         /// <summary>
         /// Gets the MEID (Mobile Equipment Identifier) of a mobile phone (for CDMA).
         /// </summary>
+        /// <remarks>
+        /// For avoding the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
+        /// For an application with API version 6 or higer, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
+        /// For an application with API version lower than 6. if an application has http://tizen.org/privilege/telephony privilege, it sets with a pseudo value.
+        /// </remarks>
         /// <since_tizen> 3 </since_tizen>
-        /// <privilege>http://tizen.org/privilege/telephony</privilege>
+        /// <privilege>http://tizen.org/privilege/securesysteminfo</privilege>
+        /// <privlevel>partner</privlevel>
         /// <value>
         /// The Mobile Equipment Identifier.
         /// Empty string if unable to complete the operation.

--- a/src/Tizen.Telephony/Tizen.Telephony/Modem.cs
+++ b/src/Tizen.Telephony/Tizen.Telephony/Modem.cs
@@ -81,8 +81,8 @@ namespace Tizen.Telephony
         /// The IMEI number is used by a GSM network to identify valid devices and therefore, can be used for stopping a stolen phone from accessing that network.
         /// </summary>
         /// <remarks>
-        /// For avoding the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
-        /// For an application with API version 6 or higer, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
+        /// To avoid the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
+        /// For an application with API version 6 or higher, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
         /// For an application with API version lower than 6. if an application has http://tizen.org/privilege/telephony privilege, it sets with a pseudo value.
         /// </remarks>
         /// <since_tizen> 3 </since_tizen>
@@ -137,8 +137,8 @@ namespace Tizen.Telephony
         /// Gets the MEID (Mobile Equipment Identifier) of a mobile phone (for CDMA).
         /// </summary>
         /// <remarks>
-        /// For avoding the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
-        /// For an application with API version 6 or higer, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
+        /// To avoid the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
+        /// For an application with API version 6 or higher, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
         /// For an application with API version lower than 6. if an application has http://tizen.org/privilege/telephony privilege, it sets with a pseudo value.
         /// </remarks>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.Telephony/Tizen.Telephony/Sim.cs
+++ b/src/Tizen.Telephony/Tizen.Telephony/Sim.cs
@@ -130,8 +130,8 @@ namespace Tizen.Telephony
         /// The Integrated Circuit Card Identification number internationally identifies SIM cards.
         /// </summary>
         /// <remarks>
-        /// For avoding the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
-        /// For an application with API version 6 or higer, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
+        /// To avoid the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
+        /// For an application with API version 6 or higher, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
         /// For an application with API version lower than 6. if an application has http://tizen.org/privilege/telephony privilege, it sets with a pseudo value.
         /// </remarks>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.Telephony/Tizen.Telephony/Sim.cs
+++ b/src/Tizen.Telephony/Tizen.Telephony/Sim.cs
@@ -129,8 +129,14 @@ namespace Tizen.Telephony
         /// Gets the Integrated Circuit Card IDentification (ICC-ID).
         /// The Integrated Circuit Card Identification number internationally identifies SIM cards.
         /// </summary>
+        /// <remarks>
+        /// For avoding the unexpected behavior of old version applications that have http://tizen.org/privilege/telephony privilege. There is an exceptional handling in case of permission denied.
+        /// For an application with API version 6 or higer, if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
+        /// For an application with API version lower than 6. if an application has http://tizen.org/privilege/telephony privilege, it sets with a pseudo value.
+        /// </remarks>
         /// <since_tizen> 3 </since_tizen>
-        /// <privilege>http://tizen.org/privilege/telephony</privilege>
+        /// <privilege>http://tizen.org/privilege/securesysteminfo</privilege>
+        /// <privlevel>partner</privlevel>
         /// <value>
         /// The Integrated Circuit Card Identification.
         /// Empty string if unable to complete the operation.


### PR DESCRIPTION
### Description of Change ###
Change privlevel and privilege of non-resettable device IDs  

- IMEI, MEID and ICCID are not getting by 3rd party application anymore. 
- The partner privlevel application can read these information with new privilege as http://tizen.org/privilege/securesysteminfo.

 - For an application with API version 6 or higher, 
if an application doesn't have http://tizen.org/privilege/securesysteminfo privilege, it sets with empty string.
 - For an application with API version lower than 6. 
if an application has http://tizen.org/privilege/telephony privilege, it sets with a pseudo value.

### API Changes ###
 - ACR: http://suprem.sec.samsung.net/jira/browse/TCSACR-288 

