### PR TITLE
[NUI] Add public types to replace nested types of Components.Button

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -57,7 +57,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <param name="eventArgs">The click information.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual void OnClick(ClickEventArgs eventArgs)
+        protected virtual void OnClicked(ClickedEventArgs eventArgs)
         {
         }
 
@@ -367,12 +367,15 @@ namespace Tizen.NUI.Components
             LayoutChild();
         }
 
-        private void OnClickInternal(ClickEventArgs eventArgs)
+        private void OnClickedInternal(ClickedEventArgs eventArgs)
         {
             Command?.Execute(CommandParameter);
-            OnClick(eventArgs);
-            Extension?.OnClick(this, eventArgs);
-            ClickEvent?.Invoke(this, eventArgs);
+            OnClicked(eventArgs);
+            Extension?.OnClicked(this, eventArgs);
+
+            ClickEventArgs nestedEventArgs = new ClickEventArgs();
+            ClickEvent?.Invoke(this, nestedEventArgs);
+            Clicked?.Invoke(this, eventArgs);
         }
 
         private void OnIconRelayout(object sender, EventArgs e)

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -23,6 +23,14 @@ using Tizen.NUI.Components.Extension;
 namespace Tizen.NUI.Components
 {
     /// <summary>
+    /// ClickedEventArgs is a class to record button click event arguments which will sent to user.
+    /// </summary>
+    /// <since_tizen> 8 </since_tizen>
+    public class ClickedEventArgs : EventArgs
+    {
+    }
+
+    /// <summary>
     /// Button is one kind of common component, a button clearly describes what action will occur when the user selects it.
     /// Button may contain text or an icon.
     /// </summary>
@@ -172,7 +180,14 @@ namespace Tizen.NUI.Components
         /// An event for the button clicked signal which can be used to subscribe or unsubscribe the event handler provided by the user.<br />
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use Clicked event instead.")]
         public event EventHandler<ClickEventArgs> ClickEvent;
+
+        /// <summary>
+        /// An event for the button clicked signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public event EventHandler<ClickedEventArgs> Clicked;
 
         /// <summary>
         /// An event for the button state changed signal which can be used to subscribe or unsubscribe the event handler provided by the user.<br />
@@ -613,8 +628,8 @@ namespace Tizen.NUI.Components
 
                     if (clicked)
                     {
-                        ClickEventArgs eventArgs = new ClickEventArgs();
-                        OnClickInternal(eventArgs);
+                        ClickedEventArgs eventArgs = new ClickedEventArgs();
+                        OnClickedInternal(eventArgs);
                     }
                 }
             }
@@ -687,8 +702,8 @@ namespace Tizen.NUI.Components
 
                         if (clicked)
                         {
-                            ClickEventArgs eventArgs = new ClickEventArgs();
-                            OnClickInternal(eventArgs);
+                            ClickedEventArgs eventArgs = new ClickedEventArgs();
+                            OnClickedInternal(eventArgs);
                         }
 
                         return true;
@@ -736,6 +751,7 @@ namespace Tizen.NUI.Components
         /// ClickEventArgs is a class to record button click event arguments which will sent to user.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated in API8; Will be removed in API10. Please use ClickedEventArgs instead.")]
         public class ClickEventArgs : EventArgs
         {
         }

--- a/src/Tizen.NUI.Components/Controls/Extension/ButtonExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/ButtonExtension.cs
@@ -83,7 +83,7 @@ namespace Tizen.NUI.Components.Extension
         /// <param name="button">The Button instance that the extension currently applied to.</param>
         /// <param name="eventArgs">The click event information.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual void OnClick(Button button, Button.ClickEventArgs eventArgs)
+        public virtual void OnClicked(Button button, ClickedEventArgs eventArgs)
         {
         }
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AnimatedImageViewTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AnimatedImageViewTest.cs
@@ -149,13 +149,13 @@ namespace Tizen.NUI.Samples
             root.Add(box);
 
             box.image.SetValues();
-            box.but1.ClickEvent += But1_ClickEvent;
+            box.but1.Clicked += But1_Clicked;
             box.but1.Style.Text.Text = new Selector<string>
             {
                 Normal = "Pause !",
                 Selected = "Play !"
             };
-            box.but2.ClickEvent += But2_ClickEvent;
+            box.but2.Clicked += But2_Clicked;
             box.but2.Style.Text.Text = new Selector<string>
             {
                 Normal = "Stop !",
@@ -175,7 +175,7 @@ namespace Tizen.NUI.Samples
             box2.image.URLs = list;
             box2.image.Play();
 
-            box2.but1.ClickEvent += But1_ClickEvent1;
+            box2.but1.Clicked += But1_Clicked1;
             box2.but1.Style.Text.Text = new Selector<string>
             {
                 Normal = "Pause !",
@@ -189,7 +189,7 @@ namespace Tizen.NUI.Samples
             box2.but1.Style.Text.MultiLine = true;
 
 
-            box2.but2.ClickEvent += But2_ClickEvent1;
+            box2.but2.Clicked += But2_Clicked1;
             box2.but2.IsSelectable = false;
             box2.but2.Style.Text.Text = new Selector<string>
             {
@@ -197,7 +197,7 @@ namespace Tizen.NUI.Samples
                 Pressed = "Up 100ms",
             };
 
-            box2.but3.ClickEvent += But3_ClickEvent;
+            box2.but3.Clicked += But3_Clicked;
             box2.but3.IsSelectable = false;
             box2.but3.Style.Text.Text = new Selector<string>
             {
@@ -208,9 +208,9 @@ namespace Tizen.NUI.Samples
 
         }
 
-        private void But3_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void But3_Clicked(object sender, ClickedEventArgs e)
         {
-            tlog.Fatal(tag, $"But3_ClickEvent()!");
+            tlog.Fatal(tag, $"But3_Clicked()!");
             var src = sender as Button;
             if (src != null)
             {
@@ -220,9 +220,9 @@ namespace Tizen.NUI.Samples
             }
         }
 
-        private void But2_ClickEvent1(object sender, Button.ClickEventArgs e)
+        private void But2_Clicked1(object sender, ClickedEventArgs e)
         {
-            tlog.Fatal(tag, $"But2_ClickEvent1()!");
+            tlog.Fatal(tag, $"But2_Clicked1()!");
             var src = sender as Button;
             if (src != null)
             {
@@ -231,9 +231,9 @@ namespace Tizen.NUI.Samples
                 box2.status.Text = $"playing now,  frame delay: {box2.image.FrameDelay}ms,  loop count: {box2.image.LoopCount}";
             }
         }
-        private void But1_ClickEvent1(object sender, Button.ClickEventArgs e)
+        private void But1_Clicked1(object sender, ClickedEventArgs e)
         {
-            tlog.Fatal(tag, $"But1_ClickEvent1()!");
+            tlog.Fatal(tag, $"But1_Clicked1()!");
             var src = sender as Button;
             if (src != null)
             {
@@ -253,9 +253,9 @@ namespace Tizen.NUI.Samples
             }
         }
 
-        private void But2_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void But2_Clicked(object sender, ClickedEventArgs e)
         {
-            tlog.Fatal(tag, $"But2_ClickEvent()!");
+            tlog.Fatal(tag, $"But2_Clicked()!");
             var src = sender as Button;
             if (src != null)
             {
@@ -272,9 +272,9 @@ namespace Tizen.NUI.Samples
             }
         }
 
-        private void But1_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void But1_Clicked(object sender, ClickedEventArgs e)
         {
-            tlog.Fatal(tag, $"But1_ClickEvent()!");
+            tlog.Fatal(tag, $"But1_Clicked()!");
             var src = sender as Button;
             if (src != null)
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ButtonSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ButtonSample.cs
@@ -81,7 +81,7 @@ namespace Tizen.NUI.Samples
             iconButton.Size = new Size(80, 80);
             iconButton.Icon.ResourceUrl = CommonResource.GetTVResourcePath() + "component/c_radiobutton/c_radiobutton_white_check.png";
             parent2.Add(iconButton);
-            iconButton.ClickEvent += (ojb, e) => {
+            iconButton.Clicked += (ojb, e) => {
                 var btn = iconButton.Icon.GetParent() as Button;
                 string name = btn.Name;
             };

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CubeTransitionEffectSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CubeTransitionEffectSample.cs
@@ -128,7 +128,7 @@ namespace Tizen.NUI.Samples
             style.PivotPoint = PivotPoint.TopLeft;
             style.Size = new Size(58, 58);
             mSlideshowButton = new Button(style);
-            mSlideshowButton.ClickEvent += OnPushButtonClicked;
+            mSlideshowButton.Clicked += OnPushButtonClicked;
 
             mSlideshowButton.RaiseToTop();
 
@@ -240,7 +240,7 @@ namespace Tizen.NUI.Samples
             if (mSlideshowButton)
             {
                 tool_bar.Remove(mSlideshowButton);
-                mSlideshowButton.ClickEvent -= OnPushButtonClicked;
+                mSlideshowButton.Clicked -= OnPushButtonClicked;
                 mSlideshowButton.Dispose();
                 mSlideshowButton = null;
             }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/GridLayoutSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/GridLayoutSample.cs
@@ -118,8 +118,8 @@ namespace Tizen.NUI.Samples
                 Size = new Size(100, 50),
                 Margin = 10,
             };
-            btn_1.ClickEvent += Btn1_ClickEvent;
-            btn_2.ClickEvent += Btn2_ClickEvent;
+            btn_1.Clicked += Btn1_Clicked;
+            btn_2.Clicked += Btn2_Clicked;
 
             bottomView.Add(btn_1);
             bottomView.Add(btn_2);
@@ -149,14 +149,14 @@ namespace Tizen.NUI.Samples
                 Size = new Size(50, 50),
                 Margin = 10,
             };
-            btn_5.ClickEvent += Btn5_ClickEvent;
-            btn_6.ClickEvent += Btn6_ClickEvent;
+            btn_5.Clicked += Btn5_Clicked;
+            btn_6.Clicked += Btn6_Clicked;
 
             bottomView_2.Add(btn_5);
             bottomView_2.Add(btn_6);
         }
 
-        private void Btn1_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void Btn1_Clicked(object sender, ClickedEventArgs e)
         {
             GridLayout layout = new GridLayout();
             layout.Columns = 5;
@@ -166,7 +166,7 @@ namespace Tizen.NUI.Samples
             layout.LayoutWithTransition = true;
         }
 
-        private void Btn2_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void Btn2_Clicked(object sender, ClickedEventArgs e)
         {
             GridLayout layout = new GridLayout();
             layout.LayoutWithTransition = true;
@@ -177,12 +177,12 @@ namespace Tizen.NUI.Samples
             layoutOption = 2;
         }
 
-        private void Btn5_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void Btn5_Clicked(object sender, ClickedEventArgs e)
         {
             ObjectProcess(true);
         }
 
-        private void Btn6_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void Btn6_Clicked(object sender, ClickedEventArgs e)
         {
             ObjectProcess(false);
         }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ItemViewDemo/ItemViewSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ItemViewDemo/ItemViewSample.cs
@@ -488,7 +488,7 @@ namespace Tizen.NUI.Samples
             mEditButton.IsSelectable = true;
             mEditButton.Size = new Size(34, 34);
             mEditButton.LeaveRequired = true;
-            mEditButton.ClickEvent += (obj, e) =>
+            mEditButton.Clicked += (obj, e) =>
             {
                 SwitchToNextMode();
             };
@@ -522,7 +522,7 @@ namespace Tizen.NUI.Samples
             mLayoutButton.IsSelectable = true;
             mLayoutButton.Size = new Size(34, 34);
             mLayoutButton.LeaveRequired = true;
-            mLayoutButton.ClickEvent += (obj, e) =>
+            mLayoutButton.Clicked += (obj, e) =>
             {
                 mCurrentLayout = (mCurrentLayout + 1) % (int)mItemView.GetLayoutCount();
                 ChangeLayout();
@@ -573,7 +573,7 @@ namespace Tizen.NUI.Samples
             mDeleteButton.Size = new Size(50, 50);
             mDeleteButton.LeaveRequired = true;
             mDeleteButton.Hide();
-            mDeleteButton.ClickEvent += (obj, e) =>
+            mDeleteButton.Clicked += (obj, e) =>
             {
                 ItemIdContainer removeList = new ItemIdContainer();
                 for (uint i = 0; i < mItemView.GetChildCount(); ++i)
@@ -616,7 +616,7 @@ namespace Tizen.NUI.Samples
             mInsertButton.Size = new Size(50, 50);
             mInsertButton.LeaveRequired = true;
             mInsertButton.Hide();
-            mInsertButton.ClickEvent += (obj, e) =>
+            mInsertButton.Clicked += (obj, e) =>
             {
                 ItemContainer insertList = new ItemContainer();
                 Random random = new Random();
@@ -659,7 +659,7 @@ namespace Tizen.NUI.Samples
             mReplaceButton.Size = new Size(50, 50);
             mReplaceButton.LeaveRequired = true;
             mReplaceButton.Hide();
-            mReplaceButton.ClickEvent += (obj, e) =>
+            mReplaceButton.Clicked += (obj, e) =>
             {
                 ItemContainer replaceList = new ItemContainer();
                 Random random = new Random();

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LoadingSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LoadingSample.cs
@@ -115,7 +115,7 @@ namespace Tizen.NUI.Samples
             button[0].BackgroundColor = Color.Green;
             layout[0].Add(button[0]);
             button[0].Focusable = true;
-            button[0].ClickEvent += propFpsAdd;
+            button[0].Clicked += propFpsAdd;
             FocusManager.Instance.SetCurrentFocusView(button[0]);
 
             button[1] = new Button();
@@ -125,7 +125,7 @@ namespace Tizen.NUI.Samples
             button[1].BackgroundColor = Color.Green;
             layout[0].Add(button[1]);
             button[1].Focusable = true;
-            button[1].ClickEvent += propFpsMinus;
+            button[1].Clicked += propFpsMinus;
             FocusManager.Instance.SetCurrentFocusView(button[1]);
 
             gridLayout.Add(layout[0]);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PopupSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PopupSample.cs
@@ -225,7 +225,7 @@ namespace Tizen.NUI.Samples
             button.WidthSpecification = 580;
             button.HeightSpecification = 80;
             button.TextLabel.Text = "LayoutDirection is left to right";
-            button.ClickEvent += ButtonClickEvent;
+            button.Clicked += ButtonClicked;
 
             parent1.Add(parent2);
             parent1.Add(button);
@@ -278,7 +278,7 @@ namespace Tizen.NUI.Samples
             }
         }
 
-        private void ButtonClickEvent(object sender, Button.ClickEventArgs e)
+        private void ButtonClicked(object sender, ClickedEventArgs e)
         {
             if (popup.LayoutDirection == ViewLayoutDirectionType.LTR)
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ProgressSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ProgressSample.cs
@@ -127,7 +127,7 @@ namespace Tizen.NUI.Samples
             button[0].BackgroundColor = Color.Green;
             layout[2].Add(button[0]);
             button[0].Focusable = true;
-            button[0].ClickEvent += ProgressAdd;
+            button[0].Clicked += ProgressAdd;
 
             button[1] = new Button();
             button[1].WidthSpecification = 140;
@@ -136,7 +136,7 @@ namespace Tizen.NUI.Samples
             button[1].BackgroundColor = Color.Green;
             layout[2].Add(button[1]);
             button[1].Focusable = true;
-            button[1].ClickEvent += ProgressMinus;
+            button[1].Clicked += ProgressMinus;
         }
 
         private void CreateAttrElements()

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PropertyNotificationTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PropertyNotificationTest.cs
@@ -41,7 +41,7 @@ namespace Tizen.NUI.Samples
                 Name = "test button",
             };
 
-            button.ClickEvent += (object source, Button.ClickEventArgs args) =>
+            button.Clicked += (object source, ClickedEventArgs args) =>
             {
                 if (++cnt % 2 == 0)
                 {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollBarSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollBarSample.cs
@@ -144,16 +144,16 @@ namespace Tizen.NUI.Samples
             }
 
             button[0].Text = "+";
-            button[0].ClickEvent += Scroll1Add;
+            button[0].Clicked += Scroll1Add;
 
             button[1].Text = "-";
-            button[1].ClickEvent += Scroll1Minus;
+            button[1].Clicked += Scroll1Minus;
 
             button[2].Text = "+ / - 4";
-            button[2].ClickEvent += Scroll1_2move;
+            button[2].Clicked += Scroll1_2move;
 
             button[3].Text = "change direction";
-            button[3].ClickEvent += Scroll1_2Changed;
+            button[3].Clicked += Scroll1_2Changed;
             button[3].Size = new Size(180, 50);
 
             // Set focus to Add Button

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SiblingOrderTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SiblingOrderTest.cs
@@ -32,7 +32,7 @@ namespace Tizen.NUI.Samples
                 Position = new Position(10, H1 + 20),
                 Text = "add new child",
             };
-            b1.ClickEvent += B1_ClickEvent;
+            b1.Clicked += B1_Clicked;
             win.Add(b1);
 
             b2 = new Button()
@@ -41,7 +41,7 @@ namespace Tizen.NUI.Samples
                 Position = new Position(10, H1 + 20 + 120),
                 Text = "refresh sibling order",
             };
-            b2.ClickEvent += B2_ClickEvent;
+            b2.Clicked += B2_Clicked;
             win.Add(b2);
 
             b3 = new Button()
@@ -50,7 +50,7 @@ namespace Tizen.NUI.Samples
                 Position = new Position(10, H1 + 20 + 120 + 120),
                 Text = "place children to fit parent",
             };
-            b3.ClickEvent += B3_ClickEvent;
+            b3.Clicked += B3_Clicked;
             win.Add(b3);
 
             text = new TextLabel()
@@ -64,7 +64,7 @@ namespace Tizen.NUI.Samples
             win.Add(text);
         }
 
-        private void B1_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void B1_Clicked(object sender, ClickedEventArgs e)
         {
             string n = "CH" + (v.ChildCount + 1);
             var ch = new TextLabel();
@@ -93,7 +93,7 @@ namespace Tizen.NUI.Samples
             a.Finished += A_Finished;
         }
 
-        private void B2_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void B2_Clicked(object sender, ClickedEventArgs e)
         {
             for(int i=0; i < v.ChildCount; i++)
             {
@@ -105,7 +105,7 @@ namespace Tizen.NUI.Samples
             }
         }
 
-        private void B3_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void B3_Clicked(object sender, ClickedEventArgs e)
         {
             for (int i = 0; i < v.ChildCount; i++)
             {
@@ -135,9 +135,9 @@ namespace Tizen.NUI.Samples
 
         public void Deactivate()
         {
-            b1.ClickEvent -= B1_ClickEvent;
-            b2.ClickEvent -= B2_ClickEvent;
-            b3.ClickEvent -= B3_ClickEvent;
+            b1.Clicked -= B1_Clicked;
+            b2.Clicked -= B2_Clicked;
+            b3.Clicked -= B3_Clicked;
 
             b1.Unparent();
             b2.Unparent();

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TabSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TabSample.cs
@@ -188,14 +188,14 @@ namespace Tizen.NUI.Samples
             button = new Button(buttonStyle);
             button.Size = new Size(500, 80);
             button.TextLabel.Text = mode[index];
-            button.ClickEvent += ButtonClickEvent;
+            button.Clicked += ButtonClicked;
             parentView[2].Add(button);
 
             // Button of LayoutDirection
             button2 = new Button(buttonStyle);
             button2.Size = new Size(500, 80);
             button2.TextLabel.Text = "LayoutDirection is left to right";
-            button2.ClickEvent += ButtonClickEvent2;
+            button2.Clicked += ButtonClicked2;
             parentView[2].Add(button2);
         }
 
@@ -264,7 +264,7 @@ namespace Tizen.NUI.Samples
             createText[1].Text = "Create Tab just by Style, Selected index from " + e.PreviousIndex + " to " + e.CurrentIndex;
         }
 
-        private void ButtonClickEvent(object sender, Button.ClickEventArgs e)
+        private void ButtonClicked(object sender, ClickedEventArgs e)
         {
             index = (index + 1) % 4;
             button.TextLabel.Text = mode[index];
@@ -282,7 +282,7 @@ namespace Tizen.NUI.Samples
             };
         }
 
-        private void ButtonClickEvent2(object sender, Button.ClickEventArgs e)
+        private void ButtonClicked2(object sender, ClickedEventArgs e)
         {
             if (tab.LayoutDirection == ViewLayoutDirectionType.LTR)
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ToastSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ToastSample.cs
@@ -121,9 +121,9 @@ namespace Tizen.NUI.Samples
                 parentView[1].Add(button[i]);
             }
             button[0].Text = "toast1_1 Show";
-            button[0].ClickEvent += toast1_1Show;
+            button[0].Clicked += toast1_1Show;
             button[1].Text = "toast2_1 Show";
-            button[1].ClickEvent += toast2_1Show;
+            button[1].Clicked += toast2_1Show;
 
             // Set init focus
             FocusManager.Instance.SetCurrentFocusView(button[0]);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WearablePopupTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WearablePopupTest.cs
@@ -90,8 +90,8 @@ namespace Tizen.NUI.Samples
             myContent1.ParentOrigin = ParentOrigin.Center;
             myContent1.PivotPoint = PivotPoint.Center;
             myPopup1.AppendContent("ContentText", myContent1);
-            leftButton.ClickEvent += LeftButton_ClickEvent;
-            rightButton.ClickEvent += RightButton_ClickEvent;
+            leftButton.Clicked += LeftButton_Clicked;
+            rightButton.Clicked += RightButton_Clicked;
             myPopup1.OutsideClicked += Mp_OutsideClicked;
 
             myPopup1.ContentContainer.WidthResizePolicy = ResizePolicyType.FitToChildren;
@@ -114,12 +114,12 @@ namespace Tizen.NUI.Samples
             NUIApplication.GetDefaultWindow().Add(t1);
         }
 
-        private void RightButton_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void RightButton_Clicked(object sender, ClickedEventArgs e)
         {
             myPopup1.Dismiss();
         }
 
-        private void LeftButton_ClickEvent(object sender, Button.ClickEventArgs e)
+        private void LeftButton_Clicked(object sender, ClickedEventArgs e)
         {
             myContent1.TextColor = Color.Yellow;
         }


### PR DESCRIPTION
To replace nested types (CA1034 of StyleCop), the following is added.
- class ClickedEventArgs
- event EventHandler<ClickedEventArgs> in Button class

The followings are deprecated.
- class ClickEventArgs in Button class
- event EventHandler<ClickEventArgs> in Button class

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
