### PR TITLE
[Bluetooth][Non-ACR] Fix the crash in GetBondedDevices API

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
@@ -103,8 +103,7 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// The manufacturer data.
         /// </summary>
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
-        internal string ManufacturerData;
+        internal IntPtr ManufacturerData;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -131,8 +130,7 @@ namespace Tizen.Network.Bluetooth
 
         internal int ManufacturerDataLength;
 
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
-        internal string ManufacturerData;
+        internal IntPtr ManufacturerData;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -246,7 +244,7 @@ namespace Tizen.Network.Bluetooth
             resultDevice.RemoteDeviceService = uuidList;
             resultDevice.RemoteDeviceCount = device.ServiceCount;
             resultDevice.RemoteManufLength = device.ManufacturerDataLength;
-            resultDevice.RemoteManufData = device.ManufacturerData;
+            resultDevice.RemoteManufData = Marshal.PtrToStringAnsi(device.ManufacturerData, device.ManufacturerDataLength);
 
             return resultDevice;
         }
@@ -283,7 +281,7 @@ namespace Tizen.Network.Bluetooth
             }
 
             resultDevice.RemotePaired = structDevice.IsPaired;
-            resultDevice.RemoteManufData = structDevice.ManufacturerData;
+            resultDevice.RemoteManufData = Marshal.PtrToStringAnsi(structDevice.ManufacturerData, structDevice.ManufacturerDataLength);
             resultDevice.RemoteManufLength = structDevice.ManufacturerDataLength;
             return resultDevice;
         }


### PR DESCRIPTION
The manufacture data can be filled without NULL termination.
Because it is the byte array type. So we should define it as
IntPrt instead of string to avoid the buffer overflow.

Exception !!!: System.Runtime.InteropServices.COMException (0x8007007A): The data area passed to a system call is too small.
at System.StubHelpers.ValueClassMarshaler.ConvertToNative(IntPtr dst, IntPtr src, IntPtr pMT, CleanupWorkListElement& pCleanupWorkList)
at Tizen.Network.Bluetooth.BluetoothAdapterImpl.GetBondedDevices()
at Tizen.Network.Bluetooth.BluetoothAdapter.GetBondedDevices()

Signed-off-by: DoHyun Pyun <dh79.pyun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
