### PR TITLE
[NUI] Removed unused getCPtr apis

### DIFF
--- a/src/Tizen.NUI/src/internal/AccessibilityActionSignal.cs
+++ b/src/Tizen.NUI/src/internal/AccessibilityActionSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AccessibilityActionSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/AccessibilityFocusOvershotSignal.cs
+++ b/src/Tizen.NUI/src/internal/AccessibilityFocusOvershotSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AccessibilityFocusOvershotSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ActivatedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/ActivatedSignalType.cs
@@ -27,11 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ActivatedSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         /// <summary>
         /// Dispose
         /// </summary>

--- a/src/Tizen.NUI/src/internal/AdaptorSignalType.cs
+++ b/src/Tizen.NUI/src/internal/AdaptorSignalType.cs
@@ -25,11 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AdaptorSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         /// <summary>
         /// Dispose
         /// </summary>

--- a/src/Tizen.NUI/src/internal/AnimatablePropertyComponentRegistration.cs
+++ b/src/Tizen.NUI/src/internal/AnimatablePropertyComponentRegistration.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AnimatablePropertyComponentRegistration obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/AnimatablePropertyRegistration.cs
+++ b/src/Tizen.NUI/src/internal/AnimatablePropertyRegistration.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AnimatablePropertyRegistration obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/AnimationSignal.cs
+++ b/src/Tizen.NUI/src/internal/AnimationSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AnimationSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ApplicationSignal.cs
+++ b/src/Tizen.NUI/src/internal/ApplicationSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ApplicationSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/AuthenticationSignalType.cs
+++ b/src/Tizen.NUI/src/internal/AuthenticationSignalType.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AuthenticationSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// <summary>
         /// Dispose

--- a/src/Tizen.NUI/src/internal/BaseObject.cs
+++ b/src/Tizen.NUI/src/internal/BaseObject.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(BaseObject obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         //you can override it to clean-up your own resources.
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Builder.cs
+++ b/src/Tizen.NUI/src/internal/Builder.cs
@@ -28,10 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Builder obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ButtonSignal.cs
+++ b/src/Tizen.NUI/src/internal/ButtonSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ButtonSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ChildPropertyRegistration.cs
+++ b/src/Tizen.NUI/src/internal/ChildPropertyRegistration.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ChildPropertyRegistration obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ConnectionTracker.cs
+++ b/src/Tizen.NUI/src/internal/ConnectionTracker.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ConnectionTracker obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ContentReceivedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/ContentReceivedSignalType.cs
@@ -30,10 +30,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ContentReceivedSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// <summary>
         /// Dispose

--- a/src/Tizen.NUI/src/internal/ControlKeySignal.cs
+++ b/src/Tizen.NUI/src/internal/ControlKeySignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ControlKeySignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/DaliException.cs
+++ b/src/Tizen.NUI/src/internal/DaliException.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(DaliException obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/DefaultRuler.cs
+++ b/src/Tizen.NUI/src/internal/DefaultRuler.cs
@@ -28,10 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(DefaultRuler obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/EventThreadCallback.cs
+++ b/src/Tizen.NUI/src/internal/EventThreadCallback.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(EventThreadCallback obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/FixedRuler.cs
+++ b/src/Tizen.NUI/src/internal/FixedRuler.cs
@@ -28,10 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FixedRuler obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/FloatSignal.cs
+++ b/src/Tizen.NUI/src/internal/FloatSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FloatSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/FocusChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/FocusChangedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FocusChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/FocusGroupChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/FocusGroupChangedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FocusGroupChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/GaussianBlurViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/GaussianBlurViewSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(GaussianBlurViewSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/HoverSignal.cs
+++ b/src/Tizen.NUI/src/internal/HoverSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(HoverSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ImageSignal.cs
+++ b/src/Tizen.NUI/src/internal/ImageSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ImageSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ItemView.cs
+++ b/src/Tizen.NUI/src/internal/ItemView.cs
@@ -31,10 +31,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ItemView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/KeyEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/KeyEventSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyEventSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/KeyInputFocusManager.cs
+++ b/src/Tizen.NUI/src/internal/KeyInputFocusManager.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyInputFocusManager obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/KeyInputFocusSignal.cs
+++ b/src/Tizen.NUI/src/internal/KeyInputFocusSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyInputFocusSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/KeyboardEventSignalType.cs
+++ b/src/Tizen.NUI/src/internal/KeyboardEventSignalType.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyboardEventSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/KeyboardResizedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/KeyboardResizedSignalType.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyboardResizedSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/KeyboardTypeSignalType.cs
+++ b/src/Tizen.NUI/src/internal/KeyboardTypeSignalType.cs
@@ -34,10 +34,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyboardTypeSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/LanguageChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/LanguageChangedSignalType.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(LanguageChangedSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ListEventSignalType.cs
+++ b/src/Tizen.NUI/src/internal/ListEventSignalType.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ListEventSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/LongPressGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/LongPressGestureDetectedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(LongPressGestureDetectedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/LowBatterySignalType.cs
+++ b/src/Tizen.NUI/src/internal/LowBatterySignalType.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(LowBatterySignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/LowMemorySignalType.cs
+++ b/src/Tizen.NUI/src/internal/LowMemorySignalType.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(LowMemorySignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ObjectCreatedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ObjectCreatedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ObjectCreatedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ObjectDestroyedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ObjectDestroyedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ObjectDestroyedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/PagePanSignal.cs
+++ b/src/Tizen.NUI/src/internal/PagePanSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PagePanSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/PageTurnSignal.cs
+++ b/src/Tizen.NUI/src/internal/PageTurnSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PageTurnSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/PanGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/PanGestureDetectedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PanGestureDetectedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/PinchGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/PinchGestureDetectedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PinchGestureDetectedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/PreFocusChangeSignal.cs
+++ b/src/Tizen.NUI/src/internal/PreFocusChangeSignal.cs
@@ -30,10 +30,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PreFocusChangeSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ProgressBarValueChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ProgressBarValueChangedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ProgressBarValueChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/PropertyRegistration.cs
+++ b/src/Tizen.NUI/src/internal/PropertyRegistration.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyRegistration obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/RenderTaskSignal.cs
+++ b/src/Tizen.NUI/src/internal/RenderTaskSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RenderTaskSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ResizedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ResizedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ResizedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/RotationGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/RotationGestureDetectedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RotationGestureDetectedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CustomActorImpl__Extension.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CustomActorImpl__Extension.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__CustomActorImpl__Extension obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__Texture.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__Texture.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__Internal__Texture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__TypeRegistry.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__TypeRegistry.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__Internal__TypeRegistry obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Actor_Dali__TouchEvent_const_RF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Actor_Dali__TouchEvent_const_RF_t.cs
@@ -24,9 +24,5 @@ namespace Tizen.NUI
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__SignalT_bool_fDali__Actor_Dali__TouchEvent_const_RF_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Actor_bool_Dali__DevelActor__VisibilityChange__TypeF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Actor_bool_Dali__DevelActor__VisibilityChange__TypeF_t.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__SignalT_void_fDali__Actor_bool_Dali__DevelActor__VisibilityChange__TypeF_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Control__Extension.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Control__Extension.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__Toolkit__Internal__Control__Extension obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__ItemFactory__Extension.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__ItemFactory__Extension.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_Dali__Toolkit__ItemFactory__Extension obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_PropertyInputContainer.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_PropertyInputContainer.cs
@@ -23,10 +23,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_PropertyInputContainer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_bundle.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_bundle.cs
@@ -45,10 +45,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_bundle obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_time_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_time_t.cs
@@ -29,10 +29,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_time_t obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_tm.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_tm.cs
@@ -31,9 +31,5 @@ namespace Tizen.NUI
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SWIGTYPE_p_tm obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/ScrollStateChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ScrollStateChangedSignal.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ScrollStateChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ScrollViewSnapStartedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ScrollViewSnapStartedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ScrollViewSnapStartedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ScrollableSignal.cs
+++ b/src/Tizen.NUI/src/internal/ScrollableSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ScrollableSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/SignalConnectorType.cs
+++ b/src/Tizen.NUI/src/internal/SignalConnectorType.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SignalConnectorType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/SignalObserver.cs
+++ b/src/Tizen.NUI/src/internal/SignalObserver.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SignalObserver obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/SliderMarkReachedSignal.cs
+++ b/src/Tizen.NUI/src/internal/SliderMarkReachedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SliderMarkReachedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/SliderValueChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/SliderValueChangedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SliderValueChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/StageWheelSignal.cs
+++ b/src/Tizen.NUI/src/internal/StageWheelSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(StageWheelSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/StateChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/StateChangedSignalType.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(StateChangedSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/StatusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/StatusSignalType.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(StatusSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/StyleChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/StyleChangedSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(StyleChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/TapGestureDetectedSignal.cs
+++ b/src/Tizen.NUI/src/internal/TapGestureDetectedSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TapGestureDetectedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/TextEditorSignal.cs
+++ b/src/Tizen.NUI/src/internal/TextEditorSignal.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TextEditorSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/TextFieldSignal.cs
+++ b/src/Tizen.NUI/src/internal/TextFieldSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TextFieldSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/TimerSignalType.cs
+++ b/src/Tizen.NUI/src/internal/TimerSignalType.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TimerSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/TouchDataSignal.cs
+++ b/src/Tizen.NUI/src/internal/TouchDataSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TouchDataSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/TouchSignal.cs
+++ b/src/Tizen.NUI/src/internal/TouchSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TouchSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/TypeAction.cs
+++ b/src/Tizen.NUI/src/internal/TypeAction.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TypeAction obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/VectorBase.cs
+++ b/src/Tizen.NUI/src/internal/VectorBase.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VectorBase obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/VectorBlob.cs
+++ b/src/Tizen.NUI/src/internal/VectorBlob.cs
@@ -23,10 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VectorBlob obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/VideoViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/VideoViewSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI {
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VideoViewSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ViewLayoutDirectionChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ViewLayoutDirectionChangedSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ViewLayoutDirectionChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ViewResourceReadySignal.cs
+++ b/src/Tizen.NUI/src/internal/ViewResourceReadySignal.cs
@@ -27,10 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ViewResourceReadySignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/ViewSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ViewSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ViewVisibilityChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/ViewVisibilityChangedSignal.cs
@@ -26,10 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ViewVisibilityChangedSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/VoidSignal.cs
+++ b/src/Tizen.NUI/src/internal/VoidSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VoidSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/WatchBoolSignal.cs
+++ b/src/Tizen.NUI/src/internal/WatchBoolSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WatchBoolSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/WatchTimeSignal.cs
+++ b/src/Tizen.NUI/src/internal/WatchTimeSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WatchTimeSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/WebViewPageLoadErrorSignal.cs
+++ b/src/Tizen.NUI/src/internal/WebViewPageLoadErrorSignal.cs
@@ -20,10 +20,6 @@ namespace Tizen.NUI
     internal class WebViewPageLoadErrorSignal : Disposable
     {
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebViewPageLoadErrorSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/WebViewPageLoadSignal.cs
+++ b/src/Tizen.NUI/src/internal/WebViewPageLoadSignal.cs
@@ -20,10 +20,6 @@ namespace Tizen.NUI
     internal class WebViewPageLoadSignal : Disposable
     {
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebViewPageLoadSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/WheelSignal.cs
+++ b/src/Tizen.NUI/src/internal/WheelSignal.cs
@@ -25,10 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WheelSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/WidgetImplPtr.cs
+++ b/src/Tizen.NUI/src/internal/WidgetImplPtr.cs
@@ -29,10 +29,5 @@ namespace Tizen.NUI
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WidgetImplPtr obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/WidgetViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/WidgetViewSignal.cs
@@ -34,10 +34,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WidgetViewSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/WindowEffectSignal.cs
+++ b/src/Tizen.NUI/src/internal/WindowEffectSignal.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WindowTransitionEffectSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/WindowFocusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/WindowFocusSignalType.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WindowFocusSignalType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/doublep.cs
+++ b/src/Tizen.NUI/src/internal/doublep.cs
@@ -24,11 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(doublep obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.doublep.delete_doublep(swigCPtr);

--- a/src/Tizen.NUI/src/internal/floatp.cs
+++ b/src/Tizen.NUI/src/internal/floatp.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(floatp obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/intp.cs
+++ b/src/Tizen.NUI/src/internal/intp.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(intp obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/uintp.cs
+++ b/src/Tizen.NUI/src/internal/uintp.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(uintp obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/internal/ushortp.cs
+++ b/src/Tizen.NUI/src/internal/ushortp.cs
@@ -24,10 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ushortp obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
@@ -389,10 +389,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FlexContainer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -867,12 +867,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ImageView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         internal void SetImage(string url, Uint16Pair size)
         {
             if(url.Contains(".json"))

--- a/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
@@ -504,11 +504,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Scrollable obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         internal ScrollableSignal ScrollStartedSignal()
         {
             ScrollableSignal ret = new ScrollableSignal(Interop.Scrollable.Scrollable_ScrollStartedSignal(swigCPtr), false);

--- a/src/Tizen.NUI/src/public/CubeTransitionEffect.cs
+++ b/src/Tizen.NUI/src/public/CubeTransitionEffect.cs
@@ -255,10 +255,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CubeTransitionEffectSignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -338,10 +334,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CubeTransitionWaveEffect obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         internal CubeTransitionWaveEffect(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.CubeTransitionWaveEffect.CubeTransitionWaveEffect_SWIGUpcast(cPtr), cMemoryOwn)
         {
@@ -370,10 +362,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CubeTransitionCrossEffect obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         internal CubeTransitionCrossEffect(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.CubeTransitionCrossEffect.CubeTransitionCrossEffect_SWIGUpcast(cPtr), cMemoryOwn)
         {
@@ -402,10 +390,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CubeTransitionFoldEffect obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         internal CubeTransitionFoldEffect(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.CubeTransitionWaveEffect.CubeTransitionWaveEffect_SWIGUpcast(cPtr), cMemoryOwn)
         {

--- a/src/Tizen.NUI/src/public/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/FocusManager.cs
@@ -410,11 +410,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FocusManager obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         internal static FocusManager Get()
         {
             FocusManager ret = new FocusManager(Interop.FocusManager.FocusManager_Get(), true);

--- a/src/Tizen.NUI/src/public/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/InputMethodContext.cs
@@ -1174,11 +1174,6 @@ namespace Tizen.NUI
                 swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
             }
 
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CallbackData obj)
-            {
-                return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, IntPtr.Zero) : obj.swigCPtr;
-            }
-
             internal static CallbackData GetCallbackDataFromPtr(IntPtr cPtr)
             {
                 CallbackData ret = new CallbackData(cPtr, false);

--- a/src/Tizen.NUI/src/public/PropertyNotifySignal.cs
+++ b/src/Tizen.NUI/src/public/PropertyNotifySignal.cs
@@ -124,10 +124,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyNotifySignal obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/ScrollViewPagePathEffect.cs
+++ b/src/Tizen.NUI/src/public/ScrollViewPagePathEffect.cs
@@ -34,10 +34,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ScrollViewPagePathEffect obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/UIComponents/CheckBoxButton.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/CheckBoxButton.cs
@@ -51,10 +51,6 @@ namespace Tizen.NUI.UIComponents
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CheckBoxButton obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/UIComponents/Popup.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/Popup.cs
@@ -1335,11 +1335,6 @@ namespace Tizen.NUI.UIComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Popup obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         internal View GetTitle()
         {
             //to fix memory leak issue, match the handle count with native side.

--- a/src/Tizen.NUI/src/public/UIComponents/PushButton.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/PushButton.cs
@@ -119,10 +119,6 @@ namespace Tizen.NUI.UIComponents
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PushButton obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/UIComponents/RadioButton.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/RadioButton.cs
@@ -69,10 +69,6 @@ namespace Tizen.NUI.UIComponents
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RadioButton obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/UIComponents/ScrollView.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/ScrollView.cs
@@ -1201,11 +1201,6 @@ namespace Tizen.NUI
             Interop.ScrollView.ScrollView_SetRulerY(swigCPtr, RulerPtr.getCPtr(ruler));
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ScrollView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         internal void ApplyConstraintToChildren(SWIGTYPE_p_Dali__Constraint constraint)
         {
             Interop.ScrollView.ScrollView_ApplyConstraintToChildren(swigCPtr, SWIGTYPE_p_Dali__Constraint.getCPtr(constraint));

--- a/src/Tizen.NUI/src/public/UIComponents/ToggleButton.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/ToggleButton.cs
@@ -161,10 +161,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ToggleButton obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/ViewWrapper.cs
+++ b/src/Tizen.NUI/src/public/ViewWrapper.cs
@@ -37,10 +37,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ViewWrapper obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
 
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/VisualFactory.cs
+++ b/src/Tizen.NUI/src/public/VisualFactory.cs
@@ -87,11 +87,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VisualFactory obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         internal VisualBase CreateVisual(Image image)
         {
             VisualBase ret = new VisualBase(Interop.VisualFactory.VisualFactory_CreateVisual__SWIG_1(swigCPtr, Image.getCPtr(image)), true);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Removed unused getCPtr apis
2. Reduce code duplication

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
