### PR TITLE
[NUI] Fix not to dispose LayoutManager in FlexibleView

### DIFF
--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
@@ -449,7 +449,7 @@ namespace Tizen.NUI.Components
                 if (mLayout != null)
                 {
                     mLayout.StopScroll(false);
-                    mLayout.Dispose();
+                    mLayout.ClearRecyclerView();
                     mLayout = null;
                 }
 

--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleViewLayoutManager.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleViewLayoutManager.cs
@@ -739,6 +739,12 @@ namespace Tizen.NUI.Components
             mChildHelper = recyclerView.GetChildHelper();
         }
 
+        internal void ClearRecyclerView()
+        {
+            mFlexibleView = null;
+            mChildHelper = null;
+        }
+
         internal void StopScroll(bool doSomethingAfterAnimationStopped)
         {
             if (mScrollAni != null && mScrollAni.State == Animation.States.Playing)


### PR DESCRIPTION
Since LayoutManager handle mLayout is not constructed by FlexibleView,
mLayout is not disposed but its member handles are cleared.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
