### PR TITLE
[NUI] NUIWidgetApplication constructor for multi widget

### DIFF
--- a/src/Tizen.NUI/src/internal/WidgetApplication.cs
+++ b/src/Tizen.NUI/src/internal/WidgetApplication.cs
@@ -26,6 +26,7 @@ namespace Tizen.NUI
         private Dictionary<System.Type, string> _widgetInfo;
         private List<Widget> _widgetList = new List<Widget>();
         private delegate System.IntPtr CreateWidgetFunctionDelegate(ref string widgetName);
+        private List<CreateWidgetFunctionDelegate> _createWidgetFunctionDelegateList = new List<CreateWidgetFunctionDelegate>();
 
         internal WidgetApplication(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -113,6 +114,9 @@ namespace Tizen.NUI
         internal void RegisterWidgetCreatingFunction(ref string widgetName)
         {
             CreateWidgetFunctionDelegate newDelegate = new CreateWidgetFunctionDelegate(WidgetCreateFunction);
+
+            // Keep this delegate until WidgetApplication is terminated
+            _createWidgetFunctionDelegateList.Add(newDelegate);
 
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(newDelegate);
             CreateWidgetFunction createWidgetFunction = new CreateWidgetFunction(ip, true);

--- a/src/Tizen.NUI/src/public/NUIWidgetApplication.cs
+++ b/src/Tizen.NUI/src/public/NUIWidgetApplication.cs
@@ -17,6 +17,7 @@
 using Tizen.Applications;
 using Tizen.Applications.CoreBackend;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Tizen.NUI
 {
@@ -35,6 +36,17 @@ namespace Tizen.NUI
         {
             NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;
             core?.RegisterWidgetInfo(new Dictionary<System.Type, string> { { widgetType, ApplicationInfo.ApplicationId } });
+        }
+
+        /// <summary>
+        /// The constructor for multi widget class and instance.
+        /// </summary>
+        /// <param name="widgetTypes">List of derived widget class type.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public NUIWidgetApplication(Dictionary<System.Type, string> widgetTypes) : base(new NUIWidgetCoreBackend())
+        {
+            NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;
+            core?.RegisterWidgetInfo(widgetTypes);
         }
 
         /// <summary>


### PR DESCRIPTION
Add new constructor for multi widget.
Previously, NUIWidgetApplication had constructor for single widget.

Now, we can support multi widget so add constructor for this.

Added:
 - public NUIWidgetApplication(Dictionary<System.Type, string> widgetTypes) : base(new NUIWidgetCoreBackend())
