### PR TITLE
[NUI] Change ScrollableBase clipping mode

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -378,7 +378,7 @@ namespace Tizen.NUI.Components
             mTapGestureDetector.Attach(this);
             mTapGestureDetector.Detected += OnTapGestureDetected;
 
-            ClippingMode = ClippingModeType.ClipToBoundingBox;
+            ClippingMode = ClippingModeType.ClipChildren;
 
             mScrollingChild = new View();
             mScrollingChild.Name = "DefaultScrollingChild";


### PR DESCRIPTION
### Description of Change ###

Previously, ScrollableBase used "ClippingModeType.ClipToBoundingBox" to clip children but it made wrong output when rotating ScrollableBase.

To fix this issue, change clipping mode to ClippingModeType.ClipChildren .


### API Changes ###
NONE