### PR TITLE
[NUI] Remove ClearBackgound operate when setting BackgroundImage

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -88,7 +88,6 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
                 string url = (string)newValue;
-                view.ClearBackground();
 
                 if (Rectangle.IsNullOrZero(view.backgroundImageBorder))
                 {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Remove ClearBackgound operate when setting BackgroundImage, otherwise blink issue exists.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
