### PR TITLE
[NUI] Padding bug in LayoutGroup fixed

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -461,7 +461,7 @@ namespace Tizen.NUI
         {
             View childOwner = child.Owner;
 
-            Extents padding = child.Padding; // Padding of this layout's owner, not of the child being measured.
+            Extents padding = Padding; // Padding of this layout's owner, not of the child being measured.
 
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification( parentWidthMeasureSpec,
                                                                                        new LayoutLength(padding.Start + padding.End ),


### PR DESCRIPTION
#516 # Description of Change ###
LayoutGroup measuring child without using the parent's padding.
Resulted in LinearLayout not reducing the childs size when padding applied to parent
Issue #2 of Layouts bug reported.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
