### PR TITLE
[NUI] Fix some API to use GetManagedBaseHandleFromNativePtr

### DIFF
--- a/src/Tizen.NUI/src/internal/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application.cs
@@ -1351,7 +1351,12 @@ namespace Tizen.NUI
 
         public Window GetWindow()
         {
-            Window ret = new Window(Interop.Application.Application_GetWindow(swigCPtr), true);
+            Window ret = Registry.GetManagedBaseHandleFromNativePtr(Interop.Application.Application_GetWindow(swigCPtr)) as Window;
+            if(ret == null)
+            {
+                ret = new Window(Interop.Application.Application_GetWindow(swigCPtr), true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -1383,7 +1388,8 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static List<Window> GetWindowList()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<Window> GetWindowList()
         {
             uint ListSize = Interop.Application.Application_GetWindowsListSize();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/WidgetImpl.cs
+++ b/src/Tizen.NUI/src/internal/WidgetImpl.cs
@@ -310,7 +310,12 @@ namespace Tizen.NUI
 
         private void SwigDirectorOnCreate(string contentInfo, global::System.IntPtr window)
         {
-            OnCreate(contentInfo, new Window(window, true));
+            Window ret = Registry.GetManagedBaseHandleFromNativePtr(window) as Window;
+            if (ret == null)
+            {
+                ret = new Window(window, true);
+            }
+            OnCreate(contentInfo, ret);
         }
 
         private void SwigDirectorOnTerminate(string contentInfo, int type)
@@ -330,7 +335,12 @@ namespace Tizen.NUI
 
         private void SwigDirectorOnResize(global::System.IntPtr window)
         {
-            OnResize(new Window(window, true));
+            Window ret = Registry.GetManagedBaseHandleFromNativePtr(window) as Window;
+            if (ret == null)
+            {
+                ret = new Window(window, true);
+            }
+            OnResize(ret);
         }
 
         private void SwigDirectorOnUpdate(string contentInfo, int force)


### PR DESCRIPTION
- Fix GetWindow() using GetManagedBaseHandleFromNativePtr

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
