### PR TITLE
[NUI] Fix GridLayout logic

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -399,8 +399,8 @@ namespace Tizen.NUI
                 int row = child.Row.Start;
                 int columnEnd = child.Column.End;
                 int rowEnd = child.Row.End;
-                float l = hLocations[column] + left.AsDecimal() + Padding.Start;
-                float t = vLocations[row] + top.AsDecimal() + Padding.Top;
+                float l = hLocations[column] + Padding.Start;
+                float t = vLocations[row] + Padding.Top;
                 float width = hLocations[columnEnd] - hLocations[column] - ColumnSpacing;
                 float height = vLocations[rowEnd] - vLocations[row] - RowSpacing;
 


### PR DESCRIPTION
### Description of Change ###
Previously, children of GridLayout inherits top position of parents so if
positionY of GridLayout is not 0, the children are also moved same size.

Now, they don't inherit top position of parents.

### API Changes ###
NONE
