### PR TITLE
[NUI] Fix reparenting of Child bug

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2020 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,10 @@ namespace Tizen.NUI.BaseComponents
                 // If child already has a parent then re-parent child
                 if (oldParent != null)
                 {
+                    if (child.Layout !=null)
+                    {
+                        child.Layout.SetReplaceFlag();
+                    }
                     oldParent.Remove(child);
                 }
                 child.InternalParent = this;

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,11 @@ namespace Tizen.NUI
             {
                 if( childLayout == layoutItem )
                 {
-                    Window.Instance.LayoutController.AddToRemovalStack(childLayout);
+                    if (! childLayout.IsReplaceFlag())
+                    {
+                        Window.Instance.LayoutController.AddToRemovalStack(childLayout);
+                    }
+                    childLayout.ClearReplaceFlag();
                     LayoutChildren.Remove(childLayout);
                     childLayout.ConditionForAnimation = childLayout.ConditionForAnimation | TransitionCondition.Remove;
                     // Add LayoutItem to the transition stack so can animate it out.

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ namespace Tizen.NUI
 
         private Extents _padding;
         private Extents _margin;
+
+        private bool parentReplacement = false;
 
         /// <summary>
         /// [Draft] Condition event that is causing this Layout to transition.
@@ -301,6 +303,21 @@ namespace Tizen.NUI
             {
                 return ( Flags & LayoutFlags.ForceLayout) == LayoutFlags.ForceLayout;
             }
+        }
+
+        internal void SetReplaceFlag()
+        {
+            parentReplacement = true;
+        }
+
+        internal bool IsReplaceFlag()
+        {
+            return parentReplacement;
+        }
+
+        internal void ClearReplaceFlag()
+        {
+            parentReplacement = false;
         }
 
         /// <summary>


### PR DESCRIPTION
If a child is added to a different layout the transition finished
animation can cause it to be removed from the new parent.

Cause : The removal animation is added to the stack, the add animation is added to
the stack.  Animations are run.  When animations finish the itemRemovalQueue is run, this
removes the child as the removal code added it to the itemRemovalQueue.

Fix : In the case of replacement, set a flag on the child so the removal code can excluded it
from the itemRemovalQueue.

Change-Id: Ib7da9e446c990258c8415e584bbb624dae4d6fa5

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
