### PR TITLE
[RPCPort][ACR] Support synchronous connection requests and private file sharing

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
@@ -144,6 +144,18 @@ internal static partial class Interop
             //int rpc_port_parcel_burst_write(rpc_port_parcel_h h, const unsigned char *buf, unsigned int size);
             [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_burst_write")]
             internal static extern ErrorCode Write(IntPtr parcelHandle, byte[] buf, int size);
+
+            //int rpc_port_set_private_sharing_array(rpc_port_h port, const char* paths[], unsigned int size);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array")]
+            internal static extern ErrorCode SetPrivateSharingArray(IntPtr handle, string[] paths, uint size);
+
+            //int rpc_port_set_private_sharing(rpc_port_h port, const char* path);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array")]
+            internal static extern ErrorCode SetPrivateSharing(IntPtr handle, string path);
+
+            //int rpc_port_unset_private_sharing(rpc_port_h port);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_unset_private_sharing")]
+            internal static extern ErrorCode UnsetPrivateSharing(IntPtr handle);
         }
 
         internal static partial class Proxy

--- a/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
@@ -19,6 +19,7 @@ using System.Runtime.InteropServices;
 
 using Tizen.Internals.Errors;
 using Tizen.Applications;
+using System.Reflection;
 
 internal static partial class Interop
 {
@@ -144,18 +145,6 @@ internal static partial class Interop
             //int rpc_port_parcel_burst_write(rpc_port_parcel_h h, const unsigned char *buf, unsigned int size);
             [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_burst_write")]
             internal static extern ErrorCode Write(IntPtr parcelHandle, byte[] buf, int size);
-
-            //int rpc_port_set_private_sharing_array(rpc_port_h port, const char* paths[], unsigned int size);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array")]
-            internal static extern ErrorCode SetPrivateSharingArray(IntPtr handle, string[] paths, uint size);
-
-            //int rpc_port_set_private_sharing(rpc_port_h port, const char* path);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array")]
-            internal static extern ErrorCode SetPrivateSharing(IntPtr handle, string path);
-
-            //int rpc_port_unset_private_sharing(rpc_port_h port);
-            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_unset_private_sharing")]
-            internal static extern ErrorCode UnsetPrivateSharing(IntPtr handle);
         }
 
         internal static partial class Proxy
@@ -262,6 +251,21 @@ internal static partial class Interop
             //int rpc_port_stub_get_port(rpc_port_stub_h h, rpc_port_port_type_e type, const char* instance, rpc_port_h *port);
             [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_stub_get_port")]
             internal static extern ErrorCode GetPort(IntPtr handle, PortType t, string instance, out IntPtr port);
+        }
+
+        internal static partial class Port
+        {
+            //int rpc_port_set_private_sharing_array(rpc_port_h port, const char* paths[], unsigned int size);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array")]
+            internal static extern ErrorCode SetPrivateSharingArray(IntPtr handle, string[] paths, uint size);
+
+            //int rpc_port_set_private_sharing(rpc_port_h port, const char* path);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_set_private_sharing_array")]
+            internal static extern ErrorCode SetPrivateSharing(IntPtr handle, string path);
+
+            //int rpc_port_unset_private_sharing(rpc_port_h port);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_unset_private_sharing")]
+            internal static extern ErrorCode UnsetPrivateSharing(IntPtr handle);
         }
     }
 }

--- a/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
@@ -207,6 +207,10 @@ internal static partial class Interop
             //int rpc_port_proxy_get_port(rpc_port_proxy_h h, rpc_port_port_type_e type, rpc_port_h* port);
             [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_get_port")]
             internal static extern ErrorCode GetPort(IntPtr handle, PortType t, out IntPtr port);
+
+            //int rpc_port_proxy_connect_sync(rpc_port_proxy_h h, const char* appid, const char* port);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_proxy_connect_sync")]
+            internal static extern ErrorCode ConnectSync(IntPtr handle, string appId, string port);
         }
 
         internal static partial class Stub

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
@@ -302,68 +302,6 @@ namespace Tizen.Applications.RPCPort
             return ret;
         }
 
-        /// <summary>
-        /// Shares private files with other applications.
-        /// </summary>
-        /// <remarks>
-        /// If all added paths are under the caller application's data path which can be obtained, those will be shared to the target application.
-        /// Platform will grant a temporary permission to the target application for those files and revoke it when the target application is terminated or UnshareFile() is called.
-        /// Paths should be regular files. The target application can just read them.
-        /// Note that the target application doesn't have read permission of the directory that is obtained by caller's data path. You should open the file path with read only mode directly.
-        /// </remarks>
-        /// <param name="p">The RPC Port object to be used for the file sharing.</param>
-        /// <param name="paths">The file paths to be shared.</param>
-        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
-        /// <since_tizen> 8 </since_tizen>
-        public void ShareFile(Port p, string[] paths)
-        {
-            if (p == null || paths == null)
-                throw new InvalidIOException();
-
-            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Parcel.SetPrivateSharingArray(p.Handle, paths, (uint)paths.Length);
-            if (err != Interop.LibRPCPort.ErrorCode.None)
-                throw new InvalidIOException();
-        }
-
-        /// <summary>
-        /// Shares the private file with other applications.
-        /// </summary>
-        /// <remarks>
-        /// If the path is under the caller application's data path which can be obtained, this will be shared to the target application.
-        /// Platform will grant a temporary permission to the target application for the file and revoke it when the target application is terminated or UnshareFile() is called..
-        /// Paths should be regular files. The target application can just read it.
-        /// Note that the target application doesn't have read permission of the directory that is obtained by caller's data path. You should open the file path with read only mode directly.
-        /// </remarks>
-        /// <param name="p">The RPC Port object to be used for the file sharing.</param>
-        /// <param name="path">The file path to be shared.</param>
-        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
-        /// <since_tizen> 8 </since_tizen>
-        public void ShareFile(Port p, string path)
-        {
-            if (p == null || path == null)
-                throw new InvalidIOException();
-
-            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Parcel.SetPrivateSharing(p.Handle, path);
-            if (err != Interop.LibRPCPort.ErrorCode.None)
-                throw new InvalidIOException();
-        }
-
-        /// <summary>
-        /// Unshares the private file.
-        /// </summary>
-        /// <param name="p">The RPC Port object</param>
-        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
-        /// <since_tizen> 8 </since_tizen>
-        public void UnshareFile(Port p)
-        {
-            if (p == null)
-                throw new InvalidIOException();
-
-            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Parcel.UnsetPrivateSharing(p.Handle);
-            if (err != Interop.LibRPCPort.ErrorCode.None)
-                throw new InvalidIOException();
-        }
-
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
@@ -302,6 +302,68 @@ namespace Tizen.Applications.RPCPort
             return ret;
         }
 
+        /// <summary>
+        /// Shares private files with other applications.
+        /// </summary>
+        /// <remarks>
+        /// If all added paths are under the caller application's data path which can be obtained, those will be shared to the target application.
+        /// Platform will grant a temporary permission to the target application for those files and revoke it when the target application is terminated or UnshareFile() is called.
+        /// Paths should be regular files. The target application can just read them.
+        /// Note that the target application doesn't have read permission of the directory that is obtained by caller's data path. You should open the file path with read only mode directly.
+        /// </remarks>
+        /// <param name="p">The RPC Port object to be used for the file sharing.</param>
+        /// <param name="paths">The file paths to be shared.</param>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        public void ShareFile(Port p, string[] paths)
+        {
+            if (p == null || paths == null)
+                throw new InvalidIOException();
+
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Parcel.SetPrivateSharingArray(p.Handle, paths, (uint)paths.Length);
+            if (err != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
+
+        /// <summary>
+        /// Shares the private file with other applications.
+        /// </summary>
+        /// <remarks>
+        /// If the path is under the caller application's data path which can be obtained, this will be shared to the target application.
+        /// Platform will grant a temporary permission to the target application for the file and revoke it when the target application is terminated or UnshareFile() is called..
+        /// Paths should be regular files. The target application can just read it.
+        /// Note that the target application doesn't have read permission of the directory that is obtained by caller's data path. You should open the file path with read only mode directly.
+        /// </remarks>
+        /// <param name="p">The RPC Port object to be used for the file sharing.</param>
+        /// <param name="path">The file path to be shared.</param>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        public void ShareFile(Port p, string path)
+        {
+            if (p == null || path == null)
+                throw new InvalidIOException();
+
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Parcel.SetPrivateSharing(p.Handle, path);
+            if (err != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
+
+        /// <summary>
+        /// Unshares the private file.
+        /// </summary>
+        /// <param name="p">The RPC Port object</param>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        public void UnshareFile(Port p)
+        {
+            if (p == null)
+                throw new InvalidIOException();
+
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Parcel.UnsetPrivateSharing(p.Handle);
+            if (err != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
+
         #region IDisposable Support
         private bool disposedValue = false;
 

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
@@ -57,7 +57,7 @@ namespace Tizen.Applications.RPCPort
         /// <param name="paths">The file paths to be shared.</param>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
         /// <since_tizen> 8 </since_tizen>
-        public void ShareFile(IEnumerable<string > paths)
+        public void ShareFile(IEnumerable<string> paths)
         {
             if (paths == null)
                 throw new InvalidIOException();

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
@@ -15,6 +15,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Tizen.Applications.RPCPort
 {
@@ -55,12 +57,13 @@ namespace Tizen.Applications.RPCPort
         /// <param name="paths">The file paths to be shared.</param>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
         /// <since_tizen> 8 </since_tizen>
-        public void ShareFile(string[] paths)
+        public void ShareFile(IEnumerable<string > paths)
         {
             if (paths == null)
                 throw new InvalidIOException();
 
-            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Port.SetPrivateSharingArray(Handle, paths, (uint)paths.Length);
+            string[] pathArray = paths.ToArray<string>();
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Port.SetPrivateSharingArray(Handle, pathArray, (uint)pathArray.Length);
             if (err != Interop.LibRPCPort.ErrorCode.None)
                 throw new InvalidIOException();
         }
@@ -68,7 +71,7 @@ namespace Tizen.Applications.RPCPort
         /// <summary>
         /// Shares the private file with other applications.
         /// </summary>
-        /// <seealso cref="ShareFile(string[])"/>
+        /// <seealso cref="ShareFile(IEnumerable{string})"/>
         /// <param name="path">The file path to be shared.</param>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
         /// <since_tizen> 8 </since_tizen>

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
@@ -42,5 +42,56 @@ namespace Tizen.Applications.RPCPort
 
         internal IntPtr Handle { get; set; }
         internal Port() { }
+
+        /// <summary>
+        /// Shares private files with other applications.
+        /// </summary>
+        /// <remarks>
+        /// If all added paths are under the caller application's data path which can be obtained, those will be shared to the target application.
+        /// Platform will grant a temporary permission to the target application for those files and revoke it when the target application is terminated or UnshareFile() is called.
+        /// Paths should be regular files. The target application can just read them.
+        /// Note that the target application doesn't have read permission of the directory that is obtained by caller's data path. You should open the file path with read only mode directly.
+        /// </remarks>
+        /// <param name="paths">The file paths to be shared.</param>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        public void ShareFile(string[] paths)
+        {
+            if (paths == null)
+                throw new InvalidIOException();
+
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Port.SetPrivateSharingArray(Handle, paths, (uint)paths.Length);
+            if (err != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
+
+        /// <summary>
+        /// Shares the private file with other applications.
+        /// </summary>
+        /// <seealso cref="ShareFile(string[])"/>
+        /// <param name="path">The file path to be shared.</param>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        public void ShareFile(string path)
+        {
+            if (path == null)
+                throw new InvalidIOException();
+
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Port.SetPrivateSharing(Handle, path);
+            if (err != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
+
+        /// <summary>
+        /// Unshares the private file.
+        /// </summary>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurrs.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        public void UnshareFile()
+        {
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Port.UnsetPrivateSharing(Handle);
+            if (err != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/ProxyBase.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/ProxyBase.cs
@@ -87,6 +87,31 @@ namespace Tizen.Applications.RPCPort
         }
 
         /// <summary>
+        /// Connects to port synchronously.
+        /// </summary>
+        /// <param name="appid">The target stub app ID.</param>
+        /// <param name="port">The name of the RPC port.</param>
+        /// <exception cref="InvalidIDException">Thrown when not available app ID is used.</exception>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
+        /// <exception cref="PermissionDeniedException">Thrown when the permission is denied.</exception>
+        /// <privilege>http://tizen.org/privilege/datasharing</privilege>
+        /// <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
+        /// <since_tizen> 8 </since_tizen>
+        protected void ConnectSync(string appid, string port)
+        {
+            var err = Interop.LibRPCPort.Proxy.ConnectSync(_proxy, appid, port);
+            switch (err)
+            {
+                case Interop.LibRPCPort.ErrorCode.InvalidParameter:
+                    throw new InvalidIDException();
+                case Interop.LibRPCPort.ErrorCode.PermissionDenied:
+                    throw new PermissionDeniedException();
+                case Interop.LibRPCPort.ErrorCode.IoError:
+                    throw new InvalidIOException();
+            }
+        }
+
+        /// <summary>
         /// Gets a port.
         /// </summary>
         /// <param name="t">The type of port.</param>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Support synchronous connection requests and private file sharing
To support synchronous connection requests, ConnectSync() is added.
To support private file sharing, ShareFile() and UnshareFile() are added.
When the application calls ShareFile() method, platform will grant a temporary permission to the target application for files and revoke it when the target application is terminated or UnshareFile() method is called.
The target application doesn't have read permission of the directory that is obtained by caller's data path(Tizen.Applications.DirectoryInfo.Data). The developer should open the file path with read only mode directly. Because, platform grants read permission to the passed file path.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: TCSACR-362

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
- void ConnectSync(string appId, string port);
- void ShareFile(string[] paths);
- void ShareFile(string path);
- void UnshareFile();