### PR TITLE
[NUI] Scrollbar inherits VisualView instead of Control

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollbarBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollbarBase.cs
@@ -15,6 +15,7 @@
  *
  */
 using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI.Components
 {
@@ -24,22 +25,22 @@ namespace Tizen.NUI.Components
     /// This only contains non-graphical functionalities of basic scrollbar.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public abstract class ScrollbarBase : Control
+    public abstract class ScrollbarBase : VisualView
     {
         #region Constructors
 
         /// <summary>
         /// Create an empty ScrollbarBase.
         /// </summary>
-        public ScrollbarBase() : base()
+        public ScrollbarBase() : base(CustomViewBehaviour.ViewBehaviourDefault)
         {
         }
 
         /// <summary>
-        /// Create an empty Scrollbar with a ControlStyle instance to set style properties.
+        /// Create an empty Scrollbar with a ViewStyle instance to set style properties.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ScrollbarBase(ControlStyle style) : base(style)
+        public ScrollbarBase(ViewStyle style) : base(CustomViewBehaviour.ViewBehaviourDefault, style)
         {
         }
 

--- a/src/Tizen.NUI.Components/Style/ScrollbarStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ScrollbarStyle.cs
@@ -15,6 +15,7 @@
  *
  */
 using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 
 namespace Tizen.NUI.Components
@@ -23,7 +24,7 @@ namespace Tizen.NUI.Components
     /// ScrollbarStyle is a class which saves Scrollbar's style data.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class ScrollbarStyle : ControlStyle
+    public class ScrollbarStyle : ViewStyle
     {
         #region Fields
 

--- a/src/Tizen.NUI/src/public/BaseComponents/VisualView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VisualView.cs
@@ -51,15 +51,30 @@ namespace Tizen.NUI.BaseComponents
         /// Constructor.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public VisualView() : base(typeof(VisualView).FullName, CustomViewBehaviour.ViewBehaviourDefault | CustomViewBehaviour.RequiresTouchEventsSupport)
+        public VisualView() : this(CustomViewBehaviour.ViewBehaviourDefault | CustomViewBehaviour.RequiresTouchEventsSupport)
         {
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public VisualView(ViewStyle viewStyle) : base(typeof(VisualView).FullName, CustomViewBehaviour.ViewBehaviourDefault | CustomViewBehaviour.RequiresTouchEventsSupport, viewStyle)
+        public VisualView(ViewStyle viewStyle) : this(CustomViewBehaviour.ViewBehaviourDefault | CustomViewBehaviour.RequiresTouchEventsSupport, viewStyle)
         {
 
+        }
+
+        /// <summary>Create a VisualView with specified behaviour.</summary>
+        /// <param name="behaviour">CustomView behaviour</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VisualView(CustomViewBehaviour behaviour) : base(typeof(VisualView).FullName, behaviour)
+        {
+        }
+
+        /// <summary>Create a VisualView with specified behaviour and a style.</summary>
+        /// <param name="behaviour">CustomView behaviour</param>
+        /// <param name="viewStyle">The ViewStyle.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VisualView(CustomViewBehaviour behaviour, ViewStyle viewStyle) : base(typeof(VisualView).FullName, behaviour, viewStyle)
+        {
         }
 
         // static constructor registers the control type (for user can add kinds of visuals to it)


### PR DESCRIPTION
* Control always be a hit actor for touching, but the scrollbar does not need to be.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
