### PR TITLE
[Build] Add tizen-arm64, tizen.6.0.0-arm64 RIDs to runtime.json

### DIFF
--- a/pkg/Tizen.NET/runtime.json
+++ b/pkg/Tizen.NET/runtime.json
@@ -17,6 +17,12 @@
         "linux-x86"
       ]
     },
+    "tizen-arm64": {
+      "#import": [
+        "tizen",
+        "linux-arm64"
+      ]
+    },
     "tizen.4.0.0": {
       "#import": [
         "tizen"
@@ -83,6 +89,12 @@
       "#import": [
         "tizen.6.0.0",
         "tizen.5.5.0-x86"
+      ]
+    },
+    "tizen.6.0.0-arm64": {
+      "#import": [
+        "tizen.6.0.0",
+        "tizen-arm64"
       ]
     }
   }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Add runtime identifiers for arm64

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
