### PR TITLE
[NUI] replace field declaration to property

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -844,7 +844,7 @@ namespace Tizen.NUI.Components
         {
             /// <summary> Button index which is clicked in Popup </summary>
             /// <since_tizen> 6 </since_tizen>
-            public int ButtonIndex;
+            public int ButtonIndex { get; set; }
         }
     }
 }


### PR DESCRIPTION
This would fix the below StyleCop error.
 - CA1051: Do not declare visible instance fields

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
