### PR TITLE
[Application] Separating Language changing logic and Region changing logic

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -208,7 +208,7 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         protected virtual void OnLocaleChanged(LocaleChangedEventArgs e)
         {
-            ChangeCurrentCultureInfo(e.Locale);
+            ChangeCurrentUICultureInfo(e.Locale);
             LocaleChanged?.Invoke(this, e);
         }
 
@@ -220,6 +220,7 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         protected virtual void OnRegionFormatChanged(RegionFormatChangedEventArgs e)
         {
+            ChangeCurrentCultureInfo(e.Region);
             RegionFormatChanged?.Invoke(this, e);
         }
 
@@ -253,21 +254,27 @@ namespace Tizen.Applications
             base.Dispose(disposing);
         }
 
-        private void ChangeCurrentCultureInfo(string locale)
+        private CultureInfo ConvertCultureInfo(string locale)
         {
             ULocale pLocale = new ULocale(locale);
-            CultureInfo currentCultureInfo = null;
-
             try
             {
-                currentCultureInfo = new CultureInfo(pLocale.Locale.Replace("_", "-"));
+                return new CultureInfo(pLocale.Locale.Replace("_", "-"));
             }
             catch (CultureNotFoundException)
             {
-                currentCultureInfo = GetFallbackCultureInfo(pLocale);
+                return GetFallbackCultureInfo(pLocale);
             }
+        }
 
-            CultureInfo.CurrentUICulture = CultureInfo.CurrentCulture = currentCultureInfo;
+        private void ChangeCurrentCultureInfo(string locale)
+        {
+            CultureInfo.CurrentCulture = ConvertCultureInfo(locale);
+        }
+
+        private void ChangeCurrentUICultureInfo(string locale)
+        {
+            CultureInfo.CurrentUICulture = ConvertCultureInfo(locale);
         }
 
         private CultureInfo GetCultureInfo(string locale)


### PR DESCRIPTION
### Description of Change ###
 .net framework provide two kinds of current `CultureInfo`s. 
They are designed to represent a different kind of culture info,

 First is `CurrentCultureInfo`, it is representing `region/format` information, it is provide by `SystemSettings.LocaleCountry` on tizen

 Second is `CurrentUICultureInfo` it is representing `Language` information, it is provide by `SystemSettings.LocaleLanguage` on tizen

So, we should update `CurrentUICultureInfo` when Locale was updated
and we should update `CurrentCultureInfo` when RegionFormat was Changed


https://wpf.2000things.com/2013/02/25/763-the-difference-between-currentculture-and-currentuiculture/

https://stackoverflow.com/questions/329033/what-is-the-difference-between-currentculture-and-currentuiculture-properties-of

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
