### PR TITLE
[NUI] NaturalSize returns size set instead of Zero for CustomViews

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -325,7 +325,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public new virtual Size2D GetNaturalSize()
         {
-            return new Size2D(0, 0);
+            return sizeSetExplicitly;  // Returns the size set explicitly on View unless Overridden.
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -58,6 +58,8 @@ namespace Tizen.NUI.BaseComponents
         private Dictionary<string, Transition> transDictionary = new Dictionary<string, Transition>();
         private string[] transitionNames;
 
+        internal Size2D sizeSetExplicitly = new Size2D(); // Store size set by API, will be used in place of NaturalSize if not set.
+
         /// <summary>
         /// Creates a new instance of a view.
         /// </summary>
@@ -553,6 +555,7 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
+                sizeSetExplicitly = value;  // Store size set by API, will be used in place of NaturalSize if not set.
                 SetValue(Size2DProperty, value);
                 // Set Specification so when layouts measure this View it matches the value set here.
                 // All Views are currently Layouts.


### PR DESCRIPTION
Change-Id: I3e900c09df94d19b93d35d5bf947a99cefd5337b

### Description of Change ###
Previously CustomViews returned zero for NaturalSize.

Now return the size set if NaturalSize not overridden.

In the case of Controls derived from CustomView that have their size explicitly set via the View API, that size is returned as the NaturalSize, not the size that may have been set internally by native code.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
