### PR TITLE
[NUI] Change suggested minimun size in Layout.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1714,10 +1714,6 @@ namespace Tizen.NUI.BaseComponents
                 // MATCH_PARENT spec + parent container size can be used to limit
                 if (_layout != null)
                 {
-                    // Note: it only works if minimum size is >= than natural size.
-                    // To force the size it should be done through the width&height spec or Size2D.
-                    _layout.MinimumHeight = new Tizen.NUI.LayoutLength(value.Width);
-                    _layout.MinimumWidth = new Tizen.NUI.LayoutLength(value.Height);
                     _layout.RequestLayout();
                 }
                 SetValue(MaximumSizeProperty, value);

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -367,8 +367,16 @@ namespace Tizen.NUI
         {
             get
             {
-                int naturalWidth = Owner.NaturalSize2D.Width;
-                return new LayoutLength(Math.Max( MinimumWidth.AsDecimal(), naturalWidth ));
+                float maximumWidth = Owner.MaximumSize.Width;
+                float minimumWidth = Owner.MinimumSize.Width;
+
+                float baseHeight = Owner.MaximumSize.Height > 0 ? Math.Min(Owner.MaximumSize.Height,Owner.NaturalSize.Height) : Owner.NaturalSize.Height;
+                float baseWidth = Owner.GetWidthForHeight(baseHeight);
+
+                float result = minimumWidth > 0 ? Math.Max(baseWidth, minimumWidth) : baseWidth;
+                result = maximumWidth > 0 ? Math.Min(result, maximumWidth) : result;
+
+                return new LayoutLength(result);
             }
         }
 
@@ -381,8 +389,16 @@ namespace Tizen.NUI
         {
             get
             {
-                int naturalHeight = Owner.NaturalSize2D.Height;
-                return new LayoutLength(Math.Max( MinimumHeight.AsDecimal(), naturalHeight ));
+                float maximumHeight = Owner.MaximumSize.Height;
+                float minimumHeight = Owner.MinimumSize.Height;
+
+                float baseWidth = Owner.MaximumSize.Width > 0 ? Math.Min(Owner.MaximumSize.Width,Owner.NaturalSize.Width) : Owner.NaturalSize.Width;
+                float baseHeight = Owner.GetHeightForWidth(baseWidth);
+
+                float result = minimumHeight > 0 ? Math.Max(baseHeight, minimumHeight) : baseHeight;
+                result = maximumHeight > 0 ? Math.Min(result, maximumHeight) : result;
+
+                return new LayoutLength(result);
             }
         }
 


### PR DESCRIPTION
### Description of Change ###

When user set maximum size or minimum size instaed of size and specification,
it means that user want to use natural size of component and makes it bigger than minimum and smaller than maximum.

Currently, when using text, it lays whole text on one line and returns its size as natural size even if multiline is enabled.
So, we need to calculate HeightForWidth with MaximunWidth to know candidate height of multiline text.

Use GetHeightForWidth / GetWidthForHeight size as suggested minimun size.

### API Changes ###
NONE