### PR TITLE
[NUI] Support the different file name of Xaml

### DIFF
--- a/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
@@ -272,39 +272,29 @@ namespace Tizen.NUI.Xaml
             {
                 Assembly assembly = type.Assembly;
 
-                Stream stream = null;
-
-                foreach (string str in assembly.GetManifestResourceNames())
-                {
-                    string resourceClassName = str.Substring(0, str.LastIndexOf('.'));
-                    int index = resourceClassName.LastIndexOf('.');
-                    if (0 <= index && index < resourceClassName.Length)
-                    {
-                        resourceClassName = resourceClassName.Substring(index + 1);
-
-                        if (resourceClassName == type.Name)
-                        {
-                            stream = assembly.GetManifestResourceStream(str);
-                            break;
-                        }
-                    }
-                }
-
-                if (null == stream)
+                var resourceId = XamlResourceIdAttribute.GetResourceIdForType(type);
+                if (null == resourceId)
                 {
                     throw new XamlParseException(string.Format("Can't find type {0} in embedded resource", type.FullName), new XmlLineInfo());
                 }
                 else
                 {
-                    Byte[] buffer = new byte[stream.Length];
-                    stream.Read(buffer, 0, (int)stream.Length);
+                    Stream stream = assembly.GetManifestResourceStream(resourceId);
 
-                    string ret = System.Text.Encoding.Default.GetString(buffer);
-                    return ret;
+                    if (null != stream)
+                    {
+                        Byte[] buffer = new byte[stream.Length];
+                        stream.Read(buffer, 0, (int)stream.Length);
+
+                        string ret = System.Text.Encoding.Default.GetString(buffer);
+                        return ret;
+                    }
+                    else
+                    {
+                        throw new XamlParseException(string.Format("Can't get xaml stream {0} in embedded resource", type.FullName), new XmlLineInfo());
+                    }
                 }
             }
-
-            return null;
         }
 
         //if the assembly was generated using a version of XamlG that doesn't outputs XamlResourceIdAttributes, we still need to find the resource, and load it

--- a/src/Tizen.NUI/src/internal/XamlBinding/ResourcesExtensions.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/ResourcesExtensions.cs
@@ -14,6 +14,11 @@ namespace Tizen.NUI.Binding
                 if (ve != null && ve.IsResourcesCreated)
                 {
                     resources = resources ?? new Dictionary<string, object>();
+                    if (null == resources)
+                    {
+                        return null;
+                    }
+
                     if (ve.XamlResources != null)
                     {
                         foreach (KeyValuePair<string, object> res in ve.XamlResources.MergedResources)
@@ -27,10 +32,16 @@ namespace Tizen.NUI.Binding
                             }
                     }
                 }
+
                 var app = element as Application;
                 if (app != null && app.SystemResources != null)
                 {
                     resources = resources ?? new Dictionary<string, object>(8);
+                    if (null == resources)
+                    {
+                        return null;
+                    }
+
                     foreach (KeyValuePair<string, object> res in app.SystemResources)
                         if (!resources.ContainsKey(res.Key))
                             resources.Add(res.Key, res.Value);

--- a/src/Tizen.NUI/src/public/XamlBinding/ContentPage.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/ContentPage.cs
@@ -260,7 +260,7 @@ namespace Tizen.NUI
                 }
                 if (trans)
                 {
-                    transDictionary.Add(trans.Name, trans);
+                    transDictionary?.Add(trans.Name, trans);
                 }
             }
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Support the different file name of Xaml.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
