### PR TITLE
[ElmSharp] Update the SystemTime internal struct

### DIFF
--- a/src/ElmSharp/Interop/Interop.Libc.cs
+++ b/src/ElmSharp/Interop/Interop.Libc.cs
@@ -39,7 +39,7 @@ internal static partial class Interop
             public int tm_isdst;
 
             // The glibc version of struct tm has additional fields
-            public long tm_gmtoff;
+            public IntPtr tm_gmtoff;
             public IntPtr tm_zone;
 
             public static implicit operator SystemTime(DateTime value)


### PR DESCRIPTION
### Description of Change ###
This PR fix the size of internal `SystemTime64` struct for considering based OS arch (64bit or 32bit). Unlike 64bit, native (C) `long` size = 4 byte on the 32 bit machine. So, we should use `IntPtr` instead of `long`.

