### PR TITLE
[NUI] Fix Animation Dispose() to make local variable of Animation instance make working properly

### DIFF
--- a/src/Tizen.NUI/src/public/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation.cs
@@ -1285,28 +1285,20 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         protected override void Dispose(DisposeTypes type)
         {
-            if (this != null)
-            {
-                if (_animationFinishedEventCallback != null)
-                {
-                    FinishedSignal().Disconnect(_finishedCallbackOfNative);
-                }
-
-                if (_animationProgressReachedEventCallback != null)
-                {
-
-                    ProgressReachedSignal().Disconnect(_animationProgressReachedEventCallback);
-                }
-            }
-
-            if(disposed)
+            if (disposed)
             {
                 return;
             }
 
-            if (this != null)
+            if (_finishedCallbackOfNative != null)
             {
-                this.Clear();
+                FinishedSignal().Disconnect(_finishedCallbackOfNative);
+            }
+
+            if (_animationProgressReachedEventCallback != null)
+            {
+
+                ProgressReachedSignal().Disconnect(_animationProgressReachedEventCallback);
             }
 
             //Release your own unmanaged resources here.


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix Animation Dispose() to make local variable of Animation instance make working properly

- NUI Animation class is binding to DALi native Animation class.
- Animation class inherits from BaseHandle class so it has a reference count.
- In NUI side, if the Animation class is instanced in local scope, it is disposed automatically by DisposeQueue. Here the reference count of native DALi Animation is decreased and it will be managed by smart pointer so this is not a matter in NUI side.
- NUI Animation Dispose() need care only the events which are connected to native DALi, so event handlers of Finished and ProgressReached are certainly disconnected.
- Animation which has been created as local variable will work properly. (ex: if LoopCount is set to 100 and it is even local variable, it will animate 100 times and stop normally.)


### API Changes ###
nothing