### PR TITLE
[Tizen.WebView] Deprecate an enumeration value for text file based co…

### DIFF
--- a/src/Tizen.WebView/Tizen.WebView/CookieManager.cs
+++ b/src/Tizen.WebView/Tizen.WebView/CookieManager.cs
@@ -46,6 +46,7 @@ namespace Tizen.WebView
         /// <summary>
         /// Cookies are stored in a text file in the Mozilla "cookies.txt" format.
         /// </summary>
+        [Obsolete("Deprecated since API level 8.")]
         Text,
         /// <summary>
         /// Cookies are stored in a SQLite file in the current Mozilla format.


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Chromium supports only SQLite based persistent cookie storage.
This patch deprecates an enumeration for text file based cookie storage, CookiePersistentStorage.Text.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: TCSACR-314

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
