### PR TITLE
[Tizen.Applications.Alarm] Use IntPtr instead of long type

### DIFF
--- a/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
+++ b/src/Tizen.Applications.Alarm/Interop/Interop.Alarm.cs
@@ -37,7 +37,7 @@ internal static partial class Interop
             internal int wday; /* day of the week, range 0 to 6*/
             internal int yday; /* day in the year, range 0 to 365*/
             internal int isdst; /* daylight saving time*/
-            internal long tm_gmtoff;
+            internal IntPtr tm_gmtoff; // Workaround: Use IntPtr instead of long type to match struct size with "struct tm" in time.h
             internal IntPtr tm_zone;
         };
 


### PR DESCRIPTION
### Description of Change ###
Use IntPtr instead of long type to match struct size

