### PR TITLE
[Bluetooth][Non-ACR] Add NULL check logic for Marshal.PtrToStringAnsi

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
@@ -244,7 +244,9 @@ namespace Tizen.Network.Bluetooth
             resultDevice.RemoteDeviceService = uuidList;
             resultDevice.RemoteDeviceCount = device.ServiceCount;
             resultDevice.RemoteManufLength = device.ManufacturerDataLength;
-            resultDevice.RemoteManufData = Marshal.PtrToStringAnsi(device.ManufacturerData, device.ManufacturerDataLength);
+
+            if (device.ManufacturerData != IntPtr.Zero)
+                resultDevice.RemoteManufData = Marshal.PtrToStringAnsi(device.ManufacturerData, device.ManufacturerDataLength);
 
             return resultDevice;
         }
@@ -281,8 +283,11 @@ namespace Tizen.Network.Bluetooth
             }
 
             resultDevice.RemotePaired = structDevice.IsPaired;
-            resultDevice.RemoteManufData = Marshal.PtrToStringAnsi(structDevice.ManufacturerData, structDevice.ManufacturerDataLength);
             resultDevice.RemoteManufLength = structDevice.ManufacturerDataLength;
+
+            if (structDevice.ManufacturerData != IntPtr.Zero)
+                resultDevice.RemoteManufData = Marshal.PtrToStringAnsi(structDevice.ManufacturerData, structDevice.ManufacturerDataLength);
+
             return resultDevice;
         }
 


### PR DESCRIPTION
This patchset is to avoid ArgumentNullException error. There are some
cases to come NULL variable from Native API.

BluetoothAdapterImpl.cs: RegisterDiscoveryStateChangedEvent(258) > Discovery state changed callback is called
Unhandled exception.
System.ArgumentNullException: Value cannot be null. (Parameter 'ptr')
at System.Runtime.InteropServices.Marshal.PtrToStringAnsi(IntPtr ptr, Int32 len)
at Tizen.Network.Bluetooth.BluetoothUtils.ConvertStructToDiscoveredDevice(BluetoothDiscoveredDeviceStruct structDevice)
at Tizen.Network.Bluetooth.BluetoothAdapterImpl.<RegisterDiscoveryStateChangedEvent>b__45_0(Int32 result, BluetoothDeviceDiscoveryState state, IntPtr deviceInfo, IntPtr user

Signed-off-by: DoHyun Pyun <dh79.pyun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
