### PR TITLE
[Applications.Common] Add a new element of ApplicationComponentType

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationComponentType.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationComponentType.cs
@@ -41,5 +41,11 @@ namespace Tizen.Applications
         /// Component type is watch application.
         /// </summary>
         WatchApplication,
+
+        /// <summary>
+        /// Component type is component-based application.
+        /// </summary>
+        /// <since_tizen> 7 </since_tizen>
+        ComponentBasedApplication,
     }
 }


### PR DESCRIPTION
Adds:
 - ComponentBasedApplication

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
From Tizen 5.5, platform supports a new application model that is component-based application.
ComponentBasedApplication is added on ApplicationComponentType.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: TCSACR-304

Added:
 - ApplicationComponentType.ComponentBasedApplication // enumeration
