### PR TITLE
[NUI] remove SelectGroup.ItemGroup setter

### DIFF
--- a/src/Tizen.NUI.Components/Controls/SelectGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectGroup.cs
@@ -32,13 +32,11 @@ namespace Tizen.NUI.Components
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class SelectGroup
     {
-        private List<SelectButton> itemGroup;
-
         /// <summary> Selection group composed of items </summary>
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected List<SelectButton> ItemGroup { get => itemGroup; set => itemGroup = value; }
+        protected List<SelectButton> ItemGroup { get; }
 
         private int selectedIndex;
 


### PR DESCRIPTION
Since `SelectGroup.ItemGroup` is initialized in `SelectGroup` constructor, it
should not be assigned by api user.

Also, this fixes `CA2227: Collection properties should be read only`.
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2227?view=vs-2019

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
