### PR TITLE
[NUI] throw exception when profile not found

### DIFF
--- a/src/Tizen.NUI.Components/Utils/StyleManager.cs
+++ b/src/Tizen.NUI.Components/Utils/StyleManager.cs
@@ -255,8 +255,7 @@ namespace Tizen.NUI.Components
             }
             catch
             {
-                Tizen.Log.Error("NUI", "Unknown device profile\n");
-                return;
+                throw new NotSupportedException("Unknown device profile");
             }
 
             if (string.Equals(currentProfile, wearableThemeName))


### PR DESCRIPTION
fixes CA1031

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
