### PR TITLE
[NUI] Fix to not reset IsSelected on pressed

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -109,22 +109,14 @@ namespace Tizen.NUI.Components
 
             if (isEnabled)
             {
-                if (isPressed)
-                {
-                    // Pressed
-                    targetState = ControlStates.Pressed;
-                }
-                else
-                {
-                    // Normal
-                    targetState = ControlStates.Normal;
+                // Normal
+                targetState = ControlStates.Normal;
 
-                    // Selected
-                    targetState |= (IsSelected ? ControlStates.Selected : 0);
+                // Selected
+                targetState |= (IsSelected ? ControlStates.Selected : 0);
 
-                    // Focused, SelectedFocused
-                    targetState |= (IsFocused ? ControlStates.Focused : 0);
-                }
+                // Pressed, PressedSelected, Focused, SelectedFocused
+                targetState |= (isPressed ? ControlStates.Pressed : (IsFocused ? ControlStates.Focused : 0));
             }
             else
             {


### PR DESCRIPTION
### Description of Change ###
IsSelected in Button was reset to "false", since "target" state is only set with Pressed without any consideration on current IsSelected value.
(You can easily check the issue by clicking twice CheckBox control. It's never be unselected.)

I just reverted back some logics in UpdateState. If other modifications are needed, please give me feedback.


