### PR TITLE
[NUI] Resolve CA1823 of StyleCop

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/LinearLayoutManager.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/LinearLayoutManager.cs
@@ -28,7 +28,6 @@ namespace Tizen.NUI.Components
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class LinearListLayoutManager : LayoutManager
     {
-        private float mLayoutOriginPosition = 0;
         private int firstVisibleItemIndex = -1;
         private int lastVisibleItemIndex = -1;
 

--- a/src/Tizen.NUI.Components/Controls/Scrollbar.cs
+++ b/src/Tizen.NUI.Components/Controls/Scrollbar.cs
@@ -110,7 +110,6 @@ namespace Tizen.NUI.Components
         private Animation thumbSizeAnimation;
         private Calculator calculator;
         private Size containerSize = new Size(0, 0);
-        private float currentPosition;
 
         #endregion Fields
 

--- a/src/Tizen.NUI.Wearable/src/public/Popup.cs
+++ b/src/Tizen.NUI.Wearable/src/public/Popup.cs
@@ -548,10 +548,8 @@ namespace Tizen.NUI.Wearable
         private TextLabel title;
         private ScrollableBase scroll;
         private Dictionary<string, View> scrollList;
-        private EventHandler buttonClick;
         private Timer timer;
         private PopupStyle popupStyle;
-        private bool wrapContent = false;
         private View buttonContainer;
         private string firstButtonIndex;
         private View titleContentContainer;

--- a/src/Tizen.NUI.Wearable/src/public/WearableList.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WearableList.cs
@@ -110,8 +110,6 @@ namespace Tizen.NUI.Wearable
             }
         }
 
-        private float dragStartPosition = 0.0f;
-
         private void OnScrollDragStart(object source, ScrollableBase.ScrollEventArgs args)
         {
             RecycleItem prevFocusedItem = FocusedItem;


### PR DESCRIPTION
To resolve CA1823 of StyleCop in Tizen.NUI.Components and
Tizen.NUI.Wearable, unused variables are removed.

'isNeedAnimation' in CircularPagination.cs is not removed because it is
marked as 'TODO'.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
