### PR TITLE
[NUI] Consume Touch/Hover when popup is posted

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -200,7 +200,6 @@ namespace Tizen.NUI.Components
         private ButtonGroup btGroup = null;
         private Window window = null;
         private Layer container = new Layer();
-        private PanGestureDetector detector = new PanGestureDetector();
         static Popup() { }
 
         /// <summary>
@@ -734,8 +733,10 @@ namespace Tizen.NUI.Components
 
         private void Initialize()
         {
-            detector.Attach(this);
             container.Add(this);
+            container.SetTouchConsumed(true);
+            container.SetHoverConsumed(true);
+
             LeaveRequired = true;
             PropertyChanged += PopupStylePropertyChanged;
 


### PR DESCRIPTION
### Description of Change ###
Popup should be always on top of layer when popup is posted.
And should consume all touch,hover because it is on top.

Set Touch/Hover consume to true.


### API Changes ###
NONE