### PR TITLE
[NUI] Workaround: fix CustomAlgorithmInterface crash error

### DIFF
--- a/src/Tizen.NUI/src/internal/CustomAlgorithmInterface.cs
+++ b/src/Tizen.NUI/src/internal/CustomAlgorithmInterface.cs
@@ -66,10 +66,23 @@ namespace Tizen.NUI
 
         private global::System.IntPtr SwigDirectorGetNextFocusableView(global::System.IntPtr current, global::System.IntPtr proposed, int direction)
         {
-            View currentView = Registry.GetManagedBaseHandleFromNativePtr(current) as View;
-            View proposedView = Registry.GetManagedBaseHandleFromNativePtr(proposed) as View;
+            if (current == global::System.IntPtr.Zero && proposed == global::System.IntPtr.Zero)
+            {
+                return global::System.IntPtr.Zero;
+            }
 
-            return View.getCPtr(GetNextFocusableView(currentView, proposedView, (View.FocusDirection)direction)).Handle;
+            try
+            {
+                View currentView = Registry.GetManagedBaseHandleFromNativePtr(current) as View;
+                View proposedView = Registry.GetManagedBaseHandleFromNativePtr(proposed) as View;
+
+                return View.getCPtr(GetNextFocusableView(currentView, proposedView, (View.FocusDirection)direction)).Handle;
+            }
+            catch (global::System.Exception ex)
+            {
+              Tizen.Log.Error("NUI","Registry Error: "+ ex);
+            }
+            return global::System.IntPtr.Zero;
         }
 
         internal delegate global::System.IntPtr SwigDelegateCustomAlgorithmInterface_0(global::System.IntPtr current, global::System.IntPtr proposed, int direction);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageLoading.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageLoading.cs
@@ -38,7 +38,7 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetClosestImageSize__SWIG_4")]
             public static extern global::System.IntPtr GetClosestImageSize__SWIG_4(string jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetOriginalImageSPize")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetOriginalImageSize")]
             public static extern global::System.IntPtr GetOriginalImageSize(string jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DownloadImageSynchronously__SWIG_0")]

--- a/test/NUITestSample/NUITestSample/examples/GetOriginalImageSizeTest.cs
+++ b/test/NUITestSample/NUITestSample/examples/GetOriginalImageSizeTest.cs
@@ -1,0 +1,60 @@
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using mypath = Tizen.Applications.Application.Current;
+
+namespace mytest
+{
+    public class myTestApp : NUIApplication
+    {
+        public myTestApp() : base()
+        {
+        }
+        public myTestApp(string styleSheet) : base(styleSheet)
+        {
+        }
+
+        Window win;
+        protected override void OnCreate()
+        {
+            base.OnCreate();
+            win = Window.Instance;
+            win.BackgroundColor = Color.Cyan;
+            View v1 = new View();
+            v1.Size2D = new Size2D(100, 100);
+            v1.BackgroundColor = Color.Blue;
+            win.GetDefaultLayer().Add(v1);
+
+            ImageView iv = new ImageView();
+            iv.ResourceUrl = mypath.DirectoryInfo.Resource + @"/images/Dali/DaliDemo/Logo-for-demo.png";
+            iv.Position2D = new Position2D(50, 200);
+            win.GetDefaultLayer().Add(iv);
+
+            Size2D imageSize = ImageLoading.GetOriginalImageSize(iv.ResourceUrl);
+            TextLabel tl = new TextLabel();
+            tl.Position2D = new Position2D(iv.Position2D.X, iv.Position2D.Y + imageSize.Height);
+            tl.MultiLine = true;
+            tl.Text = $"ResourceUrl: {iv.ResourceUrl} \nOriginalImageSize: W({imageSize.Width}), H({imageSize.Height})";
+            win.GetDefaultLayer().Add(tl);
+
+            //==================
+            iv = new ImageView();
+            iv.ResourceUrl = mypath.DirectoryInfo.Resource + @"/images/Dali/DaliDemo/demo-tile-texture.9.png";
+            iv.Position2D = new Position2D(50, 600);
+            win.GetDefaultLayer().Add(iv);
+
+            imageSize = ImageLoading.GetOriginalImageSize(iv.ResourceUrl);
+            tl = new TextLabel();
+            tl.Position2D = new Position2D(iv.Position2D.X, iv.Position2D.Y + imageSize.Height);
+            tl.MultiLine = true;
+            tl.Text = $"ResourceUrl: {iv.ResourceUrl} \nOriginalImageSize: W({imageSize.Width}), H({imageSize.Height})";
+            win.GetDefaultLayer().Add(tl);
+        }
+
+        //[STAThread]
+        //static void Main(string[] args)
+        //{
+        //    new myTestApp().Run(args);
+        //}
+    }
+}


### PR DESCRIPTION
### Description of Change ###
[NUI] Workaround: fix CustomAlgorithmInterface crash error occurred only in emulator, will be removed later after a proper solution is found
    
- fix CSharp_Dali_GetOriginalImageSize spelling error.
- add "GetOriginalImageSizeTest.cs" as sample APP.

### API Changes ###
Nothing