### PR TITLE
[NUI] Add SlidingStarted event to Slider

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -45,6 +45,7 @@ namespace Tizen.NUI.Components
         private EventHandler<ValueChangedArgs> valueChangedHandler;
         private EventHandler<SlidingFinishedArgs> slidingFinishedHandler;
         private EventHandler<SliderValueChangedEventArgs> sliderValueChangedHandler;
+        private EventHandler<SliderSlidingStartedEventArgs> sliderSlidingStartedHandler;
         private EventHandler<SliderSlidingFinishedEventArgs> sliderSlidingFinishedHandler;
         private EventHandler<StateChangedArgs> stateChangedHandler;
 
@@ -180,6 +181,12 @@ namespace Tizen.NUI.Components
                 else if (direction == DirectionType.Vertical)
                 {
                     currentSlidedOffset = slidedTrackImage.SizeHeight;
+                }
+                if (null != sliderSlidingStartedHandler)
+                {
+                    SliderSlidingStartedEventArgs args = new SliderSlidingStartedEventArgs();
+                    args.CurrentValue = curValue;
+                    sliderSlidingStartedHandler(this, args);
                 }
                 UpdateState(isFocused, true);
             }

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -38,6 +38,19 @@ namespace Tizen.NUI.Components
     /// Slider sliding finished event data.
     /// </summary>
     /// <since_tizen> 8 </since_tizen>
+    public class SliderSlidingStartedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Current Slider value
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public float CurrentValue { get; set; }
+    }
+
+    /// <summary>
+    /// Slider sliding finished event data.
+    /// </summary>
+    /// <since_tizen> 8 </since_tizen>
     public class SliderSlidingFinishedEventArgs : EventArgs
     {
         /// <summary>
@@ -177,6 +190,22 @@ namespace Tizen.NUI.Components
             remove
             {
                 sliderValueChangedHandler -= value;
+            }
+        }
+
+        /// <summary>
+        /// The sliding finished event handler.
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public event EventHandler<SliderSlidingStartedEventArgs> SlidingStarted
+        {
+            add
+            {
+                sliderSlidingStartedHandler += value;
+            }
+            remove
+            {
+                sliderSlidingStartedHandler -= value;
             }
         }
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SliderSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SliderSample.cs
@@ -250,6 +250,7 @@ namespace Tizen.NUI.Samples
             source.MaxValue = MAX_VALUE;
             source.StateChangedEvent += OnStateChanged;
             source.ValueChanged += OnValueChanged;
+            source.SlidingStarted += OnSlidingStarted;
             source.SlidingFinished += OnSlidingFinished;
             source.Size = new Size(w, h);
             source.CurrentValue = curValue;
@@ -267,6 +268,7 @@ namespace Tizen.NUI.Samples
             source.MaxValue = MAX_VALUE;
             source.StateChangedEvent += OnStateChanged;
             source.ValueChanged += OnValueChanged;
+            source.SlidingStarted += OnSlidingStarted;
             source.SlidingFinished += OnSlidingFinished;
             source.Size = new Size(w, h);
             source.CurrentValue = curValue;
@@ -285,6 +287,22 @@ namespace Tizen.NUI.Samples
                 else
                 {
                     inforText[0].Text = "currentValue = " + args.CurrentValue;
+                }
+            }
+        }
+
+        private void OnSlidingStarted(object sender, SliderSlidingStartedEventArgs args)
+        {
+            Slider source = sender as Slider;
+            if (source != null)
+            {
+                if (source == slider_style[0] || source == slider_style[1] || source == slider_style[2] || source == slider_style[3])
+                {
+                    inforText[1].Text = "Started currentValue = " + args.CurrentValue;
+                }
+                else
+                {
+                    inforText[0].Text = "Started currentValue = " + args.CurrentValue;
                 }
             }
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
SlidingStarted event is added to Slider, which was missing while SlidingFinished event already exists.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: https://code.sec.samsung.net/jira/browse/TCSACR-363

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
