### PR TITLE
[NUI] Remove draft property in ScrollableBase

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -29,6 +29,7 @@ namespace Tizen.NUI.Components
 	    static bool LayoutDebugScrollableBase = false; // Debug flag
         private Direction mScrollingDirection = Direction.Vertical;
         private bool mScrollEnabled = true;
+        private int mPageWidth = 0;
 
         private class ScrollableBaseCustomLayout : LayoutGroup
         {
@@ -108,6 +109,8 @@ namespace Tizen.NUI.Components
                 SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), widthMeasureSpec, childWidthState ),
                                        ResolveSizeAndState( new LayoutLength(totalHeight), heightMeasureSpec, childHeightState ) );
 
+                // Size of ScrollableBase is changed. Change Page width too.
+                scrollableBase.mPageWidth = (int)MeasuredWidth.Size.AsRoundedValue();
             }
 
             protected override void OnLayout(bool changed, LayoutLength left, LayoutLength top, LayoutLength right, LayoutLength bottom)
@@ -250,25 +253,11 @@ namespace Tizen.NUI.Components
         public int CurrentPage { get; private set; } = 0;
 
         /// <summary>
-        /// [Draft] Pages mode, Number of pages.
-        /// </summary>
-        /// This may be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public int NumberOfPages { set; get; } = 1;
-
-        /// <summary>
         /// [Draft] Duration of scroll animation.
         /// </summary>
         /// This may be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int ScrollDuration { set; get; } = 125;
-
-        /// <summary>
-        /// [Draft] Width of the Page.
-        /// </summary>
-        /// This may be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public int PageWidth { set; get; } = 1080; // Temporary use for prototype, should get ScrollableBase width
 
         /// <summary>
         /// ScrollEventArgs is a class to record scroll event arguments which will sent to user.
@@ -626,11 +615,11 @@ namespace Tizen.NUI.Components
                                                                 " currentPage[" + CurrentPage + "]" );
 
             //Increment current page if total displacement enough to warrant a page change.
-            if (Math.Abs(totalDisplacementForPan) > (PageWidth * ratioOfScreenWidthToCompleteScroll))
+            if (Math.Abs(totalDisplacementForPan) > (mPageWidth * ratioOfScreenWidthToCompleteScroll))
             {
                 if (totalDisplacementForPan < 0)
                 {
-                    CurrentPage = Math.Min(NumberOfPages - 1, ++CurrentPage);
+                    CurrentPage = Math.Min(Math.Max(mScrollingChild.Children.Count - 1,0), ++CurrentPage);
                 }
                 else
                 {
@@ -639,7 +628,7 @@ namespace Tizen.NUI.Components
             }
 
             // Animate to new page or reposition to current page
-            int destinationX = -(CurrentPage * PageWidth);
+            int destinationX = -(CurrentPage * mPageWidth);
             Debug.WriteLineIf(LayoutDebugScrollableBase, "Snapping to page[" + CurrentPage + "] to:"+ destinationX + " from:" + mScrollingChild.PositionX);
             AnimateChildTo(ScrollDuration, destinationX);
         }
@@ -652,7 +641,7 @@ namespace Tizen.NUI.Components
               {
                   if(flickDisplacement < 0)
                   {
-                      CurrentPage = Math.Min(NumberOfPages - 1, CurrentPage + 1);
+                      CurrentPage = Math.Min(Math.Max(mScrollingChild.Children.Count - 1,0), CurrentPage + 1);
                       Debug.WriteLineIf(LayoutDebugScrollableBase, "Snap - to page:" + CurrentPage);
                   }
                   else
@@ -660,7 +649,7 @@ namespace Tizen.NUI.Components
                       CurrentPage = Math.Max(0, CurrentPage - 1);
                       Debug.WriteLineIf(LayoutDebugScrollableBase, "Snap + to page:" + CurrentPage);
                   }
-                  float targetPosition = -(CurrentPage* PageWidth); // page size
+                  float targetPosition = -(CurrentPage* mPageWidth); // page size
                   Debug.WriteLineIf(LayoutDebugScrollableBase, "Snapping to :" + targetPosition);
                   AnimateChildTo(ScrollDuration,targetPosition);
               }


### PR DESCRIPTION
### Description of Change ###
NumberOfPage was draft property to know how many pages user wants.
For now, NumberOfPage is replaced to the count of container children.

PageWidth was draft property to know how big one page is.
For now, PageWidth will be automatically set to width of ScrollableBase.

### API Changes ###
NONE