### PR TITLE
[NUI] Remove workaround, Fix PropertyMap().Add() problem

### DIFF
--- a/src/Tizen.NUI/src/public/PropertyMap.cs
+++ b/src/Tizen.NUI/src/public/PropertyMap.cs
@@ -32,10 +32,6 @@ namespace Tizen.NUI
         public PropertyMap() : this(Interop.PropertyMap.new_Property_Map__SWIG_0(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            
-            // workaround : when do "new PropertyMap().Add(xxx, xxx).Add(xxx, xxx)", it has garbage values sometimes.
-            // this will be fixed later.
-            Clear();
         }
 
         /// <summary>
@@ -150,9 +146,9 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public PropertyMap Add(string key, PropertyValue value)
         {
-            PropertyMap ret = new PropertyMap(Interop.PropertyMap.Property_Map_Add__SWIG_0(swigCPtr, key, PropertyValue.getCPtr(value)), false);
+            Interop.PropertyMap.Property_Map_Add__SWIG_0(swigCPtr, key, PropertyValue.getCPtr(value));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            return this;
         }
 
         /// <summary>
@@ -165,9 +161,9 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public PropertyMap Add(int key, PropertyValue value)
         {
-            PropertyMap ret = new PropertyMap(Interop.PropertyMap.Property_Map_Add__SWIG_2(swigCPtr, key, PropertyValue.getCPtr(value)), false);
+            Interop.PropertyMap.Property_Map_Add__SWIG_2(swigCPtr, key, PropertyValue.getCPtr(value));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            return this;
         }
 
         /// <summary>
@@ -178,18 +174,17 @@ namespace Tizen.NUI
         /// <returns>Returns a reference to this object.</returns>
         public PropertyMap Add(KeyValue keyValue)
         {
-            PropertyMap ret = new PropertyMap();
-            if ( keyValue.KeyInt != null )
+            if (keyValue.KeyInt != null)
             {
-                ret = new PropertyMap(Interop.PropertyMap.Property_Map_Add__SWIG_2(swigCPtr, (int)keyValue.KeyInt, PropertyValue.getCPtr(keyValue.TrueValue)), false);
+                Interop.PropertyMap.Property_Map_Add__SWIG_2(swigCPtr, (int)keyValue.KeyInt, PropertyValue.getCPtr(keyValue.TrueValue));
             }
-            else if ( keyValue.KeyString != null )
+            else if (keyValue.KeyString != null)
             {
-                ret = new PropertyMap(Interop.PropertyMap.Property_Map_Add__SWIG_0(swigCPtr, keyValue.KeyString, PropertyValue.getCPtr(keyValue.TrueValue)), false);
+                Interop.PropertyMap.Property_Map_Add__SWIG_0(swigCPtr, keyValue.KeyString, PropertyValue.getCPtr(keyValue.TrueValue));
             }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-            return ret;
+            return this;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
[NUI] Remove workaround, Fix PropertyMap().Add() problem
- Remove workaround : https://github.com/Samsung/TizenFX/pull/1894
- The native PropertyMap object is deleted by GC, When using like this : new PropertyMap().Add(xxx).Add(xxx);
- Fix to maintain swigCPtr in the scope of Add() method

### API Changes ###
none