### PR TITLE
[NUI] Prevent Height and Width specs being overwritten

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1778,8 +1778,18 @@ namespace Tizen.NUI.BaseComponents
                 if (_widthPolicy >= 0)
                 {
                     _measureSpecificationWidth = new MeasureSpecification( new LayoutLength(value), MeasureSpecification.ModeType.Exactly );
-                    Size2D.Width = _widthPolicy;
 
+                    if(_heightPolicy>=0) // Policy an exact value
+                    {
+                        Size2D.Width = _widthPolicy;
+                    }
+                    else
+                    {
+                        // Store _heightPolicy in the Size2D memember as will be reset to 0 by a Size2D callback.
+                        // Size2D height will store the specification value (negative number) this will then be applied to the
+                        // HeightSpecification when the Size2D callback is invoked.
+                        Size2D = new Size2D(_widthPolicy,_heightPolicy);
+                    }
                 }
                 _layout?.RequestLayout();
             }
@@ -1801,7 +1811,18 @@ namespace Tizen.NUI.BaseComponents
                 if (_heightPolicy >= 0)
                 {
                     _measureSpecificationHeight = new MeasureSpecification( new LayoutLength(value), MeasureSpecification.ModeType.Exactly );
-                    Size2D.Height = _heightPolicy;
+
+                    if(_widthPolicy>=0) // Policy an exact value
+                    {
+                        Size2D.Height = _heightPolicy;
+                    }
+                    else
+                    {
+                        // Store widthPolicy in the Size2D memember as will be reset to 0 by a Size2D callback.
+                        // Size2D height will store the specification value (negative number) this will then be applied to the
+                        // HeightSpecification when the Size2D callback is invoked.
+                        Size2D = new Size2D(_widthPolicy,_heightPolicy);
+                    }
 
                 }
                _layout?.RequestLayout();


### PR DESCRIPTION

Change-Id: I80a4e1166f35e4c09c116916262ac965de54b048

### Description of Change ###
When setting the WidthSpecification or HeightSpecification with an exact value
the Size.Width or Size.Height is set but this in turns triggers a callback which
sets Size(width,height) but uses the stored height or width value which may not be
the set Width or Height Specification hence sets them to 0;


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
