### PR TITLE
[Tizen.Network.Connection] Init/deinit without ManagedThreadId

### DIFF
--- a/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
+++ b/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
@@ -34,10 +34,10 @@ internal static partial class Interop
         public delegate bool IPv6AddressCallback(IntPtr ipv6, IntPtr userData);
 
         [DllImport(Libraries.Connection, EntryPoint = "connection_create")]
-        public static extern int Create(int tid, out IntPtr handle);
+        public static extern int Create(out IntPtr handle);
 
         [DllImport(Libraries.Connection, EntryPoint = "connection_destroy")]
-        public static extern int Destroy(int tid, IntPtr handle);
+        public static extern int Destroy(IntPtr handle);
 
         [DllImport(Libraries.Connection, EntryPoint = "connection_get_type")]
         public static extern int GetType(IntPtr handle, out int type);

--- a/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
+++ b/src/Tizen.Network.Connection/Interop/Interop.Connection.cs
@@ -33,10 +33,10 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate bool IPv6AddressCallback(IntPtr ipv6, IntPtr userData);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_create_cs")]
+        [DllImport(Libraries.Connection, EntryPoint = "connection_create")]
         public static extern int Create(int tid, out IntPtr handle);
 
-        [DllImport(Libraries.Connection, EntryPoint = "connection_destroy_cs")]
+        [DllImport(Libraries.Connection, EntryPoint = "connection_destroy")]
         public static extern int Destroy(int tid, IntPtr handle);
 
         [DllImport(Libraries.Connection, EntryPoint = "connection_get_type")]

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -34,8 +34,8 @@ namespace Tizen.Network.Connection
         public HandleHolder()
         {
             _tid = Thread.CurrentThread.ManagedThreadId;
-            Log.Info(Globals.LogTag, "PInvoke connection_create for Thread " + _tid);
-            int ret = Interop.Connection.Create(_tid, out Handle);
+            Log.Info(Globals.LogTag, "MOON PInvoke connection_create for Thread " + _tid);
+            int ret = Interop.Connection.Create(out Handle);
             Log.Info(Globals.LogTag, "Handle: " + Handle);
             if(ret != (int)ConnectionError.None)
             {
@@ -60,7 +60,7 @@ namespace Tizen.Network.Connection
         {
 
             Log.Info(Globals.LogTag, "PInvoke connection_destroy for Thread " + _tid);
-            Interop.Connection.Destroy(_tid, Handle);
+            Interop.Connection.Destroy(Handle);
             if (Handle != IntPtr.Zero)
             {
                 Handle = IntPtr.Zero;

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -34,7 +34,7 @@ namespace Tizen.Network.Connection
         public HandleHolder()
         {
             _tid = Thread.CurrentThread.ManagedThreadId;
-            Log.Info(Globals.LogTag, "MOON PInvoke connection_create for Thread " + _tid);
+            Log.Info(Globals.LogTag, "PInvoke connection_create for Thread " + _tid);
             int ret = Interop.Connection.Create(out Handle);
             Log.Info(Globals.LogTag, "Handle: " + Handle);
             if(ret != (int)ConnectionError.None)
@@ -162,6 +162,7 @@ namespace Tizen.Network.Connection
             {
                 if (_ConnectionTypeChanged != null)
                 {
+                    Log.Debug(Globals.LogTag, "ConnectionTypeChanged event");
                     _ConnectionTypeChanged(null, new ConnectionTypeEventArgs(type));
                 }
             };
@@ -233,6 +234,7 @@ namespace Tizen.Network.Connection
             {
                 if (_EthernetCableStateChanged != null)
                 {
+                    Log.Debug(Globals.LogTag, "EthernetCableStateChanged event");
                     _EthernetCableStateChanged(null, new EthernetCableStateEventArgs(state));
                 }
             };
@@ -314,6 +316,7 @@ namespace Tizen.Network.Connection
 
                     if ((string.IsNullOrEmpty(ipv4) == false) || (string.IsNullOrEmpty(ipv6) == false))
                     {
+                        Log.Debug(Globals.LogTag, "IPAddressChanged event");
                         _IPAddressChanged(null, new AddressEventArgs(ipv4, ipv6));
                     }
                 }
@@ -389,6 +392,7 @@ namespace Tizen.Network.Connection
 
                     if ((string.IsNullOrEmpty(ipv4) == false) || (string.IsNullOrEmpty(ipv6) == false))
                     {
+                        Log.Debug(Globals.LogTag, "ProxyAddressChanged event");
                         _ProxyAddressChanged(null, new AddressEventArgs(ipv4, ipv6));
                     }
                 }

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionProfile.cs
@@ -101,6 +101,7 @@ namespace Tizen.Network.Connection
             {
                 if (_ProfileStateChanged != null)
                 {
+                    Log.Debug(Globals.LogTag, "ProfileStateChanged event");
                     _ProfileStateChanged(null, new ProfileStateEventArgs(state));
                 }
             };


### PR DESCRIPTION
### Description of Change ###
Native capi, capi-network-connection is revised for multi-thread safety.
ConnectionInternalManager used ManagedThreadId to initialize and deinitialize connection capi because connection capi managed handles as thread local and there was a crash issue when C# GC tries to deinitialize the handle used by C#.
For now, capi-network-connection handles this issue.


### Related Link ###
https://review.tizen.org/gerrit/#/c/platform/core/api/connection/+/203344/