### PR TITLE
[NUI] Add dispose checking in just a few methods of Timer class

### DIFF
--- a/src/Tizen.NUI/src/public/Timer.cs
+++ b/src/Tizen.NUI/src/public/Timer.cs
@@ -204,6 +204,12 @@ namespace Tizen.NUI
                 }
             }
 
+            if (swigCPtr.Handle == global::System.IntPtr.Zero || disposed)
+            {
+                NUILog.Error("[ERR] already disposed! can not get this done! just return here! please make sure that the handle gets free when using explicit Dispose()! For example, timer.Dispose(); timer = null; this must be done!");
+                return;
+            }
+
             played = true;
             Interop.Timer.Timer_Start(swigCPtr);
 
@@ -227,6 +233,12 @@ namespace Tizen.NUI
                     StackFrame sf = st.GetFrame(i);
                     Tizen.Log.Error("NUI", " Method " + sf.GetMethod());
                 }
+            }
+
+            if (swigCPtr.Handle == global::System.IntPtr.Zero || disposed)
+            {
+                NUILog.Error("[ERR] already disposed! can not get this done! just return here! please make sure that the handle gets free when using explicit Dispose()! For example, timer.Dispose(); timer = null; this must be done!");
+                return;
             }
 
             played = false;
@@ -254,6 +266,12 @@ namespace Tizen.NUI
                 }
             }
 
+            if (swigCPtr.Handle == global::System.IntPtr.Zero || disposed)
+            {
+                NUILog.Error("[ERR] already disposed! can not get this done! just return here! please make sure that the handle gets free when using explicit Dispose()! For example, timer.Dispose(); timer = null; this must be done!");
+                return false;
+            }
+
             bool ret = Interop.Timer.Timer_IsRunning(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
@@ -273,6 +291,12 @@ namespace Tizen.NUI
         {
             NUILog.Debug($"(0x{swigCPtr.Handle:X})SetInterval({milliSec})");
 
+            if (swigCPtr.Handle == global::System.IntPtr.Zero || disposed)
+            {
+                NUILog.Error("[ERR] already disposed! can not get this done! just return here! please make sure that the handle gets free when using explicit Dispose()! For example, timer.Dispose(); timer = null; this must be done!");
+                return;
+            }
+
             played = true;
 
             Interop.Timer.Timer_SetInterval(swigCPtr, milliSec);
@@ -281,6 +305,12 @@ namespace Tizen.NUI
 
         internal uint GetInterval()
         {
+            if(swigCPtr.Handle == global::System.IntPtr.Zero || disposed)
+            {
+                NUILog.Error("[ERR] already disposed! can not get this done! just return here! please make sure that the handle gets free when using explicit Dispose()! For example, timer.Dispose(); timer = null; this must be done!");
+                return 0;
+            }
+
             uint ret = Interop.Timer.Timer_GetInterval(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;


### PR DESCRIPTION
### Description of Change ###
[NUI] Add dispose checking in just a few methods of Timer class
- DF191218-00096 defect seems to be caused by the wrong handling of object which has been disposed, specially Timer object.
- Adding defensive check routine whether the Timer object is disposed or not.
- Just added in a few methods of Timer class so that there will be no overhead.

### API Changes ###
nothing