### PR TITLE
[ElmSharp] Add preloading on API8

### DIFF
--- a/src/ElmSharp/ElmSharp/Elementary.cs
+++ b/src/ElmSharp/ElmSharp/Elementary.cs
@@ -207,7 +207,8 @@ namespace ElmSharp
         /// <since_tizen> preview </since_tizen>
         public static void Initialize()
         {
-            Interop.Elementary.elm_init(0, null);
+            if (!Window.IsPreloaded)
+                Interop.Elementary.elm_init(0, null);
         }
 
         /// <summary>
@@ -235,7 +236,7 @@ namespace ElmSharp
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void ThemeOverlay()
         {
-            if (File.Exists(_themeFilePath))
+            if (!Window.IsPreloaded && File.Exists(_themeFilePath))
             {
                 AddThemeOverlay(_themeFilePath);
             }

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -25,6 +25,10 @@ namespace ElmSharp
             s_precreated = this;
             if (useBaseLayout)
                 InitializeBaseLayout();
+            WarmupWidgets();
+            BackButtonPressed += DummyHandler;
+            BackButtonPressed -= DummyHandler;
+            void DummyHandler(object sender, System.EventArgs e) { }
         }
 
         public Layout BaseLayout
@@ -44,6 +48,25 @@ namespace ElmSharp
 
             BaseLayout = layout;
             conformant.SetContent(BaseLayout);
+        }
+
+        public void WarmupWidgets()
+        {
+            new Entry(this).Unrealize();
+            new Scroller(this).Unrealize();
+            new Box(this).Unrealize();
+            new Label(this).Unrealize();
+            new GenList(this).Unrealize();
+            new Button(this).Unrealize();
+            new Check(this).Unrealize();
+            new Naviframe(this).Unrealize();
+            new Slider(this).Unrealize();
+            new Spinner(this).Unrealize();
+            new ProgressBar(this).Unrealize();
+            new GestureLayer(this).Unrealize();
+            new Polygon(this).Unrealize();
+            new Image(this).Unrealize();
+            //TODO: Consider to call Image.LoadAsync()
         }
 
         public static PreloadedWindow GetInstance()

--- a/src/ElmSharp/ElmSharp/Window.cs
+++ b/src/ElmSharp/ElmSharp/Window.cs
@@ -1079,6 +1079,8 @@ namespace ElmSharp
             }
         }
 
+        internal static bool IsPreloaded { get; private set; }
+
         /// <summary>
         /// Creates a socket to provide the service for the Plug widget.
         /// </summary>
@@ -1302,6 +1304,7 @@ namespace ElmSharp
             Elementary.Initialize();
             Elementary.ThemeOverlay();
             _ = new PreloadedWindow();
+            IsPreloaded = true;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
This PR applies two more preloading options on PreloadedWindow which has already been applied on  https://github.com/Samsung/TizenFX/pull/1255.
- Preloading widgets which are used when initializing Xamarin Forms Tizen platform renderers.
- Preloading events which are used at application launching time.

### API Changes ###
- N/A