### PR TITLE
[NUI] Fix Position type converter error when Position get 2 parameters in XAML

### DIFF
--- a/src/Tizen.NUI/src/internal/XamlBinding/PositionTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/PositionTypeConverter.cs
@@ -59,6 +59,12 @@ namespace Tizen.NUI.Binding
                     int z = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[2].Trim());
                     return new Position(x, y, z);
                 }
+                else if (parts.Length == 2)
+                {
+                    int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
+                    int y = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
+                    return new Position(x, y);
+                }
             }
 
             throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Position)}");

--- a/src/Tizen.NUI/src/internal/XamlBinding/PositionTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/PositionTypeConverter.cs
@@ -54,15 +54,15 @@ namespace Tizen.NUI.Binding
                 parts = value.Split(',');
                 if (parts.Length == 3)
                 {
-                    int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
-                    int y = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
-                    int z = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[2].Trim());
+                    float x = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
+                    float y = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
+                    float z = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[2].Trim());
                     return new Position(x, y, z);
                 }
                 else if (parts.Length == 2)
                 {
-                    int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
-                    int y = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
+                    float x = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
+                    float y = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
                     return new Position(x, y);
                 }
             }

--- a/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
@@ -28,6 +28,12 @@ namespace Tizen.NUI.Binding
                     int z = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[2].Trim());
                     return new Size(x, y, z);
                 }
+                else if (parts.Length == 2)
+                {
+                    int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
+                    int y = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
+                    return new Size(x, y);
+                }
             }
 
             throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Size)}");

--- a/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
@@ -23,15 +23,15 @@ namespace Tizen.NUI.Binding
                 string[] parts = value.Split(',');
                 if (parts.Length == 3)
                 {
-                    int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
-                    int y = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
-                    int z = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[2].Trim());
+                    float x = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
+                    float y = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
+                    float z = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[2].Trim());
                     return new Size(x, y, z);
                 }
                 else if (parts.Length == 2)
                 {
-                    int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
-                    int y = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
+                    float x = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
+                    float y = GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[1].Trim());
                     return new Size(x, y);
                 }
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Fix Position type converter error when Position get 2 parameters in XAML

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
