### PR TITLE
[ElmSharp] Add more preloading components

### DIFF
--- a/src/ElmSharp/ElmSharp/Elementary.cs
+++ b/src/ElmSharp/ElmSharp/Elementary.cs
@@ -236,7 +236,7 @@ namespace ElmSharp
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void ThemeOverlay()
         {
-            if (File.Exists(_themeFilePath))
+            if (!Window.IsPreloaded && File.Exists(_themeFilePath))
             {
                 AddThemeOverlay(_themeFilePath);
             }

--- a/src/ElmSharp/ElmSharp/Elementary.cs
+++ b/src/ElmSharp/ElmSharp/Elementary.cs
@@ -207,7 +207,8 @@ namespace ElmSharp
         /// <since_tizen> preview </since_tizen>
         public static void Initialize()
         {
-            Interop.Elementary.elm_init(0, null);
+            if (!Window.IsPreloaded)
+                Interop.Elementary.elm_init(0, null);
         }
 
         /// <summary>

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -20,15 +20,14 @@ namespace ElmSharp
     {
         static PreloadedWindow s_precreated;
 
-        public PreloadedWindow(bool useBaseLayout=true, bool preloadWidgets=true, bool preloadEvents=true) : base("PreloadWindow")
+        public PreloadedWindow(bool useBaseLayout=true) : base("PreloadWindow")
         {
             s_precreated = this;
             if (useBaseLayout)
                 InitializeBaseLayout();
-            if (preloadWidgets)
-                CreateWidgets();
-            if (preloadEvents)
-                AddRemoveEvents();
+            CreateWidgets();
+            BackButtonPressed += DummyHandler;
+            BackButtonPressed -= DummyHandler;
         }
 
         public Layout BaseLayout
@@ -52,31 +51,25 @@ namespace ElmSharp
 
         public void CreateWidgets()
         {
-            _ = new Entry(this);
-            _ = new Scroller(this);
-            _ = new Box(this);
-            _ = new Label(this);
-            _ = new GenList(this);
-            _ = new Button(this);
-            _ = new Check(this);
-            _ = new Naviframe(this);
-            _ = new Slider(this);
-            _ = new Spinner(this);
-            _ = new ProgressBar(this);
-            _ = new GestureLayer(this);
-            _ = new Polygon(this);
-            _ = new Image(this);
+            new Entry(this).Unrealize();
+            new Scroller(this).Unrealize();
+            new Box(this).Unrealize();
+            new Label(this).Unrealize();
+            new GenList(this).Unrealize();
+            new Button(this).Unrealize();
+            new Check(this).Unrealize();
+            new Naviframe(this).Unrealize();
+            new Slider(this).Unrealize();
+            new Spinner(this).Unrealize();
+            new ProgressBar(this).Unrealize();
+            new GestureLayer(this).Unrealize();
+            new Polygon(this).Unrealize();
+            new Image(this).Unrealize();
             //TODO: Need to call Image.LoadAsync()
         }
 
         void DummyHandler(object sender, System.EventArgs e)
         {
-        }
-
-        public void AddRemoveEvents()
-        {
-            this.BackButtonPressed += DummyHandler;
-            this.BackButtonPressed -= DummyHandler;
         }
 
         public static PreloadedWindow GetInstance()

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -28,6 +28,7 @@ namespace ElmSharp
             CreateWidgets();
             BackButtonPressed += DummyHandler;
             BackButtonPressed -= DummyHandler;
+            void DummyHandler(object sender, System.EventArgs e) { }
         }
 
         public Layout BaseLayout
@@ -65,11 +66,7 @@ namespace ElmSharp
             new GestureLayer(this).Unrealize();
             new Polygon(this).Unrealize();
             new Image(this).Unrealize();
-            //TODO: Need to call Image.LoadAsync()
-        }
-
-        void DummyHandler(object sender, System.EventArgs e)
-        {
+            //TODO: Consider to call Image.LoadAsync()
         }
 
         public static PreloadedWindow GetInstance()

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -25,7 +25,7 @@ namespace ElmSharp
             s_precreated = this;
             if (useBaseLayout)
                 InitializeBaseLayout();
-            CreateWidgets();
+            WarmupWidgets();
             BackButtonPressed += DummyHandler;
             BackButtonPressed -= DummyHandler;
             void DummyHandler(object sender, System.EventArgs e) { }
@@ -50,7 +50,7 @@ namespace ElmSharp
             conformant.SetContent(BaseLayout);
         }
 
-        public void CreateWidgets()
+        public void WarmupWidgets()
         {
             new Entry(this).Unrealize();
             new Scroller(this).Unrealize();

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -20,11 +20,15 @@ namespace ElmSharp
     {
         static PreloadedWindow s_precreated;
 
-        public PreloadedWindow(bool useBaseLayout=true) : base("PreloadWindow")
+        public PreloadedWindow(bool useBaseLayout=true, bool preloadWidgets=true, bool preloadEvents=true) : base("PreloadWindow")
         {
             s_precreated = this;
             if (useBaseLayout)
                 InitializeBaseLayout();
+            if (preloadWidgets)
+                CreateWidgets();
+            if (preloadEvents)
+                AddRemoveEvents();
         }
 
         public Layout BaseLayout
@@ -44,6 +48,35 @@ namespace ElmSharp
 
             BaseLayout = layout;
             conformant.SetContent(BaseLayout);
+        }
+
+        public void CreateWidgets()
+        {
+            _ = new Entry(this);
+            _ = new Scroller(this);
+            _ = new Box(this);
+            _ = new Label(this);
+            _ = new GenList(this);
+            _ = new Button(this);
+            _ = new Check(this);
+            _ = new Naviframe(this);
+            _ = new Slider(this);
+            _ = new Spinner(this);
+            _ = new ProgressBar(this);
+            _ = new GestureLayer(this);
+            _ = new Polygon(this);
+            _ = new Image(this);
+            //TODO: Need to call Image.LoadAsync()
+        }
+
+        void DummyHandler(object sender, System.EventArgs e)
+        {
+        }
+
+        public void AddRemoveEvents()
+        {
+            this.BackButtonPressed += DummyHandler;
+            this.BackButtonPressed -= DummyHandler;
         }
 
         public static PreloadedWindow GetInstance()

--- a/src/ElmSharp/ElmSharp/Window.cs
+++ b/src/ElmSharp/ElmSharp/Window.cs
@@ -1079,6 +1079,8 @@ namespace ElmSharp
             }
         }
 
+        internal static bool IsPreloaded { get; private set; }
+
         /// <summary>
         /// Creates a socket to provide the service for the Plug widget.
         /// </summary>
@@ -1302,6 +1304,7 @@ namespace ElmSharp
             Elementary.Initialize();
             Elementary.ThemeOverlay();
             _ = new PreloadedWindow();
+            IsPreloaded = true;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
This PR enables two more preloading options on `PreloadedWindow`.
- Preloading widgets which are used when initializing Xamarin Forms Tizen platform renderers.
  - `Entry`
  - `Scroller`
  - `Box`
  - `Label`
  - `GenList`
  - `Button`
  - `Check`
  - `Naviframe`
  - `Slider`
  - `Spinner`
  - `ProgressBar`
  - `GestureLayer`
  - `Polygon`
  - `Image`

- Preloading events which are used at application launching time.
  - `PreloadedWindow.BackButtonPressed`


### API Changes ###
N/A