### PR TITLE
[NUI] replace field declaration with property

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -1175,7 +1175,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         protected override void OnThemeChangedEvent(object sender, StyleManager.ThemeChangeEventArgs e)
         {
-            ButtonStyle buttonStyle = StyleManager.Instance.GetViewStyle(style) as ButtonStyle;
+            ButtonStyle buttonStyle = StyleManager.Instance.GetViewStyle(StyleName) as ButtonStyle;
             if (buttonStyle != null)
             {
                 Style.CopyFrom(buttonStyle);

--- a/src/Tizen.NUI.Components/Controls/CheckBox.cs
+++ b/src/Tizen.NUI.Components/Controls/CheckBox.cs
@@ -58,11 +58,11 @@ namespace Tizen.NUI.Components
         {
             get
             {
-                return itemGroup as CheckBoxGroup;
+                return base.ItemGroup as CheckBoxGroup;
             }
             internal set
             {
-                itemGroup = value;
+                base.ItemGroup = value;
             }
         }
     }

--- a/src/Tizen.NUI.Components/Controls/CheckBoxGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/CheckBoxGroup.cs
@@ -84,7 +84,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CheckBox GetItem(int index)
         {
-            return itemGroup[index] as CheckBox;
+            return ItemGroup[index] as CheckBox;
         }
 
         /// <summary>
@@ -97,9 +97,9 @@ namespace Tizen.NUI.Components
         public int[] GetCheckedIndices()
         {
             List<int> selectedItemsList = new List<int>();
-            for (int i = 0; i < itemGroup.Count; i++)
+            for (int i = 0; i < ItemGroup.Count; i++)
             {
-                if (itemGroup[i].IsSelected)
+                if (ItemGroup[i].IsSelected)
                 {
                     selectedItemsList.Add(i);
                 }
@@ -120,7 +120,7 @@ namespace Tizen.NUI.Components
         {
             List<CheckBox> selectedList = new List<CheckBox>();
 
-            foreach (CheckBox check in itemGroup)
+            foreach (CheckBox check in ItemGroup)
             {
                 if (check.IsSelected)
                 {
@@ -140,7 +140,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsCheckedAll()
         {
-            foreach (CheckBox cb in itemGroup)
+            foreach (CheckBox cb in ItemGroup)
             {
                 if (!cb.IsSelected)
                 {
@@ -159,7 +159,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void CheckAll(bool state)
         {
-            foreach (CheckBox cb in itemGroup)
+            foreach (CheckBox cb in ItemGroup)
             {
                 cb.IsSelected = state;
             }

--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -44,7 +44,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected string style;
+        protected string StyleName { get; set; }
 
         private TapGestureDetector tapGestureDetector = new TapGestureDetector();
 
@@ -109,9 +109,9 @@ namespace Tizen.NUI.Components
             }
 
             ApplyStyle(viewStyle);
-            this.style = styleSheet;
+            this.StyleName = styleSheet;
 
-            Initialize(style);
+            Initialize(StyleName);
         }
 
         /// Internal used.

--- a/src/Tizen.NUI.Components/Controls/DropDown.cs
+++ b/src/Tizen.NUI.Components/Controls/DropDown.cs
@@ -829,12 +829,12 @@ namespace Tizen.NUI.Components
             /// <since_tizen> 6 </since_tizen>
             /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public int Index;
+            public int Index { get; set; }
             /// <summary> Clicked item text string of DropDown's list </summary>
             /// <since_tizen> 6 </since_tizen>
             /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public string Text;
+            public string Text { get; set; }
         }
         #endregion
 

--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
@@ -814,7 +814,7 @@ namespace Tizen.NUI.Components
             /// <since_tizen> 6 </since_tizen>
             /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public ViewHolder ClickedView;
+            public ViewHolder ClickedView { get; set; }
         }
 
         /// <summary>
@@ -831,7 +831,7 @@ namespace Tizen.NUI.Components
             /// <since_tizen> 6 </since_tizen>
             /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public ViewHolder TouchedView;
+            public ViewHolder TouchedView { get; set; }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/ImageScrollBar.cs
+++ b/src/Tizen.NUI.Components/Controls/ImageScrollBar.cs
@@ -473,7 +473,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         protected override void OnThemeChangedEvent(object sender, StyleManager.ThemeChangeEventArgs e)
         {
-            ScrollBarStyle tempStyle = StyleManager.Instance.GetViewStyle(style) as ScrollBarStyle;
+            ScrollBarStyle tempStyle = StyleManager.Instance.GetViewStyle(StyleName) as ScrollBarStyle;
             if (tempStyle != null)
             {
                 Style.CopyFrom(tempStyle);

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -737,7 +737,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         protected override void OnThemeChangedEvent(object sender, StyleManager.ThemeChangeEventArgs e)
         {
-            PopupStyle popupStyle = StyleManager.Instance.GetViewStyle(style) as PopupStyle;
+            PopupStyle popupStyle = StyleManager.Instance.GetViewStyle(StyleName) as PopupStyle;
             if (popupStyle != null)
             {
                 string strSaveTitleText = TitleText;

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -120,9 +120,8 @@ namespace Tizen.NUI.Components
             return instance.state;
         });
 
-        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected ProgressStatusType state = ProgressStatusType.Determinate;
+        /// This needs to be considered more if public-open is necessary.
+        private ProgressStatusType state = ProgressStatusType.Determinate;
 
         private const float round = 0.5f;
         private ImageView trackImage = null;
@@ -423,7 +422,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         protected override void OnThemeChangedEvent(object sender, StyleManager.ThemeChangeEventArgs e)
         {
-            ProgressStyle tempStyle = StyleManager.Instance.GetViewStyle(style) as ProgressStyle;
+            ProgressStyle tempStyle = StyleManager.Instance.GetViewStyle(StyleName) as ProgressStyle;
             if (null != tempStyle)
             {
                 Style.CopyFrom(tempStyle);
@@ -435,9 +434,9 @@ namespace Tizen.NUI.Components
         /// Change Image status. It can be override.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        /// This needs to be considered more if public-open is necessary.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual void UpdateStates()
+        private void UpdateStates()
         {
             ChangeImageState(state);
         }
@@ -446,9 +445,9 @@ namespace Tizen.NUI.Components
         /// Update progress value
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        /// This needs to be considered more if public-open is necessary.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual void UpdateValue()
+        private void UpdateValue()
         {
             if (null == trackImage || null == progressImage)
             {

--- a/src/Tizen.NUI.Components/Controls/RadioButton.cs
+++ b/src/Tizen.NUI.Components/Controls/RadioButton.cs
@@ -69,11 +69,11 @@ namespace Tizen.NUI.Components
         {
             get
             {
-                return itemGroup as RadioButtonGroup;
+                return base.ItemGroup as RadioButtonGroup;
             }
             internal set
             {
-                itemGroup = value;
+                base.ItemGroup = value;
             }
         }
 

--- a/src/Tizen.NUI.Components/Controls/RadioButtonGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/RadioButtonGroup.cs
@@ -54,7 +54,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RadioButton GetItem(int index)
         {
-            return itemGroup[index] as RadioButton;
+            return ItemGroup[index] as RadioButton;
         }
 
         /// <summary>
@@ -96,12 +96,12 @@ namespace Tizen.NUI.Components
         protected override void SelectionHandler(SelectButton selection)
         {
             RadioButton radio = selection as RadioButton;
-            if (!itemGroup.Contains(radio))
+            if (!ItemGroup.Contains(radio))
             {
                 return;
             }
 
-            foreach (RadioButton btn in itemGroup)
+            foreach (RadioButton btn in ItemGroup)
             {
                 if (btn != null && btn != radio && btn.IsEnabled == true)
                 {

--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -359,7 +359,9 @@ namespace Tizen.NUI.Components
         // If false then can only flick pages when the current animation/scroll as ended.
         private bool flickWhenAnimating = false;
         private PropertyNotification propertyNotification;
-        protected float finalTargetPosition;
+
+        // Let's consider more whether this needs to be set as protected.
+        private float finalTargetPosition;
 
         /// <summary>
         /// [Draft] Constructor
@@ -507,7 +509,9 @@ namespace Tizen.NUI.Components
 
         private bool readyToNotice = false;
 
-        protected float noticeAnimationEndBeforePosition = 0.0f;
+        private float noticeAnimationEndBeforePosition = 0.0f;
+        // Let's consider more whether this needs to be set as protected.
+        public float NoticeAnimationEndBeforePosition { get => noticeAnimationEndBeforePosition; set => noticeAnimationEndBeforePosition = value; }
 
         private void OnScroll()
         {
@@ -521,8 +525,8 @@ namespace Tizen.NUI.Components
         {
             // Check whether we reached pre-reached target position
             if (readyToNotice &&
-                mScrollingChild.CurrentPosition.Y <= finalTargetPosition + noticeAnimationEndBeforePosition &&
-                mScrollingChild.CurrentPosition.Y >= finalTargetPosition - noticeAnimationEndBeforePosition)
+                mScrollingChild.CurrentPosition.Y <= finalTargetPosition + NoticeAnimationEndBeforePosition &&
+                mScrollingChild.CurrentPosition.Y >= finalTargetPosition - NoticeAnimationEndBeforePosition)
             {
                 //Notice first
                 readyToNotice = false;

--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -30,13 +30,16 @@ namespace Tizen.NUI.Components
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class SelectButton : Button
     {
+        private SelectGroup itemGroup = null;
+
         /// <summary>
         /// Item group which is used to manager all SelectButton in it.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected SelectGroup itemGroup = null;
+        protected SelectGroup ItemGroup { get => itemGroup; set => itemGroup = value; }
+
         static SelectButton() { }
 
         /// <summary>
@@ -92,9 +95,9 @@ namespace Tizen.NUI.Components
         {
             get
             {
-                if (itemGroup != null)
+                if (ItemGroup != null)
                 {
-                    return itemGroup.GetIndex(this);
+                    return ItemGroup.GetIndex(this);
                 }
 
                 return -1;
@@ -217,7 +220,7 @@ namespace Tizen.NUI.Components
             /// <since_tizen> 6 </since_tizen>
             /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public bool IsSelected;
+            public bool IsSelected { get; set; }
         }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/SelectGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectGroup.cs
@@ -32,11 +32,13 @@ namespace Tizen.NUI.Components
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class SelectGroup
     {
+        private List<SelectButton> itemGroup;
+
         /// <summary> Selection group composed of items </summary>
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected List<SelectButton> itemGroup;
+        protected List<SelectButton> ItemGroup { get => itemGroup; set => itemGroup = value; }
 
         private int selectedIndex;
 
@@ -46,7 +48,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public int Count => itemGroup.Count;
+        public int Count => ItemGroup.Count;
 
         /// <summary>
         /// Get the index of currently or latest selected item.
@@ -64,7 +66,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected SelectGroup()
         {
-            itemGroup = new List<SelectButton>();
+            ItemGroup = new List<SelectButton>();
         }
 
         /// <summary>
@@ -77,7 +79,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Contains(SelectButton selection)
         {
-            return itemGroup.Contains(selection);
+            return ItemGroup.Contains(selection);
         }
 
         /// <summary>
@@ -90,7 +92,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int GetIndex(SelectButton selection)
         {
-            return itemGroup.IndexOf(selection);
+            return ItemGroup.IndexOf(selection);
         }
 
         /// <summary>
@@ -103,11 +105,11 @@ namespace Tizen.NUI.Components
         protected void AddSelection(SelectButton selection)
         {
             if (null == selection) return;
-            if (itemGroup.Contains(selection))
+            if (ItemGroup.Contains(selection))
             {
                 return;
             }
-            itemGroup.Add(selection);
+            ItemGroup.Add(selection);
             selection.SelectedEvent += OnSelectedEvent;
         }
 
@@ -120,12 +122,12 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void RemoveSelection(SelectButton selection)
         {
-            if (!itemGroup.Contains(selection))
+            if (!ItemGroup.Contains(selection))
             {
                 return;
             }
             selection.SelectedEvent -= OnSelectedEvent;
-            itemGroup.Remove(selection);
+            ItemGroup.Remove(selection);
         }
 
         /// <summary>
@@ -164,7 +166,7 @@ namespace Tizen.NUI.Components
             /// <since_tizen> 6 </since_tizen>
             /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public int SelectedIndex;
+            public int SelectedIndex { get; set; }
         }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -838,7 +838,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         protected override void OnThemeChangedEvent(object sender, StyleManager.ThemeChangeEventArgs e)
         {
-            SliderStyle sliderStyle = StyleManager.Instance.GetViewStyle(style) as SliderStyle;
+            SliderStyle sliderStyle = StyleManager.Instance.GetViewStyle(StyleName) as SliderStyle;
             if (sliderStyle != null)
             {
                 Style?.CopyFrom(sliderStyle);

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -359,7 +359,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         protected override void OnThemeChangedEvent(object sender, StyleManager.ThemeChangeEventArgs e)
         {
-            SwitchStyle switchStyle = StyleManager.Instance.GetViewStyle(style) as SwitchStyle;
+            SwitchStyle switchStyle = StyleManager.Instance.GetViewStyle(StyleName) as SwitchStyle;
             if (null != switchStyle)
             {
                 Style.CopyFrom(switchStyle);

--- a/src/Tizen.NUI.Components/Controls/Tab.cs
+++ b/src/Tizen.NUI.Components/Controls/Tab.cs
@@ -468,7 +468,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         protected override void OnThemeChangedEvent(object sender, StyleManager.ThemeChangeEventArgs e)
         {
-            TabStyle tabStyle = StyleManager.Instance.GetViewStyle(style) as TabStyle;
+            TabStyle tabStyle = StyleManager.Instance.GetViewStyle(StyleName) as TabStyle;
             if (tabStyle != null)
             {
                 Style.CopyFrom(tabStyle);

--- a/src/Tizen.NUI.Wearable/src/public/WearableList.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WearableList.cs
@@ -47,7 +47,7 @@ namespace Tizen.NUI.Wearable
             mContainer.PositionUsesPivotPoint = true;
             mContainer.ParentOrigin = Tizen.NUI.ParentOrigin.Center;
             mContainer.PivotPoint = Tizen.NUI.PivotPoint.TopCenter;
-            noticeAnimationEndBeforePosition = 50;
+            NoticeAnimationEndBeforePosition = 50;
 
             ScrollAvailableArea = new Vector2( 0, mContainer.SizeHeight);
 


### PR DESCRIPTION
This would fix CA1051 warnings which indicates that
"Do not declare visible instance fields".

This patch restores the diff in
409a8ccea4f26cd7ca4db8e2549e81aac09121a2
except the modification on opened API.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
