### PR TITLE
[NUI] Fix scrolling

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -569,16 +569,7 @@ namespace Tizen.NUI.Components
             if (animate)
             {
                 // Calculate scroll animaton duration
-                float scrollDistance = 0.0f;
-                if (childCurrentPosition < childTargetPosition)
-                {
-                    scrollDistance = Math.Abs(childCurrentPosition + childTargetPosition);
-                }
-                else
-                {
-                    scrollDistance = Math.Abs(childCurrentPosition - childTargetPosition);
-                }
-
+                float scrollDistance = Math.Abs(displacement);
                 int duration = (int)((320*FlickAnimationSpeed) + (scrollDistance * FlickAnimationSpeed));
                 Debug.WriteLineIf(LayoutDebugScrollableBase, "Scroll Animation Duration:" + duration + " Distance:" + scrollDistance);
 


### PR DESCRIPTION
### Description of Change ###
Previously, Scrolling was working wierdly when scrolling to first item.
Scrolling to first item was so so slow but scrolling to last item was fine.

This is because when calculation for scroll distance is wrong.

So, fix the equation.

### API Changes ###
NONE