### PR TITLE
[NUI] Change for AddFrameRenderedCallback to maintain the reference

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AddFrameRenderedCallbackTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AddFrameRenderedCallbackTest.cs
@@ -22,13 +22,18 @@ namespace Tizen.NUI.Samples
 
         Window win;
         Window.FrameCallbackType cb;
+        TextLabel tl;
+        View view;
         void test()
         {
+            tlog.Fatal(tag, $"test start");
             win = NUIApplication.GetDefaultWindow();
             win.TouchEvent += WinTouchEvent;
-            View view = new View();
+            view = new View();
             view.Size = new Size(100, 100);
             view.BackgroundColor = Color.Blue;
+            view.Focusable = true;
+            view.KeyEvent += View_KeyEvent;
             win.Add(view);
 
             cb = testCallback;
@@ -38,6 +43,14 @@ namespace Tizen.NUI.Samples
             Timer timer = new Timer(5000);
             timer.Tick += testOnTick;
             timer.Start();
+
+            tl = new TextLabel("frameId");
+            tl.Size = new Size(500, 200);
+            tl.Position = new Position(10, 200);
+            tl.BackgroundColor = Color.White;
+            win.Add(tl);
+
+            FocusManager.Instance.SetCurrentFocusView(view);
         }
 
         private void WinTouchEvent(object sender, Window.TouchEventArgs e)
@@ -60,7 +73,49 @@ namespace Tizen.NUI.Samples
 
         void testCallback(int id)
         {
-            Console.WriteLine($"testCallback() id={id}");
+            tlog.Fatal(tag, $"testCallback() id={id}");
+            tl.Text = $"frameId={id}";
+        }
+
+        private bool View_KeyEvent(object source, View.KeyEventArgs e)
+        {
+            if (e.Key.State == Key.StateType.Down)
+            {
+                if (e.Key.KeyPressedName == "1")
+                {
+                    cb = testCallback;
+                    win.AddFrameRenderedCallback(cb, cnt++);
+                    tlog.Fatal(tag, $"1) testOnTick() AddFrameRenderedCallback() send id={cnt}");
+                }
+                else if (e.Key.KeyPressedName == "2")
+                {
+                    cb = testCallback;
+                    win.AddFramePresentedCallback(cb, cnt++);
+                    tlog.Fatal(tag, $"2) testOnTick() AddFramePresentedCallback() send id={cnt}");
+                }
+                else if (e.Key.KeyPressedName == "3")
+                {
+                    cb = testCallback;
+                    win.AddFramePresentedCallback(cb, cnt++);
+                    cb = null;
+                    tlog.Fatal(tag, $"3) testOnTick() AddFramePresentedCallback() send id={cnt}");
+                }
+                else if (e.Key.KeyPressedName == "4")
+                {
+                    win.AddFrameRenderedCallback((int id) =>
+                    {
+                        tlog.Fatal(tag, $"testCallback() id={id}");
+                        tl.Text = $"frameId={id}";
+                    }, cnt++);
+                    tlog.Fatal(tag, $"4) testOnTick() AddFrameRenderedCallback() send id={cnt}");
+                }
+                else if (e.Key.KeyPressedName == "Return")
+                {
+                    Random rand = new Random();
+                    view.BackgroundColor = new Color((float)rand.NextDouble(), (float)rand.NextDouble(), (float)rand.NextDouble(), 1);
+                }
+            }
+            return true;
         }
 
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI.Samples
             //checkCaptureNew();
         }
 
-        private void onCaptureFinished(object sender, CaptureFinishStateEventArgs e)
+        private void onCaptureFinished(object sender, CaptureFinishedEventArgs e)
         {
             log.Debug(tag, $"onCaptureFinished() statue={e.Success} \n");
 


### PR DESCRIPTION
### Description of Change ###
Change for AddFrameRenderedCallback to maintain the reference of user callback
- Fix for the already merged patch : https://github.com/Samsung/TizenFX/pull/1811
- http://wiki.vd.sec.samsung.net/pages/viewpage.action?pageId=4213716
- Using Dictionary to maintain native callback reference so that it is not to be garbage collected
- Small fix added : CaptureTest code's build error is fixed

### API Changes ###
none