### PR TITLE
[NUI] Fix ControlState issues.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -884,14 +884,22 @@ namespace Tizen.NUI.Components
 
             if (isEnabled)
             {
-                // Normal
-                targetState = ControlStates.Normal;
+                if (isPressed)
+                {
+                    // Pressed
+                    targetState = ControlStates.Pressed;
+                }
+                else
+                {
+                    // Normal
+                    targetState = ControlStates.Normal;
 
-                // Selected
-                targetState |= (IsSelected ? ControlStates.Selected : 0);
+                    // Selected
+                    targetState |= (IsSelected ? ControlStates.Selected : 0);
 
-                // Pressed, PressedSelected, Focused, SelectedFocused
-                targetState |= (isPressed ? ControlStates.Pressed : (IsFocused ? ControlStates.Focused : 0));
+                    // Focused, SelectedFocused
+                    targetState |= (IsFocused ? ControlStates.Focused : 0);
+                }
             }
             else
             {
@@ -928,6 +936,8 @@ namespace Tizen.NUI.Components
             Extension = style.CreateExtension();
 
             CreateComponents();
+
+            EnableControlStatePropagation = true;
 
             if (ButtonOverlayImage != null)
             {

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -849,6 +849,8 @@ namespace Tizen.NUI.Components
             {
                 CreateThumb();
             }
+
+            EnableControlStatePropagation = true;
         }
 
         private void Initialize()

--- a/src/Tizen.NUI.Components/Controls/Tab.cs
+++ b/src/Tizen.NUI.Components/Controls/Tab.cs
@@ -691,6 +691,8 @@ namespace Tizen.NUI.Components
                     VerticalAlignment = VerticalAlignment.Center
                 };
                 Add(TextItem);
+
+                EnableControlStatePropagation = true;
             }
 
             internal int Index

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -193,15 +193,7 @@ namespace Tizen.NUI.BaseComponents
                     return SelectedFocused != null ? SelectedFocused : (Selected != null ? Selected : Other);
                 default:
                 {
-                    // Handle combined states
-                    if ((int)(state & ControlStates.Selected) != 0 && Selected != null)
-                    {
-                        return Selected;
-                    }
-                    else if ((int)(state & ControlStates.Pressed) != 0 && Pressed != null)
-                    {
-                        return Pressed;
-                    }
+                    // TODO Handle combined states
                     return Other;
                 }
             }
@@ -256,7 +248,7 @@ namespace Tizen.NUI.BaseComponents
         {
             targetView = view;
             targetBindableProperty = bindableProperty;
-            view.ControlStateChangeEvent += OnViewControlState;
+            view.ControlStateChangeEventInternal += OnViewControlState;
         }
 
         /// <summary>
@@ -275,7 +267,7 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void OnViewControlState(View obj, View.ControlStateChagedInfo controlStateChangedInfo)
+        private void OnViewControlState(View obj, View.ControlStateChangedInfo controlStateChangedInfo)
         {
             if (null != obj && null != GetValue(controlStateChangedInfo.CurrentState))
             {
@@ -336,8 +328,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (hadMultiValue != HasMultiValue())
             {
-                if (hadMultiValue) view.ControlStateChangeEvent -= controlStateChanged;
-                else view.ControlStateChangeEvent += controlStateChanged;
+                if (hadMultiValue) view.ControlStateChangeEventInternal -= controlStateChanged;
+                else view.ControlStateChangeEventInternal += controlStateChanged;
             }
         }
 
@@ -357,7 +349,7 @@ namespace Tizen.NUI.BaseComponents
         {
             if (HasMultiValue())
             {
-                view.ControlStateChangeEvent -= controlStateChanged;
+                view.ControlStateChangeEventInternal -= controlStateChanged;
             }
             selector = null;
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -1583,7 +1583,7 @@ namespace Tizen.NUI.BaseComponents
             TextShadow = instance;
         }
 
-        private void OnControlStateChangedForShadow(View obj, ControlStateChagedInfo controlStateChangedInfo)
+        private void OnControlStateChangedForShadow(View obj, ControlStateChangedInfo controlStateChangedInfo)
         {
             UpdateTextShadowVisual();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -1059,35 +1059,77 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public class ControlStateChagedInfo
+        public class ControlStateChangedInfo
         {
             /// <summary>
             /// The previous control state.
             /// </summary>
-            public ControlStateChagedInfo(ControlStates previousState, ControlStates currentState, Touch touch)
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public ControlStateChangedInfo(ControlStates previousState, ControlStates currentState, InputMethodType inputMethod, object inputData)
             {
                 PreviousState = previousState;
                 CurrentState = currentState;
-                Touch = touch;
+                InputMethod = inputMethod;
+                InputData = inputData;
             }
 
             /// <summary>
             /// The previous control state.
             /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public ControlStates PreviousState { get; }
 
             /// <summary>
             /// The current control state.
             /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             public ControlStates CurrentState { get; }
 
             /// <summary>
-            /// The touch information in case the state has changed by touching.
+            /// Indicates the input method that triggered this change.
             /// </summary>
-            /// <remarks>
-            /// The value is null if it is not the case.
-            /// </remarks>
-            public Touch Touch { get; }
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public InputMethodType InputMethod { get; }
+
+            /// <summary>
+            /// The input method data in detail.
+            ///
+            /// The type of data depends on the InputMethod,
+            /// ---------------------------------------
+            ///  InputMethod    |   Typep of InputData
+            /// ---------------------------------------
+            ///  None           |   (null)
+            ///  Touch          |   Tizen.NUI.Touch
+            ///  Key            |   Tizen.NUI.Key
+            /// ---------------------------------------
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public object InputData { get; }
+
+            /// <summary>
+            /// List of input method that can trigger ControlStates change.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public enum InputMethodType
+            {
+                /// <summary>
+                /// ControlState has changed without user input.
+                /// </summary>
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                None,
+
+                /// <summary>
+                /// ControlState has changed by a touch.
+                /// </summary>
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                Touch,
+
+                /// <summary>
+                /// ControlState has changed by key input.
+                /// </summary>
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                Key,
+            }
         }
 
         private EventHandlerWithReturnType<object, WheelEventArgs, bool> WindowWheelEventHandler;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1259,7 +1259,7 @@ namespace Tizen.NUI.BaseComponents
             SizeModeFactor = new Vector3(x, y, z);
         }
 
-        private void OnControlStateChangedForShadow(View obj, ControlStateChagedInfo controlStateChangedInfo)
+        private void OnControlStateChangedForShadow(View obj, ControlStateChangedInfo controlStateChangedInfo)
         {
             var boxShadowSelector = (Selector<Shadow>)GetValue(BoxShadowSelectorProperty);
 
@@ -1298,7 +1298,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void UpdateShadow(ShadowBase shadow, bool needToListenStateChanged)
         {
-            ControlStateChangeEvent -= OnControlStateChangedForShadow;
+            ControlStateChangeEventInternal -= OnControlStateChangedForShadow;
 
             if (shadow == null)
             {
@@ -1311,11 +1311,11 @@ namespace Tizen.NUI.BaseComponents
 
             if (needToListenStateChanged)
             {
-                ControlStateChangeEvent += OnControlStateChangedForShadow;
+                ControlStateChangeEventInternal += OnControlStateChangedForShadow;
             }
         }
 
-        private void OnControlStateChangedForCornerRadius(View obj, ControlStateChagedInfo controlStateChangedInfo)
+        private void OnControlStateChangedForCornerRadius(View obj, ControlStateChangedInfo controlStateChangedInfo)
         {
             var selector = (Selector<float?>)GetValue(CornerRadiusSelectorProperty);
 
@@ -1334,11 +1334,11 @@ namespace Tizen.NUI.BaseComponents
 
         private void UpdateCornerRadius(float value, bool needToListenStateChanged)
         {
-            ControlStateChangeEvent -= OnControlStateChangedForCornerRadius;
+            ControlStateChangeEventInternal -= OnControlStateChangedForCornerRadius;
 
             if (needToListenStateChanged)
             {
-                ControlStateChangeEvent += OnControlStateChangedForCornerRadius;
+                ControlStateChangeEventInternal += OnControlStateChangedForCornerRadius;
             }
 
             if (value != 0)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CheckBoxSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CheckBoxSample.cs
@@ -417,7 +417,7 @@ namespace Tizen.NUI.Samples
                 createText[1].Dispose();
                 createText[1] = null;
 
-                window.Remove(root);
+                NUIApplication.GetDefaultWindow().Remove(root);
                 root.Dispose();
             }
         }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
@@ -33,6 +33,7 @@
     <ProjectReference Include="../../../src/Tizen.System.SystemSettings/Tizen.System.SystemSettings.csproj" />
     <ProjectReference Include="../../../src/Tizen.NUI/Tizen.NUI.csproj" />
     <ProjectReference Include="../../../src/Tizen.NUI.Components/Tizen.NUI.Components.csproj" />
+    <ProjectReference Include="../../../src/Tizen.NUI.Wearable/Tizen.NUI.Wearable.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Fix ControlState propagation to false.
* Fix typo in class name : ControlStateChagedInfo -> ControlStateChangedInfo
* Enhance ControlStateChangeInfo to have InputMethod property.
* Remove combined ControlState handling in Selector: It needs to be well-designed first.
* Fix test/Tizen.NUI.Samples compile errors.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
