### PR TITLE
[NUI] Fix VisualMap.OutputVisualMap

### DIFF
--- a/src/Tizen.NUI/src/public/VisualMaps.cs
+++ b/src/Tizen.NUI/src/public/VisualMaps.cs
@@ -661,10 +661,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         protected virtual void ComposingPropertyMap()
         {
-            if (null == _outputVisualMap)
-            {
-                _outputVisualMap = new PropertyMap();
-            }
+            _outputVisualMap = new PropertyMap();
 
             if (_shader != null) { _outputVisualMap.Add(Visual.Property.Shader, new PropertyValue(_shader)); }
             if (_premultipliedAlpha != null) { _outputVisualMap.Add(Visual.Property.PremultipliedAlpha, new PropertyValue((bool)_premultipliedAlpha)); }
@@ -672,6 +669,13 @@ namespace Tizen.NUI
             if (_opacity != null) { _outputVisualMap.Add(Visual.Property.Opacity, new PropertyValue((float)_opacity)); }
             if (_visualFittingMode != null) { _outputVisualMap.Add(Visual.Property.VisualFittingMode, new PropertyValue((int)_visualFittingMode)); }
             if (_cornerRadius != null) { _outputVisualMap.Add(Visual.Property.CornerRadius, new PropertyValue((int)_cornerRadius)); }
+
+            var transformMap = OutputTransformMap;
+
+            if (!transformMap.Empty())
+            {
+                _outputVisualMap.Add(Visual.Property.Transform, new PropertyValue(transformMap));
+            }
         }
 
         private void ComposingTransformMap()


### PR DESCRIPTION
* Previously, VisualMap.OutputVisualMap returns a visual map without transform data.
  It causes misunderstanding frequently.
  Now it returns full visual map including transform data.
* Fix VisualMap.OutputVisualMap to create new PropertyMap everytime to
  prevent increasing map size.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
