### PR TITLE
[NUI] Remove 'EditorBrowsable' to HeightSpecification

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1788,7 +1788,6 @@ namespace Tizen.NUI.BaseComponents
         /// The required policy for this dimension, LayoutParamPolicies enum or exact value.
         ///</summary>
         /// <since_tizen> 6 </since_tizen>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public int HeightSpecification
         {
             get


### PR DESCRIPTION
Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- HeightSpecification of View opens public in API level 6.
- Please have a look at TCSACR-278


### API Changes ###
- N/A