### PR TITLE
[NUI] Fix scroll item touch issue

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -924,22 +924,30 @@ namespace Tizen.NUI.Components
 
                 float panVelocity = (ScrollingDirection == Direction.Horizontal) ? e.PanGesture.Velocity.X : e.PanGesture.Velocity.Y;
 
-                if(panVelocity != 0 || SnapToPage)
+                if (SnapToPage)
                 {
-                    if (SnapToPage)
+                    PageSnap(panVelocity);
+                }
+                else
+                {
+                    if(panVelocity == 0)
                     {
-                        PageSnap(panVelocity);
+                        float currentScrollPosition = (ScrollingDirection == Direction.Horizontal ? ContentContainer.CurrentPosition.X : ContentContainer.CurrentPosition.Y);
+                        scrollAnimation.DefaultAlphaFunction = new AlphaFunction(AlphaFunction.BuiltinFunctions.Linear);
+                        scrollAnimation.Duration = 0;
+                        scrollAnimation.AnimateTo(ContentContainer, (ScrollingDirection == Direction.Horizontal) ? "PositionX" : "PositionY", currentScrollPosition);
+                        scrollAnimation.Play();
                     }
                     else
                     {
                         Decelerating(panVelocity, scrollAnimation);
                     }
-
-                    totalDisplacementForPan = 0;
-                    scrolling = true;
-                    readyToNotice = true;
-                    OnScrollAnimationStarted();
                 }
+
+                totalDisplacementForPan = 0;
+                scrolling = true;
+                readyToNotice = true;
+                OnScrollAnimationStarted();
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
Previously when velocity is 0, ScrollAnimationFinished callback is not
working so touch interrupt view is not disappear.

Now, ScrollAnimation is started even if velocity is 0.

### API Changes ###
NONE