### PR TITLE
[NUI] add Xaml support for NUI.Components

### DIFF
--- a/src/Tizen.NUI.Components.Design/AttributeTableBuilder.cs
+++ b/src/Tizen.NUI.Components.Design/AttributeTableBuilder.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reflection;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace Tizen.NUI.Components
+{
+    internal class AttributeTableBuilder : Microsoft.Windows.Design.Metadata.AttributeTableBuilder
+    {
+        private void AddAttributesForTypes()
+        {
+            Type typeFromHandle = typeof(Control);
+            AddTypeAttributes(typeFromHandle, new EditorBrowsableAttribute(EditorBrowsableState.Always));
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AttributeTableBuilder() : base()
+        {
+            Assembly assembly = typeof(Control).Assembly;
+            AddAssemblyAttributes(assembly, new global::System.Windows.Markup.XmlnsDefinitionAttribute("http://tizen.org/Tizen.NUI/2018/XAML", "Tizen.NUI.Components"));
+            AddAttributesForTypes();
+        }
+
+        private void AddTypeAttributes(Type type, params Attribute[] attribs)
+        {
+            this.AddCallback(type, builder => builder.AddCustomAttributes(attribs));
+        }
+
+        private void AddMemberAttributes(Type type, string memberName, params Attribute[] attribs)
+        {
+            this.AddCallback(type, builder => builder.AddCustomAttributes(attribs));
+        }
+
+        private void AddAssemblyAttributes(Assembly assembly, params Attribute[] attribs)
+        {
+            this.AddCustomAttributes(assembly, attribs);
+        }
+    }
+}

--- a/src/Tizen.NUI.Components.Design/Properties/AssemblyInfo.cs
+++ b/src/Tizen.NUI.Components.Design/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Microsoft.Windows.Design.Metadata;
+
+[assembly: ProvideMetadata(typeof(Tizen.NUI.Components.RegisterMetadata))]
+

--- a/src/Tizen.NUI.Components.Design/RegisterMetadata.cs
+++ b/src/Tizen.NUI.Components.Design/RegisterMetadata.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Windows.Design.Metadata;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Components
+{
+    internal class RegisterMetadata : IProvideAttributeTable
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AttributeTable AttributeTable => new AttributeTableBuilder().CreateTable();
+    }
+}

--- a/src/Tizen.NUI.Components.Design/Tizen.NUI.Components.Design.csproj
+++ b/src/Tizen.NUI.Components.Design/Tizen.NUI.Components.Design.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ArtifactsDirectory>$(OutputBaseDir)bin\design\</ArtifactsDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tizen.NUI.Components\Tizen.NUI.Components.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.Windows.Design.Extensibility">
+      <HintPath>$(ExternalLibraryDir)Microsoft.Windows.Design.Extensibility.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Xaml">
+      <HintPath>$(ExternalLibraryDir)System.Xaml.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/src/Tizen.NUI.Components/Properties/AssemblyInfo.cs
+++ b/src/Tizen.NUI.Components/Properties/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+using System.Runtime.CompilerServices;
+
+using Tizen.NUI;
+
+[assembly: InternalsVisibleTo("Tizen.NUI.Design, Publickey=0024000004800000940000000602000000240000525341310004000001000100d115b1004248416b12d21b626cfb17149c9303fe394693fd3b32d7872e89559a4fa96c98110c2e62eea48aca693bddbe17094ca8ea2e2cd79970ca590fb672b9b371b5d7002076817321f62d6483ea50c56dbd1f37b185a4c24c47718876e6ae6d266508c551170d4cbdda3f82edaff9405ee3d7857282d8269e8e518d2f0fb2")]
+
+
+[assembly: XmlnsDefinition("http://tizen.org/Tizen.NUI/2018/XAML", "Tizen.NUI.Components")]


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
We can now use `Tizen.NUI.Components` namespace with 
`http://tizen.org/Tizen.NUI/2018/XAML` uri.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
