### PR TITLE
[NUI] Fix Tizen.NUI.Samples crash error when it is terminated

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliDemo.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliDemo.cs
@@ -110,7 +110,7 @@ namespace Tizen.NUI.Samples
                     }
                     else
                     {
-                        Dispose();
+                        Exit();
                     }
                 }
             }


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix Tizen.NUI.Samples crash error when it is terminated
- When NUIApplication is terminated, Dispose() is not needed, but Exit() needs to be called.


### API Changes ###
nothing