### PR TITLE
[NUI] Fix ScrollTo to move pan position to the argument position

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -591,7 +591,9 @@ namespace Tizen.NUI.Components
             float currentPositionX = mScrollingChild.CurrentPosition.X != 0 ? mScrollingChild.CurrentPosition.X : mScrollingChild.Position.X;
             float currentPositionY = mScrollingChild.CurrentPosition.Y != 0 ? mScrollingChild.CurrentPosition.Y : mScrollingChild.Position.Y;
             float delta = ScrollingDirection == Direction.Horizontal ? currentPositionX : currentPositionY;
-            delta -= position;
+            // The argument position is the new pan position. So the new position of ScrollableBase becomes (-position).
+            // To move ScrollableBase's position to (-position), it moves by (-position - currentPosition).
+            delta = -position - delta;
 
             ScrollBy(delta, animate);
         }


### PR DESCRIPTION
Previously, ScrollTo moved pan position including the ScrollableBase's
current position.
e.g. ScrollTo(360, true); //moves by 360
     ScrollTo(0, true); //moves by 360 again based on current position

The argument position is the new pan position. So the new position of
ScrollableBase becomes (-position).
To move ScrollableBase's position to (-position), it moves by
(-position - currentPosition).

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
