### PR TITLE
[NUI] Remove IME_F31 PredictiveString in NUI sample

### DIFF
--- a/test/NUITestSample/NUITestSample/examples/text-test2.cs
+++ b/test/NUITestSample/NUITestSample/examples/text-test2.cs
@@ -193,14 +193,6 @@ namespace TextTest2
             Tizen.Log.Debug("NUI", "e.ImfEventData.EventName= " + e?.ImfEventData?.EventName);
             Tizen.Log.Debug("NUI", "e.ImfEventData.NumberOfChars= " + e?.ImfEventData?.NumberOfChars);
 
-            //Be able to compare VD specific private command with ImfEventData.predictiveString
-            if (e.ImfEventData.PredictiveString == "IME_F31")
-            {
-                ImfManager.Get().Deactivate();
-                ImfManager.Get().HideInputPanel();
-                // Do Something the user wants
-                Tizen.Log.Debug("NUI", "ImfManager ImfEventData.PredictiveString: IME_F31!!!");
-            }
             ImfManager.ImfCallbackData callbackData = new ImfManager.ImfCallbackData(true, 0, e.ImfEventData.PredictiveString, false);
             Tizen.Log.Debug("NUI", "ImfManager return callbackData!!!");
             return callbackData;


### PR DESCRIPTION
Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- Remove to use "IME_F31" in NUI test sample


### API Changes ###
- N/A