### PR TITLE
[NUI] Fix attributes crash when Padding not set

### DIFF
--- a/src/Tizen.NUI.Components/Attributes/ViewAttributes.cs
+++ b/src/Tizen.NUI.Components/Attributes/ViewAttributes.cs
@@ -99,7 +99,10 @@ namespace Tizen.NUI.Components
                 Opacity = attributes.Opacity.Clone() as FloatSelector;
             }
 
-            Padding.CopyFrom(attributes.Padding);
+            if( attributes.Padding !=null )
+            {
+                Padding.CopyFrom(attributes.Padding);
+            }
         }
         /// <summary>
         /// View Position

--- a/src/Tizen.NUI.Components/Controls/DropDown.cs
+++ b/src/Tizen.NUI.Components/Controls/DropDown.cs
@@ -642,6 +642,10 @@ namespace Tizen.NUI.Components
             }
             set
             {
+                if (dropDownAttributes.ListPadding == null)
+                {
+                    dropDownAttributes.ListPadding = new Extents();
+                }
                 dropDownAttributes.ListPadding.CopyFrom(value);
 
                 if (null == listPadding)


### PR DESCRIPTION
Change-Id: I8f03e40985b58715b7f80fe2a84bb508a0346608

### Description of Change ###
Fix crash that occurs if Padding attribute not set in DropDownButtonAttributes.