### PR TITLE
[Bluetooth][Non-ACR] Fix LeDevice constructor exception issue

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGatt.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothGatt.cs
@@ -359,7 +359,6 @@ namespace Tizen.Network.Bluetooth
             if (ret != (int)BluetoothError.None)
             {
                 Log.Error(Globals.LogTag, "Failed to set gatt connection state changed callback, Error - " + (BluetoothError)ret);
-                BluetoothErrorFactory.ThrowBluetoothException(ret);
             }
         }
 
@@ -369,7 +368,6 @@ namespace Tizen.Network.Bluetooth
             if (ret != (int)BluetoothError.None)
             {
                 Log.Error(Globals.LogTag, "Failed to unset gatt connection state changed callback, Error - " + (BluetoothError)ret);
-                BluetoothErrorFactory.ThrowBluetoothException(ret);
             }
         }
 


### PR DESCRIPTION
Exception is occured on BluetoothLeDevice constructor if GATT not supported.
BluetoothGattClient.StaticConnectionStateChanged += (s, e) =>
Remove exception throw logic on the event handler StaticConnectionStateChanged for consistency

Signed-off-by: Wootak Jung <wootak.jung@samsung.com>