### PR TITLE
[NUI] cleanup MeasureChild Methods

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -62,11 +62,11 @@ namespace Tizen.NUI.Components
 
                         if (scrollingDirection == Direction.Vertical)
                         {
-                            MeasureChild(childLayout, widthMeasureSpec, unrestrictedMeasureSpec);  // Height unrestricted by parent
+                            MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), unrestrictedMeasureSpec, new LayoutLength(0));  // Height unrestricted by parent
                         }
                         else
                         {
-                            MeasureChild(childLayout, unrestrictedMeasureSpec, heightMeasureSpec);  // Width unrestricted by parent
+                            MeasureChildWithMargins(childLayout, unrestrictedMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));  // Width unrestricted by parent
                         }
 
                         float childWidth = childLayout.MeasuredWidth.Size.AsDecimal();

--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -72,7 +72,7 @@ namespace Tizen.NUI
                 if (childLayout != null)
                 {
                     // Get size of child
-                    MeasureChild( childLayout, widthMeasureSpec, heightMeasureSpec );
+                    MeasureChildWithMargins( childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0) );
                     float childWidth = childLayout.MeasuredWidth.Size.AsDecimal();
                     float childHeight = childLayout.MeasuredHeight.Size.AsDecimal();
 

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -410,14 +410,14 @@ namespace Tizen.NUI
 
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
                                     new MeasureSpecification(
-                                        new LayoutLength(parentMeasureSpecificationWidth.Size - (Padding.Start + Padding.End + child.Margin.Start + child.Margin.End)),
+                                        new LayoutLength(parentMeasureSpecificationWidth.Size - (child.Margin.Start + child.Margin.End)),
                                         parentMeasureSpecificationWidth.Mode),
-                                    new LayoutLength(child.Padding.Start + child.Padding.End),
+                                    new LayoutLength(Padding.Start + Padding.End),
                                     new LayoutLength(child.WidthSpecification));
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                                     new MeasureSpecification(
-                                        new LayoutLength(parentMeasureSpecificationHeight.Size - (Padding.Top + Padding.Bottom + child.Margin.Top + child.Margin.Bottom)),
+                                        new LayoutLength(parentMeasureSpecificationHeight.Size - (child.Margin.Top + child.Margin.Bottom)),
                                         parentMeasureSpecificationHeight.Mode),
                                     new LayoutLength(Padding.Top + Padding.Bottom),
                                     new LayoutLength(child.HeightSpecification));

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -211,7 +211,7 @@ namespace Tizen.NUI
                 {
                     if (childLayout != null)
                     {
-                        MeasureChild(childLayout, widthMeasureSpec, heightMeasureSpec);
+                        MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
                     }
                 }
 

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -282,7 +282,7 @@ namespace Tizen.NUI
             MeasureSpecification.ModeType resultMode = MeasureSpecification.ModeType.Unspecified;
 
             // Child only can use parent's size without parent's padding and own margin.
-            LayoutLength resultSize = new LayoutLength(Math.Max( 0.0f, parentMeasureSpec.Size.AsDecimal()));
+            LayoutLength resultSize = new LayoutLength(Math.Max( 0.0f, (parentMeasureSpec.Size - padding).AsDecimal()));
             switch( specMode )
             {
                 // Parent has imposed an exact size on us
@@ -388,7 +388,7 @@ namespace Tizen.NUI
             {
                 if( childLayout != null )
                 {
-                    MeasureChild( childLayout, widthMeasureSpec, heightMeasureSpec );
+                    MeasureChildWithMargins( childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0) );
                     LayoutLength childWidth = new LayoutLength(childLayout.MeasuredWidth.Size);
                     LayoutLength childHeight = new LayoutLength( childLayout.MeasuredHeight.Size);
 
@@ -496,7 +496,7 @@ namespace Tizen.NUI
         {
             foreach( LayoutItem childLayout in LayoutChildren )
             {
-                MeasureChild( childLayout, widthMeasureSpec, heightMeasureSpec );
+                MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
             }
         }
 
@@ -514,27 +514,22 @@ namespace Tizen.NUI
             View childOwner = child.Owner;
 
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
-                        new MeasureSpecification(
-                            new LayoutLength(parentWidthMeasureSpec.Size - (Padding.Start + Padding.End + childOwner.Margin.Start + childOwner.Margin.End)),
-                            parentWidthMeasureSpec.Mode),
+                        new MeasureSpecification(new LayoutLength(parentWidthMeasureSpec.Size), parentWidthMeasureSpec.Mode),
                         new LayoutLength(Padding.Start + Padding.End ),
                         new LayoutLength(childOwner.WidthSpecification) );
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
-                        new MeasureSpecification(
-                            new LayoutLength(parentHeightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childOwner.Margin.Top + childOwner.Margin.Bottom)),
-                            parentHeightMeasureSpec.Mode),
+                        new MeasureSpecification(new LayoutLength(parentHeightMeasureSpec.Size), parentHeightMeasureSpec.Mode),
                         new LayoutLength(Padding.Top + Padding.Bottom),
                         new LayoutLength(childOwner.HeightSpecification));
 
-            child.Measure( childWidthMeasureSpec, childHeightMeasureSpec );
+            child.Measure(childWidthMeasureSpec, childHeightMeasureSpec);
         }
 
         /// <summary>
         /// Ask one of the children of this view to measure itself, taking into
         /// account both the MeasureSpec requirements for this view and its padding.<br />
-        /// and margins. The child must have MarginLayoutParams The heavy lifting is
-        /// done in GetChildMeasureSpecification.<br />
+        /// and margins. The heavy lifting is done in GetChildMeasureSpecification.<br />
         /// </summary>
         /// <param name="child">The child to measure.</param>
         /// <param name="parentWidthMeasureSpec">The width requirements for this view.</param>
@@ -549,14 +544,14 @@ namespace Tizen.NUI
 
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
                         new MeasureSpecification(
-                            new LayoutLength(parentWidthMeasureSpec.Size + widthUsed - (Padding.Start + Padding.End + childOwner.Margin.Start + childOwner.Margin.End)),
+                            new LayoutLength(parentWidthMeasureSpec.Size + widthUsed - (childOwner.Margin.Start + childOwner.Margin.End)),
                             parentWidthMeasureSpec.Mode),
                         new LayoutLength(Padding.Start + Padding.End ),
                         new LayoutLength(childOwner.WidthSpecification) );
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                         new MeasureSpecification(
-                            new LayoutLength(parentHeightMeasureSpec.Size + heightUsed - (Padding.Top + Padding.Bottom + childOwner.Margin.Top + childOwner.Margin.Bottom)),
+                            new LayoutLength(parentHeightMeasureSpec.Size + heightUsed - (childOwner.Margin.Top + childOwner.Margin.Bottom)),
                             parentHeightMeasureSpec.Mode),
                         new LayoutLength(Padding.Top + Padding.Bottom),
                         new LayoutLength(childOwner.HeightSpecification));

--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -230,7 +230,7 @@ namespace Tizen.NUI
                 childWidthMeasureSpec = new MeasureSpecification( new LayoutLength(childLength), MeasureSpecification.ModeType.Exactly );
                 childHeightMeasureSpec = GetChildMeasureSpecification( 
                                             new MeasureSpecification(
-                                                new LayoutLength(heightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childLayout.Owner.Margin.Top + childLayout.Owner.Margin.Bottom)),
+                                                new LayoutLength(heightMeasureSpec.Size - (childLayout.Owner.Margin.Top + childLayout.Owner.Margin.Bottom)),
                                                 heightMeasureSpec.Mode),
                                             new LayoutLength(Padding.Top + Padding.Bottom),
                                             new LayoutLength(desiredHeight));
@@ -239,7 +239,7 @@ namespace Tizen.NUI
             {
                 childWidthMeasureSpec = GetChildMeasureSpecification(
                                             new MeasureSpecification(
-                                                new LayoutLength(widthMeasureSpec.Size - (Padding.Start + Padding.End + childLayout.Owner.Margin.Start + childLayout.Owner.Margin.End)),
+                                                new LayoutLength(widthMeasureSpec.Size - (childLayout.Owner.Margin.Start + childLayout.Owner.Margin.End)),
                                                 widthMeasureSpec.Mode),
                                             new LayoutLength(Padding.Start + Padding.End),
                                             new LayoutLength(desiredWidth));
@@ -310,14 +310,14 @@ namespace Tizen.NUI
                         // optimal width.
                         MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
                                                 new MeasureSpecification(
-                                                    new LayoutLength(widthMeasureSpec.Size - (Padding.Start + Padding.End + childLayout.Margin.Start + childLayout.Margin.End)),
+                                                    new LayoutLength(widthMeasureSpec.Size - (childLayout.Margin.Start + childLayout.Margin.End)),
                                                     widthMeasureSpec.Mode),
                                                 new LayoutLength(Padding.Start + Padding.End),
                                                 new LayoutLength(LayoutParamPolicies.WrapContent));
 
                         MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                                                 new MeasureSpecification(
-                                                    new LayoutLength(heightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childLayout.Margin.Top + childLayout.Margin.Bottom)),
+                                                    new LayoutLength(heightMeasureSpec.Size - (childLayout.Margin.Top + childLayout.Margin.Bottom)),
                                                     heightMeasureSpec.Mode),
                                                 new LayoutLength(Padding.Top + Padding.Bottom),
                                                 new LayoutLength(childDesiredHeight));
@@ -327,7 +327,7 @@ namespace Tizen.NUI
                     }
                     else
                     {
-                        MeasureChild(childLayout, widthMeasureSpec, heightMeasureSpec);
+                        MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
                     }
 
                     LayoutLength childWidth = childLayout.MeasuredWidth.Size;
@@ -510,14 +510,14 @@ namespace Tizen.NUI
                         // We'll restore the original height of 0 after measurement.
                         MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
                                                 new MeasureSpecification(
-                                                    new LayoutLength(widthMeasureSpec.Size - (Padding.Start + Padding.End + childLayout.Margin.Start + childLayout.Margin.End)),
+                                                    new LayoutLength(widthMeasureSpec.Size - (childLayout.Margin.Start + childLayout.Margin.End)),
                                                     widthMeasureSpec.Mode),
                                                 new LayoutLength(Padding.Start + Padding.End),
                                                 new LayoutLength(childDesiredWidth));
 
                         MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                                                 new MeasureSpecification(
-                                                    new LayoutLength(heightMeasureSpec.Size - (Padding.Top + Padding.Bottom + childLayout.Margin.Top + childLayout.Margin.Bottom)),
+                                                    new LayoutLength(heightMeasureSpec.Size - (childLayout.Margin.Top + childLayout.Margin.Bottom)),
                                                     heightMeasureSpec.Mode),
                                                 new LayoutLength(Padding.Top + Padding.Bottom),
                                                 new LayoutLength(LayoutParamPolicies.WrapContent));
@@ -527,7 +527,7 @@ namespace Tizen.NUI
                     }
                     else
                     {
-                        MeasureChild( childLayout, widthMeasureSpec, heightMeasureSpec );
+                        MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
                     }
 
                     LayoutLength childHeight = childLayout.MeasuredHeight.Size;


### PR DESCRIPTION
- Duplicated Padding accumulation is removed.
- Use `MeasureChildWithMargins` to consider Margin.

No logical changes.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
