### PR TITLE
[ElmSharp] Fix InvalidOperationException in DisposeEvent

### DIFF
--- a/src/ElmSharp/ElmSharp/EvasObject.cs
+++ b/src/ElmSharp/ElmSharp/EvasObject.cs
@@ -1119,7 +1119,8 @@ namespace ElmSharp
 
         private void DisposeEvent()
         {
-            foreach (var evt in _eventStore)
+            var events = new List<IInvalidatable>(_eventStore);
+            foreach (var evt in events)
             {
                 evt.Dispose();
             }


### PR DESCRIPTION
### Description of Change ###
Fixed InvalidOperationException in the enumeration in EvasObject.DisposeEvent()

We had an issue in our production app, where this exception causes half of the app crashes our users are experiencing.
"exception" : "InvalidOperationException Collection was modified; enumeration operation may not execute.",
"stackTrace" : "
at System.Collections.Generic.HashSet1.Enumerator.MoveNext() at ElmSharp.EvasObject.DisposeEvent() at ElmSharp.EvasObject.Unrealize() at Xamarin.Forms.Platform.Tizen.VisualElementRenderer1.Dispose(Boolean disposing)
at Xamarin.Forms.Platform.Tizen.LayoutRenderer.Dispose(Boolean disposing)
at Xamarin.Forms.Platform.Tizen.VisualElementRenderer1.Dispose() at Xamarin.Forms.Platform.Tizen.VisualElementRenderer1.Dispose(Boolean disposing)
at Tizen.Wearable.CircularUI.Forms.Renderer.CirclePageRenderer.<>n__0(Boolean disposing)
at...

### API Changes ###
None

Changed:
- Fixed InvalidOperationException in the enumeration in EvasObject.DisposeEvent()
