### PR TITLE
[NUI] Add Selector constructor with SelectorChangedCallback internally

### DIFF
--- a/src/Tizen.NUI.Components/Utils/Selector.cs
+++ b/src/Tizen.NUI.Components/Utils/Selector.cs
@@ -151,6 +151,14 @@ namespace Tizen.NUI.Components
         {
         }
 
+        internal ColorSelector(SelectorChangedCallback<Color> cb) : base(cb)
+        {
+        }
+
+        internal ColorSelector(SelectorChangedCallback<Color> cb, Selector<Color> selector) : base(cb, selector)
+        {
+        }
+
         /// <summary>
         /// Color selector clone function.
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -58,6 +58,24 @@ namespace Tizen.NUI.BaseComponents
             Clone(value);
         }
 
+        internal Selector(SelectorChangedCallback<T> cb) : this()
+        {
+            callback = cb;
+        }
+
+        internal Selector(SelectorChangedCallback<T> cb, T value) : this(value)
+        {
+            callback = cb;
+        }
+
+        internal Selector(SelectorChangedCallback<T> cb, Selector<T> value) : this(value)
+        {
+            callback = cb;
+        }
+
+        internal delegate void SelectorChangedCallback<T>(Selector<T> value);
+        private SelectorChangedCallback<T> callback = null;
+
 
         /// <summary>
         /// All State.
@@ -78,8 +96,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Normal
         {
-            get => Find(x => x.State == ControlState.Normal).Value;
-            set => Add(ControlState.Normal, value);
+            get
+            {
+                return Find(x => x.State == ControlState.Normal).Value;
+            }
+            set
+            {
+                Add(ControlState.Normal, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// Pressed State.
@@ -89,8 +114,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Pressed
         {
-            get => Find(x => x.State == ControlState.Pressed).Value;
-            set => Add(ControlState.Pressed, value);
+            get
+            {
+                return Find(x => x.State == ControlState.Pressed).Value;
+            }
+            set
+            {
+                Add(ControlState.Pressed, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// Focused State.
@@ -100,8 +132,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Focused
         {
-            get => Find(x => x.State == ControlState.Focused).Value;
-            set => Add(ControlState.Focused, value);
+            get
+            {
+                return Find(x => x.State == ControlState.Focused).Value;
+            }
+            set
+            {
+                Add(ControlState.Focused, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// Selected State.
@@ -111,8 +150,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Selected
         {
-            get => Find(x => x.State == ControlState.Selected).Value;
-            set => Add(ControlState.Selected, value);
+            get
+            {
+                return Find(x => x.State == ControlState.Selected).Value;
+            }
+            set
+            {
+                Add(ControlState.Selected, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// Disabled State.
@@ -122,8 +168,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Disabled
         {
-            get => Find(x => x.State == ControlState.Disabled).Value;
-            set => Add(ControlState.Disabled, value);
+            get
+            {
+                return Find(x => x.State == ControlState.Disabled).Value;
+            }
+            set
+            {
+                Add(ControlState.Disabled, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// DisabledFocused State.
@@ -133,8 +186,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T DisabledFocused
         {
-            get => Find(x => x.State == ControlState.DisabledFocused).Value;
-            set => Add(ControlState.DisabledFocused, value);
+            get
+            {
+                return Find(x => x.State == ControlState.DisabledFocused).Value;
+            }
+            set
+            {
+                Add(ControlState.DisabledFocused, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// SelectedFocused State.
@@ -143,8 +203,15 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         public T SelectedFocused
         {
-            get => Find(x => x.State == ControlState.SelectedFocused).Value;
-            set => Add(ControlState.SelectedFocused, value);
+            get
+            {
+                return Find(x => x.State == ControlState.SelectedFocused).Value;
+            }
+            set
+            {
+                Add(ControlState.SelectedFocused, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// DisabledSelected State.
@@ -154,8 +221,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T DisabledSelected
         {
-            get => Find(x => x.State == ControlState.DisabledSelected).Value;
-            set => Add(ControlState.DisabledSelected, value);
+            get
+            {
+                return Find(x => x.State == ControlState.DisabledSelected).Value;
+            }
+            set
+            {
+                Add(ControlState.DisabledSelected, value);
+                callback?.Invoke(this);
+            }
         }
 
         /// <summary>
@@ -166,8 +240,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Other
         {
-            get => Find(x => x.State == ControlState.Other).Value;
-            set => Add(ControlState.Other, value);
+            get
+            {
+                return Find(x => x.State == ControlState.Other).Value;
+            }
+            set
+            {
+                Add(ControlState.Other, value);
+                callback?.Invoke(this);
+            }
         }
         /// <summary>
         /// Get value by State.


### PR DESCRIPTION
To track property changes of Selector class, Selector constructor with
SelectorChangedCallback is added internally.

This is the same method applied to Color class.

By using this constructor, ColorSelector class also tracks property
changes internally.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
