### PR TITLE
[NUI] Change VS Code settings in Ubuntu

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/.vscode/launch.json
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/netcoreapp2.0/Tizen.NUI.Samples.dll",
+            "program": "${workspaceFolder}/bin/Debug/netcoreapp3.1/Tizen.NUI.Samples.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "console": "internalConsole",

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Program.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Program.cs
@@ -20,7 +20,6 @@ namespace Tizen.NUI.Samples
 {
     public class Application
     {
-        [STAThread]
         static void Main(string[] args)
         {
             new DaliDemo("").Run(args);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Tizen.NUI.Samples</RootNamespace>
     <AssemblyName>Tizen.NUI.Samples</AssemblyName>
+    <StartupObject>Tizen.NUI.Samples.Application</StartupObject>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
### Description of Change ###
[NUI] Change VS Code settings in Ubuntu
- change to use .Net Core 3.1
- move to dotnet core 3.1 =>
  1. download pkg for Ubuntu : https://dotnet.microsoft.com/download/dotnet-core/thank-you/sdk-3.1.302-linux-x64-binaries
  2. install downloaded pkg : 
```
$ mkdir -p $HOME/dotnet && tar zxf dotnet-sdk-3.1.302-linux-x64.tar.gz -C $HOME/dotnet
$ export DOTNET_ROOT=$HOME/dotnet
$ export PATH=$PATH:$HOME/dotnet

```
  3. remove previously installed nupkg : 
`$ sudo rm -rf ~/.nuget/`
  4. do dotnet restore : 
```
$ cd {your tizenfx path}/test/Tizen.NUI.Samples/Tizen.NUI.Samples
$ dotnet clean
$ dotnet restore
$ dotnet build Tizen.NUI.Samples.csproj

```
  OR you can do restore in VS Code command palette (ctrl+shift+p) => restore All projects


### API Changes ###
none