### PR TITLE
[NUI] Implement IDisposable to class containing disposable class

### DIFF
--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.Helper.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.Helper.cs
@@ -73,7 +73,7 @@ namespace Tizen.NUI.Components
             }
         }
 
-        internal class ChildHelper
+        internal class ChildHelper : Disposable
         {
             private FlexibleView mFlexibleView;
 
@@ -179,6 +179,27 @@ namespace Tizen.NUI.Components
                     return null;
                 }
                 return mViewList[index];
+            }
+
+            protected override void Dispose(DisposeTypes type)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                if (type == DisposeTypes.Explicit)
+                {
+                    Clear();
+
+                    if (mTapGestureDetector != null)
+                    {
+                        mTapGestureDetector.Detected -= OnTapGestureDetected;
+                        mTapGestureDetector.Dispose();
+                        mTapGestureDetector = null;
+                    }
+                }
+                base.Dispose(type);
             }
 
             private void OnTapGestureDetected(object source, TapGestureDetector.DetectedEventArgs e)

--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
@@ -449,6 +449,8 @@ namespace Tizen.NUI.Components
                 if (mLayout != null)
                 {
                     mLayout.StopScroll(false);
+                    mLayout.Dispose();
+                    mLayout = null;
                 }
 
                 if (mAdapter != null)
@@ -480,6 +482,7 @@ namespace Tizen.NUI.Components
                 if (mChildHelper != null)
                 {
                     mChildHelper.Clear();
+                    mChildHelper.Dispose();
                     mChildHelper = null;
                 }
             }

--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleViewLayoutManager.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleViewLayoutManager.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.Components
     /// </summary>
     /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public abstract class FlexibleViewLayoutManager
+    public abstract class FlexibleViewLayoutManager : Disposable
     {
         /// <summary>
         /// Direction
@@ -706,6 +706,26 @@ namespace Tizen.NUI.Components
         protected virtual FlexibleViewViewHolder FindLastVisibleItemView()
         {
             return null;
+        }
+
+        /// <summary>
+        /// Dispose FlexibleView and all children on it.
+        /// </summary>
+        /// <param name="type">Dispose type.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                mScrollAni?.Dispose();
+            }
+
+            base.Dispose(type);
         }
 
         internal virtual FlexibleViewViewHolder OnFocusSearchFailed(FlexibleViewViewHolder focused, FlexibleViewLayoutManager.Direction direction, FlexibleViewRecycler recycler)

--- a/src/Tizen.NUI.Components/Style/ButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ButtonStyle.cs
@@ -270,6 +270,27 @@ namespace Tizen.NUI.Components
             return null;
         }
 
+        /// <summary>
+        /// Dispose ButtonStyle and all children on it.
+        /// </summary>
+        /// <param name="type">Dispose type.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                iconPadding?.Dispose();
+                textPadding?.Dispose();
+            }
+
+            base.Dispose(type);
+        }
+
         private void InitSubStyle()
         {
             Overlay = new ImageViewStyle()

--- a/src/Tizen.NUI.Components/Style/ControlStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ControlStyle.cs
@@ -27,8 +27,16 @@ namespace Tizen.NUI.Components
     /// <since_tizen> 6 </since_tizen>
     /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class ControlStyle : ViewStyle
+    public class ControlStyle : ViewStyle, global::System.IDisposable
     {
+        /// <summary>
+        /// A Flag to check if it is already disposed.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool disposed = false;
+
+        private bool isDisposeQueued = false;
+
         static ControlStyle () { }
 
         /// <summary>
@@ -54,6 +62,63 @@ namespace Tizen.NUI.Components
             if(null == style) return;
 
             this.CopyFrom(style);
+        }
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ~ControlStyle()
+        {
+            if (!isDisposeQueued)
+            {
+                isDisposeQueued = true;
+                DisposeQueue.Instance.Add(this);
+            }
+        }
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Dispose()
+        {
+            //Throw excpetion if Dispose() is called in separate thread.
+            if (!Window.IsInstalled())
+            {
+                throw new global::System.InvalidOperationException("This API called from separate thread. This API must be called from MainThread.");
+            }
+
+            if (isDisposeQueued)
+            {
+                Dispose(DisposeTypes.Implicit);
+            }
+            else
+            {
+                Dispose(DisposeTypes.Explicit);
+                global::System.GC.SuppressFinalize(this);
+            }
+        }
+
+        /// <summary>
+        /// Dispose.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+            }
+
+            disposed = true;
         }
 
         private void InitSubstyle()

--- a/src/Tizen.NUI.Components/Style/SliderStyle.cs
+++ b/src/Tizen.NUI.Components/Style/SliderStyle.cs
@@ -271,6 +271,26 @@ namespace Tizen.NUI.Components
             }
         }
 
+        /// <summary>
+        /// Dispose SliderStyle and all children on it.
+        /// </summary>
+        /// <param name="type">Dispose type.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                trackPadding?.Dispose();
+            }
+
+            base.Dispose(type);
+        }
+
         private void InitSubStyle()
         {
             Track = new ImageViewStyle();

--- a/src/Tizen.NUI.Wearable/src/public/WearableStyle/CircularProgressStyle.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WearableStyle/CircularProgressStyle.cs
@@ -269,6 +269,27 @@ namespace Tizen.NUI.Wearable
             }
         }
 
+        /// <summary>
+        /// Dispose CircularProgressStyle and all children on it.
+        /// </summary>
+        /// <param name="type">Dispose type.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                trackColor?.Dispose();
+                progressColor?.Dispose();
+            }
+
+            base.Dispose(type);
+        }
+
         private void Initialize()
         {
             isEnabled = true;


### PR DESCRIPTION
IDisposable is implemented to class containing disposable class instance
in Tizen.NUI.Components and Tizen.NUI.Wearable to resolve CA1001 of
StyleCop.

Extension classes in Tizen.NUI.Components are not included to this patch
because it has OnDispose() method similar to Dispose().

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
