### PR TITLE
[IoTConnectivity] Handle the exception for getting Dictionary item

### DIFF
--- a/src/Tizen.Network.IoTConnectivity/Tizen.Network.IoTConnectivity/RemoteResource.cs
+++ b/src/Tizen.Network.IoTConnectivity/Tizen.Network.IoTConnectivity/RemoteResource.cs
@@ -39,7 +39,7 @@ namespace Tizen.Network.IoTConnectivity
         private ResourceOptions _options;
 
         private static int _responseCompletionId = 1;
-        private static IDictionary<IntPtr, TaskCompletionSource<RemoteResponse>> _taskCompletionMap = new ConcurrentDictionary<IntPtr, TaskCompletionSource<RemoteResponse>>();
+        private static ConcurrentDictionary<IntPtr, TaskCompletionSource<RemoteResponse>> _taskCompletionMap = new ConcurrentDictionary<IntPtr, TaskCompletionSource<RemoteResponse>>();
 
         private static Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback _getResultCallback = NativeGetResultCallbackHandler;
         private static Interop.IoTConnectivity.Client.RemoteResource.ResponseCallback _putResultCallback = NativePutResultCallbackHandler;
@@ -423,8 +423,15 @@ namespace Tizen.Network.IoTConnectivity
         private static void NativeGetResultCallbackHandler(IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData)
         {
             IntPtr responseCompletionId = userData;
-            TaskCompletionSource<RemoteResponse> responseCompletionSource = _taskCompletionMap[responseCompletionId];
-            _taskCompletionMap.Remove(responseCompletionId);
+            TaskCompletionSource<RemoteResponse> responseCompletionSource;
+
+            Log.Info(IoTConnectivityErrorFactory.LogTag, "Result callback for : " + responseCompletionId);
+
+            if (!_taskCompletionMap.TryRemove(responseCompletionId, out responseCompletionSource))
+            {
+                Log.Error(IoTConnectivityErrorFactory.LogTag, "Failed to remove Key");
+                return;
+            }
 
             if (responseHandle != IntPtr.Zero)
             {
@@ -479,8 +486,15 @@ namespace Tizen.Network.IoTConnectivity
         private static void NativePutResultCallbackHandler(IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData)
         {
             IntPtr responseCompletionId = userData;
-            TaskCompletionSource<RemoteResponse> responseCompletionSource = _taskCompletionMap[responseCompletionId];
-            _taskCompletionMap.Remove(responseCompletionId);
+            TaskCompletionSource<RemoteResponse> responseCompletionSource;
+
+            Log.Info(IoTConnectivityErrorFactory.LogTag, "Result callback for : " + responseCompletionId);
+
+            if (!_taskCompletionMap.TryRemove(responseCompletionId, out responseCompletionSource))
+            {
+                Log.Error(IoTConnectivityErrorFactory.LogTag, "Failed to remove Key");
+                return;
+            }
 
             if (err == (int)(IoTConnectivityError.Iotivity))
             {
@@ -542,8 +556,15 @@ namespace Tizen.Network.IoTConnectivity
         private static void NativePostResultCallbackHandler(IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData)
         {
             IntPtr responseCompletionId = userData;
-            TaskCompletionSource<RemoteResponse> responseCompletionSource = _taskCompletionMap[responseCompletionId];
-            _taskCompletionMap.Remove(responseCompletionId);
+            TaskCompletionSource<RemoteResponse> responseCompletionSource;
+
+            Log.Info(IoTConnectivityErrorFactory.LogTag, "Result callback for : " + responseCompletionId);
+
+            if (!_taskCompletionMap.TryRemove(responseCompletionId, out responseCompletionSource))
+            {
+                Log.Error(IoTConnectivityErrorFactory.LogTag, "Failed to remove Key");
+                return;
+            }
 
             if (responseHandle != IntPtr.Zero)
             {
@@ -595,8 +616,15 @@ namespace Tizen.Network.IoTConnectivity
         private static void NativeDeleteResultCallbackHandler(IntPtr resource, int err, int requestType, IntPtr responseHandle, IntPtr userData)
         {
             IntPtr responseCompletionId = userData;
-            TaskCompletionSource<RemoteResponse> responseCompletionSource = _taskCompletionMap[responseCompletionId];
-            _taskCompletionMap.Remove(responseCompletionId);
+            TaskCompletionSource<RemoteResponse> responseCompletionSource;
+
+            Log.Info(IoTConnectivityErrorFactory.LogTag, "Result callback for : " + responseCompletionId);
+
+            if (!_taskCompletionMap.TryRemove(responseCompletionId, out responseCompletionSource))
+            {
+                Log.Error(IoTConnectivityErrorFactory.LogTag, "Failed to remove Key");
+                return;
+            }
 
             if (err == (int)(IoTConnectivityError.Iotivity))
             {


### PR DESCRIPTION
We should prevent the crash in next exception case.

Unhandled exception.

System.Collections.Generic.KeyNotFoundException: The given key '2' was not present in the dictionary.
 at System.Collections.Concurrent.ConcurrentDictionary`2.ThrowKeyNotFoundException(Object key)
 at System.Collections.Concurrent.ConcurrentDictionary`2.get_Item(TKey key)
 at Tizen.Network.IoTConnectivity.RemoteResource.NativePutResultCallbackHandler(IntPtr resource, Int32 err, Int32 requestType, IntPtr responseHandle, IntPtr userData)

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
