### PR TITLE
[NUI] Interrupt pan when popup is popped

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -200,6 +200,7 @@ namespace Tizen.NUI.Components
         private ButtonGroup btGroup = null;
         private Window window = null;
         private Layer container = new Layer();
+        private PanGestureDetector detector = new PanGestureDetector();
         static Popup() { }
 
         /// <summary>
@@ -733,6 +734,7 @@ namespace Tizen.NUI.Components
 
         private void Initialize()
         {
+            detector.Attach(this);
             container.Add(this);
             LeaveRequired = true;
             PropertyChanged += PopupStylePropertyChanged;

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -109,6 +109,7 @@ namespace Tizen.NUI
                             Interop.Actor.Actor_Remove(View.getCPtr(childLayout.Owner.Parent), View.getCPtr(childLayout.Owner));
                             if (NDalicPINVOKE.SWIGPendingException.Pending)
                                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                            childLayout.Owner.InternalParent = null;
                         }
                     }
 


### PR DESCRIPTION
### Description of Change ###
Currently, panning is working even if there is popup over component.
As workaround, add PanGestureDetector to Popup to prevent panning.

Additionally, add View to ScrollableBase which is to interrupt touching during scrolling.


### API Changes ###
NONE