### PR TITLE
[AudioManager] Apply EditorBrowsableState.Never for deprecated API

### DIFF
--- a/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDevice.cs
@@ -18,6 +18,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using System.Linq;
+using System.ComponentModel;
 
 namespace Tizen.Multimedia
 {
@@ -83,6 +84,7 @@ namespace Tizen.Multimedia
         /// <value>The <see cref="AudioDeviceState"/> of the device.</value>
         /// <since_tizen> 3 </since_tizen>
         [Obsolete("Deprecated since API level 5. Please use the IsRunning property instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public AudioDeviceState State
         {
             get
@@ -107,7 +109,7 @@ namespace Tizen.Multimedia
                     ThrowIfError("Failed to get the running state of the device");
 
                 return isRunning;
-			}
+            }
         }
 
         /// <summary>

--- a/src/Tizen.Multimedia/AudioManager/AudioDeviceOptions.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDeviceOptions.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.ComponentModel;
 
 namespace Tizen.Multimedia
 {
@@ -56,12 +57,14 @@ namespace Tizen.Multimedia
         /// Deactivated devices.
         /// </summary>
         [Obsolete("Deprecated since API level 5.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         Deactivated = 0x1000,
 
         /// <summary>
         /// Activated devices.
         /// </summary>
         [Obsolete("Deprecated since API level 5.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         Activated = 0x2000,
 
         /// <summary>

--- a/src/Tizen.Multimedia/AudioManager/AudioDeviceState.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDeviceState.cs
@@ -15,7 +15,8 @@
  */
 
 using System;
- 
+using System.ComponentModel;
+
 namespace Tizen.Multimedia
 {
     /// <summary>
@@ -23,6 +24,7 @@ namespace Tizen.Multimedia
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [Obsolete("Deprecated since API level 5.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public enum AudioDeviceState
     {
         /// <summary>

--- a/src/Tizen.Multimedia/AudioManager/AudioDeviceStateChangedEventArgs.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioDeviceStateChangedEventArgs.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.ComponentModel;
 
 namespace Tizen.Multimedia
 {
@@ -23,6 +24,7 @@ namespace Tizen.Multimedia
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [Obsolete("Deprecated since API level 5. Please use the AudioDeviceRunningChangedEventArgs class instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class AudioDeviceStateChangedEventArgs : EventArgs
     {
         internal AudioDeviceStateChangedEventArgs(AudioDevice device, AudioDeviceState changedState)

--- a/src/Tizen.Multimedia/AudioManager/AudioManager.cs
+++ b/src/Tizen.Multimedia/AudioManager/AudioManager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Tizen.Multimedia
 {
@@ -166,6 +167,7 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         [Obsolete("Deprecated since API level 5. Please use the DeviceRunningStateChanged property instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static event EventHandler<AudioDeviceStateChangedEventArgs> DeviceStateChanged
         {
             add


### PR DESCRIPTION
Signed-off-by: Sangchul Lee <sc11.lee@samsung.com>

It is related to TCSACR-302 that is to remove deprecated API rejected by PM. Instead, we made a decision to apply editorbrowsable attribute to 'never' for those API.