### PR TITLE
[NUI] Add VS Code setting files for Ubuntu

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/.vscode/launch.json
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.0/Tizen.NUI.Samples.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        }
+    ]
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/.vscode/tasks.json
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Tizen.NUI.Samples.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/Tizen.NUI.Samples.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/Tizen.NUI.Samples.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.code-workspace
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../../../src/Tizen.NUI"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
### Description of Change ###
Add VS Code setting files for Ubuntu

- Some setting files are added for VS Code Ubuntu working
- .Net Core Extension Pack needs be installed in Code
- in console, 
cd test/Tizen.NUI.Samples/Tizen.NUI.Samples
code Tizen.NUI.Samples.code-workspace
ctrl + shift + p (command pallete)
restore (select .NET restore all projects)
set some break point in the source code by F9
F5 (run debugging)

### API Changes ###
none