### PR TITLE
[Applications] Add app manager attach/detach window API for internal

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.ApplicationManager.cs
@@ -188,6 +188,14 @@ internal static partial class Interop
         internal static extern ErrorCode AppManagerGetAppContextByInstanceId(string applicationId, string instanceId, out IntPtr handle);
         //int app_manager_get_app_context_by_instance_id (const char *app_id, const char *instance_id, app_context_h *app_context);
 
+        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_attach_window")]
+        internal static extern ErrorCode AppManagerAttachWindow(string parentAppId, string childAppId);
+        //int app_manager_attach_window(const char *parent_app_id, const char *child_app_id);
+
+        [DllImport(Libraries.AppManager, EntryPoint = "app_manager_detach_window")]
+        internal static extern ErrorCode AppManagerDetachWindow(string applicationId);
+        //int app_manager_detach_window(const char *app_id);
+
         [DllImport(Libraries.AppManager, EntryPoint = "app_context_destroy")]
         internal static extern ErrorCode AppContextDestroy(IntPtr handle);
         //int app_context_destroy(app_context_h app_context)

--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
@@ -559,6 +559,75 @@ namespace Tizen.Applications
 
             return result;
         }
+
+        /// <summary>
+        /// Attaches the window of the child application to the window of the parent application.
+        /// </summary>
+        /// <remarks>
+        /// This method is only available for platform level signed applications.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when failed because of permission denied.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AttachWindow(string parentAppId, string childAppId)
+        {
+            Interop.ApplicationManager.ErrorCode err = Interop.ApplicationManager.ErrorCode.None;
+
+            err = Interop.ApplicationManager.AppManagerAttachWindow(parentAppId, childAppId);
+            if (err != Interop.ApplicationManager.ErrorCode.None)
+            {
+                switch (err)
+                {
+                    case Interop.ApplicationManager.ErrorCode.InvalidParameter:
+                        throw new ArgumentException("Invalid argument.");
+                    case Interop.ApplicationManager.ErrorCode.PermissionDenied:
+                        throw new UnauthorizedAccessException("Permission denied.");
+                    case Interop.ApplicationManager.ErrorCode.IoError:
+                        throw new InvalidOperationException("IO error at unmanaged code.");
+                    case Interop.ApplicationManager.ErrorCode.OutOfMemory:
+                        throw new InvalidOperationException("Out-of-memory at unmanaged code.");
+                    case Interop.ApplicationManager.ErrorCode.NoSuchApp:
+                        throw new InvalidOperationException("No such application.");
+                }
+            }
+
+        }
+
+        /// <summary>
+        /// Detaches the window of the application from its parent window.
+        /// </summary>
+        /// <remarks>
+        /// This method is only available for platform level signed applications.
+        /// </remarks>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when failed because of permission denied.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DetachWindow(string applicationId)
+        {
+            Interop.ApplicationManager.ErrorCode err = Interop.ApplicationManager.ErrorCode.None;
+
+            err = Interop.ApplicationManager.AppManagerDetachWindow(applicationId);
+            if (err != Interop.ApplicationManager.ErrorCode.None)
+            {
+                switch (err)
+                {
+                    case Interop.ApplicationManager.ErrorCode.InvalidParameter:
+                        throw new ArgumentException("Invalid argument.");
+                    case Interop.ApplicationManager.ErrorCode.PermissionDenied:
+                        throw new UnauthorizedAccessException("Permission denied.");
+                    case Interop.ApplicationManager.ErrorCode.IoError:
+                        throw new InvalidOperationException("IO error at unmanaged code.");
+                    case Interop.ApplicationManager.ErrorCode.OutOfMemory:
+                        throw new InvalidOperationException("Out-of-memory at unmanaged code.");
+                    case Interop.ApplicationManager.ErrorCode.NoSuchApp:
+                        throw new InvalidOperationException("No such application.");
+                }
+            }
+        }
     }
 
     internal static class FilterExtension


### PR DESCRIPTION
Signed-off-by: SukHyung, Kang <shine.kang@samsung.com>

### Description of Change ###
Add app manager attach/detach window API for internal


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: Non-ACR

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - public static void AttachWindow(string parentAppId, string childAppId)
 - public static void DetachWindow(string applicationId)

