### PR TITLE
[NUI] Remove non-touch related deprecated APIs

### DIFF
--- a/src/Tizen.NUI/src/internal/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application.cs
@@ -148,30 +148,6 @@ namespace Tizen.NUI
     }
 
     /**
-      * @brief Event arguments that passed via NUIApplicationResize signal
-      *
-      */
-    internal class NUIApplicationResizedEventArgs : EventArgs
-    {
-        private Application _application;
-        /**
-          * @brief Application - is the application that is being Resized
-          *
-          */
-        public Application Application
-        {
-            get
-            {
-                return _application;
-            }
-            set
-            {
-                _application = value;
-            }
-        }
-    }
-
-    /**
       * @brief Event arguments that passed via NUIApplicationLanguageChanged signal
       *
       */
@@ -501,11 +477,6 @@ namespace Tizen.NUI
                 this.ResetSignal().Disconnect(_applicationResetEventCallbackDelegate);
             }
 
-            if (_applicationResizeEventCallbackDelegate != null)
-            {
-                this.ResizeSignal().Disconnect(_applicationResizeEventCallbackDelegate);
-            }
-
             if (_applicationLanguageChangedEventCallbackDelegate != null)
             {
                 this.LanguageChangedSignal().Disconnect(_applicationLanguageChangedEventCallbackDelegate);
@@ -580,11 +551,6 @@ namespace Tizen.NUI
         private delegate void NUIApplicationResetEventCallbackDelegate(IntPtr application);
         private DaliEventHandler<object, NUIApplicationResetEventArgs> _applicationResetEventHandler;
         private NUIApplicationResetEventCallbackDelegate _applicationResetEventCallbackDelegate;
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void NUIApplicationResizeEventCallbackDelegate(IntPtr application);
-        private DaliEventHandler<object, NUIApplicationResizedEventArgs> _applicationResizeEventHandler;
-        private NUIApplicationResizeEventCallbackDelegate _applicationResizeEventCallbackDelegate;
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void NUIApplicationLanguageChangedEventCallbackDelegate(IntPtr application);
@@ -849,52 +815,6 @@ namespace Tizen.NUI
                 NUIApplicationResetEventArgs e = new NUIApplicationResetEventArgs();
                 e.Application = this;
                 _applicationResetEventHandler.Invoke(this, e);
-            }
-        }
-
-        /**
-          * @brief Event for Resized signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. Resized signal is emitted when application is resized
-          */
-        public event DaliEventHandler<object, NUIApplicationResizedEventArgs> Resized
-        {
-            add
-            {
-                lock (this)
-                {
-                    // Restricted to only one listener
-                    if (_applicationResizeEventHandler == null)
-                    {
-                        _applicationResizeEventHandler += value;
-
-                        _applicationResizeEventCallbackDelegate = new NUIApplicationResizeEventCallbackDelegate(OnNUIApplicationResize);
-                        this.ResizeSignal().Connect(_applicationResizeEventCallbackDelegate);
-                    }
-                }
-            }
-
-            remove
-            {
-                lock (this)
-                {
-                    if (_applicationResizeEventHandler != null)
-                    {
-                        this.ResizeSignal().Disconnect(_applicationResizeEventCallbackDelegate);
-                    }
-
-                    _applicationResizeEventHandler -= value;
-                }
-            }
-        }
-
-        // Callback for Application ResizeSignal
-        private void OnNUIApplicationResize(IntPtr data)
-        {
-            if (_applicationResizeEventHandler != null)
-            {
-                NUIApplicationResizedEventArgs e = new NUIApplicationResizedEventArgs();
-                e.Application = this;
-                _applicationResizeEventHandler.Invoke(this, e);
             }
         }
 
@@ -1361,12 +1281,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        public void ReplaceWindow(Rectangle windowPosition, string name)
-        {
-            Interop.Application.Application_ReplaceWindow(swigCPtr, Rectangle.getCPtr(windowPosition), name);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         public static string GetResourcePath()
         {
             string ret = Interop.Application.Application_GetResourcePath();
@@ -1438,13 +1352,6 @@ namespace Tizen.NUI
         internal ApplicationSignal ResetSignal()
         {
             ApplicationSignal ret = new ApplicationSignal(NDalicPINVOKE.Application_ResetSignal(swigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal ApplicationSignal ResizeSignal()
-        {
-            ApplicationSignal ret = new ApplicationSignal(NDalicPINVOKE.Application_ResizeSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
@@ -29,9 +29,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ActorSignal")]
             public static extern void delete_ActorSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TouchedSignal")]
-            public static extern global::System.IntPtr Actor_TouchedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_TouchSignal")]
             public static extern global::System.IntPtr Actor_TouchSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
@@ -63,9 +63,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetWindowHandleFromNUI")]
             public static extern global::System.IntPtr Application_GetWindowHandleFromNUI(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_ReplaceWindow")]
-            public static extern void Application_ReplaceWindow(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, string jarg3);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetResourcePath")]
             public static extern string Application_GetResourcePath();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalic.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalic.cs
@@ -289,9 +289,6 @@ namespace Tizen.NUI
     
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WrapActorConstraint")]
             public static extern void WrapActorConstraint(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-           
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DEFAULT_RENDERING_BACKEND_get")]
-            public static extern uint DEFAULT_RENDERING_BACKEND_get();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PushButton.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PushButton.cs
@@ -11,15 +11,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PushButton_SWIGUpcast")]
             public static extern global::System.IntPtr PushButton_SWIGUpcast(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PushButton_Property_UNSELECTED_ICON_get")]
-            public static extern int PushButton_Property_UNSELECTED_ICON_get();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PushButton_Property_SELECTED_ICON_get")]
-            public static extern int PushButton_Property_SELECTED_ICON_get();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PushButton_Property_ICON_ALIGNMENT_get")]
-            public static extern int PushButton_Property_ICON_ALIGNMENT_get();
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PushButton_Property_LABEL_PADDING_get")]
             public static extern int PushButton_Property_LABEL_PADDING_get();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -8,9 +8,6 @@ namespace Tizen.NUI
     {
         internal static partial class TextEditor
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_RENDERING_BACKEND_get")]
-            public static extern int TextEditor_Property_RENDERING_BACKEND_get();
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_TEXT_get")]
             public static extern int TextEditor_Property_TEXT_get();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -8,9 +8,6 @@ namespace Tizen.NUI
     {
         internal static partial class TextField
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_RENDERING_BACKEND_get")]
-            public static extern int TextField_Property_RENDERING_BACKEND_get();
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_TEXT_get")]
             public static extern int TextField_Property_TEXT_get();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -8,9 +8,6 @@ namespace Tizen.NUI
     {
         internal static partial class TextLabel
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDERING_BACKEND_get")]
-            public static extern int TextLabel_Property_RENDERING_BACKEND_get();
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_get")]
             public static extern int TextLabel_Property_TEXT_get();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewImplSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewImplSignal.cs
@@ -104,18 +104,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnInitializeSwigExplicitViewImpl")]
             public static extern void ViewImpl_OnInitializeSwigExplicitViewImpl(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnControlChildAdd")]
-            public static extern void ViewImpl_OnControlChildAdd(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnControlChildAddSwigExplicitViewImpl")]
-            public static extern void ViewImpl_OnControlChildAddSwigExplicitViewImpl(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnControlChildRemove")]
-            public static extern void ViewImpl_OnControlChildRemove(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnControlChildRemoveSwigExplicitViewImpl")]
-            public static extern void ViewImpl_OnControlChildRemoveSwigExplicitViewImpl(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnStyleChange")]
             public static extern void ViewImpl_OnStyleChange(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowFocusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowFocusSignalType.cs
@@ -21,7 +21,7 @@ namespace Tizen.NUI
             public static extern void WindowFocusSignalType_Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowFocusSignalType_Emit")]
-            public static extern void WindowFocusSignalType_Emit(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            public static extern void WindowFocusSignalType_Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, bool focusIn);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowFocusSignalType")]
             public static extern global::System.IntPtr new_WindowFocusSignalType();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowInternal.cs
@@ -8,15 +8,6 @@ namespace Tizen.NUI
     {
         internal static partial class WindowInternal
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_ShowIndicator")]
-            public static extern void Window_ShowIndicator(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetIndicatorBgOpacity")]
-            public static extern void Window_SetIndicatorBgOpacity(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RotateIndicator")]
-            public static extern void Window_RotateIndicator(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetNativeHandle")]
             public static extern global::System.IntPtr Window_GetNativeHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
         }

--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -253,9 +253,6 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_ResetSignal")]
         public static extern global::System.IntPtr Application_ResetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_ResizeSignal")]
-        public static extern global::System.IntPtr Application_ResizeSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
-
         [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_AppControlSignal")]
         public static extern global::System.IntPtr Application_AppControlSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/internal/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewImpl.cs
@@ -371,18 +371,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        public virtual void OnControlChildAdd(View child)
-        {
-            if (SwigDerivedClassHasMethod("OnControlChildAdd", swigMethodTypes22)) Interop.ViewImplSignal.ViewImpl_OnControlChildAddSwigExplicitViewImpl(swigCPtr, View.getCPtr(child)); else Interop.ViewImplSignal.ViewImpl_OnControlChildAdd(swigCPtr, View.getCPtr(child));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        public virtual void OnControlChildRemove(View child)
-        {
-            if (SwigDerivedClassHasMethod("OnControlChildRemove", swigMethodTypes23)) Interop.ViewImplSignal.ViewImpl_OnControlChildRemoveSwigExplicitViewImpl(swigCPtr, View.getCPtr(child)); else Interop.ViewImplSignal.ViewImpl_OnControlChildRemove(swigCPtr, View.getCPtr(child));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         public virtual void OnStyleChange(StyleManager styleManager, StyleChangeType change)
         {
             if (SwigDerivedClassHasMethod("OnStyleChange", swigMethodTypes24)) Interop.ViewImplSignal.ViewImpl_OnStyleChangeSwigExplicitViewImpl(swigCPtr, StyleManager.getCPtr(styleManager), (int)change); else Interop.ViewImplSignal.ViewImpl_OnStyleChange(swigCPtr, StyleManager.getCPtr(styleManager), (int)change);
@@ -538,10 +526,6 @@ namespace Tizen.NUI
                 swigDelegate20 = new SwigDelegateViewImpl_20(SwigDirectorOnLayoutNegotiated);
             if (SwigDerivedClassHasMethod("OnInitialize", swigMethodTypes21))
                 swigDelegate21 = new SwigDelegateViewImpl_21(SwigDirectorOnInitialize);
-            if (SwigDerivedClassHasMethod("OnControlChildAdd", swigMethodTypes22))
-                swigDelegate22 = new SwigDelegateViewImpl_22(SwigDirectorOnControlChildAdd);
-            if (SwigDerivedClassHasMethod("OnControlChildRemove", swigMethodTypes23))
-                swigDelegate23 = new SwigDelegateViewImpl_23(SwigDirectorOnControlChildRemove);
             if (SwigDerivedClassHasMethod("OnStyleChange", swigMethodTypes24))
                 swigDelegate24 = new SwigDelegateViewImpl_24(SwigDirectorOnStyleChange);
             if (SwigDerivedClassHasMethod("OnAccessibilityActivated", swigMethodTypes25))
@@ -713,24 +697,6 @@ namespace Tizen.NUI
         private void SwigDirectorOnInitialize()
         {
             OnInitialize();
-        }
-
-        private void SwigDirectorOnControlChildAdd(global::System.IntPtr child)
-        {
-            View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
-            {
-                OnControlChildAdd(view);
-            }
-        }
-
-        private void SwigDirectorOnControlChildRemove(global::System.IntPtr child)
-        {
-            View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
-            {
-                OnControlChildRemove(view);
-            }
         }
 
         private void SwigDirectorOnStyleChange(global::System.IntPtr styleManager, int change)

--- a/src/Tizen.NUI/src/internal/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewWrapperImpl.cs
@@ -64,10 +64,6 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public delegate void OnLayoutNegotiatedDelegate(float size, DimensionType dimension);
         /// <since_tizen> 3 </since_tizen>
-        public delegate void OnControlChildAddDelegate(View child);
-        /// <since_tizen> 3 </since_tizen>
-        public delegate void OnControlChildRemoveDelegate(View child);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void OnStyleChangeDelegate(StyleManager styleManager, StyleChangeType change);
         /// <since_tizen> 3 </since_tizen>
         public delegate bool OnAccessibilityActivatedDelegate();
@@ -119,8 +115,6 @@ namespace Tizen.NUI
         public new RelayoutDependentOnChildrenDelegate RelayoutDependentOnChildren;
         public new OnCalculateRelayoutSizeDelegate OnCalculateRelayoutSize;
         public new OnLayoutNegotiatedDelegate OnLayoutNegotiated;
-        public new OnControlChildAddDelegate OnControlChildAdd;
-        public new OnControlChildRemoveDelegate OnControlChildRemove;
         public new OnStyleChangeDelegate OnStyleChange;
         public new OnAccessibilityActivatedDelegate OnAccessibilityActivated;
         public new OnAccessibilityPanDelegate OnAccessibilityPan;
@@ -287,8 +281,6 @@ namespace Tizen.NUI
             Delegate19 = new DelegateViewWrapperImpl_19(DirectorOnCalculateRelayoutSize);
             Delegate20 = new DelegateViewWrapperImpl_20(DirectorOnLayoutNegotiated);
             Delegate21 = new DelegateViewWrapperImpl_21(DirectorOnInitialize);
-            Delegate22 = new DelegateViewWrapperImpl_22(DirectorOnControlChildAdd);
-            Delegate23 = new DelegateViewWrapperImpl_23(DirectorOnControlChildRemove);
             Delegate24 = new DelegateViewWrapperImpl_24(DirectorOnStyleChange);
             Delegate25 = new DelegateViewWrapperImpl_25(DirectorOnAccessibilityActivated);
             Delegate26 = new DelegateViewWrapperImpl_26(DirectorOnAccessibilityPan);
@@ -443,27 +435,6 @@ namespace Tizen.NUI
 
         private void DirectorOnInitialize()
         {
-        }
-
-        private void DirectorOnControlChildAdd(global::System.IntPtr child)
-        {
-            View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
-            {
-                if (null != OnControlChildAdd)
-                {
-                    OnControlChildAdd(view);
-                }
-            }
-        }
-
-        private void DirectorOnControlChildRemove(global::System.IntPtr child)
-        {
-            View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
-            {
-                OnControlChildRemove(view);
-            }
         }
 
         private void DirectorOnStyleChange(global::System.IntPtr styleManager, int change)

--- a/src/Tizen.NUI/src/internal/WindowFocusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/WindowFocusSignalType.cs
@@ -62,9 +62,9 @@ namespace Tizen.NUI
             }
         }
 
-        public void Emit(bool arg)
+        public void Emit(Window window, bool focusIn)
         {
-            Interop.WindowFocusSignalType.WindowFocusSignalType_Emit(swigCPtr, arg);
+            Interop.WindowFocusSignalType.WindowFocusSignalType_Emit(swigCPtr, Window.getCPtr(window), focusIn);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -732,15 +732,6 @@ namespace Tizen.NUI.BaseComponents
             viewWrapperImpl.EmitFocusSignal(focusGained);
         }
 
-
-        private void OnControlChildAdd(View child)
-        {
-        }
-
-        private void OnControlChildRemove(View child)
-        {
-        }
-
         private void Initialize()
         {
             // Registering CustomView virtual functions to viewWrapperImpl delegates.
@@ -765,8 +756,6 @@ namespace Tizen.NUI.BaseComponents
             viewWrapperImpl.RelayoutDependentOnChildren = new ViewWrapperImpl.RelayoutDependentOnChildrenDelegate(RelayoutDependentOnChildren);
             viewWrapperImpl.OnCalculateRelayoutSize = new ViewWrapperImpl.OnCalculateRelayoutSizeDelegate(OnCalculateRelayoutSize);
             viewWrapperImpl.OnLayoutNegotiated = new ViewWrapperImpl.OnLayoutNegotiatedDelegate(OnLayoutNegotiated);
-            viewWrapperImpl.OnControlChildAdd = new ViewWrapperImpl.OnControlChildAddDelegate(OnControlChildAdd);
-            viewWrapperImpl.OnControlChildRemove = new ViewWrapperImpl.OnControlChildRemoveDelegate(OnControlChildRemove);
             viewWrapperImpl.OnStyleChange = new ViewWrapperImpl.OnStyleChangeDelegate(OnStyleChange);
             viewWrapperImpl.OnAccessibilityActivated = new ViewWrapperImpl.OnAccessibilityActivatedDelegate(OnAccessibilityActivated);
             viewWrapperImpl.OnAccessibilityPan = new ViewWrapperImpl.OnAccessibilityPanDelegate(OnAccessibilityPan);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1191,7 +1191,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal new class Property
         {
-            internal static readonly int RENDERING_BACKEND = Interop.TextEditor.TextEditor_Property_RENDERING_BACKEND_get();
             internal static readonly int TEXT = Interop.TextEditor.TextEditor_Property_TEXT_get();
             internal static readonly int TEXT_COLOR = Interop.TextEditor.TextEditor_Property_TEXT_COLOR_get();
             internal static readonly int FONT_FAMILY = Interop.TextEditor.TextEditor_Property_FONT_FAMILY_get();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1358,7 +1358,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal new class Property
         {
-            internal static readonly int RENDERING_BACKEND = Interop.TextField.TextField_Property_RENDERING_BACKEND_get();
             internal static readonly int TEXT = Interop.TextField.TextField_Property_TEXT_get();
             internal static readonly int PLACEHOLDER_TEXT = Interop.TextField.TextField_Property_PLACEHOLDER_TEXT_get();
             internal static readonly int PLACEHOLDER_TEXT_FOCUSED = Interop.TextField.TextField_Property_PLACEHOLDER_TEXT_FOCUSED_get();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -1053,7 +1053,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal new class Property
         {
-            internal static readonly int RENDERING_BACKEND = Interop.TextLabel.TextLabel_Property_RENDERING_BACKEND_get();
             internal static readonly int TEXT = Interop.TextLabel.TextLabel_Property_TEXT_get();
             internal static readonly int FONT_FAMILY = Interop.TextLabel.TextLabel_Property_FONT_FAMILY_get();
             internal static readonly int FONT_STYLE = Interop.TextLabel.TextLabel_Property_FONT_STYLE_get();

--- a/src/Tizen.NUI/src/public/UIComponents/PushButton.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/PushButton.cs
@@ -129,9 +129,6 @@ namespace Tizen.NUI.UIComponents
 
         internal new class Property
         {
-            internal static readonly int UNSELECTED_ICON = Interop.PushButton.PushButton_Property_UNSELECTED_ICON_get();
-            internal static readonly int SELECTED_ICON = Interop.PushButton.PushButton_Property_SELECTED_ICON_get();
-            internal static readonly int ICON_ALIGNMENT = Interop.PushButton.PushButton_Property_ICON_ALIGNMENT_get();
             internal static readonly int LABEL_PADDING = Interop.PushButton.PushButton_Property_LABEL_PADDING_get();
             internal static readonly int ICON_PADDING = Interop.PushButton.PushButton_Property_ICON_PADDING_get();
         }

--- a/src/Tizen.NUI/src/public/Window.cs
+++ b/src/Tizen.NUI/src/public/Window.cs
@@ -203,26 +203,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Enumeration for opacity of the indicator.
-        /// </summary>
-        internal enum IndicatorBackgroundOpacity
-        {
-            Opaque = 100,
-            Translucent = 50,
-            Transparent = 0
-        }
-
-        /// <summary>
-        /// Enumeration for visible mode of the indicator.
-        /// </summary>
-        internal enum IndicatorVisibleMode
-        {
-            Invisible = 0,
-            Visible = 1,
-            Auto = 2
-        }
-
-        /// <summary>
         /// The stage instance property (read-only).<br />
         /// Gets the current window.<br />
         /// </summary>
@@ -1047,24 +1027,6 @@ namespace Tizen.NUI
             bool ret = Interop.Stage.Stage_IsInstalled();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
-        }
-
-        internal void ShowIndicator(Window.IndicatorVisibleMode visibleMode)
-        {
-            Interop.WindowInternal.Window_ShowIndicator(swigCPtr, (int)visibleMode);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        internal void SetIndicatorBackgroundOpacity(Window.IndicatorBackgroundOpacity opacity)
-        {
-            Interop.WindowInternal.Window_SetIndicatorBgOpacity(swigCPtr, (int)opacity);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        internal void RotateIndicator(Window.WindowOrientation orientation)
-        {
-            Interop.WindowInternal.Window_RotateIndicator(swigCPtr, (int)orientation);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
Remove some internal APIs after some deprecated APIs removed in DALi native code


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
