### PR TITLE
[NFC][Non-ACR] Fix NFC Csharp TC failed issue

### DIFF
--- a/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcTag.cs
+++ b/src/Tizen.Network.Nfc/Tizen.Network.Nfc/NfcTag.cs
@@ -129,6 +129,9 @@ namespace Tizen.Network.Nfc
         internal NfcTag(IntPtr handle)
         {
             _tagHandle = handle;
+            _nativeTransceiveCallback = TransceiveCompletedCallback;
+            _nativeVoidCallback = VoidCallback;
+            _nativeTagReadCallback = ReadNdefCallback;
         }
 
         /// <summary>


### PR DESCRIPTION
- https://code.sec.samsung.net/jira/browse/TFDF-10927
- It seems that the callback is missing from the constructor in API8 branch

Signed-off-by: Jihoon Jung <jh8801.jung@samsung.com>
