### PR TITLE
[NUI] Fix Switch selection bug.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -25,12 +25,6 @@ namespace Tizen.NUI.Components
         private StringSelector iconURLSelector = new StringSelector();
 
         /// <summary>
-        /// The last touch information triggering selected state change.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected Touch SelectionChangedByTouch { get; set; }
-
-        /// <summary>
         /// The ButtonExtension instance that is injected by ButtonStyle.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -107,35 +101,17 @@ namespace Tizen.NUI.Components
             ControlState sourceState = ControlState;
             ControlState targetState;
 
-            if (isEnabled)
-            {
-                if (isPressed)
-                {
-                    // Pressed
-                    targetState = ControlState.Pressed;
-                }
-                else
-                {
-                    // Normal
-                    targetState = ControlState.Normal;
+            // Normal, Disabled
+            targetState = IsEnabled ? ControlState.Normal : ControlState.Disabled;
 
-                    // Selected
-                    if (IsSelected) targetState += ControlState.Selected;
+            // Selected, DisabledSelected
+            if (IsSelected) targetState += ControlState.Selected;
 
-                    // Focused, SelectedFocused
-                    if (IsFocused) targetState += ControlState.Focused;
-                }
-            }
-            else
-            {
-                // Disabled
-                targetState = ControlState.Disabled;
+            // Pressed, PressedSelected
+            if (isPressed) targetState += ControlState.Pressed;
 
-                // DisabledSelected
-                if (IsSelected) targetState += ControlState.Selected;
-                // DisabledFocused
-                else if (IsFocused) targetState += ControlState.Focused;
-            }
+            // Focused, FocusedPressed, FocusedPressedSelected, DisabledFocused, DisabledSelectedFocused
+            if (IsFocused) targetState += ControlState.Focused;
 
             if (sourceState != targetState)
             {

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -645,7 +645,11 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public override bool OnKey(Key key)
         {
-            if (null == key) return false;
+            if (!IsEnabled || null == key)
+            {
+                return false;
+            }
+
             if (key.State == Key.StateType.Down)
             {
                 if (key.KeyPressedName == "Return")
@@ -710,7 +714,11 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public override bool OnTouch(Touch touch)
         {
-            if (null == touch) return false;
+            if (!IsEnabled || null == touch)
+            {
+                return false;
+            }
+
             PointStateType state = touch.GetState(0);
 
             switch (state)

--- a/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
@@ -36,16 +36,11 @@ namespace Tizen.NUI.Components.Extension
             slidingAnimation = new Animation(100);
         }
 
-        public override void OnClick(Button button, Button.ClickEventArgs eventArgs)
+        /// <inheritdoc/>
+        public override void OnSelectedChanged(Switch switchButton)
         {
-            if (button as Switch == null)
-            {
-                throw new Exception("SlidingSwitchExtension must be used within a SwitchStyle or derived class.");
-            }
-
-            var switchButton = (Switch)button;
-            var track = switchButton.GetCurrentTrack(this);
-            var thumb = switchButton.GetCurrentThumb(this);
+            var track = switchButton.Track;
+            var thumb = switchButton.Thumb;
 
             if (track == null || thumb == null || null == slidingAnimation)
             {

--- a/src/Tizen.NUI.Components/Controls/Extension/SwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SwitchExtension.cs
@@ -52,5 +52,14 @@ namespace Tizen.NUI.Components.Extension
         {
             return thumb;
         }
+
+        /// <summary>
+        /// Called when the Switch's selection has changed.
+        /// </summary>
+        /// <param name="switchButton">The Switch instance that the extension currently applied to.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual void OnSelectedChanged(Switch switchButton)
+        {
+        }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -273,18 +273,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public override bool OnKey(Key key)
         {
-            if (!IsEnabled || null == key) return false;
-
-            bool ret = base.OnKey(key);
-            if (key.State == Key.StateType.Up)
-            {
-                if (key.KeyPressedName == "Return")
-                {
-                    OnSelect();
-                }
-            }
-
-            return ret;
+            return base.OnKey(key);
         }
 
         /// <summary>
@@ -296,19 +285,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public override bool OnTouch(Touch touch)
         {
-            if(!IsEnabled || null == touch) return false;
-
-            PointStateType state = touch.GetState(0);
-            bool ret = base.OnTouch(touch);
-            switch (state)
-            {
-                case PointStateType.Up:
-                    OnSelect();
-                    break;
-                default:
-                    break;
-            }
-            return ret;
+            return base.OnTouch(touch);
         }
 
         /// <summary>
@@ -319,6 +296,25 @@ namespace Tizen.NUI.Components
         protected override ViewStyle CreateViewStyle()
         {
             return new SwitchStyle();
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnControlStateChanged(ControlStateChangedEventArgs controlStateChangedInfo)
+        {
+            base.OnControlStateChanged(controlStateChangedInfo);
+
+            if (!IsSelectable)
+            {
+                return;
+            }
+
+            bool previousSelected = controlStateChangedInfo.PreviousState.Contains(ControlState.Selected);
+
+            if (previousSelected != IsSelected)
+            {
+                OnSelect();
+            }
         }
 
         private void Initialize()
@@ -343,6 +339,8 @@ namespace Tizen.NUI.Components
 
         private void OnSelect()
         {
+            ((SwitchExtension)Extension)?.OnSelectedChanged(this);
+
             if (SelectedEvent != null)
             {
                 SelectEventArgs eventArgs = new SelectEventArgs();
@@ -360,34 +358,6 @@ namespace Tizen.NUI.Components
             /// <summary> Select state of Switch </summary>
             /// <since_tizen> 6 </since_tizen>
             public bool IsSelected;
-        }
-
-        /// <summary>
-        /// Get current track part to the attached SwitchExtension.
-        /// </summary>
-        /// <remarks>
-        /// It returns null if the passed extension is invaild.
-        /// </remarks>
-        /// <param name="extension">The extension instance that is currently attached to this Switch.</param>
-        /// <return>The switch's track part.</return>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ImageView GetCurrentTrack(SwitchExtension extension)
-        {
-            return (extension == Extension) ? Track : null;
-        }
-
-         /// <summary>
-        /// Get current thumb part to the attached SwitchExtension.
-        /// </summary>
-        /// <remarks>
-        /// It returns null if the passed extension is invaild.
-        /// </remarks>
-        /// <param name="extension">The extension instance that is currently attached to this Switch.</param>
-        /// <return>The switch's thumb part.</return>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ImageView GetCurrentThumb(SwitchExtension extension)
-        {
-            return (extension == Extension) ? Thumb : null;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -169,42 +169,29 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T GetValue(ControlState state)
         {
-            if(All != null)
+            if (All != null)
             {
                 return All;
             }
-            switch(state)
-            {
-                case null:
-                case var s when s == ControlState.Normal:
-                    return Normal != null? Normal : Other;
-                case var s when s == ControlState.Focused:
-                    return Focused != null? Focused : Other;
-                case var s when s == ControlState.Pressed:
-                    return Pressed != null? Pressed : Other;
-                case var s when s == ControlState.Disabled:
-                    return Disabled != null? Disabled : Other;
-                case var s when s == ControlState.Selected:
-                   return Selected != null? Selected : Other;
-                case var s when s == ControlState.DisabledFocused:
-                    return DisabledFocused != null? DisabledFocused : (Disabled != null ? Disabled : Other);
-                case var s when s == ControlState.DisabledSelected:
-                    return DisabledSelected != null ? DisabledSelected : (Disabled != null ? Disabled : Other);
-                case var s when s == ControlState.SelectedFocused:
-                    return SelectedFocused != null ? SelectedFocused : (Selected != null ? Selected : Other);
-                default:
-                {
-                    StateValuePair<T> value = Find(x => x.State == state);
-                    if (value.Value != null)
-                        return value.Value;
 
-                    value = Find(x => state.Contains(x.State));
-                    if (value.Value != null)
-                        return value.Value;
-                    return Other;
+            StateValuePair<T> value = Find(x => x.State == state);
+            if (value.Value != null)
+            {
+                return value.Value;
+            }
+
+            if (state.IsCombined)
+            {
+                value = Find(x => state.Contains(x.State));
+                if (value.Value != null)
+                {
+                    return value.Value;
                 }
             }
+
+            return Other;
         }
+
         /// <summary>
         /// Clone function.
         /// </summary>


### PR DESCRIPTION
Previously, when a Switch is selected by code, the thumb is not moved to left/right.
```
var switchButton = new Switch()
{
  IsSelected = true,
}
```
Thumb is moved only if the user touches the switch area or presses return key.

This patch fixes this problem and to do that, it needed to change belows,

* Switch does not listen Touch/Key event anymore to detect selection changed
  Instead it uses ControlState changed event which is clearer.
* Button produces more complicate combined state such as "SelectedPressed".
* Clean up the code that is redundant in Selector.GetValue().

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
