### PR TITLE
[NUI] make GridLayout.Orientation default value as Horizontal

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -75,7 +75,7 @@ namespace Tizen.NUI
         public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.CreateAttached("VerticalAlignment", typeof(Alignment), typeof(GridLayout), Alignment.Start, propertyChanged: OnChildPropertyChanged);
 
         private const int CellUndefined = int.MinValue;
-        private Orientation gridOrientation = Orientation.Vertical;
+        private Orientation gridOrientation = Orientation.Horizontal;
         private int columns = 1;
         private int rows = 1;
         private float columnSpacing = 0;


### PR DESCRIPTION
Before commit c04eaacb3186b0ea9e499d7a930b10e074134d32, child was added
from left to right by default. but now they are added from top to
bottom.
This patch reverts auto-placement rule to keep backward compatibility.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
