### PR TITLE
[NUI][Style] Fix style loading issue when extending control classes

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -53,7 +53,16 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Control() : base()
         {
-            ViewStyle viewStyle = StyleManager.Instance.GetComponentStyle(this.GetType());
+            var cur_type = this.GetType();
+            ViewStyle viewStyle = null;
+
+            do
+            {
+                if (cur_type.Equals(typeof(Tizen.NUI.Components.Control))) break;
+                viewStyle = StyleManager.Instance.GetComponentStyle(cur_type);
+                cur_type = cur_type.BaseType;
+            }
+            while (viewStyle == null);
 
             if (viewStyle != null)
             {


### PR DESCRIPTION
When a NUI.Component.Control class was extended, the default style
was not loaded well.
This was because searching style logic was executed with not whole base classes
but only with the inherited class.