### PR TITLE
[NUI] add exception code for NUIWidgetApplication

### DIFF
--- a/src/Tizen.NUI/src/public/NUIWidgetApplication.cs
+++ b/src/Tizen.NUI/src/public/NUIWidgetApplication.cs
@@ -18,6 +18,7 @@ using Tizen.Applications;
 using Tizen.Applications.CoreBackend;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System;
 
 namespace Tizen.NUI
 {
@@ -44,8 +45,15 @@ namespace Tizen.NUI
         /// <param name="widgetTypes">List of derived widget class type.</param>
         public NUIWidgetApplication(Dictionary<System.Type, string> widgetTypes) : base(new NUIWidgetCoreBackend())
         {
-            NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;
-            core?.RegisterWidgetInfo(widgetTypes);
+            if( widgetTypes == null )
+            {
+              throw new InvalidOperationException("Dictionary is null");
+            }
+            else
+            {
+                NUIWidgetCoreBackend core = Backend as NUIWidgetCoreBackend;
+                core?.RegisterWidgetInfo(widgetTypes);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
if application use null dictionary for creating NUIWidgetApplication,
we need to throw exception.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
