### PR TITLE
[NUI] Use padding & margin to meausre size in Layout

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -95,8 +95,8 @@ namespace Tizen.NUI.Components
                 }
 
 
-                MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
-                MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+                MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth), new LayoutLength(Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+                MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
                 totalWidth = widthSizeAndState.Size.AsDecimal();
                 totalHeight = heightSizeAndState.Size.AsDecimal();
 
@@ -107,8 +107,8 @@ namespace Tizen.NUI.Components
                 widthSizeAndState.State = childWidthState;
                 heightSizeAndState.State = childHeightState;
 
-                SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), widthMeasureSpec, childWidthState ),
-                                       ResolveSizeAndState( new LayoutLength(totalHeight), heightMeasureSpec, childHeightState ) );
+                SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), new LayoutLength(Padding.Start + Padding.End), widthMeasureSpec, childWidthState ),
+                                       ResolveSizeAndState( new LayoutLength(totalHeight), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec, childHeightState ) );
 
                 // Size of ScrollableBase is changed. Change Page width too.
                 scrollableBase.mPageWidth = (int)MeasuredWidth.Size.AsRoundedValue();

--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -95,8 +95,8 @@ namespace Tizen.NUI.Components
                 }
 
 
-                MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth), new LayoutLength(Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
-                MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+                MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth + Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+                MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight + Padding.Top + Padding.Bottom), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
                 totalWidth = widthSizeAndState.Size.AsDecimal();
                 totalHeight = heightSizeAndState.Size.AsDecimal();
 
@@ -107,8 +107,8 @@ namespace Tizen.NUI.Components
                 widthSizeAndState.State = childWidthState;
                 heightSizeAndState.State = childHeightState;
 
-                SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), new LayoutLength(Padding.Start + Padding.End), widthMeasureSpec, childWidthState ),
-                                       ResolveSizeAndState( new LayoutLength(totalHeight), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec, childHeightState ) );
+                SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth + Padding.Start + Padding.End), widthMeasureSpec, childWidthState ),
+                                       ResolveSizeAndState( new LayoutLength(totalHeight + Padding.Top + Padding.Bottom), heightMeasureSpec, childHeightState ) );
 
                 // Size of ScrollableBase is changed. Change Page width too.
                 scrollableBase.mPageWidth = (int)MeasuredWidth.Size.AsRoundedValue();

--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -104,8 +104,8 @@ namespace Tizen.NUI
             }
 
 
-            MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
-            MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+            MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth), new LayoutLength(0), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+            MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight), new LayoutLength(0), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
             totalWidth = widthSizeAndState.Size.AsDecimal();
             totalHeight = heightSizeAndState.Size.AsDecimal();
 
@@ -116,8 +116,8 @@ namespace Tizen.NUI
             widthSizeAndState.State = childState.widthState;
             heightSizeAndState.State = childState.heightState;
 
-            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), widthMeasureSpec, childState.widthState ),
-                                   ResolveSizeAndState( new LayoutLength(totalHeight), heightMeasureSpec, childState.heightState ) );
+            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), new LayoutLength(0), widthMeasureSpec, childState.widthState ),
+                                   ResolveSizeAndState( new LayoutLength(totalHeight), new LayoutLength(0), heightMeasureSpec, childState.heightState ) );
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -104,8 +104,8 @@ namespace Tizen.NUI
             }
 
 
-            MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth), new LayoutLength(0), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
-            MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight), new LayoutLength(0), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+            MeasuredSize widthSizeAndState = ResolveSizeAndState(new LayoutLength(totalWidth), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+            MeasuredSize heightSizeAndState = ResolveSizeAndState(new LayoutLength(totalHeight), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
             totalWidth = widthSizeAndState.Size.AsDecimal();
             totalHeight = heightSizeAndState.Size.AsDecimal();
 
@@ -116,8 +116,8 @@ namespace Tizen.NUI
             widthSizeAndState.State = childState.widthState;
             heightSizeAndState.State = childState.heightState;
 
-            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), new LayoutLength(0), widthMeasureSpec, childState.widthState ),
-                                   ResolveSizeAndState( new LayoutLength(totalHeight), new LayoutLength(0), heightMeasureSpec, childState.heightState ) );
+            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(totalWidth), widthMeasureSpec, childState.widthState ),
+                                   ResolveSizeAndState( new LayoutLength(totalHeight), heightMeasureSpec, childState.heightState ) );
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -409,12 +409,14 @@ namespace Tizen.NUI
             LayoutItem childLayout = child.Layout;
 
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(parentMeasureSpecificationWidth,
-                                    new LayoutLength(childLayout.Padding.Start + childLayout.Padding.End),
-                                    new LayoutLength(child.WidthSpecification));
+                                    new LayoutLength(Padding.Start + Padding.End),
+                                    new LayoutLength(child.WidthSpecification),
+                                    new LayoutLength(child.Margin.Start + child.Margin.End));
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(parentMeasureSpecificationHeight,
-                                    new LayoutLength(childLayout.Padding.Top + childLayout.Padding.Bottom),
-                                    new LayoutLength(child.HeightSpecification));
+                                    new LayoutLength(Padding.Top + Padding.Bottom),
+                                    new LayoutLength(child.HeightSpecification),
+                                    new LayoutLength(child.Margin.Top + child.Margin.Bottom));
 
             childLayout.Measure( childWidthMeasureSpec, childHeightMeasureSpec);
 

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -408,15 +408,19 @@ namespace Tizen.NUI
 
             LayoutItem childLayout = child.Layout;
 
-            MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(parentMeasureSpecificationWidth,
-                                    new LayoutLength(Padding.Start + Padding.End),
-                                    new LayoutLength(child.WidthSpecification),
-                                    new LayoutLength(child.Margin.Start + child.Margin.End));
+            MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
+                                    new MeasureSpecification(
+                                        new LayoutLength(parentMeasureSpecificationWidth.Size - (Padding.Start + Padding.End + child.Margin.Start + child.Margin.End)),
+                                        parentMeasureSpecificationWidth.Mode),
+                                    new LayoutLength(child.Padding.Start + child.Padding.End),
+                                    new LayoutLength(child.WidthSpecification));
 
-            MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(parentMeasureSpecificationHeight,
+            MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
+                                    new MeasureSpecification(
+                                        new LayoutLength(parentMeasureSpecificationHeight.Size - (Padding.Top + Padding.Bottom + child.Margin.Top + child.Margin.Bottom)),
+                                        parentMeasureSpecificationHeight.Mode),
                                     new LayoutLength(Padding.Top + Padding.Bottom),
-                                    new LayoutLength(child.HeightSpecification),
-                                    new LayoutLength(child.Margin.Top + child.Margin.Bottom));
+                                    new LayoutLength(child.HeightSpecification));
 
             childLayout.Measure( childWidthMeasureSpec, childHeightMeasureSpec);
 

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -208,8 +208,8 @@ namespace Tizen.NUI
 
             } // Children exists
 
-            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(widthSize), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK ),
-                                   ResolveSizeAndState( new LayoutLength(heightSize), heightMeasureSpec,  MeasuredSize.StateType.MeasuredSizeOK ) );
+            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(widthSize), new LayoutLength(Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK ),
+                                   ResolveSizeAndState( new LayoutLength(heightSize), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec,  MeasuredSize.StateType.MeasuredSizeOK ) );
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -208,8 +208,8 @@ namespace Tizen.NUI
 
             } // Children exists
 
-            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(widthSize), new LayoutLength(Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK ),
-                                   ResolveSizeAndState( new LayoutLength(heightSize), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec,  MeasuredSize.StateType.MeasuredSizeOK ) );
+            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(widthSize + Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK ),
+                                   ResolveSizeAndState( new LayoutLength(heightSize + Padding.Top + Padding.Bottom), heightMeasureSpec,  MeasuredSize.StateType.MeasuredSizeOK ) );
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -246,87 +246,97 @@ namespace Tizen.NUI
         /// for one dimension (height or width) of one child view.<br />
         /// </summary>
         /// <param name="parentMeasureSpec">The requirements for this view. MeasureSpecification.</param>
-        /// <param name="padding">The padding of this view for the current dimension and margins, if applicable. LayoutLength.</param>
+        /// <param name="parentPadding">The padding of this parent. LayoutLength.</param>
         /// <param name="childDimension"> How big the child wants to be in the current dimension. LayoutLength.</param>
+        /// <param name="childMargin"> The margin of the child. LayoutLength.</param>
         /// <returns>a MeasureSpec for the child.</returns>
-        public static MeasureSpecification GetChildMeasureSpecification(MeasureSpecification parentMeasureSpec, LayoutLength padding, LayoutLength childDimension)
+        public static MeasureSpecification GetChildMeasureSpecification(MeasureSpecification parentMeasureSpec, LayoutLength parentPadding, LayoutLength childDimension, LayoutLength childMargin)
         {
             MeasureSpecification.ModeType specMode = parentMeasureSpec.Mode;
             MeasureSpecification.ModeType resultMode = MeasureSpecification.ModeType.Unspecified;
-            LayoutLength resultSize = new LayoutLength(Math.Max( 0.0f, (parentMeasureSpec.Size.AsDecimal() - padding.AsDecimal() ) )); // reduce available size by the owners padding
 
+            // Child only can use parent's size without parent's padding and own margin.
+            LayoutLength resultSize = new LayoutLength(Math.Max( 0.0f, (parentMeasureSpec.Size.AsDecimal()-parentPadding.AsDecimal()-childMargin.AsDecimal())));
             switch( specMode )
             {
                 // Parent has imposed an exact size on us
                 case MeasureSpecification.ModeType.Exactly:
                 {
-                if ((int)childDimension.AsRoundedValue() == LayoutParamPolicies.MatchParent)
-                {
-                    // Child wants to be our size. So be it.
-                    resultMode = MeasureSpecification.ModeType.Exactly;
-                }
-                else if ((int)childDimension.AsRoundedValue() == LayoutParamPolicies.WrapContent)
-                {
-                    // Child wants to determine its own size. It can't be
-                    // bigger than us.
-                    resultMode = MeasureSpecification.ModeType.AtMost;
-                }
-                else
-                {
-                    resultSize = childDimension;
-                    resultMode = MeasureSpecification.ModeType.Exactly;
-                }
+                    if ((int)childDimension.AsRoundedValue() == LayoutParamPolicies.MatchParent)
+                    {
+                        // Child wants to be our size. So be it.
+                        resultMode = MeasureSpecification.ModeType.Exactly;
+                    }
+                    else if ((int)childDimension.AsRoundedValue() == LayoutParamPolicies.WrapContent)
+                    {
+                        // Child wants to determine its own size. It can't be
+                        // bigger than us.
+                        // Don't need parent's size. Size of this child will be determined by its children.
+                        resultMode = MeasureSpecification.ModeType.AtMost;
+                    }
+                    else
+                    {
+                        // Child has its own size.
+                        resultSize = childDimension;
+                        resultMode = MeasureSpecification.ModeType.Exactly;
+                    }
 
-                break;
+                    break;
                 }
 
                 // Parent has imposed a maximum size on us
                 case MeasureSpecification.ModeType.AtMost:
                 {
-                if (childDimension.AsRoundedValue() == LayoutParamPolicies.MatchParent)
-                {
-                    // Child wants to be our size, but our size is not fixed.
-                    // Constrain child to not be bigger than us.
-                    resultMode = MeasureSpecification.ModeType.AtMost;
-                }
-                else if (childDimension.AsRoundedValue() == LayoutParamPolicies.WrapContent)
-                {
-                    // Child wants to determine its own size. It can't be
-                    // bigger than us.
-                    resultMode = MeasureSpecification.ModeType.AtMost;
-                }
-                else
-                {
-                    // Child wants a specific size... so be it
-                    resultSize = childDimension + padding;
-                    resultMode = MeasureSpecification.ModeType.Exactly;
-                }
+                    if (childDimension.AsRoundedValue() == LayoutParamPolicies.MatchParent)
+                    {
+                        // Crashed. Cannot calculate. 
 
-                break;
+                        // Child wants to be our size, but our size is not fixed.
+                        // Constrain child to not be bigger than us.
+                        resultMode = MeasureSpecification.ModeType.AtMost;
+                    }
+                    else if (childDimension.AsRoundedValue() == LayoutParamPolicies.WrapContent)
+                    {
+                        // Child wants to determine its own size. It can't be
+                        // bigger than us.
+
+                        // Don't need parent's size. Size of this child will be determined by its children.
+                        resultMode = MeasureSpecification.ModeType.AtMost;
+                    }
+                    else
+                    {
+                        // Child wants a specific size... so be it
+                        resultSize = childDimension;
+                        resultMode = MeasureSpecification.ModeType.Exactly;
+                    }
+
+                    break;
                 }
 
                 // Parent asked to see how big we want to be
                 case MeasureSpecification.ModeType.Unspecified:
                 {
+                    if ((childDimension.AsRoundedValue() == LayoutParamPolicies.MatchParent))
+                    {
+                        // Child wants to be our size... find out how big it should be
 
-                if ((childDimension.AsRoundedValue() == LayoutParamPolicies.MatchParent))
-                {
-                    // Child wants to be our size... find out how big it should be
-                    resultMode = MeasureSpecification.ModeType.Unspecified;
-                }
-                else if (childDimension.AsRoundedValue() == (LayoutParamPolicies.WrapContent))
-                {
-                    // Child wants to determine its own size.... find out how big
-                    // it should be
-                    resultMode = MeasureSpecification.ModeType.Unspecified;
-                }
-                else
-                {
-                    // Child wants a specific size... let him have it
-                    resultSize = childDimension + padding;
-                    resultMode = MeasureSpecification.ModeType.Exactly;
-                }
-                break;
+                        // There is no one who has exact size in parent hierarchy.
+                        // Cannot calculate.
+                        resultMode = MeasureSpecification.ModeType.Unspecified;
+                    }
+                    else if (childDimension.AsRoundedValue() == (LayoutParamPolicies.WrapContent))
+                    {
+                        // Child wants to determine its own size.... find out how big
+                        // it should be
+                        resultMode = MeasureSpecification.ModeType.Unspecified;
+                    }
+                    else
+                    {
+                        // Child wants a specific size... let him have it
+                        resultSize = childDimension;
+                        resultMode = MeasureSpecification.ModeType.Exactly;
+                    }
+                    break;
                 }
             } // switch
 
@@ -477,15 +487,15 @@ namespace Tizen.NUI
         {
             View childOwner = child.Owner;
 
-            Extents padding = childOwner.Padding; // Padding of this layout's owner, not of the child being measured.
-
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification( parentWidthMeasureSpec,
-                                                                                       new LayoutLength(padding.Start + padding.End ),
-                                                                                       new LayoutLength(childOwner.WidthSpecification) );
+                                                                                       new LayoutLength(Padding.Start + Padding.End ),
+                                                                                       new LayoutLength(childOwner.WidthSpecification),
+                                                                                       new LayoutLength(childOwner.Margin.Start + childOwner.Margin.End) );
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification( parentHeightMeasureSpec,
-                                                                                        new LayoutLength(padding.Top + padding.Bottom),
-                                                                                        new LayoutLength(childOwner.HeightSpecification) );
+                                                                                        new LayoutLength(Padding.Top + Padding.Bottom),
+                                                                                        new LayoutLength(childOwner.HeightSpecification),
+                                                                                        new LayoutLength(childOwner.Margin.Top + childOwner.Margin.Bottom) );
 
             child.Measure( childWidthMeasureSpec, childHeightMeasureSpec );
         }
@@ -505,19 +515,17 @@ namespace Tizen.NUI
         protected virtual void MeasureChildWithMargins(LayoutItem child, MeasureSpecification parentWidthMeasureSpec, LayoutLength widthUsed, MeasureSpecification parentHeightMeasureSpec, LayoutLength heightUsed)
         {
             View childOwner = child.Owner;
-            int desiredWidth = childOwner.WidthSpecification;
-            int desiredHeight = childOwner.HeightSpecification;
-
-            Extents padding = child.Padding; // Padding of this layout's owner, not of the child being measured.
 
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification( parentWidthMeasureSpec,
-                                                                                       new LayoutLength( padding.Start + padding.End ) +
-                                                                                       widthUsed, new LayoutLength(desiredWidth) );
+                                                                                       new LayoutLength( Padding.Start + Padding.End ) +
+                                                                                       widthUsed, new LayoutLength(childOwner.WidthSpecification),
+                                                                                       new LayoutLength(childOwner.Margin.Start + childOwner.Margin.End) );
 
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification( parentHeightMeasureSpec,
-                                                                                        new LayoutLength( padding.Top + padding.Bottom )+
-                                                                                        heightUsed, new LayoutLength(desiredHeight) );
+                                                                                        new LayoutLength( Padding.Top + Padding.Bottom )+
+                                                                                        heightUsed, new LayoutLength(childOwner.HeightSpecification),
+                                                                                       new LayoutLength(childOwner.Margin.Start + childOwner.Margin.End) );
 
             child.Measure( childWidthMeasureSpec, childHeightMeasureSpec );
         }

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -246,17 +246,16 @@ namespace Tizen.NUI
         /// for one dimension (height or width) of one child view.<br />
         /// </summary>
         /// <param name="parentMeasureSpec">The requirements for this view. MeasureSpecification.</param>
-        /// <param name="parentPadding">The padding of this parent. LayoutLength.</param>
+        /// <param name="padding">The padding of this view for the current dimension and margins, if applicable. LayoutLength.</param>
         /// <param name="childDimension"> How big the child wants to be in the current dimension. LayoutLength.</param>
-        /// <param name="childMargin"> The margin of the child. LayoutLength.</param>
         /// <returns>a MeasureSpec for the child.</returns>
-        public static MeasureSpecification GetChildMeasureSpecification(MeasureSpecification parentMeasureSpec, LayoutLength parentPadding, LayoutLength childDimension, LayoutLength childMargin)
+        public static MeasureSpecification GetChildMeasureSpecification(MeasureSpecification parentMeasureSpec, LayoutLength padding, LayoutLength childDimension)
         {
             MeasureSpecification.ModeType specMode = parentMeasureSpec.Mode;
             MeasureSpecification.ModeType resultMode = MeasureSpecification.ModeType.Unspecified;
 
             // Child only can use parent's size without parent's padding and own margin.
-            LayoutLength resultSize = new LayoutLength(Math.Max( 0.0f, (parentMeasureSpec.Size.AsDecimal()-parentPadding.AsDecimal()-childMargin.AsDecimal())));
+            LayoutLength resultSize = new LayoutLength(Math.Max( 0.0f, parentMeasureSpec.Size.AsDecimal()));
             switch( specMode )
             {
                 // Parent has imposed an exact size on us
@@ -487,15 +486,19 @@ namespace Tizen.NUI
         {
             View childOwner = child.Owner;
 
-            MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification( parentWidthMeasureSpec,
-                                                                                       new LayoutLength(Padding.Start + Padding.End ),
-                                                                                       new LayoutLength(childOwner.WidthSpecification),
-                                                                                       new LayoutLength(childOwner.Margin.Start + childOwner.Margin.End) );
+            MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
+                        new MeasureSpecification(
+                            new LayoutLength(parentWidthMeasureSpec.Size - (Padding.Start + Padding.End + childOwner.Margin.Start + childOwner.Margin.End)),
+                            parentWidthMeasureSpec.Mode),
+                        new LayoutLength(Padding.Start + Padding.End ),
+                        new LayoutLength(childOwner.WidthSpecification) );
 
-            MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification( parentHeightMeasureSpec,
-                                                                                        new LayoutLength(Padding.Top + Padding.Bottom),
-                                                                                        new LayoutLength(childOwner.HeightSpecification),
-                                                                                        new LayoutLength(childOwner.Margin.Top + childOwner.Margin.Bottom) );
+            MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
+                        new MeasureSpecification(
+                            new LayoutLength(parentHeightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childOwner.Margin.Top + childOwner.Margin.Bottom)),
+                            parentHeightMeasureSpec.Mode),
+                        new LayoutLength(Padding.Top + Padding.Bottom),
+                        new LayoutLength(childOwner.HeightSpecification));
 
             child.Measure( childWidthMeasureSpec, childHeightMeasureSpec );
         }
@@ -516,18 +519,22 @@ namespace Tizen.NUI
         {
             View childOwner = child.Owner;
 
-            MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification( parentWidthMeasureSpec,
-                                                                                       new LayoutLength( Padding.Start + Padding.End ) +
-                                                                                       widthUsed, new LayoutLength(childOwner.WidthSpecification),
-                                                                                       new LayoutLength(childOwner.Margin.Start + childOwner.Margin.End) );
 
+            MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
+                        new MeasureSpecification(
+                            new LayoutLength(parentWidthMeasureSpec.Size + widthUsed - (Padding.Start + Padding.End + childOwner.Margin.Start + childOwner.Margin.End)),
+                            parentWidthMeasureSpec.Mode),
+                        new LayoutLength(Padding.Start + Padding.End ),
+                        new LayoutLength(childOwner.WidthSpecification) );
 
-            MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification( parentHeightMeasureSpec,
-                                                                                        new LayoutLength( Padding.Top + Padding.Bottom )+
-                                                                                        heightUsed, new LayoutLength(childOwner.HeightSpecification),
-                                                                                       new LayoutLength(childOwner.Margin.Start + childOwner.Margin.End) );
-
+            MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
+                        new MeasureSpecification(
+                            new LayoutLength(parentHeightMeasureSpec.Size + heightUsed - (Padding.Top + Padding.Bottom + childOwner.Margin.Top + childOwner.Margin.Bottom)),
+                            parentHeightMeasureSpec.Mode),
+                        new LayoutLength(Padding.Top + Padding.Bottom),
+                        new LayoutLength(childOwner.HeightSpecification));
             child.Measure( childWidthMeasureSpec, childHeightMeasureSpec );
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -396,15 +396,16 @@ namespace Tizen.NUI
         /// Utility to reconcile a desired size and state, with constraints imposed by a MeasureSpecification.
         ///</summary>
         /// <param name="size"> How big the layout wants to be.</param>
+        /// <param name="padding"> Padding of owner.</param>
         /// <param name="measureSpecification"> Constraints imposed by the parent.</param>
         /// <param name="childMeasuredState"> Size information bit mask for the layout's children.</param>
         /// <returns> A measured size, which may indicate that it is too small. </returns>
         /// <since_tizen> 6 </since_tizen>
-        protected MeasuredSize ResolveSizeAndState( LayoutLength size, MeasureSpecification measureSpecification, MeasuredSize.StateType childMeasuredState )
+        protected MeasuredSize ResolveSizeAndState( LayoutLength size, LayoutLength padding, MeasureSpecification measureSpecification, MeasuredSize.StateType childMeasuredState )
         {
             var specMode = measureSpecification.Mode;
             LayoutLength specSize = measureSpecification.Size;
-            MeasuredSize result = new MeasuredSize( size, childMeasuredState);
+            MeasuredSize result = new MeasuredSize( size + padding, childMeasuredState);
 
             switch( specMode )
             {

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -396,16 +396,15 @@ namespace Tizen.NUI
         /// Utility to reconcile a desired size and state, with constraints imposed by a MeasureSpecification.
         ///</summary>
         /// <param name="size"> How big the layout wants to be.</param>
-        /// <param name="padding"> Padding of owner.</param>
         /// <param name="measureSpecification"> Constraints imposed by the parent.</param>
         /// <param name="childMeasuredState"> Size information bit mask for the layout's children.</param>
         /// <returns> A measured size, which may indicate that it is too small. </returns>
         /// <since_tizen> 6 </since_tizen>
-        protected MeasuredSize ResolveSizeAndState( LayoutLength size, LayoutLength padding, MeasureSpecification measureSpecification, MeasuredSize.StateType childMeasuredState )
+        protected MeasuredSize ResolveSizeAndState( LayoutLength size, MeasureSpecification measureSpecification, MeasuredSize.StateType childMeasuredState )
         {
             var specMode = measureSpecification.Mode;
             LayoutLength specSize = measureSpecification.Size;
-            MeasuredSize result = new MeasuredSize( size + padding, childMeasuredState);
+            MeasuredSize result = new MeasuredSize( size, childMeasuredState );
 
             switch( specMode )
             {

--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -228,17 +228,21 @@ namespace Tizen.NUI
             if (horizontal)
             {
                 childWidthMeasureSpec = new MeasureSpecification( new LayoutLength(childLength), MeasureSpecification.ModeType.Exactly );
-                childHeightMeasureSpec = GetChildMeasureSpecification( heightMeasureSpec,
+                childHeightMeasureSpec = GetChildMeasureSpecification( 
+                                            new MeasureSpecification(
+                                                new LayoutLength(heightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childLayout.Owner.Margin.Top + childLayout.Owner.Margin.Bottom)),
+                                                heightMeasureSpec.Mode),
                                             new LayoutLength(Padding.Top + Padding.Bottom),
-                                            new LayoutLength(desiredHeight),
-                                            new LayoutLength(childLayout.Owner.Margin.Top + childLayout.Owner.Margin.Bottom) );
+                                            new LayoutLength(desiredHeight));
             }
             else // vertical
             {
-                childWidthMeasureSpec = GetChildMeasureSpecification( widthMeasureSpec,
+                childWidthMeasureSpec = GetChildMeasureSpecification(
+                                            new MeasureSpecification(
+                                                new LayoutLength(widthMeasureSpec.Size - (Padding.Start + Padding.End + childLayout.Owner.Margin.Start + childLayout.Owner.Margin.End)),
+                                                widthMeasureSpec.Mode),
                                             new LayoutLength(Padding.Start + Padding.End),
-                                            new LayoutLength(desiredWidth),
-                                            new LayoutLength(childLayout.Owner.Margin.Start + childLayout.Owner.Margin.End) );
+                                            new LayoutLength(desiredWidth));
 
                 childHeightMeasureSpec = new MeasureSpecification( new LayoutLength(childLength), MeasureSpecification.ModeType.Exactly);
             }
@@ -304,15 +308,19 @@ namespace Tizen.NUI
                         // this child is only laid out using excess space. Measure
                         // using WrapContent so that we can find out the view's
                         // optimal width.
-                        MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(widthMeasureSpec,
+                        MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
+                                                new MeasureSpecification(
+                                                    new LayoutLength(widthMeasureSpec.Size - (Padding.Start + Padding.End + childLayout.Margin.Start + childLayout.Margin.End)),
+                                                    widthMeasureSpec.Mode),
                                                 new LayoutLength(Padding.Start + Padding.End),
-                                                new LayoutLength(LayoutParamPolicies.WrapContent),
-                                                new LayoutLength(childLayout.Margin.Start + childLayout.Margin.End));
+                                                new LayoutLength(LayoutParamPolicies.WrapContent));
 
-                        MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(heightMeasureSpec,
+                        MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
+                                                new MeasureSpecification(
+                                                    new LayoutLength(heightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childLayout.Margin.Top + childLayout.Margin.Bottom)),
+                                                    heightMeasureSpec.Mode),
                                                 new LayoutLength(Padding.Top + Padding.Bottom),
-                                                new LayoutLength(childDesiredHeight),
-                                                new LayoutLength(childLayout.Margin.Top + childLayout.Margin.Bottom));
+                                                new LayoutLength(childDesiredHeight));
 
                         childLayout.Measure( childWidthMeasureSpec, childHeightMeasureSpec);
                         usedExcessSpace += childLayout.MeasuredWidth.Size.AsDecimal();
@@ -372,7 +380,7 @@ namespace Tizen.NUI
 
             float widthSize = _totalLength;
             widthSize = Math.Max( widthSize, SuggestedMinimumWidth.AsDecimal());
-            MeasuredSize widthSizeAndState = ResolveSizeAndState( new LayoutLength(widthSize), new LayoutLength(Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
+            MeasuredSize widthSizeAndState = ResolveSizeAndState( new LayoutLength(widthSize + Padding.Start + Padding.End), widthMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK);
             widthSize = widthSizeAndState.Size.AsDecimal();
 
             // 2nd phase:
@@ -445,7 +453,7 @@ namespace Tizen.NUI
             widthSizeAndState.State = childState.widthState;
 
             SetMeasuredDimensions(widthSizeAndState,
-                                  ResolveSizeAndState( new LayoutLength(maxHeight), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec, childState.heightState ));
+                                  ResolveSizeAndState( new LayoutLength(maxHeight + Padding.Top + Padding.Bottom), heightMeasureSpec, childState.heightState ));
 
             if (matchHeight)
             {
@@ -500,15 +508,19 @@ namespace Tizen.NUI
                         // using WrapContent so that we can find out the view's
                         // optimal height.
                         // We'll restore the original height of 0 after measurement.
-                        MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(widthMeasureSpec,
-                                                                    new LayoutLength(Padding.Start + Padding.End),
-                                                                    new LayoutLength(childDesiredWidth),
-                                                                    new LayoutLength(childLayout.Margin.Start + childLayout.Margin.End) );
+                        MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
+                                                new MeasureSpecification(
+                                                    new LayoutLength(widthMeasureSpec.Size - (Padding.Start + Padding.End + childLayout.Margin.Start + childLayout.Margin.End)),
+                                                    widthMeasureSpec.Mode),
+                                                new LayoutLength(Padding.Start + Padding.End),
+                                                new LayoutLength(childDesiredWidth));
 
-                        MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification( heightMeasureSpec,
-                                                                    new LayoutLength(Padding.Top + Padding.Bottom),
-                                                                    new LayoutLength(LayoutParamPolicies.WrapContent),
-                                                                    new LayoutLength(childLayout.Margin.Top + childLayout.Margin.Bottom) );
+                        MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
+                                                new MeasureSpecification(
+                                                    new LayoutLength(heightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childLayout.Margin.Top + childLayout.Margin.Bottom)),
+                                                    heightMeasureSpec.Mode),
+                                                new LayoutLength(Padding.Top + Padding.Bottom),
+                                                new LayoutLength(LayoutParamPolicies.WrapContent));
 
                         childLayout.Measure(childWidthMeasureSpec, childHeightMeasureSpec);
                         usedExcessSpace += childLayout.MeasuredHeight.Size.AsDecimal();
@@ -569,7 +581,7 @@ namespace Tizen.NUI
 
             float heightSize = _totalLength;
             heightSize = Math.Max( heightSize, SuggestedMinimumHeight.AsDecimal());
-            MeasuredSize heightSizeAndState = ResolveSizeAndState( new LayoutLength(heightSize), new LayoutLength(Padding.Top + Padding.Bottom), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK );
+            MeasuredSize heightSizeAndState = ResolveSizeAndState( new LayoutLength(heightSize + Padding.Top + Padding.Bottom), heightMeasureSpec, MeasuredSize.StateType.MeasuredSizeOK );
             heightSize = heightSizeAndState.Size.AsDecimal();
 
             // 2nd phase:
@@ -637,7 +649,7 @@ namespace Tizen.NUI
 
             heightSizeAndState.State = childState.heightState;
 
-            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(maxWidth), new LayoutLength(Padding.Top + Padding.Bottom), widthMeasureSpec, childState.widthState ),
+            SetMeasuredDimensions( ResolveSizeAndState( new LayoutLength(maxWidth + Padding.Top + Padding.Bottom), widthMeasureSpec, childState.widthState ),
                                   heightSizeAndState );
 
             if (matchWidth)


### PR DESCRIPTION
### Description of Change ###
Previously, padding of parent and margin of child are not concerned when measure child size.

For now, When child use MatchParent,
the size of child will be ParentSize - ParentPadding - childMargin.

And when child use WrapContent,
the size of child will be GrandchildSize + childPadding.

Also Weight will be use only ParentSize - ParentPadding - childMargin size for measuring.

### API Changes ###
NONE
