### PR TITLE
[MediaVision] Fix wrong key string value

### DIFF
--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceModelConfiguration.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceModelConfiguration.cs
@@ -46,7 +46,7 @@ namespace Tizen.Multimedia.Vision
         private const string _keyModelStdValue = "MV_INFERENCE_MODEL_STD_VALUE";
         private const string _keyBackendType = "MV_INFERENCE_BACKEND_TYPE";
         private const string _keyTargetType = "MV_INFERENCE_TARGET_TYPE";
-        private const string _keyTargetDevice = "MV_INFERENCE_TARGET_DEVICE_TYPE";
+        private const string _keyTargetDeviceType = "MV_INFERENCE_TARGET_DEVICE_TYPE";
         private const string _keyInputTensorWidth = "MV_INFERENCE_INPUT_TENSOR_WIDTH";
         private const string _keyInputTensorHeight = "MV_INFERENCE_INPUT_TENSOR_HEIGHT";
         private const string _keyInputTensorChannels = "MV_INFERENCE_INPUT_TENSOR_CHANNELS";
@@ -353,13 +353,13 @@ namespace Tizen.Multimedia.Vision
         {
             get
             {
-                return (InferenceTargetDevice)GetInt(_keyTargetDevice);
+                return (InferenceTargetDevice)GetInt(_keyTargetDeviceType);
             }
             set
             {
                 ValidationUtil.ValidateEnum(typeof(InferenceTargetDevice), value, nameof(Device));
 
-                Set(_keyTargetDevice, (int)value);
+                Set(_keyTargetDeviceType, (int)value);
             }
         }
 

--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceModelConfiguration.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceModelConfiguration.cs
@@ -46,7 +46,7 @@ namespace Tizen.Multimedia.Vision
         private const string _keyModelStdValue = "MV_INFERENCE_MODEL_STD_VALUE";
         private const string _keyBackendType = "MV_INFERENCE_BACKEND_TYPE";
         private const string _keyTargetType = "MV_INFERENCE_TARGET_TYPE";
-        private const string _keyTargetDevice = "MV_INFERENCE_TARGET_DEVICE";
+        private const string _keyTargetDevice = "MV_INFERENCE_TARGET_DEVICE_TYPE";
         private const string _keyInputTensorWidth = "MV_INFERENCE_INPUT_TENSOR_WIDTH";
         private const string _keyInputTensorHeight = "MV_INFERENCE_INPUT_TENSOR_HEIGHT";
         private const string _keyInputTensorChannels = "MV_INFERENCE_INPUT_TENSOR_CHANNELS";


### PR DESCRIPTION
Wrong key string value of MV_INFERENCE_TARGET_DEVICE.
In NativeACR, MV_INFERENCE_TARGET_DEVICE_TYPE is added.
This patch fix it.

Signed-off-by: Tae-Young Chung <ty83.chung@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: Non-ACR

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
