### PR TITLE
[NUI] Add ScrollPosition and ScrollCurrentPosition to ScrollbarBase

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Scrollbar.cs
+++ b/src/Tizen.NUI.Components/Controls/Scrollbar.cs
@@ -112,6 +112,7 @@ namespace Tizen.NUI.Components
         private Size containerSize = new Size(0, 0);
         private ScrollbarStyle scrollbarStyle => ViewStyle as ScrollbarStyle;
         private bool mScrollEnabled = true;
+        private float previousPosition;
 
         #endregion Fields
 
@@ -312,6 +313,7 @@ namespace Tizen.NUI.Components
             }
 
             calculator.contentLength = contentLength > 0.0f ? contentLength : 0.0f;
+            previousPosition = calculator.currentPosition;
             calculator.currentPosition = position;
 
             thumbVisual.Size = calculator.CalculateThumbSize(ThumbThickness, trackVisual.Size);
@@ -352,6 +354,7 @@ namespace Tizen.NUI.Components
                 return;
             }
 
+            previousPosition = calculator.currentPosition;
             calculator.currentPosition = position;
             thumbVisual.Position = calculator.CalculateThumbScrollPosition(trackVisual.Size, thumbVisual.Position, TrackPadding);
 
@@ -501,6 +504,62 @@ namespace Tizen.NUI.Components
                 if (value != mScrollEnabled)
                 {
                     mScrollEnabled = value;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override Position ScrollPosition
+        {
+            get
+            {
+                if (calculator == null)
+                {
+                    return new Position(0.0f, 0.0f);
+                }
+
+                float length = Math.Min(Math.Max(calculator.currentPosition, 0.0f), calculator.contentLength - calculator.visibleLength);
+
+                if (calculator is HorizontalCalculator)
+                {
+                    return new Position(length, 0.0f);
+                }
+                else
+                {
+                    return new Position(0.0f, length);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override Position ScrollCurrentPosition
+        {
+            get
+            {
+                if (calculator == null)
+                {
+                    return new Position(0.0f, 0.0f);
+                }
+
+                float length = Math.Min(Math.Max(calculator.currentPosition, 0.0f), calculator.contentLength - calculator.visibleLength);
+
+                if (thumbPositionAnimation != null)
+                {
+                    float progress = thumbPositionAnimation.CurrentProgress;
+                    float previousLength = Math.Min(Math.Max(previousPosition, 0.0f), calculator.contentLength - calculator.visibleLength);
+
+                    length = ((1.0f - progress) * previousLength) + (progress * length);
+                }
+
+                if (calculator is HorizontalCalculator)
+                {
+                    return new Position(length, 0.0f);
+                }
+                else
+                {
+                    return new Position(0.0f, length);
                 }
             }
         }

--- a/src/Tizen.NUI.Components/Controls/ScrollbarBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollbarBase.cs
@@ -93,6 +93,18 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public abstract bool ScrollEnabled { get; set; }
 
+        /// <summary>
+        /// Scroll position given to ScrollTo or Update.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public abstract Position ScrollPosition { get; }
+
+        /// <summary>
+        /// Current scroll position in the middle of ScrollTo or Update animation.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public abstract Position ScrollCurrentPosition { get; }
+
         #endregion Methods
     }
 }

--- a/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
@@ -91,6 +91,7 @@ namespace Tizen.NUI.Wearable
         private ArcVisual thumbVisual;
         private float contentLength;
         private float visibleLength;
+        private float previousPosition;
         private float currentPosition;
         private float directionAlpha;
         private Size containerSize = new Size(0, 0);
@@ -285,6 +286,7 @@ namespace Tizen.NUI.Wearable
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void Update(float contentLength, float position, uint durationMs = 0, AlphaFunction alphaFunction = null)
         {
+            this.previousPosition = this.currentPosition;
             this.currentPosition = position;
             this.contentLength = contentLength > 0.0f ? contentLength : 0.0f;
 
@@ -320,6 +322,7 @@ namespace Tizen.NUI.Wearable
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void ScrollTo(float position, uint durationMs = 0, AlphaFunction alphaFunction = null)
         {
+            previousPosition = currentPosition;
             currentPosition = position;
 
             if (mScrollEnabled == false)
@@ -479,6 +482,40 @@ namespace Tizen.NUI.Wearable
                 {
                     mScrollEnabled = value;
                 }
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override Position ScrollPosition
+        {
+            get
+            {
+                bool isHorizontal = (directionAlpha == 270.0f) ? true : false;
+                float length = Math.Min(Math.Max(currentPosition, 0.0f), contentLength - visibleLength);
+
+                return (isHorizontal ? new Position(length, 0.0f) : new Position(0.0f, length));
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override Position ScrollCurrentPosition
+        {
+            get
+            {
+                bool isHorizontal = (directionAlpha == 270.0f) ? true : false;
+                float length = Math.Min(Math.Max(currentPosition, 0.0f), contentLength - visibleLength);
+
+                if (thumbStartAngleAnimation != null)
+                {
+                    float progress = thumbStartAngleAnimation.CurrentProgress;
+                    float previousLength = Math.Min(Math.Max(previousPosition, 0.0f), contentLength - visibleLength);
+
+                    length = ((1.0f - progress) * previousLength) + (progress * length);
+                }
+
+                return (isHorizontal ? new Position(length, 0.0f) : new Position(0.0f, length));
             }
         }
 


### PR DESCRIPTION
To get the scroll position given to ScrollTo or Update, ScrollPosition
is added.

To get the current scroll position in the middle of ScrollTo or Update
animation, ScrollCurrentPosition is added.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
