### PR TITLE
[NUI] Change wrong comment of PositionUsesPivotPoint

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -855,7 +855,7 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// Determines whether the pivot point should be used to determine the position of the view.
-        /// This is true by default.
+        /// This is false by default.
         /// </summary>
         /// <remarks>If false, then the top-left of the view is used for the position.
         /// Setting this to false will allow scaling or rotation around the pivot point without affecting the view's position.


### PR DESCRIPTION
### Description of Change ###
- Change wrong comment of PositionUsesPivotPoint.
- DALi native default is true, but NUI's default is false.

### API Changes ###
none