### PR TITLE
[StreamRecorder] Handle NotSupportedException as new feature added

### DIFF
--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -131,6 +131,7 @@ namespace Tizen.Multimedia
         /// <seealso cref="StreamRecorderAudioOptions"/>
         /// <seealso cref="StreamRecorderVideoOptions"/>
         /// <since_tizen> 4 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Prepare(StreamRecorderOptions options)
         {
             if (options == null)
@@ -163,10 +164,12 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Idle"/> state.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Prepare"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Unprepare()
         {
             if (State == RecorderState.Idle)
@@ -189,6 +192,7 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Recording"/> state.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="UnauthorizedAccessException">The access of the resources can not be granted.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
@@ -196,6 +200,7 @@ namespace Tizen.Multimedia
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Start()
         {
             if (State == RecorderState.Recording)
@@ -218,12 +223,14 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Paused"/> state.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Pause()
         {
             if (State == RecorderState.Paused)
@@ -251,12 +258,14 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
         /// <privilege>http://tizen.org/privilege/externalstorage</privilege>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="UnauthorizedAccessException">The access to the resources can not be granted.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Commit()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -272,11 +281,13 @@ namespace Tizen.Multimedia
         /// The recorder state must be <see cref="RecorderState.Recording"/> state by <see cref="Start"/> or
         /// <see cref="RecorderState.Paused"/> state by <see cref="Pause"/>.
         /// </remarks>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Cancel()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -360,7 +371,9 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Release any unmanaged resources used by this object.
         /// </summary>
+        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Dispose()
         {
             Dispose(true);

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -34,11 +34,11 @@ namespace Tizen.Multimedia
         private bool _audioEnabled;
         private bool _videoEnabled;
         private StreamRecorderVideoFormat _sourceFormat;
-        private const string Feature = "http://tizen.org/feature/multimedia.streamrecorder.record";
+        private const string Feature = "http://tizen.org/feature/multimedia.stream_recorder";
 
         private static bool IsSupported()
         {
-            return System.Information.TryGetValue(Feature, out bool isSupported) ? isSupported : false;
+            return System.Information.TryGetValue(Feature, out bool isSupported) && isSupported;
         }
 
         /// <summary>
@@ -46,12 +46,12 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
+        /// <feature> http://tizen.org/feature/multimedia.stream_recorder </feature>
         public StreamRecorder()
         {
             if (IsSupported() == false)
             {
-                throw new PlatformNotSupportedException(
+                throw new NotSupportedException(
                     $"The feature({Feature}) is not supported on the current device.");
             }
 

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -131,7 +131,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="StreamRecorderAudioOptions"/>
         /// <seealso cref="StreamRecorderVideoOptions"/>
         /// <since_tizen> 4 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Prepare(StreamRecorderOptions options)
         {
             if (options == null)
@@ -169,7 +168,6 @@ namespace Tizen.Multimedia
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Prepare"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Unprepare()
         {
             if (State == RecorderState.Idle)
@@ -200,7 +198,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Start()
         {
             if (State == RecorderState.Recording)
@@ -230,7 +227,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Commit"/>
         /// <seealso cref="Cancel"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Pause()
         {
             if (State == RecorderState.Paused)
@@ -265,7 +261,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Commit()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -287,7 +282,6 @@ namespace Tizen.Multimedia
         /// <seealso cref="Start"/>
         /// <seealso cref="Pause"/>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Cancel()
         {
             ValidateState(RecorderState.Paused, RecorderState.Recording);
@@ -373,7 +367,6 @@ namespace Tizen.Multimedia
         /// </summary>
         /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
-        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public void Dispose()
         {
             Dispose(true);

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -34,14 +34,27 @@ namespace Tizen.Multimedia
         private bool _audioEnabled;
         private bool _videoEnabled;
         private StreamRecorderVideoFormat _sourceFormat;
+        private const string Feature = "http://tizen.org/feature/multimedia.streamrecorder.record";
+
+        private static bool IsSupported()
+        {
+            return System.Information.TryGetValue(Feature, out bool isSupported) ? isSupported : false;
+        }
 
         /// <summary>
         /// Initialize a new instance of the <see cref="StreamRecorder"/> class.
         /// </summary>
         /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
+        /// <feature> http://tizen.org/feature/multimedia.streamrecorder.record </feature>
         public StreamRecorder()
         {
+            if (IsSupported() == false)
+            {
+                throw new PlatformNotSupportedException(
+                    $"The feature({Feature}) is not supported on the current device.");
+            }
+
             try
             {
                 Native.Create(out _handle).ThrowIfError("Failed to create stream recorder.");

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -163,7 +163,6 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Idle"/> state.
         /// </remarks>
-        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Prepare"/>
@@ -190,7 +189,6 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Recording"/> state.
         /// </remarks>
-        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="UnauthorizedAccessException">The access of the resources can not be granted.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
@@ -220,7 +218,6 @@ namespace Tizen.Multimedia
         /// <br/>
         /// It has no effect if the recorder is already in the <see cref="RecorderState.Paused"/> state.
         /// </remarks>
-        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>
@@ -254,7 +251,6 @@ namespace Tizen.Multimedia
         /// </remarks>
         /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
         /// <privilege>http://tizen.org/privilege/externalstorage</privilege>
-        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="UnauthorizedAccessException">The access to the resources can not be granted.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
@@ -365,7 +361,6 @@ namespace Tizen.Multimedia
         /// <summary>
         /// Release any unmanaged resources used by this object.
         /// </summary>
-        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <since_tizen> 3 </since_tizen>
         public void Dispose()
         {

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -123,7 +123,6 @@ namespace Tizen.Multimedia
         /// <exception cref="ArgumentException">Both <see cref="StreamRecorderOptions.Audio"/> and
         ///     <see cref="StreamRecorderOptions.Video"/> are null.
         /// </exception>
-        /// <exception cref="NotSupportedException"><paramref name="options"/> contains a value which is not supported.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Unprepare"/>
         /// <seealso cref="Start"/>

--- a/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
+++ b/src/Tizen.Multimedia.StreamRecorder/StreamRecorder/StreamRecorder.cs
@@ -123,6 +123,7 @@ namespace Tizen.Multimedia
         /// <exception cref="ArgumentException">Both <see cref="StreamRecorderOptions.Audio"/> and
         ///     <see cref="StreamRecorderOptions.Video"/> are null.
         /// </exception>
+        /// <exception cref="NotSupportedException"><paramref name="options"/> contains a value which is not supported.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Unprepare"/>
         /// <seealso cref="Start"/>
@@ -271,7 +272,6 @@ namespace Tizen.Multimedia
         /// The recorder state must be <see cref="RecorderState.Recording"/> state by <see cref="Start"/> or
         /// <see cref="RecorderState.Paused"/> state by <see cref="Pause"/>.
         /// </remarks>
-        /// <exception cref="NotSupportedException">The feature is not supported.</exception>
         /// <exception cref="InvalidOperationException">The recorder is not in the valid state.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="StreamRecorder"/> has already been disposed.</exception>
         /// <seealso cref="Start"/>


### PR DESCRIPTION
-Tizen.Multimedia.StreamRecorder.StreamRecorder()

Signed-off-by: Hyunsoo Park <hance.park@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
feature is added. (http://tizen.org/feature/multimedia.streamrecorder.record)
So related APIs are modified.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:TCSACR-305
(https://code.sec.samsung.net/jira/browse/TCSACR-305)

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
private const string Feature = "http://tizen.org/feature/network.streamrecorder.record"; // feature
private static bool IsSupported(); // for checking

Changed:
Description is changed about below APIs. 

-Tizen.Multimedia.StreamRecorder.StreamRecorder()
-->