### PR TITLE
[NUI] Add public types to replace nested types of Components.Switch

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -66,7 +66,14 @@ namespace Tizen.NUI.Components
         /// An event for the item selected signal which can be used to subscribe or unsubscribe the event handler provided by the user.<br />
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SelectedChanged event instead.")]
         public event EventHandler<SelectEventArgs> SelectedEvent;
+
+        /// <summary>
+        /// An event for the item selected signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public event EventHandler<SelectedChangedEventArgs> SelectedChanged;
 
         /// <summary>
         /// Return a copied Style instance of Switch
@@ -334,12 +341,20 @@ namespace Tizen.NUI.Components
                 eventArgs.IsSelected = IsSelected;
                 SelectedEvent(this, eventArgs);
             }
+
+            if (SelectedChanged != null)
+            {
+                SelectedChangedEventArgs eventArgs = new SelectedChangedEventArgs();
+                eventArgs.IsSelected = IsSelected;
+                SelectedChanged(this, eventArgs);
+            }
         }
 
         /// <summary>
         /// SelectEventArgs is a class to record item selected arguments which will sent to user.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SelectedChangedEventArgs instead.")]
         public class SelectEventArgs : EventArgs
         {
             /// <summary> Select state of Switch </summary>


### PR DESCRIPTION
To replace nested types (CA1034 of StyleCop), the following is added.
- event EventHandler<SelectedChangedEventArgs> in Switch class

The followings are deprecated.
- class SelectEventArgs in Switch class
- event EventHandler<SelectEventArgs> in Switch class

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
