### PR TITLE
[NUI] ScrollableBase usage improvement

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
@@ -33,7 +33,7 @@ namespace Tizen.NUI.Components
         protected int mTotalItemCount = 15;
         private List<PropertyNotification> notifications = new List<PropertyNotification>();
 
-        public RecyclerView()
+        public RecyclerView() : base()
         {
             Initialize(new RecycleAdapter(), new RecycleLayoutManager());
         }
@@ -53,26 +53,13 @@ namespace Tizen.NUI.Components
 
         private void Initialize(RecycleAdapter adapter, RecycleLayoutManager layoutManager)
         {
-            Name = "[List]";
-            mContainer = new View()
-            {
-                WidthSpecification = ScrollingDirection == Direction.Vertical ? LayoutParamPolicies.MatchParent : LayoutParamPolicies.WrapContent,
-                HeightSpecification = ScrollingDirection == Direction.Horizontal ? LayoutParamPolicies.MatchParent : LayoutParamPolicies.WrapContent,
-                Layout = new AbsoluteLayout()
-                {
-                    SetPositionByLayout = false,
-                },
-                Name = "Container",
-            };
-
-            Add(mContainer);
             ScrollEvent += OnScroll;
 
             mAdapter = adapter;
             mAdapter.OnDataChanged += OnAdapterDataChanged;
 
             mLayoutManager = layoutManager;
-            mLayoutManager.Container = mContainer;
+            mLayoutManager.Container = ContentContainer;
             mLayoutManager.ItemSize = mAdapter.CreateRecycleItem().Size;
             mLayoutManager.DataCount = mAdapter.Data.Count;
 
@@ -81,7 +68,7 @@ namespace Tizen.NUI.Components
 
         private void OnItemSizeChanged(object source, PropertyNotification.NotifyEventArgs args)
         {
-            mLayoutManager.Layout(ScrollingDirection == Direction.Horizontal ? mContainer.CurrentPosition.X : mContainer.CurrentPosition.Y);
+            mLayoutManager.Layout(ScrollingDirection == Direction.Horizontal ? ContentContainer.CurrentPosition.X : ContentContainer.CurrentPosition.Y);
         }
         
         public int TotalItemCount 
@@ -99,9 +86,9 @@ namespace Tizen.NUI.Components
 
         private void InitializeItems()
         {
-            for(int i = mContainer.Children.Count -1 ; i > -1 ; i--)
+            for(int i = Children.Count -1 ; i > -1 ; i--)
             {
-                mContainer.Children[i].Unparent();
+                Children[i].Unparent();
                 notifications[i].Notified -= OnItemSizeChanged;
                 notifications.RemoveAt(i);
             }
@@ -116,7 +103,7 @@ namespace Tizen.NUI.Components
                 {
                     mAdapter.BindData(item);
                 }
-                mContainer.Add(item);
+                Add(item);
 
                 PropertyNotification noti = item.AddPropertyNotification("size", PropertyCondition.Step(0.1f));
                 noti.Notified += OnItemSizeChanged;
@@ -127,11 +114,11 @@ namespace Tizen.NUI.Components
 
             if (ScrollingDirection == Direction.Horizontal)
             {
-                mContainer.SizeWidth = mLayoutManager.CalculateLayoutOrientationSize();
+                ContentContainer.SizeWidth = mLayoutManager.CalculateLayoutOrientationSize();
             }
             else
             {
-                mContainer.SizeHeight = mLayoutManager.CalculateLayoutOrientationSize();
+                ContentContainer.SizeHeight = mLayoutManager.CalculateLayoutOrientationSize();
             }
         }
 
@@ -148,11 +135,11 @@ namespace Tizen.NUI.Components
 
                 if (ScrollingDirection == Direction.Horizontal)
                 {
-                    mContainer.SizeWidth = mLayoutManager.CalculateLayoutOrientationSize();
+                    ContentContainer.SizeWidth = mLayoutManager.CalculateLayoutOrientationSize();
                 }
                 else
                 {
-                    mContainer.SizeHeight = mLayoutManager.CalculateLayoutOrientationSize();
+                    ContentContainer.SizeHeight = mLayoutManager.CalculateLayoutOrientationSize();
                 }
             }
         }
@@ -199,7 +186,7 @@ namespace Tizen.NUI.Components
             set
             {
                 mLayoutManager = value;
-                mLayoutManager.Container = mContainer;
+                mLayoutManager.Container = ContentContainer;
                 mLayoutManager.ItemSize = mAdapter.CreateRecycleItem().Size;
                 mLayoutManager.DataCount = mAdapter.Data.Count;
                 InitializeItems();
@@ -217,7 +204,7 @@ namespace Tizen.NUI.Components
         {
             List<RecycleItem> changedData = new List<RecycleItem>();
 
-            foreach (RecycleItem item in mContainer.Children)
+            foreach (RecycleItem item in Children)
             {
                 changedData.Add(item);
             }

--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -15,6 +15,7 @@
  */
 using System;
 using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -201,8 +202,15 @@ namespace Tizen.NUI.Components
                 if (value != mScrollingDirection)
                 {
                     mScrollingDirection = value;
-                    mPanGestureDetector.RemoveDirection(value == Direction.Horizontal ? PanGestureDetector.DirectionVertical : PanGestureDetector.DirectionHorizontal);
-                    mPanGestureDetector.AddDirection(value == Direction.Horizontal ? PanGestureDetector.DirectionHorizontal : PanGestureDetector.DirectionVertical);
+                    mPanGestureDetector.RemoveDirection(value == Direction.Horizontal ?
+                        PanGestureDetector.DirectionVertical : PanGestureDetector.DirectionHorizontal);
+                    mPanGestureDetector.AddDirection(value == Direction.Horizontal ?
+                        PanGestureDetector.DirectionHorizontal : PanGestureDetector.DirectionVertical);
+
+                    ContentContainer.WidthSpecification = mScrollingDirection == Direction.Vertical ?
+                        LayoutParamPolicies.MatchParent : LayoutParamPolicies.WrapContent;
+                    ContentContainer.HeightSpecification = mScrollingDirection == Direction.Vertical ?
+                        LayoutParamPolicies.WrapContent : LayoutParamPolicies.MatchParent;
                 }
             }
         }
@@ -359,7 +367,7 @@ namespace Tizen.NUI.Components
 
                 scrollBar = value;
                 scrollBar.Name = "ScrollBar";
-                Add(scrollBar);
+                base.Add(scrollBar);
 
                 if (hideScrollbar)
                 {
@@ -409,7 +417,6 @@ namespace Tizen.NUI.Components
         private float childTargetPosition = 0.0f;
         private PanGestureDetector mPanGestureDetector;
         private TapGestureDetector mTapGestureDetector;
-        private View mScrollingChild;
         private View mInterruptTouchingChild;
         private ScrollbarBase scrollBar;
         private float multiplier = 1.0f;
@@ -432,6 +439,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ScrollableBase() : base()
         {
+            base.Layout = new ScrollableBaseCustomLayout();
             mPanGestureDetector = new PanGestureDetector();
             mPanGestureDetector.Attach(this);
             mPanGestureDetector.AddDirection(PanGestureDetector.DirectionVertical);
@@ -443,22 +451,63 @@ namespace Tizen.NUI.Components
 
             ClippingMode = ClippingModeType.ClipChildren;
 
-            mScrollingChild = new View();
-            mScrollingChild.Name = "DefaultScrollingChild";
+            //Default Scrolling child
+            ContentContainer = new View()
+            {
+                WidthSpecification = ScrollingDirection == Direction.Vertical ? LayoutParamPolicies.MatchParent : LayoutParamPolicies.WrapContent,
+                HeightSpecification = ScrollingDirection == Direction.Vertical ? LayoutParamPolicies.WrapContent : LayoutParamPolicies.MatchParent,
+                Layout = new AbsoluteLayout(){SetPositionByLayout = false},
+            };
+            ContentContainer.Relayout += OnScrollingChildRelayout;
+            propertyNotification = ContentContainer.AddPropertyNotification("position", PropertyCondition.Step(1.0f));
+            propertyNotification.Notified += OnPropertyChanged;
+            base.Add(ContentContainer);
 
-            //Interrupt touching when panning is started;
+            //Interrupt touching when panning is started
             mInterruptTouchingChild = new View()
             {
-                Name = "InterruptTouchingChild",
                 Size = new Size(Window.Instance.WindowSize),
                 BackgroundColor = Color.Transparent,
             };
-
             mInterruptTouchingChild.TouchEvent += OnIterruptTouchingChildTouched;
 
-            Layout = new ScrollableBaseCustomLayout();
-
             Scrollbar = new Scrollbar();
+        }
+
+        /// <summary>
+        /// Container which has content of ScrollableBase.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public View ContentContainer { get; private set; }
+
+        /// <summary>
+        /// Set the layout on this View. Replaces any existing Layout.
+        /// </summary>
+        public new LayoutItem Layout
+        {
+            get
+            {
+                return ContentContainer.Layout;
+            }
+            set
+            {
+                ContentContainer.Layout = value;
+                if(ContentContainer.Layout != null)
+                {
+                    ContentContainer.Layout.SetPositionByLayout = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// List of children of Container.
+        /// </summary>
+        public new List<View> Children
+        {
+            get
+            {
+                return ContentContainer.Children;
+            }
         }
 
         private bool OnIterruptTouchingChildTouched(object source, View.TouchEventArgs args)
@@ -477,27 +526,9 @@ namespace Tizen.NUI.Components
         /// <param name="view">The child which has been added.</param>
         /// This may be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnChildAdd(View view)
+        public override void Add(View view)
         {
-            if (null != view && view.Name != "InterruptTouchingChild" && view.Name != "ScrollBar")
-            {
-                if (null != mScrollingChild && mScrollingChild.Name != "DefaultScrollingChild")
-                {
-                    propertyNotification.Notified -= OnPropertyChanged;
-                    mScrollingChild.RemovePropertyNotification(propertyNotification);
-                    mScrollingChild.Relayout -= OnScrollingChildRelayout;
-                }
-
-                mScrollingChild = view;
-                mScrollingChild.Layout.SetPositionByLayout = false;
-                propertyNotification = mScrollingChild?.AddPropertyNotification("position", PropertyCondition.Step(1.0f));
-                if (null != propertyNotification)
-                {
-                    propertyNotification.Notified += OnPropertyChanged;
-                }
-                mScrollingChild.Relayout += OnScrollingChildRelayout;
-                mScrollingChild.LowerToBottom();
-            }
+            ContentContainer.Add(view);
         }
 
         /// <summary>
@@ -506,23 +537,23 @@ namespace Tizen.NUI.Components
         /// <param name="view">The child which has been removed.</param>
         /// This may be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnChildRemove(View view)
+        public override void Remove(View view)
         {
-            if (view.Name != "InterruptTouchingChild" && view.Name != "ScrollBar")
+            if(SnapToPage && CurrentPage == Children.IndexOf(view) &&  CurrentPage == Children.Count -1)
             {
-                propertyNotification.Notified -= OnPropertyChanged;
-                mScrollingChild.RemovePropertyNotification(propertyNotification);
-                mScrollingChild.Relayout -= OnScrollingChildRelayout;
-
-                mScrollingChild.Layout.SetPositionByLayout = true;
-                mScrollingChild = new View();
+                // Target View is current page and also last child.
+                // CurrentPage should be changed to previous page.
+                CurrentPage = Math.Max(0, CurrentPage-1);
+                ScrollToIndex(CurrentPage);
             }
+
+            ContentContainer.Remove(view);
         }
 
         private void OnScrollingChildRelayout(object source, EventArgs args)
         {
             // Size is changed. Calculate maxScrollDistance.
-            bool isSizeChanged = previousContainerSize.Width != mScrollingChild.Size.Width || previousContainerSize.Height != mScrollingChild.Size.Height;
+            bool isSizeChanged = previousContainerSize.Width != ContentContainer.Size.Width || previousContainerSize.Height != ContentContainer.Size.Height;
 
             if (isSizeChanged)
             {
@@ -530,7 +561,7 @@ namespace Tizen.NUI.Components
                 SetScrollbar();
             }
 
-            previousContainerSize = mScrollingChild.Size;
+            previousContainerSize = ContentContainer.Size;
         }
 
         /// <summary>
@@ -544,9 +575,9 @@ namespace Tizen.NUI.Components
             if (Scrollbar)
             {
                 bool isHorizontal = ScrollingDirection == Direction.Horizontal;
-                float contentLength = isHorizontal ? mScrollingChild.Size.Width : mScrollingChild.Size.Height;
+                float contentLength = isHorizontal ? ContentContainer.Size.Width : ContentContainer.Size.Height;
                 float viewportLength = isHorizontal ? Size.Width : Size.Height;
-                float currentPosition = isHorizontal ? mScrollingChild.CurrentPosition.X : mScrollingChild.CurrentPosition.Y;
+                float currentPosition = isHorizontal ? ContentContainer.CurrentPosition.X : ContentContainer.CurrentPosition.Y;
                 Scrollbar.Initialize(contentLength, viewportLength, currentPosition, isHorizontal);
             }
         }
@@ -559,7 +590,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ScrollToIndex(int index)
         {
-            if (mScrollingChild.ChildCount - 1 < index || index < 0)
+            if (ContentContainer.ChildCount - 1 < index || index < 0)
             {
                 return;
             }
@@ -569,31 +600,31 @@ namespace Tizen.NUI.Components
                 CurrentPage = index;
             }
 
-            float targetPosition = Math.Min(ScrollingDirection == Direction.Vertical ? mScrollingChild.Children[index].Position.Y : mScrollingChild.Children[index].Position.X, maxScrollDistance);
+            float targetPosition = Math.Min(ScrollingDirection == Direction.Vertical ? Children[index].Position.Y : Children[index].Position.X, maxScrollDistance);
             AnimateChildTo(ScrollDuration, -targetPosition);
         }
 
         private void OnScrollDragStart()
         {
-            ScrollEventArgs eventArgs = new ScrollEventArgs(mScrollingChild.CurrentPosition);
+            ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollDragStartEvent?.Invoke(this, eventArgs);
         }
 
         private void OnScrollDragEnd()
         {
-            ScrollEventArgs eventArgs = new ScrollEventArgs(mScrollingChild.CurrentPosition);
+            ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollDragEndEvent?.Invoke(this, eventArgs);
         }
 
         private void OnScrollAnimationStart()
         {
-            ScrollEventArgs eventArgs = new ScrollEventArgs(mScrollingChild.CurrentPosition);
+            ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollAnimationStartEvent?.Invoke(this, eventArgs);
         }
 
         private void OnScrollAnimationEnd()
         {
-            ScrollEventArgs eventArgs = new ScrollEventArgs(mScrollingChild.CurrentPosition);
+            ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollAnimationEndEvent?.Invoke(this, eventArgs);
         }
 
@@ -605,12 +636,12 @@ namespace Tizen.NUI.Components
 
         private void OnScroll()
         {
-            ScrollEventArgs eventArgs = new ScrollEventArgs(mScrollingChild.CurrentPosition);
+            ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollEvent?.Invoke(this, eventArgs);
 
             bool isHorizontal = ScrollingDirection == Direction.Horizontal;
-            float contentLength = isHorizontal ? mScrollingChild.Size.Width : mScrollingChild.Size.Height;
-            float currentPosition = isHorizontal ? mScrollingChild.CurrentPosition.X : mScrollingChild.CurrentPosition.Y;
+            float contentLength = isHorizontal ? ContentContainer.Size.Width : ContentContainer.Size.Height;
+            float currentPosition = isHorizontal ? ContentContainer.CurrentPosition.X : ContentContainer.CurrentPosition.Y;
 
             scrollBar.Update(contentLength, Math.Abs(currentPosition));
             CheckPreReachedTargetPosition();
@@ -620,8 +651,8 @@ namespace Tizen.NUI.Components
         {
             // Check whether we reached pre-reached target position
             if (readyToNotice &&
-                mScrollingChild.CurrentPosition.Y <= finalTargetPosition + NoticeAnimationEndBeforePosition &&
-                mScrollingChild.CurrentPosition.Y >= finalTargetPosition - NoticeAnimationEndBeforePosition)
+                ContentContainer.CurrentPosition.Y <= finalTargetPosition + NoticeAnimationEndBeforePosition &&
+                ContentContainer.CurrentPosition.Y >= finalTargetPosition - NoticeAnimationEndBeforePosition)
             {
                 //Notice first
                 readyToNotice = false;
@@ -682,7 +713,7 @@ namespace Tizen.NUI.Components
 
             scrollAnimation.Duration = duration;
             scrollAnimation.DefaultAlphaFunction = new AlphaFunction(AlphaFunction.BuiltinFunctions.EaseOutSine);
-            scrollAnimation.AnimateTo(mScrollingChild, (ScrollingDirection == Direction.Horizontal) ? "PositionX" : "PositionY", axisPosition);
+            scrollAnimation.AnimateTo(ContentContainer, (ScrollingDirection == Direction.Horizontal) ? "PositionX" : "PositionY", axisPosition);
             scrolling = true;
             OnScrollAnimationStart();
             scrollAnimation.Play();
@@ -696,8 +727,8 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ScrollTo(float position, bool animate)
         {
-            float currentPositionX = mScrollingChild.CurrentPosition.X != 0 ? mScrollingChild.CurrentPosition.X : mScrollingChild.Position.X;
-            float currentPositionY = mScrollingChild.CurrentPosition.Y != 0 ? mScrollingChild.CurrentPosition.Y : mScrollingChild.Position.Y;
+            float currentPositionX = ContentContainer.CurrentPosition.X != 0 ? ContentContainer.CurrentPosition.X : ContentContainer.Position.X;
+            float currentPositionY = ContentContainer.CurrentPosition.Y != 0 ? ContentContainer.CurrentPosition.Y : ContentContainer.Position.Y;
             float delta = ScrollingDirection == Direction.Horizontal ? currentPositionX : currentPositionY;
             // The argument position is the new pan position. So the new position of ScrollableBase becomes (-position).
             // To move ScrollableBase's position to (-position), it moves by (-position - currentPosition).
@@ -732,7 +763,7 @@ namespace Tizen.NUI.Components
                 return;
             }
 
-            float childCurrentPosition = (ScrollingDirection == Direction.Horizontal) ? mScrollingChild.PositionX : mScrollingChild.PositionY;
+            float childCurrentPosition = (ScrollingDirection == Direction.Horizontal) ? ContentContainer.PositionX : ContentContainer.PositionY;
 
             Debug.WriteLineIf(LayoutDebugScrollableBase, "ScrollBy childCurrentPosition:" + childCurrentPosition +
                                                    " displacement:" + displacement,
@@ -761,11 +792,11 @@ namespace Tizen.NUI.Components
                 // Set position of scrolling child without an animation
                 if (ScrollingDirection == Direction.Horizontal)
                 {
-                    mScrollingChild.PositionX = finalTargetPosition;
+                    ContentContainer.PositionX = finalTargetPosition;
                 }
                 else
                 {
-                    mScrollingChild.PositionY = finalTargetPosition;
+                    ContentContainer.PositionY = finalTargetPosition;
                 }
 
             }
@@ -844,13 +875,13 @@ namespace Tizen.NUI.Components
             {
                 Debug.WriteLineIf(LayoutDebugScrollableBase, "Horizontal");
 
-                scrollingChildLength = mScrollingChild.Size.Width;
+                scrollingChildLength = ContentContainer.Size.Width;
                 scrollerLength = Size.Width;
             }
             else
             {
                 Debug.WriteLineIf(LayoutDebugScrollableBase, "Vertical");
-                scrollingChildLength = mScrollingChild.Size.Height;
+                scrollingChildLength = ContentContainer.Size.Height;
                 scrollerLength = Size.Height;
             }
 
@@ -871,7 +902,7 @@ namespace Tizen.NUI.Components
             {
                 if (totalDisplacementForPan < 0)
                 {
-                    CurrentPage = Math.Min(Math.Max(mScrollingChild.Children.Count - 1, 0), ++CurrentPage);
+                    CurrentPage = Math.Min(Math.Max(Children.Count - 1, 0), ++CurrentPage);
                 }
                 else
                 {
@@ -880,20 +911,20 @@ namespace Tizen.NUI.Components
             }
 
             // Animate to new page or reposition to current page
-            float destinationX = -(mScrollingChild.Children[CurrentPage].Position.X + mScrollingChild.Children[CurrentPage].CurrentSize.Width / 2 - CurrentSize.Width / 2); // set to middle of current page
-            Debug.WriteLineIf(LayoutDebugScrollableBase, "Snapping to page[" + CurrentPage + "] to:" + destinationX + " from:" + mScrollingChild.PositionX);
+            float destinationX = -(Children[CurrentPage].Position.X + Children[CurrentPage].CurrentSize.Width / 2 - CurrentSize.Width / 2); // set to middle of current page
+            Debug.WriteLineIf(LayoutDebugScrollableBase, "Snapping to page[" + CurrentPage + "] to:" + destinationX + " from:" + ContentContainer.PositionX);
             AnimateChildTo(ScrollDuration, destinationX);
         }
 
         private void Flick(float flickDisplacement)
         {
-            if (SnapToPage)
+            if (SnapToPage && Children.Count > 0)
             {
                 if ((flickWhenAnimating && scrolling == true) || (scrolling == false))
                 {
                     if (flickDisplacement < 0)
                     {
-                        CurrentPage = Math.Min(Math.Max(mScrollingChild.Children.Count - 1, 0), CurrentPage + 1);
+                        CurrentPage = Math.Min(Math.Max(Children.Count - 1, 0), CurrentPage + 1);
                         Debug.WriteLineIf(LayoutDebugScrollableBase, "Snap - to page:" + CurrentPage);
                     }
                     else
@@ -902,7 +933,7 @@ namespace Tizen.NUI.Components
                         Debug.WriteLineIf(LayoutDebugScrollableBase, "Snap + to page:" + CurrentPage);
                     }
 
-                    float destinationX = -(mScrollingChild.Children[CurrentPage].Position.X + mScrollingChild.Children[CurrentPage].CurrentSize.Width / 2.0f - CurrentSize.Width / 2.0f); // set to middle of current page
+                    float destinationX = -(Children[CurrentPage].Position.X + Children[CurrentPage].CurrentSize.Width / 2.0f - CurrentSize.Width / 2.0f); // set to middle of current page
                     Debug.WriteLineIf(LayoutDebugScrollableBase, "Snapping to :" + destinationX);
                     AnimateChildTo(ScrollDuration, destinationX);
                 }
@@ -917,7 +948,7 @@ namespace Tizen.NUI.Components
         {
             if (e.PanGesture.State == Gesture.StateType.Started)
             {
-                Add(mInterruptTouchingChild);
+                base.Add(mInterruptTouchingChild);
                 Debug.WriteLineIf(LayoutDebugScrollableBase, "Gesture Start");
                 if (scrolling && !SnapToPage)
                 {
@@ -955,7 +986,7 @@ namespace Tizen.NUI.Components
                 else
                 {
                     // End of panning gesture but was not a flick
-                    if (SnapToPage)
+                    if (SnapToPage && Children.Count > 0)
                     {
                         PageSnap();
                     }
@@ -966,7 +997,7 @@ namespace Tizen.NUI.Components
                 }
                 totalDisplacementForPan = 0;
 
-                Remove(mInterruptTouchingChild);
+                base.Remove(mInterruptTouchingChild);
             }
         }
 

--- a/src/Tizen.NUI.Wearable/src/public/WearableList.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WearableList.cs
@@ -44,12 +44,12 @@ namespace Tizen.NUI.Wearable
             ScrollDragStartEvent += OnScrollDragStart;
             ScrollAnimationEndEvent += OnAnimationEnd;
 
-            mContainer.PositionUsesPivotPoint = true;
-            mContainer.ParentOrigin = Tizen.NUI.ParentOrigin.Center;
-            mContainer.PivotPoint = Tizen.NUI.PivotPoint.TopCenter;
+            ContentContainer.PositionUsesPivotPoint = true;
+            ContentContainer.ParentOrigin = Tizen.NUI.ParentOrigin.Center;
+            ContentContainer.PivotPoint = Tizen.NUI.PivotPoint.TopCenter;
             NoticeAnimationEndBeforePosition = 50;
 
-            ScrollAvailableArea = new Vector2(0, mContainer.SizeHeight);
+            ScrollAvailableArea = new Vector2(0, ContentContainer.SizeHeight);
 
             SetFocus(0, false);
 
@@ -58,9 +58,9 @@ namespace Tizen.NUI.Wearable
 
         protected override void SetScrollbar()
         {
-            if(mContainer != null && LayoutManager != null)
+            if(LayoutManager != null)
             {
-                Scrollbar.Initialize(mContainer.Size.Height, LayoutManager.StepSize, mContainer.CurrentPosition.Y, false);
+                Scrollbar.Initialize(ContentContainer.Size.Height, LayoutManager.StepSize, ContentContainer.CurrentPosition.Y, false);
             }
         }
 
@@ -75,13 +75,13 @@ namespace Tizen.NUI.Wearable
             {
                 base.Adapter = value;
 
-                foreach (View child in mContainer.Children)
+                foreach (View child in Children)
                 {
                     child.PositionUsesPivotPoint = true;
                     child.ParentOrigin = Tizen.NUI.ParentOrigin.TopCenter;
                 }
 
-                ScrollAvailableArea = new Vector2( 0, mContainer.SizeHeight );
+                ScrollAvailableArea = new Vector2( 0, ContentContainer.SizeHeight );
             }
         }
 
@@ -94,7 +94,7 @@ namespace Tizen.NUI.Wearable
         /// This may be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API
         public void SetFocus(int dataIndex, bool animated)
         {
-            foreach (RecycleItem item in mContainer.Children)
+            foreach (RecycleItem item in Children)
             {
                 if (item.DataIndex == dataIndex)
                 {
@@ -122,9 +122,9 @@ namespace Tizen.NUI.Wearable
         {
             int targetDataIndex = (int)Math.Round(Math.Abs(targetPosition) / mLayoutManager.StepSize);
 
-            for (int i = 0; i < mContainer.Children.Count; i++)
+            for (int i = 0; i < Children.Count; i++)
             {
-                RecycleItem item = mContainer.Children[i] as RecycleItem;
+                RecycleItem item = Children[i] as RecycleItem;
 
                 if (targetDataIndex == item.DataIndex)
                 {

--- a/src/Tizen.NUI/src/internal/GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/GaussianBlurView.cs
@@ -217,7 +217,6 @@ namespace Tizen.NUI
         /// <summary>
         /// Render the GaussianBlurView once.
         /// Must be called after you Add() it to the window.
-        /// Only works with a gaussian blur view created with blurUserImage = true.
         /// Listen to the Finished signal to determine when the rendering has completed.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -174,10 +174,8 @@ namespace Tizen.NUI.BaseComponents
             {
                 (_layout as LayoutGroup)?.RemoveChildFromLayoutGroup(child);
             }
-            else
-            {
-                RemoveChild(child);
-            }
+
+            RemoveChild(child);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -104,27 +104,13 @@ namespace Tizen.NUI
                         // Add LayoutItem to the transition stack so can animate it out.
                         NUIApplication.GetDefaultWindow().LayoutController.AddTransitionDataEntry(new LayoutData(layoutItem, ConditionForAnimation, 0, 0, 0, 0));
                     }
-                    else
-                    {
-                        if(childLayout.Owner != null)
-                        {
-                            View parent = childLayout.Owner.GetParent() as View;
-
-                            if(parent != null)
-                            {
-                                parent.RemoveChild(childLayout.Owner);
-                            }
-                            else
-                            {
-                                NUIApplication.GetDefaultWindow().Remove(childLayout.Owner);
-                            }
-                        }
-                    }
 
                     // Reset condition for animation ready for next transition when required.
                     // SetFrame usually would do this but this LayoutItem is being removed.
                     childLayout.ConditionForAnimation = TransitionCondition.Unspecified;
                     childRemoved = true;
+
+                    break;
                 }
             }
 
@@ -463,6 +449,17 @@ namespace Tizen.NUI
             Owner.ChildAdded += OnChildAddedToOwner;
 
             // Removing Child from the owners View will directly call the LayoutGroup removal API.
+        }
+
+        /// <summary>
+        /// Virtual method to allow derived classes to remove any children before it is removed from
+        /// its parent.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnUnparent()
+        {
+            // Disconnect to owner ChildAdded signal.
+            Owner.ChildAdded -= OnChildAddedToOwner;
         }
 
         // Virtual Methods that can be overridden by derived classes.


### PR DESCRIPTION
### Description of Change ###
Previously, user should make container for ScrollableBase to contain
children in ScrollableBase and it brought inconvenience to user.

For now, ScrollalbleBase creates its ContentContainer in Constructor so
user doesn't need to add container.

And ScrollableBase overrides Add/Remove function to add/remove child
to/from ContentContainer even if user call ScrollableBase.Add/Remove.

Plus, user can access to children of ContentContainer through
ScrollableBase.Children property and also can acess to Layout too.

Finally, if user want to change property of ContentContainer, they can
use getter of ContentContainer property.

### API Changes ###
NONE