### PR TITLE
[NUI] Fix the issue that size receives 2 parameters from xaml

### DIFF
--- a/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
@@ -28,6 +28,12 @@ namespace Tizen.NUI.Binding
                     int z = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[2].Trim());
                     return new Size(x, y, z);
                 }
+                else if (parts.Length == 2)
+                {
+                    int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
+                    int y = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
+                    return new Size(x, y);
+                }
             }
 
             throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Size)}");


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Fix the issue that size receives 2 parameters from xaml

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
