### PR TITLE
[NUI] Fix Button state issue

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -363,13 +363,6 @@ namespace Tizen.NUI.Components
                 isEnabled = stateEnabled;
             }
 
-            var stateSelected = (controlStateChangedInfo.CurrentState & ControlStates.Selected) == ControlStates.Selected;
-
-            if (isSelected != stateSelected)
-            {
-                isSelected = stateSelected;
-            }
-
             var statePressed = (controlStateChangedInfo.CurrentState & ControlStates.Pressed) == ControlStates.Pressed;
 
             if (isPressed != statePressed)


### PR DESCRIPTION
* This fixes the issue that a checkbox selection can not be unselected.
* Note that this is temporary solution, it need to be fixed after
  the Selector priovides priority among the states.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
