### PR TITLE
[NUI] Workaround : Add Clear() when new PropertyMap()

### DIFF
--- a/src/Tizen.NUI/src/public/PropertyMap.cs
+++ b/src/Tizen.NUI/src/public/PropertyMap.cs
@@ -32,6 +32,10 @@ namespace Tizen.NUI
         public PropertyMap() : this(Interop.PropertyMap.new_Property_Map__SWIG_0(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            
+            // workaround : when do "new PropertyMap().Add(xxx, xxx).Add(xxx, xxx)", it has garbage values sometimes.
+            // this will be fixed later.
+            Clear();
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
[NUI] Workaround : Add Clear() when new PropertyMap()
- workaround : when do "new PropertyMap().Add(xxx, xxx).Add(xxx, xxx)", it has garbage values sometimes. this will be fixed later.


### API Changes ###
none