### PR TITLE
[ElmSharp] Fix GestureLayer native callback return type

### DIFF
--- a/src/ElmSharp/ElmSharp/GestureLayer.cs
+++ b/src/ElmSharp/ElmSharp/GestureLayer.cs
@@ -552,18 +552,18 @@ namespace ElmSharp
                 SetGestureCallback(type, state, new Action<object>((info) => action((T)info)));
         }
 
-        private void GestureCallbackHandler(IntPtr data, IntPtr event_info)
+        private int GestureCallbackHandler(IntPtr data, IntPtr event_info)
         {
             // so EFL called our callback, lets use data to find the right Action to call
             var handlerIndex = (int)data;
             // thanks to the fact that we never remove item from _handlers, we don't need a lock here
             if (handlerIndex < 0 || handlerIndex >= _handlers.Count)
-                return;
+                return 0;
 
             var currentHandler = _handlers[handlerIndex];
             Action<object> action = currentHandler.Action;
             if (action == null)
-                return;
+                return 0;
 
             // the interpretation of the event_info struct pointer depends on the GestureType
             switch (currentHandler.Type)
@@ -592,6 +592,7 @@ namespace ElmSharp
                     action(Marshal.PtrToStructure<RotateData>(event_info));
                     break;
             }
+            return 0;
         }
 
         #region Info structures

--- a/src/ElmSharp/Interop/Interop.Elementary.GestureLayer.cs
+++ b/src/ElmSharp/Interop/Interop.Elementary.GestureLayer.cs
@@ -21,7 +21,7 @@ internal static partial class Interop
 {
     internal static partial class Elementary
     {
-        public delegate void GestureEventCallback(IntPtr data, IntPtr event_info);
+        public delegate int GestureEventCallback(IntPtr data, IntPtr event_info);
 
         [DllImport(Libraries.Elementary)]
         internal static extern IntPtr elm_gesture_layer_add(IntPtr parent);


### PR DESCRIPTION
### Description of Change ###
Fix internal implementation related with GetstureLayer native callback

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
