### PR TITLE
[NUI] Add MaxLength property and signal to TextEditor

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -164,6 +164,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_InputStyleChangedSignal")]
             public static extern global::System.IntPtr TextEditor_InputStyleChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_MaxLengthReachedSignal")]
+            public static extern global::System.IntPtr TextEditor_MaxLengthReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditorSignal_Empty")]
             public static extern bool TextEditorSignal_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
 
@@ -184,7 +187,7 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextEditorSignal")]
             public static extern void delete_TextEditorSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
-            
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SWIGUpcast")]
             public static extern global::System.IntPtr TextEditor_SWIGUpcast(global::System.IntPtr jarg1);
 
@@ -229,6 +232,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_SCROLL_BAR_FADE_DURATION_get")]
             public static extern int TextEditor_Property_SCROLL_BAR_FADE_DURATION_get();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_MAX_LENGTH_get")]
+            public static extern int TextEditor_Property_MAX_LENGTH_get();
 
             //manual pinvoke for text-editor ScrollStateChangedSignal
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_ScrollStateChangedSignal")]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1075,6 +1075,24 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// The MaxLength property.
+        /// </summary>
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int MaxLength
+        {
+            get
+            {
+                return (int)GetValue(MaxLengthProperty);
+            }
+            set
+            {
+                SetValue(MaxLengthProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
         /// Only used by the IL of xaml, will never changed to not hidden.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool IsCreateByXaml
@@ -1140,9 +1158,17 @@ namespace Tizen.NUI.BaseComponents
             //You should not access any managed member here except static instance.
             //because the execution order of Finalizes is non-deterministic.
 
-            if (this.HasBody() && _textEditorTextChangedCallbackDelegate != null)
+            if (this.HasBody())
             {
-                TextChangedSignal().Disconnect(_textEditorTextChangedCallbackDelegate);
+                if(_textEditorTextChangedCallbackDelegate != null)
+                {
+                    TextChangedSignal().Disconnect(_textEditorTextChangedCallbackDelegate);
+                }
+
+                if(_textEditorMaxLengthReachedCallbackDelegate != null)
+                {
+                    this.MaxLengthReachedSignal().Disconnect(_textEditorMaxLengthReachedCallbackDelegate);
+                }
             }
 
             base.Dispose(type);
@@ -1244,6 +1270,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int PLACEHOLDER_TEXT_COLOR = Interop.TextEditor.TextEditor_Property_PLACEHOLDER_TEXT_COLOR_get();
             internal static readonly int ENABLE_SHIFT_SELECTION = Interop.TextEditor.TextEditor_Property_ENABLE_SHIFT_SELECTION_get();
             internal static readonly int MATCH_SYSTEM_LANGUAGE_DIRECTION = Interop.TextEditor.TextEditor_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get();
+            internal static readonly int MAX_LENGTH = Interop.TextEditor.TextEditor_Property_MAX_LENGTH_get();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -918,5 +918,22 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty(textEditor.swigCPtr, TextEditor.Property.MATCH_SYSTEM_LANGUAGE_DIRECTION).Get(out temp);
             return (bool)temp;
         });
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int), typeof(TextEditor), default(int), propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty(textEditor.swigCPtr, TextEditor.Property.MAX_LENGTH, new Tizen.NUI.PropertyValue((int)newValue));
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            int temp = 0;
+            Tizen.NUI.Object.GetProperty(textEditor.swigCPtr, TextEditor.Property.MAX_LENGTH).Get(out temp);
+            return temp;
+        });
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 namespace Tizen.NUI.BaseComponents
@@ -32,11 +33,17 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<ScrollStateChangedEventArgs> _textEditorScrollStateChangedEventHandler;
         private ScrollStateChangedCallbackDelegate _textEditorScrollStateChangedCallbackDelegate;
 
+        private EventHandler<MaxLengthReachedEventArgs> _textEditorMaxLengthReachedEventHandler;
+        private MaxLengthReachedCallbackDelegate _textEditorMaxLengthReachedCallbackDelegate;
+
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void TextChangedCallbackDelegate(IntPtr textEditor);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void ScrollStateChangedCallbackDelegate(IntPtr textEditor, ScrollState state);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate void MaxLengthReachedCallbackDelegate(IntPtr textEditor);
 
         /// <summary>
         /// An event for the TextChanged signal which can be used to subscribe or unsubscribe the event handler
@@ -90,6 +97,32 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// The MaxLengthReached event.
+        /// </summary>
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<MaxLengthReachedEventArgs> MaxLengthReached
+        {
+            add
+            {
+                if (_textEditorMaxLengthReachedEventHandler == null)
+                {
+                    _textEditorMaxLengthReachedCallbackDelegate = (OnMaxLengthReached);
+                    MaxLengthReachedSignal().Connect(_textEditorMaxLengthReachedCallbackDelegate);
+                }
+                _textEditorMaxLengthReachedEventHandler += value;
+            }
+            remove
+            {
+                if (_textEditorMaxLengthReachedEventHandler == null && MaxLengthReachedSignal().Empty() == false)
+                {
+                    this.MaxLengthReachedSignal().Disconnect(_textEditorMaxLengthReachedCallbackDelegate);
+                }
+                _textEditorMaxLengthReachedEventHandler -= value;
+            }
+        }
+
         internal TextEditorSignal TextChangedSignal()
         {
             TextEditorSignal ret = new TextEditorSignal(Interop.TextEditor.TextEditor_TextChangedSignal(swigCPtr), false);
@@ -100,6 +133,13 @@ namespace Tizen.NUI.BaseComponents
         internal ScrollStateChangedSignal ScrollStateChangedSignal(TextEditor textEditor)
         {
             ScrollStateChangedSignal ret = new ScrollStateChangedSignal(Interop.TextEditor.TextEditor_ScrollStateChangedSignal(TextEditor.getCPtr(textEditor)), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal TextEditorSignal MaxLengthReachedSignal()
+        {
+            TextEditorSignal ret = new TextEditorSignal(Interop.TextEditor.TextEditor_MaxLengthReachedSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -133,6 +173,20 @@ namespace Tizen.NUI.BaseComponents
             {
                 //here we send all data to user event handlers
                 _textEditorScrollStateChangedEventHandler(this, e);
+            }
+        }
+
+        private void OnMaxLengthReached(IntPtr textEditor)
+        {
+            MaxLengthReachedEventArgs e = new MaxLengthReachedEventArgs();
+
+            // Populate all members of "e" (MaxLengthReachedEventArgs) with real data
+            e.TextEditor = Registry.GetManagedBaseHandleFromNativePtr(textEditor) as TextEditor;
+
+            if (_textEditorMaxLengthReachedEventHandler != null)
+            {
+                //here we send all data to user event handlers
+                _textEditorMaxLengthReachedEventHandler(this, e);
             }
         }
 
@@ -199,6 +253,33 @@ namespace Tizen.NUI.BaseComponents
                 set
                 {
                     _scrollState = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The MaxLengthReached event arguments.
+        /// </summary>
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public class MaxLengthReachedEventArgs : EventArgs
+        {
+            private TextEditor _textEditor;
+
+            /// <summary>
+            /// TextEditor.
+            /// </summary>
+            /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public TextEditor TextEditor
+            {
+                get
+                {
+                    return _textEditor;
+                }
+                set
+                {
+                    _textEditor = value;
                 }
             }
         }

--- a/test/NUITestSample/NUITestSample/examples/text-test.cs
+++ b/test/NUITestSample/NUITestSample/examples/text-test.cs
@@ -152,6 +152,7 @@ namespace TextTest
             editor.EnableSelection = true;
             editor.Focusable = true;
             editor.Placeholder = propertyMap;
+            editor.MaxLength = 10;
             window.Add(editor);
             editor.TextChanged += (obj, e) => {
                 Tizen.Log.Debug("NUI", "editor line count: " + e.TextEditor.LineCount);
@@ -159,6 +160,9 @@ namespace TextTest
 
             editor.ScrollStateChanged += (obj, e)=> {
                 Tizen.Log.Debug("NUI", "editor scroll state:" + e.ScrollState);
+            };
+            editor.MaxLengthReached += (obj, e)=> {
+                Tizen.Log.Debug("NUI", "editor max length: "+ e.TextEditor.MaxLength);
             };
 
             Tizen.Log.Debug("NUI",  "editor id: " + editor.ID);


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- To limit input to maximum characters in TextEditor,
 added MaxLength property and MaxLengthReached signal


### API Changes ###
- N/A
