### PR TITLE
[NUI] use proper constructor of ArgumentNullException

### DIFF
--- a/src/Tizen.NUI.Components/Controls/DropDown.cs
+++ b/src/Tizen.NUI.Components/Controls/DropDown.cs
@@ -857,11 +857,7 @@ namespace Tizen.NUI.Components
             [EditorBrowsable(EditorBrowsableState.Never)]
             public ViewHolder(View itemView)
             {
-                if (itemView == null)
-                {
-                    throw new ArgumentNullException("itemView may not be null");
-                }
-                this.ItemView = itemView;
+                ItemView = itemView ?? throw new ArgumentNullException(nameof(itemView), "itemView may not be null");
             }
 
             /// <summary>


### PR DESCRIPTION
use `ArgumentNullException(string paramName, string message);`
instead of `ArgumentNullException(string paramName);`.
`ArgumentNullException(string message);` doesn't exist.

Also, fixes CA2208

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
