### PR TITLE
[NFC][Non-ACR] Fix NFC Csharp TC failed issue

### DIFF
--- a/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcTag.cs
+++ b/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcTag.cs
@@ -45,6 +45,9 @@ namespace Tizen.Network.Nfc
         /// </summary>
         public NfcTag()
         {
+            // A method is need to convert delegate to pass unmanaged layer through Interop call
+            // If we do not convert explicitly it, implicitly convert was occurred
+            // and temporal delegate was created. and it could be released by GC
             _nativeTransceiveCallback = TransceiveCompletedCallback;
             _nativeVoidCallback = VoidCallback;
             _nativeTagReadCallback = ReadNdefCallback;
@@ -126,6 +129,9 @@ namespace Tizen.Network.Nfc
         internal NfcTag(IntPtr handle)
         {
             _tagHandle = handle;
+            _nativeTransceiveCallback = TransceiveCompletedCallback;
+            _nativeVoidCallback = VoidCallback;
+            _nativeTagReadCallback = ReadNdefCallback;
         }
 
         /// <summary>


### PR DESCRIPTION
- https://code.sec.samsung.net/jira/browse/TFDF-10927
- It seems that the callback is missing from the constructor in API7 branch

Signed-off-by: Jihoon Jung <jh8801.jung@samsung.com>
