### PR TITLE
[NUI] Fix ResizePolicy error when setting View.Size.Width or Height

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -545,7 +545,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 Size tmp = (Size)GetValue(SizeProperty);
-                return (null != tmp) ? tmp : size = new Size((float width, float height, float depth) => { Size = new Size(width, height, depth); }, 0, 0, 0);
+                return (null != tmp) ? tmp : size = new Size((float? width, float? height, float? depth) => { Size = new Size((float)width, (float)height, (float)depth); }, 0, 0, 0);
             }
             set => SetValue(SizeProperty, value);
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -606,19 +606,56 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        private void OnSize2DChanged(int width, int height)
+        private void OnSize2DChanged(int? width, int? height)
         {
-            Size2D = new Size2D(width, height);
+            if (width != null)
+            {
+                Tizen.NUI.Object.SetProperty(this.swigCPtr, View.Property.SIZE_WIDTH, new Tizen.NUI.PropertyValue((float)width));
+            }
+            if (height != null)
+            {
+                Tizen.NUI.Object.SetProperty(this.swigCPtr, View.Property.SIZE_HEIGHT, new Tizen.NUI.PropertyValue((float)height));
+            }
         }
 
-        private void OnMinimumSizeChanged(int width, int height)
+        private void OnMinimumSizeChanged(int? width, int? height)
         {
-            MinimumSize = new Size2D(width, height);
+            if (width != null && height != null)
+            {
+                MinimumSize = new Size2D((int)width, (int)height);
+            }
+            else if (width != null && height == null)
+            {
+                MinimumSize = new Size2D((int)width, (int)this.GetMinimumSize().Height);
+            }
+            else if (width == null && height != null)
+            {
+                MinimumSize = new Size2D((int)this.GetMinimumSize().Width, (int)height);
+            }
+            else
+            {
+                //both are null, do nothing.
+            }
         }
 
-        private void OnMaximumSizeChanged(int width, int height)
+        private void OnMaximumSizeChanged(int? width, int? height)
         {
-            MaximumSize = new Size2D(width, height);
+            if (width != null && height != null)
+            {
+                MaximumSize = new Size2D((int)width, (int)height);
+            }
+            else if (width != null && height == null)
+            {
+                MaximumSize = new Size2D((int)width, (int)this.GetMaximumSize().Height);
+            }
+            else if (width == null && height != null)
+            {
+                MaximumSize = new Size2D((int)this.GetMaximumSize().Width, (int)height);
+            }
+            else
+            {
+                //both are null, do nothing.
+            }
         }
 
         private void OnPosition2DChanged(int x, int y)
@@ -626,9 +663,20 @@ namespace Tizen.NUI.BaseComponents
             Position2D = new Position2D(x, y);
         }
 
-        private void OnSizeChanged(float width, float height, float depth)
+        private void OnSizeChanged(float? width, float? height, float? depth)
         {
-            Size = new Size(width, height, depth);
+            if (width != null)
+            {
+                Tizen.NUI.Object.SetProperty(this.swigCPtr, View.Property.SIZE_WIDTH, new Tizen.NUI.PropertyValue((float)width));
+            }
+            if (height != null)
+            {
+                Tizen.NUI.Object.SetProperty(this.swigCPtr, View.Property.SIZE_HEIGHT, new Tizen.NUI.PropertyValue((float)height));
+            }
+            if (depth != null)
+            {
+                Tizen.NUI.Object.SetProperty(this.swigCPtr, View.Property.SIZE_DEPTH, new Tizen.NUI.PropertyValue((float)depth));
+            }
         }
 
         private void OnPositionChanged(float x, float y, float z)

--- a/src/Tizen.NUI/src/public/Size.cs
+++ b/src/Tizen.NUI/src/public/Size.cs
@@ -102,7 +102,7 @@ namespace Tizen.NUI
                 Interop.Vector3.Vector3_Width_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-                callback?.Invoke(Width, Height, Depth);
+                callback?.Invoke(value, null, null);
             }
             get
             {
@@ -123,7 +123,7 @@ namespace Tizen.NUI
                 Interop.Vector3.Vector3_Height_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-                callback?.Invoke(Width, Height, Depth);
+                callback?.Invoke(null, value, null);
             }
             get
             {
@@ -144,7 +144,7 @@ namespace Tizen.NUI
                 Interop.Vector3.Vector3_Depth_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-                callback?.Invoke(Width, Height, Depth);
+                callback?.Invoke(null, null, value);
             }
             get
             {
@@ -417,7 +417,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal delegate void SizeChangedCallback(float width, float height, float depth);
+        internal delegate void SizeChangedCallback(float? width, float? height, float? depth);
 
         internal Size(SizeChangedCallback cb, float w, float h, float d) : this(Interop.Vector3.new_Vector3__SWIG_1(w, h, d), true)
         {

--- a/src/Tizen.NUI/src/public/Size2D.cs
+++ b/src/Tizen.NUI/src/public/Size2D.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal delegate void Size2DChangedCallback(int width, int height);
+        internal delegate void Size2DChangedCallback(int? width, int? height);
 
         /// <summary>
         /// The property for the width component of a size.
@@ -79,7 +79,7 @@ namespace Tizen.NUI
                 Interop.Vector2.Vector2_Width_set(swigCPtr, (float)value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-                callback?.Invoke(Width, Height);
+                callback?.Invoke(value, null);
             }
             get
             {
@@ -100,7 +100,7 @@ namespace Tizen.NUI
                 Interop.Vector2.Vector2_Height_set(swigCPtr, (float)value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-                callback?.Invoke(Width, Height);
+                callback?.Invoke(null, value);
             }
             get
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ViewSizeWidthPropertySetTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ViewSizeWidthPropertySetTest.cs
@@ -1,0 +1,221 @@
+﻿
+using global::System;
+using System.Threading.Tasks;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Samples
+{
+    public class ViewWidthSizePropertySetTest : IExample
+    {
+        public void Activate()
+        {
+            _ = test();
+            //TDD
+            SizeWidthTest1();
+            SizeWidthTest2();
+        }
+
+        public void Deactivate()
+        {
+
+        }
+
+        Window window;
+        Layer layer;
+        View root, view1;
+        public async Task test()
+        {
+            //await Task.Delay(500);
+
+            tlog.prt($"### START test : HeghtResizePolicy is changed by setting Size2D.Width \n");
+
+            window = NUIApplication.GetDefaultWindow();
+            layer = window.GetDefaultLayer();
+
+            window.TouchEvent += Window_TouchEvent;
+            window.KeyEvent += Window_KeyEvent;
+
+            root = new View()
+            {
+                Size = new Size(500, 500),
+                Position = new Position(50, 50),
+                BackgroundColor = Color.White,
+            };
+            layer.Add(root);
+
+            view1 = new View()
+            {
+                Size = new Size(100, 100),
+                BackgroundColor = Color.Cyan,
+                MaximumSize = new Size2D(1000, 1000),
+            };
+            root.Add(view1);
+        }
+
+        private void Window_KeyEvent(object sender, Window.KeyEventArgs e)
+        {
+            if (e.Key.State == Key.StateType.Down)
+            {
+                if (e.Key.KeyPressedName == "1")
+                {
+                    view1.Size2D.Width += 10;
+                }
+                else if (e.Key.KeyPressedName == "2")
+                {
+                    view1.Size2D.Height += 10;
+                }
+                else if (e.Key.KeyPressedName == "3")
+                {
+                    view1.WidthResizePolicy = ResizePolicyType.FillToParent;
+                }
+                else if (e.Key.KeyPressedName == "4")
+                {
+                    view1.WidthResizePolicy = ResizePolicyType.Fixed;
+                }
+                else if (e.Key.KeyPressedName == "5")
+                {
+                    view1.MinimumSize.Width = 500;
+                }
+                else if (e.Key.KeyPressedName == "6")
+                {
+                    view1.MinimumSize.Width = 100;
+                }
+                else if (e.Key.KeyPressedName == "7")
+                {
+                    view1.MaximumSize.Width = 700;
+                }
+                else if (e.Key.KeyPressedName == "8")
+                {
+                    view1.MaximumSize.Width = 70;
+                }
+                else if (e.Key.KeyPressedName == "0")
+                {
+                    view1.Size2D.Width -= 10;
+                    view1.Size2D.Height -= 10;
+                }
+            }
+        }
+
+        private void Window_TouchEvent(object sender, Window.TouchEventArgs e)
+        {
+            if (e.Touch.GetState(0) == PointStateType.Down)
+            {
+                string log = "";
+                log += $"view1 Size2D=({view1.Size2D.Width}, {view1.Size2D.Height}) \n";
+                log += $"SizeWidth={view1.SizeWidth}, SizeHeight={view1.SizeHeight} \n";
+                log += $"WidthResizePolicy={view1.WidthResizePolicy}, HeightResizePolicy={view1.HeightResizePolicy} \n";
+                log += $"WidthSpecification={view1.WidthSpecification}, HeightSpecification={view1.HeightSpecification} \n";
+                log += $"MinimumSize=({view1.MinimumSize.Width}, {view1.MinimumSize.Height}) \n";
+                log += $"MaximumSize=({view1.MaximumSize.Width}, {view1.MaximumSize.Height}) \n";
+                tlog.prt(log);
+            }
+        }
+
+        void SizeWidthTest1()
+        {
+            var sizeW1 = 100;
+            var sizeW2 = 200;
+            var sizeH1 = 100;
+            var sizeH2 = 200;
+
+            var view = new View()
+            {
+                Size2D = new Size2D(sizeW1, sizeH1),
+            };
+            layer.Add(view);
+
+            Assert.AreEqual(sizeW1, view.Size.Width, "Size.Width test fail!");
+            Assert.AreEqual(sizeH1, view.Size.Height, "Size.Height test fail!");
+            Assert.AreEqual(sizeW1, view.Size2D.Width, "Size2D.Width test fail!");
+            Assert.AreEqual(sizeH1, view.Size2D.Height, "Size2D.Height test fail!");
+
+            view.Size.Width = sizeW2;
+            Assert.AreEqual(sizeW2, view.Size.Width, "Size.Width test fail!");
+            Assert.AreEqual(sizeW2, view.Size2D.Width, "Size2D.Width test fail!");
+
+            view.Size2D.Height = sizeH2;
+            Assert.AreEqual(sizeH2, view.Size.Height, "Size.Height test fail!");
+            Assert.AreEqual(sizeH2, view.Size2D.Height, "Size2D.Height test fail!");
+
+            view.Unparent();
+            view.Dispose();
+        }
+
+        void SizeWidthTest2()
+        {
+            var sizeW1 = 100;
+            var sizeW2 = 200;
+            var sizeH1 = 100;
+            var resizeP1 = ResizePolicyType.FillToParent;
+            var resizeP2 = ResizePolicyType.Fixed;
+
+            var view = new View()
+            {
+                Size2D = new Size2D(sizeW1, sizeH1),
+                HeightResizePolicy = resizeP1,
+            };
+            layer.Add(view);
+
+            view.Size2D.Width = sizeW2;
+            Assert.AreEqual(sizeW2, view.Size.Width, "Size.Width test fail!");
+            Assert.AreEqual(sizeW2, view.Size2D.Width, "Size2D.Width test fail!");
+            Assert.AreEqual((int)resizeP1, (int)view.HeightResizePolicy, "HeightResizePolicy test fail!");
+            Assert.AreEqual((int)resizeP2, (int)view.WidthResizePolicy, "WidthResizePolicy test fail!");
+            Assert.AreEqual(sizeH1, view.Size.Height, "Size.Height test fail!");
+            Assert.AreEqual(sizeH1, view.Size2D.Height, "Size2D.Height test fail!");
+
+            view.Size.Width = sizeW1;
+            Assert.AreEqual(sizeW1, view.Size.Width, "Size.Width test fail!");
+            Assert.AreEqual(sizeW1, view.Size2D.Width, "Size2D.Width test fail!");
+            Assert.AreEqual((int)resizeP1, (int)view.HeightResizePolicy, "HeightResizePolicy test fail!");
+            Assert.AreEqual((int)resizeP2, (int)view.WidthResizePolicy, "WidthResizePolicy test fail!");
+            Assert.AreEqual(sizeH1, view.Size.Height, "Size.Height test fail!");
+            Assert.AreEqual(sizeH1, view.Size2D.Height, "Size2D.Height test fail!");
+
+            view.Unparent();
+            view.Dispose();
+        }
+
+
+        static class tlog
+        {
+            static public void prt(string log)
+            {
+                Tizen.Log.Debug("NUITEST", log);
+                Console.Write(log);
+            }
+        }
+
+        static class Assert
+        {
+            static public void AreEqual(float a, float b, string msg)
+            {
+                tlog.prt($"AreEqual(a={a}, b={b}) \n");
+                if (a != b)
+                {
+                    tlog.prt($"Different! FAIL! \n");
+                    throw new ApplicationException(msg);
+                }
+                else
+                {
+                    tlog.prt($"Same! PASS! \n");
+                }
+            }
+
+            static public void IsTrue(bool a, string msg)
+            {
+                tlog.prt($"IsTrue(a={a} \n");
+                if (a != true)
+                {
+                    tlog.prt($"false! FAIL! \n");
+                    throw new ApplicationException(msg);
+                }
+                else
+                {
+                    tlog.prt($"true! PASS! \n");
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Fix ResizePolicy error when setting View.Size.Width or Height
- If view.Size2D.Width is set, the View.HeightResizePolicy is set as Fixed wrongly
- Fixing this error by using View's SizeWidth/SizeHeight properties which are independent to each other
- Sample APP and test codes are also verified

### API Changes ###
none