### PR TITLE
[NUI] Change to get PropertyValue by integer

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1090,12 +1090,12 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             var view = (View)bindable;
-            string temp;
+            int temp;
             if (Tizen.NUI.Object.GetProperty(view.swigCPtr, View.Property.DRAW_MODE).Get(out temp) == false)
             {
                 NUILog.Error("DrawMode get error!");
             }
-            return temp.GetValueByDescription<DrawModeType>();
+            return (DrawModeType)temp;
         });
 
         /// <summary>
@@ -1225,12 +1225,12 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             var view = (View)bindable;
-            string temp;
+            int temp;
             if (Tizen.NUI.Object.GetProperty(view.swigCPtr, View.Property.SIZE_SCALE_POLICY).Get(out temp) == false)
             {
                 NUILog.Error("SizeScalePolicy get error!");
             }
-            return temp.GetValueByDescription<SizeScalePolicyType>();
+            return (SizeScalePolicyType)temp;
         });
 
         /// <summary>


### PR DESCRIPTION
Please refer dali patch
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/234639/

Modified to get string as integer by this patch.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
