### PR TITLE
[NUI] use correct max column/row count in validation of child column/row

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
@@ -176,12 +176,12 @@ namespace Tizen.NUI
                 verticalStretch = GetVerticalStretch(view);
                 horizontalStretch = GetHorizontalStretch(view);
 
-                if (column + columnSpan > Columns || row + rowSpan > Rows)
+                if (column + columnSpan > maxColumnConut || row + rowSpan > maxRowCount)
                 {
-                    if (column + columnSpan > Columns)
-                        Tizen.Log.Error("NUI", "Column + ColumnSapn exceeds Grid Columns. Column + ColumnSpan (" + column + " + " + columnSpan + ") > Grid Columns(" + Columns + ")");
+                    if (column + columnSpan > maxColumnConut)
+                        Tizen.Log.Error("NUI", "Column + ColumnSapn exceeds Grid Columns. Column + ColumnSpan (" + column + " + " + columnSpan + ") > Grid Columns(" + maxColumnConut + ")");
                     else
-                        Tizen.Log.Error("NUI", "Row + RowSapn exceeds Grid Rows. Row + RowSapn (" + row + " + " + rowSpan + ") > Grid Rows(" + Rows + ")");
+                        Tizen.Log.Error("NUI", "Row + RowSapn exceeds Grid Rows. Row + RowSapn (" + row + " + " + rowSpan + ") > Grid Rows(" + maxRowCount + ")");
 
                     gridChildren[i] = new GridChild(null, new Node(0, 1, 0, 0), new Node(0, 1, 0, 0));
 


### PR DESCRIPTION
Column/row of GridLayout child should be compared to max column/row count which
is decided by auto-placement of GridLayout.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
