### PR TITLE
[ElmSharp] Add ElmSharp.Wearable preloading

### DIFF
--- a/src/ElmSharp.Wearable/ElmSharp.Wearable/Preload.cs
+++ b/src/ElmSharp.Wearable/ElmSharp.Wearable/Preload.cs
@@ -20,9 +20,10 @@ namespace ElmSharp.Wearable
 {
     static class Preload
     {
-        static public void WarmupWidgets(Window win)
+        static public void WarmupWidgets(PreloadedWindow win)
         {
-            var surface = new CircleSurface();
+            var surface = new CircleSurface(win.BaseConformant);
+            win.BaseCircleSurface = surface;
             new CircleDateTimeSelector(win, surface).Unrealize();
             new CircleProgressBar(win, surface).Unrealize();
             new CircleScroller(win, surface).Unrealize();

--- a/src/ElmSharp.Wearable/ElmSharp.Wearable/Preload.cs
+++ b/src/ElmSharp.Wearable/ElmSharp.Wearable/Preload.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Copyright (c) 2016 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace ElmSharp.Wearable
+{
+    static class Preload
+    {
+        static public void WarmupWidgets(Window win)
+        {
+            var surface = new CircleSurface();
+            new CircleDateTimeSelector(win, surface).Unrealize();
+            new CircleProgressBar(win, surface).Unrealize();
+            new CircleScroller(win, surface).Unrealize();
+            new CircleSlider(win, surface).Unrealize();
+            new CircleSpinner(win, surface).Unrealize();
+            new MoreOption(win).Unrealize();
+        }
+    }
+}

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -35,7 +35,7 @@ namespace ElmSharp
 
             if (Elementary.GetProfile() == "wearable")
             {
-                PreloadElmSharpWearable();
+                WarmupWearableWidgets();
             }
         }
 
@@ -77,7 +77,7 @@ namespace ElmSharp
             //TODO: Consider to call Image.LoadAsync()
         }
 
-        public void PreloadElmSharpWearable()
+        public void WarmupWearableWidgets()
         {
             try
             {

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -15,15 +15,20 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Reflection;
 
 namespace ElmSharp
 {
-    internal class PreloadedWindow : Window
+    /// <summary>
+    /// Pre-created window which prepares features that takes time in advance.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class PreloadedWindow : Window
     {
         static PreloadedWindow s_precreated;
 
-        public PreloadedWindow(bool useBaseLayout=true) : base("PreloadWindow")
+        internal PreloadedWindow(bool useBaseLayout=true) : base("PreloadWindow")
         {
             s_precreated = this;
             if (useBaseLayout)
@@ -45,9 +50,23 @@ namespace ElmSharp
             protected set;
         }
 
+        public Conformant BaseConformant
+        {
+            get;
+            protected set;
+        }
+
+        public object BaseCircleSurface
+        {
+            get;
+            set;
+        }
+
+
         public void InitializeBaseLayout()
         {
             var conformant = new Conformant(this);
+            BaseConformant = conformant;
             conformant.Show();
 
             var layout = new Layout(conformant);

--- a/src/ElmSharp/ElmSharp/PreloadedWindow.cs
+++ b/src/ElmSharp/ElmSharp/PreloadedWindow.cs
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+using System;
+using System.Reflection;
+
 namespace ElmSharp
 {
     internal class PreloadedWindow : Window
@@ -29,6 +32,11 @@ namespace ElmSharp
             BackButtonPressed += DummyHandler;
             BackButtonPressed -= DummyHandler;
             void DummyHandler(object sender, System.EventArgs e) { }
+
+            if (Elementary.GetProfile() == "wearable")
+            {
+                PreloadElmSharpWearable();
+            }
         }
 
         public Layout BaseLayout
@@ -67,6 +75,21 @@ namespace ElmSharp
             new Polygon(this).Unrealize();
             new Image(this).Unrealize();
             //TODO: Consider to call Image.LoadAsync()
+        }
+
+        public void PreloadElmSharpWearable()
+        {
+            try
+            {
+                Assembly assem = Assembly.Load("ElmSharp.Wearable");
+                var type = assem.GetType("ElmSharp.Wearable.Preload");
+                type.GetMethod("WarmupWidgets", BindingFlags.Public | BindingFlags.Static).Invoke(null, new object[] { this });
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+                Console.WriteLine("Fail to preload ElmSharp.Wearable");
+            }
         }
 
         public static PreloadedWindow GetInstance()


### PR DESCRIPTION
### Description of Change ###
This PR suggests to invoke ElmSharp.Wearable preloading method by using reflection on `ElmSharp`.

`ElmSharp.Wearable` preloads widgets which enhance the application startup time.

  - `CircleDateTimeSelector` :  ▽24.13ms on `CircleDateTimeSelectorRenderer`
  - `CircleSurface`, `CircleProgressBar`, `CircleSlider`, `MoreOption` : ▽5ms or ▽26ms(with `ToolbarItem`) on `CirclePageRenderer`
  - `CircleScroller` : ▽6.53ms on `CircleScrollViewRenderer`
  - `CircleSpinner` : ▽9.21ms on `CircleStepperRenderer`


### API Changes ###
- N/A
