### PR TITLE
[NUI] Add public types to replace nested types of Components.Slider

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -44,6 +44,8 @@ namespace Tizen.NUI.Components
         private float currentSlidedOffset;
         private EventHandler<ValueChangedArgs> valueChangedHandler;
         private EventHandler<SlidingFinishedArgs> slidingFinishedHandler;
+        private EventHandler<SliderValueChangedEventArgs> sliderValueChangedHandler;
+        private EventHandler<SliderSlidingFinishedEventArgs> sliderSlidingFinishedHandler;
         private EventHandler<StateChangedArgs> stateChangedHandler;
 
         bool isFocused = false;
@@ -202,6 +204,13 @@ namespace Tizen.NUI.Components
                     SlidingFinishedArgs args = new SlidingFinishedArgs();
                     args.CurrentValue = curValue;
                     slidingFinishedHandler(this, args);
+                }
+
+                if (null != sliderSlidingFinishedHandler)
+                {
+                    SliderSlidingFinishedEventArgs args = new SliderSlidingFinishedEventArgs();
+                    args.CurrentValue = curValue;
+                    sliderSlidingFinishedHandler(this, args);
                 }
 
                 UpdateState(isFocused, false);

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -22,6 +22,32 @@ using Tizen.NUI.Binding;
 namespace Tizen.NUI.Components
 {
     /// <summary>
+    /// Slider value changed event data.
+    /// </summary>
+    /// <since_tizen> 8 </since_tizen>
+    public class SliderValueChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Current Slider value
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public float CurrentValue { get; set; }
+    }
+
+    /// <summary>
+    /// Slider sliding finished event data.
+    /// </summary>
+    /// <since_tizen> 8 </since_tizen>
+    public class SliderSlidingFinishedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Current Slider value
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public float CurrentValue { get; set; }
+    }
+
+    /// <summary>
     /// A slider lets users select a value from a continuous or discrete range of values by moving the slider thumb.
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
@@ -108,6 +134,7 @@ namespace Tizen.NUI.Components
         /// The value changed event handler.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use ValueChanged event instead.")]
         public event EventHandler<ValueChangedArgs> ValueChangedEvent
         {
             add
@@ -124,6 +151,7 @@ namespace Tizen.NUI.Components
         /// The sliding finished event handler.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SlidingFinished event instead.")]
         public event EventHandler<SlidingFinishedArgs> SlidingFinishedEvent
         {
             add
@@ -133,6 +161,38 @@ namespace Tizen.NUI.Components
             remove
             {
                 slidingFinishedHandler -= value;
+            }
+        }
+
+        /// <summary>
+        /// The value changed event handler.
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public event EventHandler<SliderValueChangedEventArgs> ValueChanged
+        {
+            add
+            {
+                sliderValueChangedHandler += value;
+            }
+            remove
+            {
+                sliderValueChangedHandler -= value;
+            }
+        }
+
+        /// <summary>
+        /// The sliding finished event handler.
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public event EventHandler<SliderSlidingFinishedEventArgs> SlidingFinished
+        {
+            add
+            {
+                sliderSlidingFinishedHandler += value;
+            }
+            remove
+            {
+                sliderSlidingFinishedHandler -= value;
             }
         }
 
@@ -830,6 +890,13 @@ namespace Tizen.NUI.Components
                 args.CurrentValue = curValue;
                 valueChangedHandler(this, args);
             }
+
+            if (sliderValueChangedHandler != null)
+            {
+                SliderValueChangedEventArgs args = new SliderValueChangedEventArgs();
+                args.CurrentValue = curValue;
+                sliderValueChangedHandler(this, args);
+            }
         }
 
         private bool OnTouchEventForBgTrack(object source, TouchEventArgs e)
@@ -845,6 +912,13 @@ namespace Tizen.NUI.Components
                     SlidingFinishedArgs args = new SlidingFinishedArgs();
                     args.CurrentValue = curValue;
                     slidingFinishedHandler(this, args);
+                }
+
+                if (null !=sliderSlidingFinishedHandler)
+                {
+                    SliderSlidingFinishedEventArgs args = new SliderSlidingFinishedEventArgs();
+                    args.CurrentValue = curValue;
+                    sliderSlidingFinishedHandler(this, args);
                 }
             }
             return false;
@@ -883,6 +957,13 @@ namespace Tizen.NUI.Components
                     ValueChangedArgs args = new ValueChangedArgs();
                     args.CurrentValue = curValue;
                     valueChangedHandler(this, args);
+                }
+
+                if (null != sliderValueChangedHandler)
+                {
+                    SliderValueChangedEventArgs args = new SliderValueChangedEventArgs();
+                    args.CurrentValue = curValue;
+                    sliderValueChangedHandler(this, args);
                 }
             }
         }
@@ -1000,12 +1081,14 @@ namespace Tizen.NUI.Components
         /// Value Changed event data.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderValueChangedEventArgs instead.")]
         public class ValueChangedArgs : EventArgs
         {
             /// <summary>
             /// Curren value
             /// </summary>
             /// <since_tizen> 6 </since_tizen>
+            [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderValueChangedEventArgs.CurrentValue instead.")]
             public float CurrentValue;
         }
 
@@ -1013,12 +1096,14 @@ namespace Tizen.NUI.Components
         /// Value Changed event data.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderSlidingFinishedEventArgs instead.")]
         public class SlidingFinishedArgs : EventArgs
         {
             /// <summary>
             /// Curren value
             /// </summary>
             /// <since_tizen> 6 </since_tizen>
+            [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderSlidingFinishedEventArgs.CurrentValue instead.")]
             public float CurrentValue;
         }
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SliderSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SliderSample.cs
@@ -249,8 +249,8 @@ namespace Tizen.NUI.Samples
             source.MinValue = MIN_VALUE;
             source.MaxValue = MAX_VALUE;
             source.StateChangedEvent += OnStateChanged;
-            source.ValueChangedEvent += OnValueChanged;
-            source.SlidingFinishedEvent += OnSlidingFinished;
+            source.ValueChanged += OnValueChanged;
+            source.SlidingFinished += OnSlidingFinished;
             source.Size = new Size(w, h);
             source.CurrentValue = curValue;
             return source;
@@ -266,14 +266,14 @@ namespace Tizen.NUI.Samples
             source.MinValue = MIN_VALUE;
             source.MaxValue = MAX_VALUE;
             source.StateChangedEvent += OnStateChanged;
-            source.ValueChangedEvent += OnValueChanged;
-            source.SlidingFinishedEvent += OnSlidingFinished;
+            source.ValueChanged += OnValueChanged;
+            source.SlidingFinished += OnSlidingFinished;
             source.Size = new Size(w, h);
             source.CurrentValue = curValue;
             return source;
         }
 
-        private void OnValueChanged(object sender, Slider.ValueChangedArgs args)
+        private void OnValueChanged(object sender, SliderValueChangedEventArgs args)
         {
             Slider source = sender as Slider;
             if (source != null)
@@ -289,7 +289,7 @@ namespace Tizen.NUI.Samples
             }
         }
 
-        private void OnSlidingFinished(object sender, Slider.SlidingFinishedArgs args)
+        private void OnSlidingFinished(object sender, SliderSlidingFinishedEventArgs args)
         {
             Slider source = sender as Slider;
             if (source != null)


### PR DESCRIPTION
To replace nested types (CA1034 of StyleCop), the followings are added.
- class SliderValueChangedEventArgs
- class SlidingFinishedEventArgs
- event EventHandler<SliderValueChangedEventArgs> in Slider class
- event EventHandler<SlidingFinishedEventArgs> in Slider class

The followings are deprecated.
- class ValueChangedArgs in Slider class
- class SlidingFinishedArgs in Slider class
- event EventHandler<ValueChangedArgs> in Slider class
- event EventHandler<SlidingFinishedArgs> in Slider class

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
