### PR TITLE
[NUI] Fix ControlState equality issue.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
@@ -149,6 +149,11 @@ namespace Tizen.NUI.BaseComponents
 
             newState.stateList = newState.stateList.Distinct().ToList();
 
+            if (newState.stateList.Count == 1)
+            {
+                return newState.stateList[0];
+            }
+
             return newState;
         }
 


### PR DESCRIPTION
This patch fixes such code working well.
```
ControlState a = ControlState.Normal + ControlState.Selected;

a == ControlState.Selected; // This should be true.

```

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
