### PR TITLE
[NUI] remove unnecessary code to assign children layout

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -152,22 +152,6 @@ namespace Tizen.NUI
             base.Dispose(type);
         }
 
-        // Traverse through children from the provided root.
-        // If a child has no layout but is a pure View then assign a default layout and continue traversal.
-        // If child has no layout and not a pure View then assign a LayoutItem that terminates the layouting (leaf),
-        private void AutomaticallyAssignLayouts(View rootNode)
-        {
-            for (uint i = 0; i < rootNode.ChildCount; i++)
-            {
-                View view = rootNode.GetChildAt(i);
-                if (view.Layout == null )
-                {
-                    view.Layout = new AbsoluteLayout();
-                    AutomaticallyAssignLayouts(rootNode);
-                }
-            }
-        }
-
         // Traverse the tree looking for a root node that is a layout.
         // Once found, it's children can be assigned Layouts and the Measure process started.
         private void FindRootLayouts(View rootNode)
@@ -175,8 +159,6 @@ namespace Tizen.NUI
             if (rootNode.Layout != null)
             {
                 Debug.WriteLineIf( LayoutDebugController, "LayoutController Root found:" + rootNode.Name);
-                // rootNode has a layout, ensure all children have default layouts or layout items.
-                AutomaticallyAssignLayouts(rootNode);
                 // rootNode has a layout, start measuring and layouting from here.
                 MeasureAndLayout(rootNode);
             }


### PR DESCRIPTION
`View.Layout` is set by `LayoutGroup.AddChildToLayoutGroup()`

1.When layout is set before child added
```
Tizen.NUI.LayoutGroup.AddChildToLayoutGroup() Line 164
Tizen.NUI.LayoutGroup.OnChildAddedToOnwer() Line 265
Tizen.NUI.BaseComponent.View.Add() Line 152
```

2.When layout is set after child added
```
Tizen.NUI.LayoutGroup.AddChildToLayoutGroup() Line 164
Tizen.NUI.LayoutGroup.OnAttachedToOwner() Line 466
Tizen.NUI.LayoutItem.AttachToOnwner() Line 168
Tizen.NUI.BaseComponentsView.SetLayout() Line 110
Tizen.NUI.BaseComponentsView.set_Layout() Line 2214

```

This means children's Layout is alreay assinged on `LayoutController.Process()`.
So, we don't need to assign layout again.