### PR TITLE
[StreamRecorder] Handle NotSupportedException as new feature added

### DIFF
--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -50,7 +50,7 @@ namespace Tizen.Multimedia
         {
             if (IsSupported() == false)
             {
-                throw new PlatformNotSupportedException(
+                throw new NotSupportedException(
                     $"The feature({Feature}) is not supported on the current device.");
             }
 

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -34,6 +34,12 @@ namespace Tizen.Multimedia
         private bool _audioEnabled;
         private bool _videoEnabled;
         private StreamRecorderVideoFormat _sourceFormat;
+        private const string Feature = "http://tizen.org/feature/network.streamrecorder.record";
+
+        private static bool IsSupported()
+        {
+            return System.Information.TryGetValue(Feature, out bool isSupported) ? isSupported : false;
+        }
 
         /// <summary>
         /// Initialize a new instance of the <see cref="StreamRecorder"/> class.
@@ -42,6 +48,12 @@ namespace Tizen.Multimedia
         /// <since_tizen> 3 </since_tizen>
         public StreamRecorder()
         {
+            if (IsSupported() == false)
+            {
+                throw new PlatformNotSupportedException(
+                    $"The feature({Feature}) is not supported on the current device.");
+            }
+
             try
             {
                 Native.Create(out _handle).ThrowIfError("Failed to create stream recorder.");

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -34,11 +34,11 @@ namespace Tizen.Multimedia
         private bool _audioEnabled;
         private bool _videoEnabled;
         private StreamRecorderVideoFormat _sourceFormat;
-        private const string Feature = "http://tizen.org/feature/network.streamrecorder.record";
+        private const string Feature = "http://tizen.org/feature/multimedia.stream_recorder";
 
         private static bool IsSupported()
         {
-            return System.Information.TryGetValue(Feature, out bool isSupported) ? isSupported : false;
+            return System.Information.TryGetValue(Feature, out bool isSupported) && isSupported;
         }
 
         /// <summary>
@@ -46,6 +46,7 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.stream_recorder </feature>
         public StreamRecorder()
         {
             if (IsSupported() == false)
@@ -130,7 +131,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="StreamRecorderAudioOptions"/>
         /// <seealso cref="StreamRecorderVideoOptions"/>
         /// <since_tizen> 4 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Prepare(StreamRecorderOptions options)
         {
             if (options == null)
@@ -168,7 +168,6 @@ namespace Tizen.Multimedia
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Prepare"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Unprepare()
         {
             if (State == RecorderState.Idle)
@@ -199,7 +198,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Start()
         {
             if (State == RecorderState.Recording)
@@ -229,7 +227,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Pause()
         {
             if (State == RecorderState.Paused)
@@ -264,7 +261,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Commit()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -286,7 +282,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Cancel()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -372,7 +367,6 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Dispose()
         {
             Dispose(true);

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -118,6 +118,7 @@ namespace Tizen.Multimedia
         /// <seealso cref="StreamRecorderAudioOptions"/>
         /// <seealso cref="StreamRecorderVideoOptions"/>
         /// <since_tizen> 4 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Prepare(StreamRecorderOptions options)
         {
             if (options == null)
@@ -150,10 +151,12 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Idle"/> state.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Prepare"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Unprepare()
         {
             if (State == RecorderState.Idle)
@@ -176,6 +179,7 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Recording"/> state.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="UnauthorizedAccessException">The access of the resources can not be granted.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
@@ -183,6 +187,7 @@ namespace Tizen.Multimedia
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Start()
         {
             if (State == RecorderState.Recording)
@@ -205,12 +210,14 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Paused"/> state.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Pause()
         {
             if (State == RecorderState.Paused)
@@ -238,12 +245,14 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
         /// <privilege>http://tizen.org/privilege/externalstorage</privilege>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="UnauthorizedAccessException">The access to the resources can not be granted.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Commit()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -259,11 +268,13 @@ namespace Tizen.Multimedia
         /// The recorder state must be <see cref="RecorderState.Recording"/> state by <see cref="Start"/> or
         /// <see cref="RecorderState.Paused"/> state by <see cref="Pause"/>.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Cancel()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -347,7 +358,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Release any unmanaged resources used by this object.
         /// </summary>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
-Tizen.Multimedia.StreamRecorder.StreamRecorder()

Signed-off-by: Hyunsoo Park <hance.park@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
feature is added. (http://tizen.org/feature/multimedia.streamrecorder.record)
So related APIs are modified.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:TCSACR-305
(https://code.sec.samsung.net/jira/browse/TCSACR-305)

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
private const string Feature = "http://tizen.org/feature/network.streamrecorder.record"; // feature
private static bool IsSupported(); // for checking

Changed:
Description is changed about below APIs. 

-Tizen.Multimedia.StreamRecorder.StreamRecorder()
-->
