### PR TITLE
[NUI] Fix to enable ScrollTo before touch scrolling

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -610,6 +610,11 @@ namespace Tizen.NUI.Components
             }
             else
             {
+                if (Math.Equals(maxScrollDistance, 0.0f))
+                {
+                    maxScrollDistance = CalculateMaximumScrollDistance();
+                }
+
                 targetPosition = Math.Min(0, targetPosition);
                 targetPosition = Math.Max(-maxScrollDistance, targetPosition);
             }


### PR DESCRIPTION
Previously, ScrollTo did not work unless touch scrolling had been done.
Because maxScrollDistance was not set in BoundScrollPosition.

Now, maxScrollDistance is calculated in BoundScrollPosition if
maxScrollDistance is not set in BoundScrollPosition.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
