### PR TITLE
[Build] Add struct validation

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -82,7 +82,7 @@
   <Target Name="Build">
 
     <MSBuild Projects="@(ProjectToBuild)"
-             Properties="Configuration=$(Configuration);BuildWithAnalyzer=$(BuildWithAnalyzer)"
+             Properties="Configuration=$(Configuration);BuildWithAnalyzer=$(BuildWithAnalyzer);BuildProfile=$(BuildProfile)"
              BuildInParallel="true"
              UseResultsCache="true"
              Targets="Rebuild" />

--- a/build/common.props
+++ b/build/common.props
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <DefineConstants Condition="'$(BuildProfile)' == 'tv'">$(DefineConstants);PROFILE_TV</DefineConstants>
+    <DefineConstants Condition="'$(BuildProfile)' == 'wearable'">$(DefineConstants);PROFILE_WEARABLE</DefineConstants>
+    <DefineConstants Condition="'$(BuildProfile)' == 'mobile'">$(DefineConstants);PROFILE_MOBILE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Open.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -29,6 +29,40 @@ AutoReqProv: no
 BuildRequires: dotnet-build-tools
 Requires(post): /usr/bin/vconftool
 
+# BuildRequires for StructValidator
+BuildRequires: coregl
+BuildRequires: pkgconfig(elementary)
+BuildRequires: pkgconfig(efl-extension)
+BuildRequires: pkgconfig(capi-media-camera)
+BuildRequires: pkgconfig(rua)
+BuildRequires: pkgconfig(component-based-core-base)
+BuildRequires: pkgconfig(notification)
+BuildRequires: pkgconfig(capi-appfw-service-application)
+BuildRequires: pkgconfig(capi-appfw-application)
+BuildRequires: pkgconfig(capi-appfw-widget-application)
+%if "%{profile}" != "tv"
+BuildRequires: pkgconfig(capi-appfw-watch-application)
+%endif
+BuildRequires: pkgconfig(data-control)
+BuildRequires: pkgconfig(capi-location-manager)
+BuildRequires: pkgconfig(capi-media-vision)
+BuildRequires: pkgconfig(capi-network-bluetooth)
+BuildRequires: pkgconfig(capi-network-wifi-direct)
+BuildRequires: pkgconfig(key-manager)
+%if "%{profile}" == "tv"
+BuildRequires: pkgconfig(trustzone-nwd)
+%else
+BuildRequires: pkgconfig(tef-libteec)
+%endif
+BuildRequires: pkgconfig(capi-system-sensor)
+BuildRequires: pkgconfig(capi-system-runtime-info)
+BuildRequires: pkgconfig(capi-telephony)
+BuildRequires: pkgconfig(capi-ui-inputmethod)
+BuildRequires: pkgconfig(stt-engine)
+BuildRequires: pkgconfig(tts-engine)
+BuildRequires: pkgconfig(chromium-efl)
+
+
 %description
 %{summary}
 
@@ -131,9 +165,24 @@ rm -fr %{_tizenfx_bin_path}
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 
 %define build_cmd ./tools/scripts/retry.sh ./tools/scripts/timeout.sh -t 600 ./build.sh
+%if %{defined profile}
+%{build_cmd} --full /p:BuildProfile=%{profile}
+%else
 %{build_cmd} --full
+%endif
 %{build_cmd} --pack %{TIZEN_NET_NUGET_VERSION}
 
+dotnet validate-struct %{_tizenfx_bin_path}/bin/public || echo "
+    #######################################################
+    ##################### W A R N I N G ###################
+    #######################################################
+    # The sturct size mismatches MUST BE FIXED.           #
+    # It will make building errors later                  #
+    #######################################################
+"
+
+
+# Generate filelist for rpm packaging
 GetFileList() {
   PROFILE=$1
   cat packaging/PlatformFileList.txt | grep -v "\.preload" | grep -E "#$PROFILE[[:space:]]|#$PROFILE$" | cut -d# -f1 | sed "s#^#%{DOTNET_ASSEMBLY_PATH}/#"

--- a/src/ElmSharp.Wearable/Interop/Interop.Eext.Rotary.cs
+++ b/src/ElmSharp.Wearable/Interop/Interop.Eext.Rotary.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 internal static partial class Interop
 {
     internal static partial class Eext
@@ -34,6 +36,7 @@ internal static partial class Interop
             CounterClockwise
         }
 
+        [NativeStruct("Eext_Rotary_Event_Info", Include="circle/efl_extension_rotary.h", PkgConfig="efl-extension")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct Eext_Rotary_Event_Info
         {

--- a/src/ElmSharp/ElmSharp.csproj
+++ b/src/ElmSharp/ElmSharp.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Tizen\Tizen.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/ElmSharp/ElmSharp/EcoreKeyEventArgs.cs
+++ b/src/ElmSharp/ElmSharp/EcoreKeyEventArgs.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 namespace ElmSharp
 {
     /// <summary>
@@ -51,6 +53,7 @@ namespace ElmSharp
             return new EcoreKeyEventArgs { KeyName = evt.keyname, KeyCode = (int)evt.keycode };
         }
 
+        [NativeStruct("Ecore_Event_Key", Include="Elementary.h" , PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         struct EcoreEventKey
         {

--- a/src/ElmSharp/ElmSharp/EvasKeyEventArgs.cs
+++ b/src/ElmSharp/ElmSharp/EvasKeyEventArgs.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 namespace ElmSharp
 {
     /// <summary>
@@ -92,6 +94,7 @@ namespace ElmSharp
         /// <summary>
         /// Event structure for Key Down event callbacks.
         /// </summary>
+        [NativeStruct("Evas_Event_Key_Down", Include="Elementary.h", PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         struct EvasEventKeyDown
         {

--- a/src/ElmSharp/ElmSharp/GenItemClass.cs
+++ b/src/ElmSharp/ElmSharp/GenItemClass.cs
@@ -18,6 +18,8 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 namespace ElmSharp
 {
     /// <summary>
@@ -279,6 +281,7 @@ namespace ElmSharp
         }
     }
 
+    [NativeStruct("Elm_Gen_Item_Class", Include="Elementary.h", PkgConfig="elementary")]
     [StructLayout(LayoutKind.Sequential)]
     internal class ItemClass
     {

--- a/src/ElmSharp/ElmSharp/GestureLayer.cs
+++ b/src/ElmSharp/ElmSharp/GestureLayer.cs
@@ -18,6 +18,8 @@ using System;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
+using Tizen.Internals;
+
 namespace ElmSharp
 {
     /// <summary>
@@ -601,6 +603,7 @@ namespace ElmSharp
         /// The struct of TapData.
         /// </summary>
         /// <since_tizen> preview </since_tizen>
+        [NativeStruct("Elm_Gesture_Taps_Info", Include="Elementary.h", PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         public struct TapData
         {
@@ -637,6 +640,7 @@ namespace ElmSharp
         /// The struct of MomentumData.
         /// </summary>
         /// <since_tizen> preview </since_tizen>
+        [NativeStruct("Elm_Gesture_Momentum_Info", Include="Elementary.h", PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         public struct MomentumData
         {
@@ -703,6 +707,7 @@ namespace ElmSharp
         /// The struct of LineData.
         /// </summary>
         /// <since_tizen> preview </since_tizen>
+        [NativeStruct("Elm_Gesture_Line_Info", Include="Elementary.h", PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         public struct LineData
         {
@@ -775,6 +780,7 @@ namespace ElmSharp
         /// The struct of ZoomData.
         /// </summary>
         /// <since_tizen> preview </since_tizen>
+        [NativeStruct("Elm_Gesture_Zoom_Info", Include="Elementary.h", PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         public struct ZoomData
         {
@@ -812,6 +818,7 @@ namespace ElmSharp
         /// The struct of RotateData.
         /// </summary>
         /// <since_tizen> preview </since_tizen>
+        [NativeStruct("Elm_Gesture_Rotate_Info", Include="Elementary.h", PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         public struct RotateData
         {

--- a/src/ElmSharp/Interop/Interop.Eina.cs
+++ b/src/ElmSharp/Interop/Interop.Eina.cs
@@ -17,16 +17,19 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 internal static partial class Interop
 {
     internal static partial class Eina
     {
+        [NativeStruct("Eina_Size2D", Include="Elementary.h", PkgConfig="elementary")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct Size2D
         {
             public int w;
             public int h;
-        };
+        }
 
         [DllImport(Libraries.Eina)]
         [return: MarshalAs(UnmanagedType.U1)]

--- a/src/ElmSharp/Interop/Interop.Libc.cs
+++ b/src/ElmSharp/Interop/Interop.Libc.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 internal static partial class Interop
 {
     internal static partial class Libc
@@ -25,6 +27,7 @@ internal static partial class Interop
         internal static extern int Free(IntPtr ptr);
 
         // Broken-down time is stored in the structure tm which is defined in <time.h> as follows:
+        [NativeStruct("struct tm", Include = "time.h")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct SystemTime
         {

--- a/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
+++ b/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
@@ -17,7 +17,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-using Tizen.Internals.Errors;
+using Tizen.Internals;
 using Tizen.Applications;
 using Tizen.Applications.Notifications;
 
@@ -25,6 +25,7 @@ internal static partial class Interop
 {
     internal static partial class Alarm
     {
+        [NativeStruct("struct tm", Include="time.h")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct DateTime
         {
@@ -37,7 +38,7 @@ internal static partial class Interop
             internal int wday; /* day of the week, range 0 to 6*/
             internal int yday; /* day in the year, range 0 to 365*/
             internal int isdst; /* daylight saving time*/
-            internal long tm_gmtoff;
+            internal IntPtr tm_gmtoff; // Workaround: Use IntPtr instead of long type to match struct size with "struct tm" in time.h
             internal IntPtr tm_zone;
         };
 

--- a/src/Tizen.Applications.Common/Interop/Interop.ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.ApplicationManager.cs
@@ -17,6 +17,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 internal static partial class Interop
 {
     internal static partial class ApplicationManager
@@ -334,6 +336,7 @@ internal static partial class Interop
         internal static extern ErrorCode AppInfoMetadataFilterForeach(IntPtr handle, AppInfoFilterCallback callback, IntPtr userData);
         //int app_info_metadata_filter_foreach (app_info_metadata_filter_h handle, app_info_filter_cb callback, void *user_data)
 
+        [NativeStruct("struct rua_rec", Include="rua.h", PkgConfig="rua")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct RuaRec
         {

--- a/src/Tizen.Applications.ComponentBased/AssemblyAttr.cs
+++ b/src/Tizen.Applications.ComponentBased/AssemblyAttr.cs
@@ -1,7 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+using System;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Tizen.NUI, " + PublicKey.Value)]

--- a/src/Tizen.Applications.ComponentBased/Interop/Interop.AppControl.cs
+++ b/src/Tizen.Applications.ComponentBased/Interop/Interop.AppControl.cs
@@ -1,7 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.InteropServices;
-using System.Text;
 using Tizen.Applications;
 
 internal static partial class Interop

--- a/src/Tizen.Applications.ComponentBased/Interop/Interop.CBApplication.cs
+++ b/src/Tizen.Applications.ComponentBased/Interop/Interop.CBApplication.cs
@@ -1,7 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Runtime.InteropServices;
-using System.Text;
+using Tizen.Internals;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -14,6 +29,9 @@ internal static partial class Interop
         internal delegate void CBAppExitCallback(IntPtr userData);
         internal delegate IntPtr CBAppCreateCallback(IntPtr userData);
         internal delegate void CBAppTerminateCallback(IntPtr userData);
+
+
+        [NativeStruct("component_based_app_base_lifecycle_callback_s", Include="component_based_app_base.h", PkgConfig="component-based-core-base")]
         [StructLayoutAttribute(LayoutKind.Sequential)]
         internal struct CBAppLifecycleCallbacks
         {

--- a/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/ComponentStateManger.cs
+++ b/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/ComponentStateManger.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Tizen.Applications.CoreBackend;

--- a/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/DisplayStatus.cs
+++ b/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/DisplayStatus.cs
@@ -15,7 +15,6 @@
  */
 
 using System;
-using System.Threading.Tasks;
 
 namespace Tizen.Applications.ComponentBased.Common
 {

--- a/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/FrameComponent.cs
+++ b/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/FrameComponent.cs
@@ -1,6 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Tizen.Applications.ComponentBased.Common
 {

--- a/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/FrameComponentStateManager.cs
+++ b/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/FrameComponentStateManager.cs
@@ -1,6 +1,21 @@
-﻿using System;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Tizen.Applications.ComponentBased.Common
 {

--- a/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/IWindowInfo.cs
+++ b/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/IWindowInfo.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Tizen.Applications.ComponentBased.Common
 {

--- a/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/ServiceComponent.cs
+++ b/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/ServiceComponent.cs
@@ -1,6 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Tizen.Applications.ComponentBased.Common
 {

--- a/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/ServiceComponentStateManager.cs
+++ b/src/Tizen.Applications.ComponentBased/Tizen.Applications.ComponentBased.Common/ServiceComponentStateManager.cs
@@ -1,6 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/*
+ * Copyright (c) 2019 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 
 namespace Tizen.Applications.ComponentBased.Common
 {

--- a/src/Tizen.Applications.DataControl/Interop/Interop.DataControl.cs
+++ b/src/Tizen.Applications.DataControl/Interop/Interop.DataControl.cs
@@ -18,7 +18,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using Tizen.Applications;
-using Tizen;
+using Tizen.Internals;
 using Tizen.Applications.DataControl;
 
 internal static partial class Interop
@@ -164,6 +164,7 @@ internal static partial class Interop
         internal delegate void MapBulkAddResponseCallback(int requestID,
             IntPtr provider, IntPtr bulkResults, bool providerResult, string error, IntPtr userData);
 
+        [NativeStruct("data_control_map_response_cb", Include="data_control.h", PkgConfig="data-control")]
         [StructLayoutAttribute(LayoutKind.Sequential)]
         internal struct MapResponseCallbacks
         {
@@ -184,6 +185,7 @@ internal static partial class Interop
         internal delegate void SqlBulkInsertResponseCallback(int requestID,
             IntPtr provider, IntPtr bulk_results, bool providerResult, string error, IntPtr userData);
 
+        [NativeStruct("data_control_sql_response_cb", Include="data_control.h", PkgConfig="data-control")]
         [StructLayoutAttribute(LayoutKind.Sequential)]
         internal struct SqlResponseCallbacks
         {
@@ -230,6 +232,7 @@ internal static partial class Interop
         internal delegate void MapBulkAddRequestCallback(int requestID,
             IntPtr provider, IntPtr bulkData, IntPtr userData);
 
+        [NativeStruct("data_control_provider_map_cb", Include="data_control.h", PkgConfig="data-control")]
         [StructLayoutAttribute(LayoutKind.Sequential)]
         internal struct MapRequestCallbacks
         {
@@ -252,6 +255,7 @@ internal static partial class Interop
         internal delegate void SqlBulkInsertRequestCallback(int requestID,
             IntPtr provider, IntPtr bulk_data, IntPtr userData);
 
+        [NativeStruct("data_control_provider_sql_cb", Include="data_control.h", PkgConfig="data-control")]
         [StructLayoutAttribute(LayoutKind.Sequential)]
         internal struct SqlRequestCallbacks
         {

--- a/src/Tizen.Applications.NotificationEventListener/Tizen.Applications.NotificationEventListener/NotificationListenerManager.cs
+++ b/src/Tizen.Applications.NotificationEventListener/Tizen.Applications.NotificationEventListener/NotificationListenerManager.cs
@@ -21,6 +21,8 @@ namespace Tizen.Applications.NotificationEventListener
     using System.ComponentModel;
     using System.Runtime.InteropServices;
 
+    using Tizen.Internals;
+
     /// <summary>
     /// This class provides a way to register callback function for some notification events.
     /// </summary>
@@ -40,6 +42,7 @@ namespace Tizen.Applications.NotificationEventListener
 
         private static Interop.NotificationEventListener.ChangedCallback callback;
 
+        [NativeStruct("notification_op", Include="notification_type.h", PkgConfig="notification")]
         [StructLayout(LayoutKind.Sequential)]
         private struct NotificationOperation
         {

--- a/src/Tizen.Applications.Service/Interop/Interop.Service.cs
+++ b/src/Tizen.Applications.Service/Interop/Interop.Service.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Tizen.Applications.CoreBackend;
+using Tizen.Internals;
 using Tizen.Internals.Errors;
 
 internal static partial class Interop
@@ -43,7 +44,8 @@ internal static partial class Interop
         [DllImport(Libraries.AppcoreAgent, EntryPoint = "service_app_remove_event_handler")]
         internal static extern ErrorCode RemoveEventHandler(IntPtr handle);
 
-        [StructLayoutAttribute(LayoutKind.Sequential)]
+        [NativeStruct("service_app_lifecycle_callback_s", Include="service_app.h", PkgConfig="capi-appfw-service-application")]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct ServiceAppLifecycleCallbacks
         {
             public ServiceAppCreateCallback OnCreate;

--- a/src/Tizen.Applications.UI/Interop/Interop.Application.cs
+++ b/src/Tizen.Applications.UI/Interop/Interop.Application.cs
@@ -18,6 +18,7 @@ using System;
 using System.Runtime.InteropServices;
 using Tizen.Applications;
 using Tizen.Applications.CoreBackend;
+using Tizen.Internals;
 using Tizen.Internals.Errors;
 
 internal static partial class Interop
@@ -52,6 +53,8 @@ internal static partial class Interop
         [DllImport(Libraries.Application, EntryPoint = "ui_app_remove_event_handler")]
         internal static extern ErrorCode RemoveEventHandler(IntPtr handle);
 
+
+        [NativeStruct("ui_app_lifecycle_callback_s", Include="app.h", PkgConfig="capi-appfw-application")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct UIAppLifecycleCallbacks
         {

--- a/src/Tizen.Applications.WatchApplication/Interop/Interop.Watch.cs
+++ b/src/Tizen.Applications.WatchApplication/Interop/Interop.Watch.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -61,6 +62,9 @@ internal static partial class Interop
 
         internal delegate void WatchAppAmbientChangedCallback(bool ambientMode, IntPtr userData);
 
+#if !PROFILE_TV
+        [NativeStruct("watch_app_lifecycle_callback_s", Include="watch_app.h", PkgConfig="capi-appfw-watch-application")]
+#endif
         [StructLayout(LayoutKind.Sequential)]
         internal struct WatchAppLifecycleCallbacks
         {

--- a/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
+++ b/src/Tizen.Applications.WidgetApplication/Interop/Interop.Widget.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
 using Tizen.Applications;
 
 internal static partial class Interop
@@ -127,14 +128,16 @@ internal static partial class Interop
         [DllImport(Libraries.AppCommon, EntryPoint = "app_event_get_region_format")]
         internal static extern Tizen.Internals.Errors.ErrorCode AppEventGetRegionFormat(IntPtr handle, out string region);
 
-        [StructLayoutAttribute(LayoutKind.Sequential)]
+        [NativeStruct("widget_app_lifecycle_callback_s", Include="widget_app.h", PkgConfig="capi-appfw-widget-application")]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct WidgetAppLifecycleCallbacks
         {
             public WidgetAppCreateCallback OnCreate;
             public WidgetAppTerminateCallback OnTerminate;
         }
 
-        [StructLayoutAttribute(LayoutKind.Sequential)]
+        [NativeStruct("widget_instance_lifecycle_callback_s", Include="widget_app.h", PkgConfig="capi-appfw-widget-application")]
+        [StructLayout(LayoutKind.Sequential)]
         internal struct WidgetiInstanceLifecycleCallbacks
         {
             public WidgetInstanceCreateCallback OnCreate;

--- a/src/Tizen.Location/Tizen.Location/LocationBoundary.cs
+++ b/src/Tizen.Location/Tizen.Location/LocationBoundary.cs
@@ -18,6 +18,8 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 namespace Tizen.Location
 {
     /// <summary>
@@ -348,6 +350,7 @@ namespace Tizen.Location
     /// This structure represents the coordinates of a geographical location.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [NativeStruct("location_coords_s", Include="locations.h", PkgConfig="capi-location-manager")]
     [StructLayout(LayoutKind.Sequential)]
     public struct Coordinate
     {

--- a/src/Tizen.Multimedia.Camera/Interop/Interop.Camera.cs
+++ b/src/Tizen.Multimedia.Camera/Interop/Interop.Camera.cs
@@ -16,6 +16,7 @@
  
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Multimedia;
 
 internal static partial class Interop
@@ -198,6 +199,7 @@ internal static partial class Interop
         [DllImport(Libraries.Camera, EntryPoint = "camera_attr_unset_hdr_capture_progress_cb")]
         internal static extern CameraError UnsetHdrCaptureProgressCallback(IntPtr handle);
 
+        [NativeStruct("camera_image_data_s", Include="camera.h", PkgConfig="capi-media-camera")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct StillImageDataStruct
         {
@@ -210,6 +212,7 @@ internal static partial class Interop
             internal uint ExifLength;
         }
 
+        [NativeStruct("camera_detected_face_s", Include="camera.h", PkgConfig="capi-media-camera")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct DetectedFaceStruct
         {
@@ -287,6 +290,7 @@ internal static partial class Interop
             internal RgbPlaneStruct RgbPlane;
         }
 
+        [NativeStruct("camera_preview_data_s", Include="camera.h", PkgConfig="capi-media-camera")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct CameraPreviewDataStruct
         {

--- a/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Common.cs
+++ b/src/Tizen.Multimedia.Vision/Interop/Interop.MediaVision.Common.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Multimedia.Vision;
 
 /// <summary>
@@ -107,6 +108,7 @@ internal static partial class Interop
     /// </summary>
     internal static partial class MediaVision
     {
+        [NativeStruct("mv_point_s", Include="mv_common.h", PkgConfig="capi-media-vision")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct Point
         {
@@ -114,6 +116,7 @@ internal static partial class Interop
             internal int y;
         }
 
+        [NativeStruct("mv_rectangle_s", Include="mv_common.h", PkgConfig="capi-media-vision")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct Rectangle
         {
@@ -123,6 +126,7 @@ internal static partial class Interop
             internal int height;
         }
 
+        [NativeStruct("mv_quadrangle_s", Include="mv_common.h", PkgConfig="capi-media-vision")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct Quadrangle
         {

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
@@ -22,11 +22,14 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 namespace Tizen.Network.Bluetooth
 {
     /// <summary>
     /// The structure of the device class type and service.
     /// </summary>
+    [NativeStruct("bt_class_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothClassStruct
     {
@@ -47,6 +50,7 @@ namespace Tizen.Network.Bluetooth
     /// <summary>
     /// This structure contains the information of the Bluetooth device.
     /// </summary>
+    [NativeStruct("bt_device_info_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothDeviceStruct
     {
@@ -106,7 +110,7 @@ namespace Tizen.Network.Bluetooth
         [MarshalAsAttribute(UnmanagedType.LPStr)]
         internal string ManufacturerData;
     }
-
+    [NativeStruct("bt_adapter_device_discovery_info_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothDiscoveredDeviceStruct
     {
@@ -134,7 +138,8 @@ namespace Tizen.Network.Bluetooth
         [MarshalAsAttribute(UnmanagedType.LPStr)]
         internal string ManufacturerData;
     }
-
+    
+    [NativeStruct("bt_device_sdp_info_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothDeviceSdpStruct
     {
@@ -144,6 +149,7 @@ namespace Tizen.Network.Bluetooth
         internal int ServiceCount;
     }
 
+    [NativeStruct("bt_device_connection_info_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothDeviceConnectionStruct
     {
@@ -152,6 +158,7 @@ namespace Tizen.Network.Bluetooth
         internal BluetoothDisconnectReason DisconnectReason;
     }
 
+    [NativeStruct("bt_socket_received_data_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct SocketDataStruct
     {
@@ -160,6 +167,7 @@ namespace Tizen.Network.Bluetooth
         internal IntPtr Data;
     }
 
+    [NativeStruct("bt_socket_connection_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct SocketConnectionStruct
     {
@@ -170,6 +178,7 @@ namespace Tizen.Network.Bluetooth
         internal string ServiceUuid;
     }
 
+    [NativeStruct("bt_adapter_le_device_scan_result_info_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothLeScanDataStruct
     {
@@ -189,6 +198,7 @@ namespace Tizen.Network.Bluetooth
         internal IntPtr ScanData;
     }
 
+    [NativeStruct("bt_adapter_le_service_data_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothLeServiceDataStruct
     {
@@ -205,6 +215,7 @@ namespace Tizen.Network.Bluetooth
         internal int ServiceDataLength;
     }
 
+    [NativeStruct("bt_hid_device_received_data_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothHidDeviceReceivedDataStruct
     {

--- a/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectData.cs
+++ b/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectData.cs
@@ -18,8 +18,11 @@ using System;
 using System.Runtime.InteropServices;
 using System.Collections.ObjectModel;
 
+using Tizen.Internals;
+
 namespace Tizen.Network.WiFiDirect
 {
+    [NativeStruct("wifi_direct_discovered_peer_info_s", Include="wifi-direct.h", PkgConfig="capi-network-wifi-direct")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct DiscoveredPeerStruct
     {
@@ -56,6 +59,8 @@ namespace Tizen.Network.WiFiDirect
         [MarshalAsAttribute(UnmanagedType.I1)]
         internal bool _isMiracast;
     }
+
+    [NativeStruct("wifi_direct_connected_peer_info_s", Include="wifi-direct.h", PkgConfig="capi-network-wifi-direct")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct ConnectedPeerStruct
     {

--- a/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcTypes.cs
+++ b/src/Tizen.Security.SecureRepository/Interop/Interop.CkmcTypes.cs
@@ -16,9 +16,11 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 
 internal static partial class Interop
 {
+    [NativeStruct("ckmc_policy_s", Include="ckmc/ckmc-type.h", PkgConfig="key-manager")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcPolicy
     {
@@ -33,6 +35,7 @@ internal static partial class Interop
         public readonly bool extractable;
     }
 
+    [NativeStruct("ckmc_key_s", Include="ckmc/ckmc-type.h", PkgConfig="key-manager")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcKey
     {
@@ -50,6 +53,7 @@ internal static partial class Interop
         public readonly string password;
     }
 
+    [NativeStruct("ckmc_cert_s", Include="ckmc/ckmc-type.h", PkgConfig="key-manager")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcCert
     {
@@ -64,6 +68,7 @@ internal static partial class Interop
         public readonly int dataFormat;
     }
 
+    [NativeStruct("ckmc_raw_buffer_s", Include="ckmc/ckmc-type.h", PkgConfig="key-manager")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcRawBuffer
     {
@@ -76,6 +81,7 @@ internal static partial class Interop
         public readonly UIntPtr size;
     }
 
+    [NativeStruct("ckmc_alias_list_s", Include="ckmc/ckmc-type.h", PkgConfig="key-manager")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcAliasList
     {
@@ -83,6 +89,7 @@ internal static partial class Interop
         public readonly IntPtr next;
     }
 
+    [NativeStruct("ckmc_cert_list_s", Include="ckmc/ckmc-type.h", PkgConfig="key-manager")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcCertList
     {
@@ -95,6 +102,7 @@ internal static partial class Interop
         public readonly IntPtr next;
     }
 
+    [NativeStruct("ckmc_pkcs12_s", Include="ckmc/ckmc-type.h", PkgConfig="key-manager")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct CkmcPkcs12
     {

--- a/src/Tizen.Security.TEEC/Interop/Interop.Types.cs
+++ b/src/Tizen.Security.TEEC/Interop/Interop.Types.cs
@@ -16,24 +16,33 @@
 
 
 using System;
-using System.IO;
-using System.Text;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 
 internal static partial class Interop
 {
+#if PROFILE_TV
+    private const string PkgConfig = "trustzone-nwd";
+#else
+    private const string PkgConfig = "tef-libteec";
+#endif
+
+
+    [NativeStruct("TEEC_Context", Include="tee_client_api.h", PkgConfig=PkgConfig)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_Context
     {
         public readonly IntPtr imp;
     }
 
+    [NativeStruct("TEEC_Session", Include="tee_client_api.h", PkgConfig=PkgConfig)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_Session
     {
         public readonly IntPtr imp;
     }
 
+    [NativeStruct("TEEC_UUID", Include="tee_client_api.h", PkgConfig=PkgConfig)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_UUID
     {
@@ -56,6 +65,7 @@ internal static partial class Interop
         }
     }
 
+    [NativeStruct("TEEC_SharedMemory", Include="tee_client_api.h", PkgConfig=PkgConfig)]
     [StructLayout(LayoutKind.Sequential,Pack=8)]
     internal struct TEEC_SharedMemory
     {
@@ -66,6 +76,7 @@ internal static partial class Interop
 		public byte[] padding;
     }
 
+    [NativeStruct("TEEC_Value", Include="tee_client_api.h", PkgConfig=PkgConfig)]
     [StructLayout(LayoutKind.Sequential,Pack=8)]
     internal struct TEEC_Value
     {
@@ -73,6 +84,7 @@ internal static partial class Interop
         public UInt32 b;
     }
 
+    [NativeStruct("TEEC_TempMemoryReference", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only32Bits)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_TempMemoryReference32
     {
@@ -80,6 +92,7 @@ internal static partial class Interop
         public UInt32 size;
     }
 
+    [NativeStruct("TEEC_RegisteredMemoryReference", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only32Bits)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_RegisteredMemoryReference32
     {
@@ -88,6 +101,7 @@ internal static partial class Interop
         public UInt32 offset;
     }
 
+    [NativeStruct("TEEC_Parameter", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only32Bits)]
     [StructLayout(LayoutKind.Explicit)]
     internal struct TEEC_Parameter32
     {
@@ -99,6 +113,7 @@ internal static partial class Interop
         public TEEC_Value value;
     }
 
+    [NativeStruct("TEEC_Operation", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only32Bits)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_Operation32
     {
@@ -109,6 +124,7 @@ internal static partial class Interop
         public IntPtr imp;
     }
 
+    [NativeStruct("TEEC_TempMemoryReference", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only64Bits)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_TempMemoryReference64
     {
@@ -116,6 +132,7 @@ internal static partial class Interop
         public UInt64 size;
     }
 
+    [NativeStruct("TEEC_RegisteredMemoryReference", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only64Bits)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_RegisteredMemoryReference64
     {
@@ -124,6 +141,7 @@ internal static partial class Interop
         public UInt64 offset;
     }
 
+    [NativeStruct("TEEC_Parameter", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only64Bits)]
     [StructLayout(LayoutKind.Explicit)]
     internal struct TEEC_Parameter64
     {
@@ -135,6 +153,7 @@ internal static partial class Interop
         public TEEC_Value value;
     }
 
+    [NativeStruct("TEEC_Operation", Include="tee_client_api.h", PkgConfig=PkgConfig, Arch=NativeStructArch.Only64Bits)]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TEEC_Operation64
     {

--- a/src/Tizen.Sensor/Interop/Interop.Sensor.cs
+++ b/src/Tizen.Sensor/Interop/Interop.Sensor.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Sensor;
 
 internal static partial class Interop
@@ -130,6 +131,7 @@ internal static partial class Interop
         internal static extern int Free(IntPtr ptr);
     }
 
+    [NativeStruct("sensor_event_s", Include="sensor.h", PkgConfig="capi-system-sensor")]
     [StructLayout(LayoutKind.Sequential, Pack = 0)]
     internal struct SensorEventStruct
     {

--- a/src/Tizen.System.Information/Interop/Interop.RuntimeInfo.cs
+++ b/src/Tizen.System.Information/Interop/Interop.RuntimeInfo.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.System;
 
 internal static partial class Interop
@@ -24,6 +25,7 @@ internal static partial class Interop
     {
         public delegate void RuntimeInformationChangedCallback(RuntimeInfoKey key, IntPtr userData);
 
+        [NativeStruct("runtime_memory_info_s", Include="runtime_info.h", PkgConfig="capi-system-runtime-info")]
         [StructLayout(LayoutKind.Sequential)]
         public struct MemoryInfo
         {
@@ -34,6 +36,7 @@ internal static partial class Interop
             public readonly int Swap;
         }
 
+        [NativeStruct("process_memory_info_s", Include="runtime_info.h", PkgConfig="capi-system-runtime-info")]
         [StructLayout(LayoutKind.Sequential)]
         public struct ProcessMemoryInfo
         {
@@ -46,6 +49,7 @@ internal static partial class Interop
             public readonly int PrivateDirty;
         }
 
+        [NativeStruct("runtime_cpu_usage_s", Include="runtime_info.h", PkgConfig="capi-system-runtime-info")]
         [StructLayout(LayoutKind.Sequential)]
         public struct CpuUsage
         {
@@ -55,6 +59,7 @@ internal static partial class Interop
             public readonly double IoWait;
         }
 
+        [NativeStruct("process_cpu_usage_s", Include="runtime_info.h", PkgConfig="capi-system-runtime-info")]
         [StructLayout(LayoutKind.Sequential)]
         public struct ProcessCpuUsage
         {

--- a/src/Tizen.Telephony/Interop/Interop.Telephony.cs
+++ b/src/Tizen.Telephony/Interop/Interop.Telephony.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Telephony;
 
 /// <summary>
@@ -41,6 +42,7 @@ internal static partial class Interop
       SIMNotAvailable = TIZEN_ERROR_TELEPHONY | 0x1001
     };
 
+    [NativeStruct("telephony_handle_list_s", Include="telephony_common.h", PkgConfig="capi-telephony")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct HandleList
     {

--- a/src/Tizen.Uix.InputMethod/Interop/Interop.InputMethod.cs
+++ b/src/Tizen.Uix.InputMethod/Interop/Interop.InputMethod.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Uix.InputMethod;
 
 /// <summary>
@@ -57,6 +58,7 @@ internal static partial class Interop
             On
         };
 
+        [NativeStruct("ime_callback_s", Include="inputmethod.h", PkgConfig="capi-ui-inputmethod")]
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
         internal struct ImeCallbackStruct
         {
@@ -70,6 +72,7 @@ internal static partial class Interop
             internal ImeHideCb hide;
         };
 
+        [NativeStruct("ime_preedit_attribute", Include="inputmethod.h", PkgConfig="capi-ui-inputmethod")]
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
         internal struct ImePreEditAttributeStruct
         {

--- a/src/Tizen.Uix.SttEngine/Interop/Interop.SttEngine.cs
+++ b/src/Tizen.Uix.SttEngine/Interop/Interop.SttEngine.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Uix.SttEngine;
 using static Tizen.Uix.SttEngine.Engine;
 
@@ -104,6 +105,7 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate Error PrivateDataRequestedCb(string key, out string data);
 
+        [NativeStruct("stte_request_callback_s", Include="stte.h", PkgConfig="stt-engine")]
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
         internal struct RequestCallbackStruct
         {

--- a/src/Tizen.Uix.TtsEngine/Interop/Interop.TtsEngine.cs
+++ b/src/Tizen.Uix.TtsEngine/Interop/Interop.TtsEngine.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.Uix.TtsEngine;
 using static Tizen.Uix.TtsEngine.Engine;
 
@@ -91,6 +92,7 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate Error PrivateDataRequestedCb(string key, out string data);
 
+        [NativeStruct("ttse_request_callback_s", Include="ttse.h", PkgConfig="tts-engine")]
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
         internal struct RequestCallbackStruct
         {

--- a/src/Tizen.WebView/Interop/Interop.ChromiumEwk.View.cs
+++ b/src/Tizen.WebView/Interop/Interop.ChromiumEwk.View.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Tizen.Internals;
 using Tizen.WebView;
 
 internal static partial class Interop
@@ -165,6 +166,7 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.U1)]
         internal static extern bool ewk_view_url_request_set(IntPtr obj, string url, HttpMethod method, IntPtr headers, string body);
 
+        [NativeStruct("Ewk_Script_Message", Include="ewk_view.h", PkgConfig="chromium-efl")]
         [StructLayout(LayoutKind.Sequential, CharSet =CharSet.Ansi)]
         internal struct ScriptMessage
         {

--- a/src/Tizen/Tizen.Internals/NativeStructAttribute.cs
+++ b/src/Tizen/Tizen.Internals/NativeStructAttribute.cs
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.Internals
+{
+    /// <summary>
+    /// Architecture types for mapping struct with unmanaged. 
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum NativeStructArch
+    {
+        /// Managed struct can be mapped for all architectures.
+        All = 0,
+        /// Managed struct can only be mapped in 32 bits runtime.
+        Only32Bits = 1,
+        /// Managed struct can only be mapped in 64 bits runtime.
+        Only64Bits = 2
+    }
+
+    /// <summary>
+    /// Indicates that the attributed struct maps an unmanaged struct.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="NativeStructAttribute"/> attribute provides the information needed to verify that tue struct is correctly mapped.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, AllowMultiple = true)]
+    public class NativeStructAttribute : Attribute
+    {
+        private readonly string _structName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NativeStructAttribute"/> class with the native struct information.
+        /// </summary>
+        /// <param name="structName">The name of structure to test the size.</param>
+        public NativeStructAttribute(string structName)
+        {
+            _structName = structName;
+        }
+
+        /// <summary>
+        /// The name of structure to test the size.
+        /// </summary>
+        public string StructName => _structName;
+
+        /// <summary>
+        /// The name of pkg-config that provides the header file location.
+        /// </summary>
+        public string PkgConfig { get; set; }
+
+        /// <summary>
+        /// The name of C header file(.h) that contains the struct to test.
+        /// </summary>
+        public string Include { get; set; }
+
+        /// <summary>
+        /// Runtime architecture to specify mapping.
+        /// </summary>
+        public NativeStructArch Arch { get; set; }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Add struct size validation step to GBS build process. The struct-validator of dotnet-build-tools will stop the GBS build when the sizes of structs are different between C# and Native. 

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A
Added:
 - Tizen.Internals.NativeStructAttribute (internal class)


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
