### PR TITLE
[NUI.Components] Fix focus state can't reach issue

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -37,7 +37,6 @@ namespace Tizen.NUI.Components
         protected string style;
 
         private TapGestureDetector tapGestureDetector = new TapGestureDetector();
-        private bool isFocused = false;
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -107,7 +106,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         internal bool StateFocusableOnTouchMode { get; set; }
 
-        internal bool IsFocused => (isFocused || HasFocus());
+        internal bool IsFocused { get; set; } = false;
 
         /// <summary>
         /// Dispose Control and all children on it.
@@ -171,7 +170,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void OnFocusGained()
         {
-            isFocused = true;
+            IsFocused = true;
         }
 
         /// <summary>
@@ -182,7 +181,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void OnFocusLost()
         {
-            isFocused = false;
+            IsFocused = false;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. HasFocus always return true during OnFocusGained or OnFocusLost.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
