### PR TITLE
[NUI] Restore setter of LayoutManager property to public

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
@@ -182,12 +182,12 @@ namespace Tizen.NUI.Components
             {
                 return layoutManager;
             }
-            protected set
+            set
             {
-                LayoutManager = value;
-                LayoutManager.Container = ContentContainer;
-                LayoutManager.ItemSize = Adapter.CreateRecycleItem().Size;
-                LayoutManager.DataCount = Adapter.Data.Count;
+                layoutManager = value;
+                layoutManager.Container = ContentContainer;
+                layoutManager.ItemSize = adapter.CreateRecycleItem().Size;
+                layoutManager.DataCount = adapter.Data.Count;
                 InitializeItems();
             }
         }


### PR DESCRIPTION
### Description of Change ###
Restore LayoutManager property to public because user needs public setter to set
LayoutManager.

### API Changes ##
NONE