### PR TITLE
[NUI] Constructor of NUIWidgetApplication is opened public in API level7

### DIFF
--- a/src/Tizen.NUI/src/public/NUIWidgetApplication.cs
+++ b/src/Tizen.NUI/src/public/NUIWidgetApplication.cs
@@ -42,7 +42,6 @@ namespace Tizen.NUI
         /// The constructor for multi widget class and instance.
         /// </summary>
         /// <param name="widgetTypes">List of derived widget class type.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIWidgetApplication(Dictionary<System.Type, string> widgetTypes) : base(new NUIWidgetCoreBackend())
         {
             NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;


### PR DESCRIPTION
For apply multiple class of Widget, this API need to open public

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
https://code.sec.samsung.net/jira/browse/TCSACR-299

