### PR TITLE
[Sensor] Add rotation sensor internal API

### DIFF
--- a/src/Tizen.Sensor/Tizen.Sensor/EventArgs/AutoRotationSensorDataUpdatedEventArgs.cs
+++ b/src/Tizen.Sensor/Tizen.Sensor/EventArgs/AutoRotationSensorDataUpdatedEventArgs.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.Sensor
+{
+    /// <summary>
+    /// The AutoRotationSensor changed event arguments class is used for storing the data returned by the auto rotation sensor.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AutoRotationSensorDataUpdatedEventArgs : EventArgs
+    {
+        internal AutoRotationSensorDataUpdatedEventArgs(float[] values, SensorDataAccuracy accuracy)
+        {
+            Rotaion = (AutoRotationState)values[0];
+            Accuracy = accuracy;
+        }
+
+        /// <summary>
+        /// Gets the value of the rotation state.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <value> The rotation state. </value>
+        public AutoRotationState Rotaion { get; private set; } = AutoRotationState.Degree_0;
+
+        /// <summary>
+        /// Gets the accuracy of the auto rotation data.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <value> Accuracy </value>
+        public SensorDataAccuracy Accuracy { get; private set; }
+    }
+}

--- a/src/Tizen.Sensor/Tizen.Sensor/Plugins/AutoRotationSensor.cs
+++ b/src/Tizen.Sensor/Tizen.Sensor/Plugins/AutoRotationSensor.cs
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.Sensor
+{
+    /// <summary>
+    /// The AutoRotationSensor class is used for registering callbacks for the auto rotation sensor and getting the auto rotation data.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public sealed class AutoRotationSensor : Sensor
+    {
+        private static string AccelerometerKey = "http://tizen.org/feature/sensor.accelerometer";
+
+        private event EventHandler<SensorAccuracyChangedEventArgs> _accuracyChanged;
+
+        /// <summary>
+        /// Gets the value of the rotation state.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <value> The rotation state. </value>
+        public AutoRotationState Rotaion { get; private set; } = AutoRotationState.Degree_0;
+
+
+        /// <summary>
+        /// Gets the accuracy of the auto rotation data.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <value> Accuracy </value>
+        public SensorDataAccuracy Accuracy { get; private set; } = SensorDataAccuracy.Undefined;
+
+        /// <summary>
+        /// Returns true or false based on whether the auto rotation sensor is supported by the device.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <value><c>true</c> if supported; otherwise <c>false</c>.</value>
+        public static bool IsSupported
+        {
+            get
+            {
+                Log.Info(Globals.LogTag, "Checking if the AutoRotationSensor is supported");
+                return CheckIfSupported(SensorType.AutoRotation, AccelerometerKey);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Tizen.Sensor.AutoRotationSensor"/> class.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        /// <feature>http://tizen.org/feature/sensor.auto_rotation</feature>
+        /// <exception cref="ArgumentException">Thrown when an invalid argument is used.</exception>
+        /// <exception cref="NotSupportedException">Thrown when the sensor is not supported.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the operation is invalid for the current state.</exception>
+        /// <param name='index'>
+        /// Index. Default value for this is 0. Index refers to a particular auto rotation sensor in case of multiple sensors.
+        /// </param>
+        public AutoRotationSensor(uint index = 0) : base(index)
+        {
+            Log.Info(Globals.LogTag, "Creating AutoRotationSensor object");
+        }
+
+        internal override SensorType GetSensorType()
+        {
+            return SensorType.AutoRotation;
+        }
+
+        /// <summary>
+        /// An event handler for storing the callback functions for the event corresponding to the change in the auto rotation sensor data.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+
+        public event EventHandler<AutoRotationSensorDataUpdatedEventArgs> DataUpdated;
+
+        /// <summary>
+        /// An event handler for accuracy changed events.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        public event EventHandler<SensorAccuracyChangedEventArgs> AccuracyChanged
+        {
+            add
+            {
+                if (_accuracyChanged == null)
+                {
+                    AccuracyListenStart();
+                }
+                _accuracyChanged += value;
+            }
+            remove
+            {
+                _accuracyChanged -= value;
+                if (_accuracyChanged == null)
+                {
+                    AccuracyListenStop();
+                }
+            }
+        }
+
+        private static int GetCount()
+        {
+            IntPtr list;
+            int count;
+            int error = Interop.SensorManager.GetSensorList(SensorType.AutoRotation, out list, out count);
+            if (error != (int)SensorError.None)
+            {
+                Log.Error(Globals.LogTag, "Error getting sensor list for auto rotation");
+                count = 0;
+            }
+            else
+                Interop.Libc.Free(list);
+            return count;
+        }
+
+        private static Interop.SensorListener.SensorEventCallback _callback;
+
+        internal override void EventListenStart()
+        {
+            _callback = (IntPtr sensorHandle, IntPtr eventPtr, IntPtr data) => {
+                Interop.SensorEventStruct sensorData = Interop.IntPtrToEventStruct(eventPtr);
+
+                TimeSpan = new TimeSpan((Int64)sensorData.timestamp);
+                Rotaion = (AutoRotationState)sensorData.values[0];
+                Accuracy = sensorData.accuracy;
+
+                DataUpdated?.Invoke(this, new AutoRotationSensorDataUpdatedEventArgs(sensorData.values, sensorData.accuracy));
+            };
+
+            int error = Interop.SensorListener.SetEventCallback(ListenerHandle, Interval, _callback, IntPtr.Zero);
+            if (error != (int)SensorError.None)
+            {
+                Log.Error(Globals.LogTag, "Error setting event callback for auto rotation sensor");
+                throw SensorErrorFactory.CheckAndThrowException(error, "Unable to set event callback for auto rotation");
+            }
+        }
+
+        internal override void EventListenStop()
+        {
+            int error = Interop.SensorListener.UnsetEventCallback(ListenerHandle);
+            if (error != (int)SensorError.None)
+            {
+                Log.Error(Globals.LogTag, "Error unsetting event callback for auto rotation sensor");
+                throw SensorErrorFactory.CheckAndThrowException(error, "Unable to unset event callback for auto rotation");
+            }
+        }
+
+        private static Interop.SensorListener.SensorAccuracyCallback _accuracyCallback;
+
+        private void AccuracyListenStart()
+        {
+            _accuracyCallback = (IntPtr sensorHandle, UInt64 timestamp, SensorDataAccuracy accuracy, IntPtr data) => {
+                TimeSpan = new TimeSpan((Int64)timestamp);
+                Accuracy = accuracy;
+                _accuracyChanged?.Invoke(this, new SensorAccuracyChangedEventArgs(new TimeSpan((Int64)timestamp), accuracy));
+            };
+
+            int error = Interop.SensorListener.SetAccuracyCallback(ListenerHandle, _accuracyCallback, IntPtr.Zero);
+            if (error != (int)SensorError.None)
+            {
+                Log.Error(Globals.LogTag, "Error setting accuracy event callback for auto rotation sensor");
+                throw SensorErrorFactory.CheckAndThrowException(error, "Unable to set accuracy event callback for auto rotation");
+            }
+        }
+
+        private void AccuracyListenStop()
+        {
+            int error = Interop.SensorListener.UnsetAccuracyCallback(ListenerHandle);
+            if (error != (int)SensorError.None)
+            {
+                Log.Error(Globals.LogTag, "Error unsetting accuracy event callback for auto rotation sensor");
+                throw SensorErrorFactory.CheckAndThrowException(error, "Unable to unset accuracy event callback for auto rotation");
+            }
+        }
+    }
+}

--- a/src/Tizen.Sensor/Tizen.Sensor/SensorEnumerations.cs
+++ b/src/Tizen.Sensor/Tizen.Sensor/SensorEnumerations.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.ComponentModel;
 
 namespace Tizen.Sensor
 {
@@ -110,6 +111,10 @@ namespace Tizen.Sensor
         /// <summary>
         /// Stationary activity detector.
         /// </summary>
+        /// Auto Rotaion sensor.
+        /// </summary>
+        AutoRotation = 0x901,
+        /// <summary>
         StationaryActivityDetector = 0x1A00,
         /// <summary>
         /// Walking activity detector.
@@ -318,5 +323,37 @@ namespace Tizen.Sensor
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         Detected = 1
+    }
+    
+    /// <summary>
+    /// The auto rotation state.
+    /// </summary>
+    /// <since_tizen> 3 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum AutoRotationState
+    {
+        /// <summary>
+        /// Degree_0 sate.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        Degree_0 = 0,
+
+        /// <summary>
+        /// Degree_90 state.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        Degree_90 = 1,
+
+        /// <summary>
+        /// Degree_180 state.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        Degree_180 = 2,
+
+        /// <summary>
+        /// Degree_270 state.
+        /// </summary>
+        /// <since_tizen> 3 </since_tizen>
+        Degree_270 = 3
     }
 }


### PR DESCRIPTION
Signed-off-by: MuHong Byun <mh.byun@samsung.com>

### Description of Change ###
Add auto-rotation sensor API to c # API internally

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
