### PR TITLE
[NUI] replace viewStlye with Style

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Scrollbar.cs
+++ b/src/Tizen.NUI.Components/Controls/Scrollbar.cs
@@ -36,12 +36,12 @@ namespace Tizen.NUI.Components
             var instance = ((Scrollbar)bindable);
             var thickness = (float?)newValue;
 
-            ((ScrollbarStyle)instance.viewStyle).TrackThickness = thickness;
+            instance.Style.TrackThickness = thickness;
             instance.UpdateTrackThickness(thickness ?? 0);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((ScrollbarStyle)((Scrollbar)bindable).viewStyle)?.TrackThickness ?? 0;
+            return ((Scrollbar)bindable).Style.TrackThickness ?? 0;
         });
 
         /// <summary>Bindable property of ThumbThickness</summary>
@@ -51,12 +51,12 @@ namespace Tizen.NUI.Components
             var instance = ((Scrollbar)bindable);
             var thickness = (float?)newValue;
 
-            ((ScrollbarStyle)instance.viewStyle).ThumbThickness = thickness;
+            instance.Style.ThumbThickness = thickness;
             instance.UpdateThumbThickness(thickness ?? 0);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((ScrollbarStyle)((Scrollbar)bindable).viewStyle)?.ThumbThickness ?? 0;
+            return ((Scrollbar)bindable).Style.ThumbThickness ?? 0;
         });
 
         /// <summary>Bindable property of TrackColor</summary>
@@ -66,12 +66,12 @@ namespace Tizen.NUI.Components
             var instance = ((Scrollbar)bindable);
             var color = (Color)newValue;
 
-            ((ScrollbarStyle)instance.viewStyle).TrackColor = color;
+            instance.Style.TrackColor = color;
             instance.UpdateTrackColor(color);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((ScrollbarStyle)((Scrollbar)bindable).viewStyle)?.TrackColor;
+            return ((Scrollbar)bindable).Style.TrackColor;
         });
 
         /// <summary>Bindable property of ThumbColor</summary>
@@ -81,12 +81,12 @@ namespace Tizen.NUI.Components
             var instance = ((Scrollbar)bindable);
             var color = (Color)newValue;
 
-            ((ScrollbarStyle)instance.viewStyle).ThumbColor = color;
+            instance.Style.ThumbColor = color;
             instance.UpdateThumbColor(color);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((ScrollbarStyle)((Scrollbar)bindable).viewStyle)?.ThumbColor;
+            return ((Scrollbar)bindable).Style.ThumbColor;
         });
 
         /// <summary>Bindable property of TrackPadding</summary>
@@ -96,12 +96,12 @@ namespace Tizen.NUI.Components
             var instance = ((Scrollbar)bindable);
             var trackPadding = (Extents)newValue;
 
-            ((ScrollbarStyle)instance.viewStyle).TrackPadding = trackPadding;
+            instance.Style.TrackPadding = trackPadding;
             instance.UpdateTrackPadding(trackPadding);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((ScrollbarStyle)((Scrollbar)bindable).viewStyle)?.TrackPadding;
+            return ((Scrollbar)bindable).Style.TrackPadding;
         });
 
         private ColorVisual trackVisual;
@@ -155,6 +155,16 @@ namespace Tizen.NUI.Components
 
 
         #region Properties
+
+        /// <summary>
+        /// Return a copied Style instance of Scrollbar
+        /// </summary>
+        /// <remarks>
+        /// It returns copied Style instance and changing it does not effect to the Scrollbar.
+        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new ScrollbarStyle Style => ViewStyle as ScrollbarStyle;
 
         /// <summary>
         /// The thickness of the track.

--- a/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
@@ -43,7 +43,7 @@ namespace Tizen.NUI.Wearable
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularProgressStyle)((CircularProgress)bindable).viewStyle)?.Thickness;
+            return ((CircularProgress)bindable).Style.Thickness;
         });
 
         /// <summary>Bindable property of MaxValue</summary>
@@ -113,7 +113,7 @@ namespace Tizen.NUI.Wearable
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularProgressStyle)((CircularProgress)bindable).viewStyle)?.TrackColor;
+            return ((CircularProgress)bindable).Style.TrackColor;
         });
 
         /// <summary>Bindable property of ProgressColor</summary>
@@ -128,7 +128,7 @@ namespace Tizen.NUI.Wearable
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularProgressStyle)((CircularProgress)bindable).viewStyle)?.ProgressColor;
+            return ((CircularProgress)bindable).Style.ProgressColor;
         });
 
         /// <summary>Bindable property of IsEnabled</summary>
@@ -158,12 +158,6 @@ namespace Tizen.NUI.Wearable
         private bool isEnabled = true;
 
         private Animation sweepAngleAnimation;
-
-        /// <summary>
-        /// Get style of progress.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new CircularProgressStyle Style => ViewStyle as CircularProgressStyle;
 
         #endregion Fields
 
@@ -207,6 +201,16 @@ namespace Tizen.NUI.Wearable
 
 
         #region Properties
+
+        /// <summary>
+        /// Return a copied Style instance of CircularProgress
+        /// </summary>
+        /// <remarks>
+        /// It returns copied Style instance and changing it does not effect to the CircularProgress.
+        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new CircularProgressStyle Style => ViewStyle as CircularProgressStyle;
 
         /// <summary>
         /// The thickness of the track and progress.

--- a/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
@@ -38,12 +38,12 @@ namespace Tizen.NUI.Wearable
             var instance = ((CircularScrollbar)bindable);
             var thickness = (float?)newValue;
 
-            ((CircularScrollbarStyle)instance.viewStyle).Thickness = thickness;
+            instance.Style.Thickness = thickness;
             instance.UpdateVisualThickness(thickness ?? 0);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularScrollbarStyle)((CircularScrollbar)bindable).viewStyle)?.Thickness ?? 0;
+            return ((CircularScrollbar)bindable).Style.Thickness ?? 0;
         });
 
         /// <summary>Bindable property of TrackSweepAngle</summary>
@@ -53,12 +53,12 @@ namespace Tizen.NUI.Wearable
             var instance = ((CircularScrollbar)bindable);
             var angle = (float?)newValue;
 
-            ((CircularScrollbarStyle)instance.viewStyle).TrackSweepAngle = angle;
+            instance.Style.TrackSweepAngle = angle;
             instance.UpdateTrackVisualSweepAngle(angle ?? 0);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularScrollbarStyle)((CircularScrollbar)bindable).viewStyle)?.TrackSweepAngle ?? 0;
+            return ((CircularScrollbar)bindable).Style.TrackSweepAngle ?? 0;
         });
 
         /// <summary>Bindable property of TrackColor</summary>
@@ -68,12 +68,12 @@ namespace Tizen.NUI.Wearable
             var instance = ((CircularScrollbar)bindable);
             var color = (Color)newValue;
 
-            ((CircularScrollbarStyle)instance.viewStyle).TrackColor = color;
+            instance.Style.TrackColor = color;
             instance.UpdateTrackVisualColor(color);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularScrollbarStyle)((CircularScrollbar)bindable).viewStyle)?.TrackColor;
+            return ((CircularScrollbar)bindable).Style.TrackColor;
         });
 
         /// <summary>Bindable property of ThumbColor</summary>
@@ -83,12 +83,12 @@ namespace Tizen.NUI.Wearable
             var instance = ((CircularScrollbar)bindable);
             var color = (Color)newValue;
 
-            ((CircularScrollbarStyle)instance.viewStyle).ThumbColor = color;
+            instance.Style.ThumbColor = color;
             instance.UpdateThumbVisualColor(color);
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularScrollbarStyle)((CircularScrollbar)bindable).viewStyle)?.ThumbColor;
+            return ((CircularScrollbar)bindable).Style.ThumbColor;
         });
 
         private ArcVisual trackVisual;
@@ -145,6 +145,16 @@ namespace Tizen.NUI.Wearable
 
 
         #region Properties
+
+        /// <summary>
+        /// Return a copied Style instance of CircularScrollbar
+        /// </summary>
+        /// <remarks>
+        /// It returns copied Style instance and changing it does not effect to the CircularScrollbar.
+        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new CircularScrollbarStyle Style => ViewStyle as CircularScrollbarStyle;
 
         /// <summary>
         /// The thickness of the scrollbar and track.

--- a/src/Tizen.NUI.Wearable/src/public/CircularSlider.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularSlider.cs
@@ -43,7 +43,7 @@ namespace Tizen.NUI.Wearable
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularSliderStyle)((CircularSlider)bindable).viewStyle)?.Thickness;
+            return ((CircularSlider)bindable).Style.Thickness;
         });
 
         /// <summary>Bindable property of MaxValue</summary>
@@ -113,7 +113,7 @@ namespace Tizen.NUI.Wearable
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularSliderStyle)((CircularSlider)bindable).viewStyle)?.TrackColor;
+            return ((CircularSlider)bindable).Style.TrackColor;
         });
 
         /// <summary>Bindable property of ProgressColor</summary>
@@ -128,7 +128,7 @@ namespace Tizen.NUI.Wearable
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularSliderStyle)((CircularSlider)bindable).viewStyle)?.ProgressColor;
+            return ((CircularSlider)bindable).Style.ProgressColor;
         });
 
         /// <summary>Bindable property of ThumbSize</summary>
@@ -160,7 +160,7 @@ namespace Tizen.NUI.Wearable
         },
         defaultValueCreator: (bindable) =>
         {
-            return ((CircularSliderStyle)((CircularSlider)bindable).viewStyle)?.ThumbColor;
+            return ((CircularSlider)bindable).Style.ThumbColor;
         });
 
         /// <summary>Bindable property of IsEnabled</summary>
@@ -196,12 +196,6 @@ namespace Tizen.NUI.Wearable
 
         private Animation sweepAngleAnimation;
         private Animation thumbAnimation;
-
-        /// <summary>
-        /// Get style of progress.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new CircularSliderStyle Style => ViewStyle as CircularSliderStyle;
 
         /// <summary>
         /// Value Changed event data.
@@ -260,6 +254,16 @@ namespace Tizen.NUI.Wearable
         #endregion Events
 
         #region Properties
+
+        /// <summary>
+        /// Return a copied Style instance of CircularSlider
+        /// </summary>
+        /// <remarks>
+        /// It returns copied Style instance and changing it does not effect to the CircularSlider.
+        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new CircularSliderStyle Style => ViewStyle as CircularSliderStyle;
 
         /// <summary>
         /// The thickness of the track and progress.


### PR DESCRIPTION
Use `Style` property instead of `viewStyle` field.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
