### PR TITLE
[NUI] fix wrong total expand value in expanded size calculation

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
@@ -105,7 +105,7 @@ namespace Tizen.NUI
             Node[] edgeList = isHorizontal ? hEdgeList : vEdgeList;
             int maxIndex = isHorizontal ? maxColumnConut : maxRowCount;
             float space = isHorizontal ? ColumnSpacing : RowSpacing;
-            float totalExpand = isHorizontal ? totalVerticalExpand : totalHorizontalExpand;
+            float totalExpand = isHorizontal ? totalHorizontalExpand : totalVerticalExpand;
 
             float parentDecimalSize = parentSize.AsDecimal();
             float maxExpandedSize = parentDecimalSize * LayoutChildren.Count;


### PR DESCRIPTION
The result is reversed. `totalHorizontalExpand` should be used in
horizontal orientation.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
