### PR TITLE
[SecureRepository] Changed return type to HashSet for faster alias existence checks.

### DIFF
--- a/src/Tizen.Security.SecureRepository/Tizen.Security.SecureRepository/DataManager.cs
+++ b/src/Tizen.Security.SecureRepository/Tizen.Security.SecureRepository/DataManager.cs
@@ -73,7 +73,7 @@ namespace Tizen.Security.SecureRepository
         /// <since_tizen> 3 </since_tizen>
         /// <returns>All aliases of data, which the client can access.</returns>
         /// <exception cref="ArgumentException">No alias to get.</exception>
-        static public IEnumerable<string> GetAliases()
+        static public IReadOnlyCollection<string> GetAliases()
         {
             IntPtr ptr = IntPtr.Zero;
 
@@ -82,7 +82,7 @@ namespace Tizen.Security.SecureRepository
                 Interop.CheckNThrowException(
                     Interop.CkmcManager.GetDataAliasList(out ptr),
                     "Failed to get data aliases");
-                return new SafeAliasListHandle(ptr).Aliases;
+                return new SafeAliasContainerHandle<HashSet<string>>(ptr).Aliases;
             }
             finally
             {

--- a/src/Tizen.Security.SecureRepository/Tizen.Security.SecureRepository/DataManager.cs
+++ b/src/Tizen.Security.SecureRepository/Tizen.Security.SecureRepository/DataManager.cs
@@ -73,7 +73,7 @@ namespace Tizen.Security.SecureRepository
         /// <since_tizen> 3 </since_tizen>
         /// <returns>All aliases of data, which the client can access.</returns>
         /// <exception cref="ArgumentException">No alias to get.</exception>
-        static public IReadOnlyCollection<string> GetAliases()
+        static public IEnumerable<string> GetAliases()
         {
             IntPtr ptr = IntPtr.Zero;
 

--- a/src/Tizen.Security.SecureRepository/Tizen.Security.SecureRepository/SafeAliasListHandle.cs
+++ b/src/Tizen.Security.SecureRepository/Tizen.Security.SecureRepository/SafeAliasListHandle.cs
@@ -21,12 +21,12 @@ using static Interop;
 
 namespace Tizen.Security.SecureRepository
 {
-    internal class SafeAliasListHandle
+    internal class SafeAliasContainerHandle<T> where T : ICollection<string>, new() 
     {
-        public SafeAliasListHandle(IntPtr ptr)
+        public SafeAliasContainerHandle(IntPtr ptr)
         {
             var cur = ptr;
-            var aliases = new List<string>();
+            var aliases = new T();
             while (cur != IntPtr.Zero)
             {
                 var ckmcAliasList = Marshal.PtrToStructure<Interop.CkmcAliasList>(cur);
@@ -37,9 +37,15 @@ namespace Tizen.Security.SecureRepository
             this.Aliases = aliases;
         }
 
-        public List<string> Aliases
+        public T Aliases
         {
             get; set;
+        }
+    }
+    internal class SafeAliasListHandle : SafeAliasContainerHandle<List<string>>
+    {
+        public SafeAliasListHandle(IntPtr ptr) : base(ptr)
+        {
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
#1356 was the ticket spawning this pr. DataManager and a couple of other classes expose an IEnumerable<string>, which is always a List currently. I believe all 3 occurances can be changed to HashSet, as the aliases should always be unique. If the general change would be accepted I would push the remaining 2 changes for KeyManager and CertificateManager which follow the same principle. Also, do I have to update the since_tizen documentation tag when changing the return type to a derived type?


### API Changes ###
Changed:
 - IReadonlyCollection<string> Tizen.Security.SecureRepository.DataManager.GetAliases(string key) 
The actual return type is HashSet. 