### PR TITLE
[NUI] Fix reparenting of Child bug

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2020 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,10 @@ namespace Tizen.NUI.BaseComponents
                 // If child already has a parent then re-parent child
                 if (oldParent != null)
                 {
+                    if (child.Layout !=null)
+                    {
+                        child.Layout.SetReplaceFlag();
+                    }
                     oldParent.Remove(child);
                 }
                 child.InternalParent = this;

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,11 @@ namespace Tizen.NUI
             {
                 if( childLayout == layoutItem )
                 {
-                    Window.Instance.LayoutController.AddToRemovalStack(childLayout);
+                    if (! childLayout.IsReplaceFlag())
+                    {
+                        Window.Instance.LayoutController.AddToRemovalStack(childLayout);
+                    }
+                    childLayout.ClearReplaceFlag();
                     LayoutChildren.Remove(childLayout);
                     childLayout.ConditionForAnimation = childLayout.ConditionForAnimation | TransitionCondition.Remove;
                     // Add LayoutItem to the transition stack so can animate it out.

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ namespace Tizen.NUI
 
         private Extents _padding;
         private Extents _margin;
+
+        private bool parentReplacement = false;
 
         /// <summary>
         /// [Draft] Condition event that is causing this Layout to transition.
@@ -301,6 +303,21 @@ namespace Tizen.NUI
             {
                 return ( Flags & LayoutFlags.ForceLayout) == LayoutFlags.ForceLayout;
             }
+        }
+
+        internal void SetReplaceFlag()
+        {
+            parentReplacement = true;
+        }
+
+        internal bool IsReplaceFlag()
+        {
+            return parentReplacement;
+        }
+
+        internal void ClearReplaceFlag()
+        {
+            parentReplacement = false;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
If a child is added to a different layout the transition finished
animation can cause it to be removed from the new parent.

Cause : The removal animation is added to the stack, the add animation is added to
the stack.  Animations are run.  When animations finish the itemRemovalQueue is run, this
removes the child as the removal code added it to the itemRemovalQueue.

Fix : In the case of replacement, set a flag on the child so the removal code can excluded it
from the itemRemovalQueue.

### API Changes ###
NONE