### PR TITLE
[NUI] introduce CreateViewStyle that is alternative to GetViewStyle

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -936,7 +936,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default button style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new ButtonStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -260,7 +260,7 @@ namespace Tizen.NUI.Components
 
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new ControlStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/DropDown.cs
+++ b/src/Tizen.NUI.Components/Controls/DropDown.cs
@@ -615,7 +615,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new DropDownStyle();
         }
@@ -1424,7 +1424,7 @@ namespace Tizen.NUI.Components
             /// <returns>The empty.</returns>
             /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
-            protected override ViewStyle GetViewStyle()
+            protected override ViewStyle CreateViewStyle()
             {
                 return new DropDownItemStyle();
             }

--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
@@ -472,7 +472,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return null;
         }

--- a/src/Tizen.NUI.Components/Controls/ImageScrollBar.cs
+++ b/src/Tizen.NUI.Components/Controls/ImageScrollBar.cs
@@ -460,7 +460,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default scrollbar style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new ScrollBarStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Loading.cs
+++ b/src/Tizen.NUI.Components/Controls/Loading.cs
@@ -195,7 +195,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default loading style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new LoadingStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -274,7 +274,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new PaginationStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -724,7 +724,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default popup style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new PopupStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -483,7 +483,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default progress style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new ProgressStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Scrollbar.cs
+++ b/src/Tizen.NUI.Components/Controls/Scrollbar.cs
@@ -374,7 +374,7 @@ namespace Tizen.NUI.Components
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new ScrollbarStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -763,7 +763,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default slider style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new SliderStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -341,7 +341,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default switch style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new SwitchStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Tab.cs
+++ b/src/Tizen.NUI.Components/Controls/Tab.cs
@@ -455,7 +455,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default tab style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new TabStyle();
         }

--- a/src/Tizen.NUI.Components/Controls/Toast.cs
+++ b/src/Tizen.NUI.Components/Controls/Toast.cs
@@ -337,7 +337,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <returns>The default toast style.</returns>
         /// <since_tizen> 8 </since_tizen>
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new ToastStyle();
         }

--- a/src/Tizen.NUI.Wearable/src/public/CircularPagination.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularPagination.cs
@@ -556,7 +556,7 @@ namespace Tizen.NUI.Wearable
         /// <since_tizen> 8 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new CircularPaginationStyle();
         }

--- a/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
@@ -402,7 +402,7 @@ namespace Tizen.NUI.Wearable
         /// </summary>
         /// <returns>The default progress style.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new CircularProgressStyle();
         }

--- a/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
@@ -356,7 +356,7 @@ namespace Tizen.NUI.Wearable
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new CircularScrollbarStyle();
         }

--- a/src/Tizen.NUI.Wearable/src/public/CircularSlider.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularSlider.cs
@@ -489,7 +489,7 @@ namespace Tizen.NUI.Wearable
         /// </summary>
         /// <returns>The default progress style.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new CircularSliderStyle();
         }

--- a/src/Tizen.NUI.Wearable/src/public/Popup.cs
+++ b/src/Tizen.NUI.Wearable/src/public/Popup.cs
@@ -430,7 +430,7 @@ namespace Tizen.NUI.Wearable
         /// </summary>
         /// <returns>The default popup style.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new PopupStyle();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2307,8 +2307,18 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        // TODO: It should be deprecated. please use CreateViewStyle instead.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual ViewStyle GetViewStyle()
+        {
+            return CreateViewStyle();
+        }
+
+        /// <summary>
+        /// Create Style, it is abstract function and must be override.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual ViewStyle CreateViewStyle()
         {
             return new ViewStyle();
         }


### PR DESCRIPTION
`CreateViewStyle` is alternative method of `GetViewStyle`.
To resolve CA1721, please use `CreateViewStyle` instead.
```
warning CA1721: The property name 'ViewStyle' is confusing given the existence of
method 'GetViewStyle'. Rename or remove one of these members.
```

`GetViewStyle` should be deprecated(or removed) if there is no
compatibility issue.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
