### PR TITLE
[NUI] remove input method dependency from View.ControlState

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -590,9 +590,7 @@ namespace Tizen.NUI.Components
             {
                 isSelected = value;
 
-                UpdateState(SelectionChangedByTouch);
-
-                SelectionChangedByTouch = null;
+                UpdateState();
             }
         }
 
@@ -795,7 +793,8 @@ namespace Tizen.NUI.Components
             {
                 case PointStateType.Down:
                     isPressed = true;
-                    UpdateState(touch);
+                    Extension?.SetTouchInfo(touch);
+                    UpdateState();
                     return true;
                 case PointStateType.Interrupted:
                     isPressed = false;
@@ -809,12 +808,13 @@ namespace Tizen.NUI.Components
 
                         if (Style.IsSelectable != null && Style.IsSelectable == true)
                         {
-                            SelectionChangedByTouch = touch;
+                            Extension?.SetTouchInfo(touch);
                             IsSelected = !IsSelected;
                         }
                         else
                         {
-                            UpdateState(touch);
+                            Extension?.SetTouchInfo(touch);
+                            UpdateState();
                         }
 
                         if (clicked)
@@ -877,7 +877,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void UpdateState(Touch touchInfo = null)
+        protected void UpdateState()
         {
             ControlStates sourceState = ControlState;
             ControlStates targetState;
@@ -910,8 +910,10 @@ namespace Tizen.NUI.Components
                 targetState |= (IsSelected ? ControlStates.Selected : (IsFocused ? ControlStates.Focused : 0));
             }
 
-            if (SetControlState(targetState, ControlStateChangedInfo.InputMethodType.Touch, touchInfo))
+            if (sourceState != targetState)
             {
+                ControlState = targetState;
+
                 OnUpdate();
 
                 StateChangedEventArgs e = new StateChangedEventArgs
@@ -921,7 +923,7 @@ namespace Tizen.NUI.Components
                 };
                 stateChangeHander?.Invoke(this, e);
 
-                Extension?.OnControlStateChanged(this, sourceState, touchInfo);
+                Extension?.OnControlStateChanged(this, new ControlStateChangedEventArgs(sourceState, targetState));
             }
         }
 

--- a/src/Tizen.NUI.Components/Controls/Extension/ButtonExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/ButtonExtension.cs
@@ -26,6 +26,12 @@ namespace Tizen.NUI.Components.Extension
     public abstract class ButtonExtension
     {
         /// <summary>
+        /// The Touch info to get current touch position.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected Touch TouchInfo { get; private set; }
+
+        /// <summary>
         /// Called immediately after the Button creates the text part.
         /// </summary>
         /// <param name="button">The Button instance that the extension currently applied to.</param>
@@ -65,10 +71,9 @@ namespace Tizen.NUI.Components.Extension
         /// Describes actions on Button's ControlStates changed.
         /// </summary>
         /// <param name="button">The Button instance that the extension currently applied to.</param>
-        /// <param name="previousState">The previous contol state of the Button.</param>
-        /// <param name="touchInfo">The touch information in case the state has changed by touching.</param>
+        /// <param name="args">The control state changed information.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual void OnControlStateChanged(Button button, ControlStates previousState, Touch touchInfo)
+        public virtual void OnControlStateChanged(Button button, View.ControlStateChangedEventArgs args)
         {
         }
 
@@ -99,5 +104,12 @@ namespace Tizen.NUI.Components.Extension
         public virtual void OnDispose(Button button)
         {
         }
-  }
+
+        /// <summary>
+        /// Set the Touch Info.
+        /// </summary>
+        /// <param name="touch">The Touch Info.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetTouchInfo(Touch touch) => TouchInfo = touch;
+    }
 }

--- a/src/Tizen.NUI.Components/Controls/Extension/LottieButtonExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/LottieButtonExtension.cs
@@ -55,9 +55,9 @@ namespace Tizen.NUI.Components.Extension
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnControlStateChanged(Button button, ControlStates previousState, Touch touchInfo)
+        public override void OnControlStateChanged(Button button, View.ControlStateChangedEventArgs args)
         {
-            UpdateLottieView(button, previousState, touchInfo, LottieView);
+            UpdateLottieView(button, args.PreviousState, LottieView);
         }
 
         internal static void InitializeLottieView(Button button, LottieAnimationView lottieView)
@@ -73,7 +73,7 @@ namespace Tizen.NUI.Components.Extension
             lottieStyle.PlayRange?.GetValue(ControlStates.Normal)?.Show(lottieView, true);
         }
 
-        internal static void UpdateLottieView(Button button, ControlStates previousState, Touch touchInfo, LottieAnimationView lottieView)
+        internal static void UpdateLottieView(Button button, ControlStates previousState, LottieAnimationView lottieView)
         {
             ((ILottieButtonStyle)button.Style).PlayRange?.GetValue(button.ControlState)?.Show(lottieView, ((int)previousState & (int)ControlStates.Pressed) == 0);
         }

--- a/src/Tizen.NUI.Components/Controls/Extension/LottieSwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/LottieSwitchExtension.cs
@@ -54,9 +54,9 @@ namespace Tizen.NUI.Components.Extension
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnControlStateChanged(Button button, ControlStates previousState, Touch touchInfo)
+        public override void OnControlStateChanged(Button button, View.ControlStateChangedEventArgs args)
         {
-            LottieButtonExtension.UpdateLottieView(button, previousState, touchInfo, LottieView);
+            LottieButtonExtension.UpdateLottieView(button, args.PreviousState, LottieView);
         }
     }
 }

--- a/src/Tizen.NUI.Components/PreloadStyle/OverlayAnimationButtonStyle.cs
+++ b/src/Tizen.NUI.Components/PreloadStyle/OverlayAnimationButtonStyle.cs
@@ -102,7 +102,7 @@ namespace Tizen.NUI.Components
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnControlStateChanged(Button button, ControlStates previousState, Touch touchInfo)
+        public override void OnControlStateChanged(Button button, View.ControlStateChangedEventArgs args)
         {
             if (button.ControlState != ControlStates.Pressed)
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -267,11 +267,12 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void OnViewControlState(View obj, View.ControlStateChangedInfo controlStateChangedInfo)
+        private void OnViewControlState(object obj, View.ControlStateChangedEventArgs controlStateChangedInfo)
         {
-            if (null != obj && null != GetValue(controlStateChangedInfo.CurrentState))
+            View view = obj as View;
+            if (null != view && null != GetValue(controlStateChangedInfo.CurrentState))
             {
-                obj.SetValue(targetBindableProperty, GetValue(controlStateChangedInfo.CurrentState));
+                view.SetValue(targetBindableProperty, GetValue(controlStateChangedInfo.CurrentState));
             }
         }
 
@@ -286,9 +287,9 @@ namespace Tizen.NUI.BaseComponents
     {
         protected Selector<T> selector;
         protected View view;
-        protected View.ControlStateChangesDelegate controlStateChanged;
+        protected EventHandler<View.ControlStateChangedEventArgs> controlStateChanged;
 
-        internal ViewSelector(View view, View.ControlStateChangesDelegate controlStateChanged)
+        internal ViewSelector(View view, EventHandler<View.ControlStateChangedEventArgs> controlStateChanged)
         {
             if (view == null || controlStateChanged == null)
             {
@@ -370,7 +371,7 @@ namespace Tizen.NUI.BaseComponents
     /// </summary>
     internal class CloneableViewSelector<T> : ViewSelector<T> where T : Tizen.NUI.Internal.ICloneable
     {
-        internal CloneableViewSelector(View view, View.ControlStateChangesDelegate controlStateChanged) : base(view, controlStateChanged)
+        internal CloneableViewSelector(View view, EventHandler<View.ControlStateChangedEventArgs> controlStateChanged) : base(view, controlStateChanged)
         {
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -1583,7 +1583,7 @@ namespace Tizen.NUI.BaseComponents
             TextShadow = instance;
         }
 
-        private void OnControlStateChangedForShadow(View obj, ControlStateChangedInfo controlStateChangedInfo)
+        private void OnControlStateChangedForShadow(object obj, ControlStateChangedEventArgs controlStateChangedInfo)
         {
             UpdateTextShadowVisual();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -1060,22 +1060,18 @@ namespace Tizen.NUI.BaseComponents
         /// The class represents the information of the situation where the View's control state changes.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public class ControlStateChangedInfo
+        public class ControlStateChangedEventArgs : EventArgs
         {
             /// <summary>
             /// Create an instance with mandatory fields.
             /// </summary>
             /// <param name="previousState">The previous control state.</param>
             /// <param name="currentState">The current control state.</param>
-            /// <param name="inputMethod">Indicates the input method that triggered this change.</param>
-            /// <param name="inputData">The input method data that depends on the inputMethod.</param>
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public ControlStateChangedInfo(ControlStates previousState, ControlStates currentState, InputMethodType inputMethod, object inputData)
+            public ControlStateChangedEventArgs(ControlStates previousState, ControlStates currentState)
             {
                 PreviousState = previousState;
                 CurrentState = currentState;
-                InputMethod = inputMethod;
-                InputData = inputData;
             }
 
             /// <summary>
@@ -1089,52 +1085,6 @@ namespace Tizen.NUI.BaseComponents
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             public ControlStates CurrentState { get; }
-
-            /// <summary>
-            /// Indicates the input method that triggered this change.
-            /// </summary>
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public InputMethodType InputMethod { get; }
-
-            /// <summary>
-            /// The input method data in detail.
-            ///
-            /// The type of data depends on the InputMethod,
-            /// ---------------------------------------
-            ///  InputMethod    |   Typep of InputData
-            /// ---------------------------------------
-            ///  None           |   (null)
-            ///  Touch          |   Tizen.NUI.Touch
-            ///  Key            |   Tizen.NUI.Key
-            /// ---------------------------------------
-            /// </summary>
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public object InputData { get; }
-
-            /// <summary>
-            /// List of input method that can trigger ControlStates change.
-            /// </summary>
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public enum InputMethodType
-            {
-                /// <summary>
-                /// ControlState has changed without user input.
-                /// </summary>
-                [EditorBrowsable(EditorBrowsableState.Never)]
-                None,
-
-                /// <summary>
-                /// ControlState has changed by a touch.
-                /// </summary>
-                [EditorBrowsable(EditorBrowsableState.Never)]
-                Touch,
-
-                /// <summary>
-                /// ControlState has changed by key input.
-                /// </summary>
-                [EditorBrowsable(EditorBrowsableState.Never)]
-                Key,
-            }
         }
 
         private EventHandlerWithReturnType<object, WheelEventArgs, bool> WindowWheelEventHandler;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1285,7 +1285,7 @@ namespace Tizen.NUI.BaseComponents
             SizeModeFactor = new Vector3(x, y, z);
         }
 
-        private void OnControlStateChangedForShadow(View obj, ControlStateChangedInfo controlStateChangedInfo)
+        private void OnControlStateChangedForShadow(object obj, ControlStateChangedEventArgs controlStateChangedInfo)
         {
             var boxShadowSelector = (Selector<Shadow>)GetValue(BoxShadowSelectorProperty);
 
@@ -1341,7 +1341,7 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void OnControlStateChangedForCornerRadius(View obj, ControlStateChangedInfo controlStateChangedInfo)
+        private void OnControlStateChangedForCornerRadius(object obj, ControlStateChangedEventArgs controlStateChangedInfo)
         {
             var selector = (Selector<float?>)GetValue(CornerRadiusSelectorProperty);
 


### PR DESCRIPTION


### Description of Change ###
`ConstrolState` can be changed by API or Input(`Tizen.NUI.Key` and
`Tizen.NUI.Touch`). it means `ConstrolState` is not always related to
Input method. some Controls need it to use state changed effect. however,
not all controls require that. if we need some property to change state,
we can add it to Style Extension classes.

Also, this patch rename `View.StateChagedEvent` recommended by Framework Design Guidelines.
(https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/)
