### PR TITLE
[Application] Fix widget instance id bug

### DIFF
--- a/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
+++ b/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
@@ -107,6 +107,14 @@ internal static partial class Interop
         [DllImport(Libraries.AppcoreWidget, EntryPoint = "widget_app_get_elm_win")]
         internal static extern ErrorCode GetWin(IntPtr handle, out IntPtr win);
 
+        [DllImport(Libraries.AppcoreWidget)]
+        internal static extern IntPtr widget_app_get_id(IntPtr handle);
+
+        internal static string GetAppId(IntPtr handle)
+        {
+            return Marshal.PtrToStringAnsi(widget_app_get_id(handle));
+        }
+
         [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_low_memory_status")]
         internal static extern Tizen.Internals.Errors.ErrorCode AppEventGetLowMemoryStatus(IntPtr handle, out LowMemoryStatus status);
 

--- a/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
+++ b/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
@@ -110,7 +110,7 @@ internal static partial class Interop
         [DllImport(Libraries.AppcoreWidget)]
         internal static extern IntPtr widget_app_get_id(IntPtr handle);
 
-        internal static string GetAppId(IntPtr handle)
+        internal static string GetId(IntPtr handle)
         {
             return Marshal.PtrToStringAnsi(widget_app_get_id(handle));
         }

--- a/src/Tizen.Applications.WidgetApplication/Tizen.Applications/WidgetType.cs
+++ b/src/Tizen.Applications.WidgetApplication/Tizen.Applications/WidgetType.cs
@@ -52,7 +52,7 @@ namespace Tizen.Applications
             if (b == null)
                 return 0;
 
-            b.Bind(context, Id);
+            b.Bind(context, Interop.Widget.GetAppId(context));
             WidgetInstances.Add(b);
             if (content != IntPtr.Zero)
                 bundle = new Bundle(new SafeBundleHandle(content, false));

--- a/src/Tizen.Applications.WidgetApplication/Tizen.Applications/WidgetType.cs
+++ b/src/Tizen.Applications.WidgetApplication/Tizen.Applications/WidgetType.cs
@@ -52,7 +52,7 @@ namespace Tizen.Applications
             if (b == null)
                 return 0;
 
-            b.Bind(context, Interop.Widget.GetAppId(context));
+            b.Bind(context, Interop.Widget.GetId(context));
             WidgetInstances.Add(b);
             if (content != IntPtr.Zero)
                 bundle = new Bundle(new SafeBundleHandle(content, false));


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
 Fix https://github.com/Samsung/TizenFX/issues/1150

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
