### PR TITLE
[NUI] check layout owner is null when removing childLayout

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -104,9 +104,12 @@ namespace Tizen.NUI
                     }
                     else
                     {
-                        Interop.Actor.Actor_Remove(View.getCPtr(childLayout.Owner.Parent), View.getCPtr(childLayout.Owner));
-                        if (NDalicPINVOKE.SWIGPendingException.Pending)
-                            throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                        if(childLayout.Owner != null)
+                        {
+                            Interop.Actor.Actor_Remove(View.getCPtr(childLayout.Owner.Parent), View.getCPtr(childLayout.Owner));
+                            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                        }
                     }
 
                     // Reset condition for animation ready for next transition when required.


### PR DESCRIPTION
### Description of Change ###
If layout owner is null, cannot remove owner from it's parent.
Check owner is null.

### API Changes ###
NONE