### PR TITLE
[NUI] Change View.ControlState setter to protected

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -350,6 +350,34 @@ namespace Tizen.NUI.Components
             base.Dispose(type);
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnControlStateChanged(ControlStateChangedEventArgs controlStateChangedInfo)
+        {
+            base.OnControlStateChanged(controlStateChangedInfo);
+
+            var stateEnabled = !((controlStateChangedInfo.CurrentState & ControlStates.Disabled) == ControlStates.Disabled);
+
+            if (isEnabled != stateEnabled)
+            {
+                isEnabled = stateEnabled;
+            }
+
+            var stateSelected = (controlStateChangedInfo.CurrentState & ControlStates.Selected) == ControlStates.Selected;
+
+            if (isSelected != stateSelected)
+            {
+                isSelected = stateSelected;
+            }
+
+            var statePressed = (controlStateChangedInfo.CurrentState & ControlStates.Pressed) == ControlStates.Pressed;
+
+            if (isPressed != statePressed)
+            {
+                isPressed = statePressed;
+            }
+        }
+
         /// <summary>
         /// It is hijack by using protected, style copy problem when class inherited from Button.
         /// </summary>

--- a/src/Tizen.NUI.Components/Controls/DropDown.DropDownItemView.cs
+++ b/src/Tizen.NUI.Components/Controls/DropDown.DropDownItemView.cs
@@ -199,10 +199,12 @@ namespace Tizen.NUI.Components
                     CreateCheckImage();
                     if (value)
                     {
+                        ControlState = ControlStates.Selected;
                         mCheck.Show();
                     }
                     else
                     {
+                        ControlState = ControlStates.Normal;
                         mCheck.Hide();
                     }
                 }

--- a/src/Tizen.NUI.Components/Controls/DropDown.cs
+++ b/src/Tizen.NUI.Components/Controls/DropDown.cs
@@ -739,7 +739,6 @@ namespace Tizen.NUI.Components
             if (selectedItemView != null)
             {
                 selectedItemView.IsSelected = false;
-                selectedItemView.ControlState = ControlStates.Normal;
                 adapter.GetData(selectedItemIndex).IsSelected = false;
             }
 
@@ -752,7 +751,6 @@ namespace Tizen.NUI.Components
 
             selectedItemIndex = (int)index;
             selectedItemView = view;
-            selectedItemView.ControlState = ControlStates.Selected;
             selectedItemView.IsSelected = true;
             adapter.GetData(selectedItemIndex).IsSelected = true;
             dropDownMenuFullList.Layout?.RequestLayout();
@@ -761,21 +759,16 @@ namespace Tizen.NUI.Components
         private bool ListItemTouchEvent(object sender, TouchEventArgs e)
         {
             PointStateType state = e.Touch.GetState(0);
-            DropDownItemView touchedView = sender as DropDownItemView;;
+            DropDownItemView touchedView = sender as DropDownItemView;
+
+            touchedView.OnTouch(e.Touch); // Handle control state change
+
             switch (state)
             {
                 case PointStateType.Down:
-                    if (touchedView != null)
-                    {
-                        touchedView.ControlState = ControlStates.Pressed;
-                    }
                     itemPressed = true;  // if matched with a Up then a click event.
                     break;
                 case PointStateType.Motion:
-                    if (touchedView != null)
-                    {
-                        touchedView.ControlState = ControlStates.Normal;
-                    }
                     itemPressed = false;
                     break;
                 case PointStateType.Up:

--- a/src/Tizen.NUI.Components/Controls/Tab.cs
+++ b/src/Tizen.NUI.Components/Controls/Tab.cs
@@ -599,7 +599,7 @@ namespace Tizen.NUI.Components
             LayoutChild();
             if (itemList != null && curIndex >= 0 && curIndex < itemList.Count)
             {
-                itemList[curIndex].ControlState = ControlStates.Selected;
+                itemList[curIndex].IsSelected = true;
                 UpdateUnderLinePos();
             }
             else
@@ -665,9 +665,9 @@ namespace Tizen.NUI.Components
             };
             ItemChangedEvent?.Invoke(this, e);
 
-            itemList[curIndex].ControlState = ControlStates.Normal;
+            itemList[curIndex].IsSelected = false;
             curIndex = item.Index;
-            itemList[curIndex].ControlState = ControlStates.Selected;
+            itemList[curIndex].IsSelected = true;
 
             UpdateUnderLinePos();
         }
@@ -690,6 +690,8 @@ namespace Tizen.NUI.Components
 
         internal class TabItem : View
         {
+            private bool isSelected = false;
+
             public TabItem() : base()
             {
                 TextItem = new TextLabel()
@@ -729,6 +731,19 @@ namespace Tizen.NUI.Components
             {
                 get;
                 set;
+            }
+
+            internal bool IsSelected
+            {
+                get
+                {
+                    return isSelected;
+                }
+                set
+                {
+                    ControlState = value ? ControlStates.Selected : ControlStates.Normal;
+                    isSelected = value;
+                }
             }
         }
 

--- a/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
@@ -345,10 +345,14 @@ namespace Tizen.NUI.Wearable
                 isEnabled = value;
                 if (isEnabled)
                 {
+                    ControlState = ControlStates.Normal;
+
                     UpdateTrackVisualColor(new Color(0.0f, 0.16f, 0.30f, 1.0f)); // #002A4D
                 }
                 else
                 {
+                    ControlState = ControlStates.Disabled;
+
                     UpdateTrackVisualColor(new Color(0.25f, 0.25f, 0.25f, 1.0f)); // #404040
                 }
             }
@@ -409,6 +413,20 @@ namespace Tizen.NUI.Wearable
         protected override ViewStyle CreateViewStyle()
         {
             return new CircularProgressStyle();
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnControlStateChanged(ControlStateChangedEventArgs controlStateChangedInfo)
+        {
+            base.OnControlStateChanged(controlStateChangedInfo);
+
+            var stateEnabled = !((controlStateChangedInfo.CurrentState & ControlStates.Disabled) == ControlStates.Disabled);
+
+            if (isEnabled != stateEnabled)
+            {
+                isEnabled = stateEnabled;
+            }
         }
 
 

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -184,7 +184,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 return controlStates;
             }
-            set
+            protected set
             {
                 if (controlStates == value)
                 {


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
Setting ControlState is now allowed only in the derived class of View.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
