### PR TITLE
[MachineLearning.Inference] Add CustomFilter class and more functionality  to MachineLearning module.

### DIFF
--- a/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
+++ b/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
@@ -110,6 +110,78 @@ internal static partial class Interop
         /* int ml_pipeline_custom_easy_filter_unregister (ml_custom_easy_filter_h custom); */
         [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_custom_easy_filter_unregister", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError UnregisterCustomFilter(IntPtr custom_handle);
+
+        /* int ml_pipeline_element_get_handle (ml_pipeline_h pipe, const char *element_name, ml_pipeline_element_h *elem_h); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_handle", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetElementHandle(IntPtr pipeline_handle, string element_name, out IntPtr element_handle);
+
+        /* int ml_pipeline_element_release_handle (ml_pipeline_element_h elem_h); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_release_handle", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError ReleaseElementHandle(IntPtr element_handle);
+
+        /* int ml_pipeline_element_set_property_bool (ml_pipeline_element_h elem_h, const char *property_name, const int32_t value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_bool", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyBool(IntPtr element_handle, string property_name, int value);
+
+        /* int ml_pipeline_element_set_property_string (ml_pipeline_element_h elem_h, const char *property_name, const char *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_string", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyString(IntPtr element_handle, string property_name, string value);
+
+        /* int ml_pipeline_element_set_property_int32 (ml_pipeline_element_h elem_h, const char *property_name, const int32_t value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_int32", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyInt32(IntPtr element_handle, string property_name, int value);
+
+        /* int ml_pipeline_element_set_property_int64 (ml_pipeline_element_h elem_h, const char *property_name, const int64_t value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_int64", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyInt64(IntPtr element_handle, string property_name, long value);
+
+        /* int ml_pipeline_element_set_property_uint32 (ml_pipeline_element_h elem_h, const char *property_name, const uint32_t value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_uint32", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyUInt32(IntPtr element_handle, string property_name, uint value);
+
+        /* int ml_pipeline_element_set_property_uint64 (ml_pipeline_element_h elem_h, const char *property_name, const uint64_t value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_uint64", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyUInt64(IntPtr element_handle, string property_name, ulong value);
+
+        /* int ml_pipeline_element_set_property_double (ml_pipeline_element_h elem_h, const char *property_name, const double value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_double", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyDouble(IntPtr element_handle, string property_name, double value);
+
+        /* int ml_pipeline_element_set_property_enum (ml_pipeline_element_h elem_h, const char *property_name, const uint32_t value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_set_property_enum", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError SetPropertyEnum(IntPtr element_handle, string property_name, uint value);
+
+        /* int ml_pipeline_element_get_property_bool (ml_pipeline_element_h elem_h, const char *property_name, int32_t *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_bool", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyBool(IntPtr element_handle, string property_name, out int value);
+
+        /* int ml_pipeline_element_get_property_string (ml_pipeline_element_h elem_h, const char *property_name, char **value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_string", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyString(IntPtr element_handle, string property_name, out string value);
+
+        /* int ml_pipeline_element_get_property_int32 (ml_pipeline_element_h elem_h, const char *property_name, int32_t *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_int32", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyInt32(IntPtr element_handle, string property_name, out int value);
+
+        /* int ml_pipeline_element_get_property_int64 (ml_pipeline_element_h elem_h, const char *property_name, int64_t *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_int64", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyInt64(IntPtr element_handle, string property_name, out long value);
+
+        /* int ml_pipeline_element_get_property_uint32 (ml_pipeline_element_h elem_h, const char *property_name, uint32_t *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_uint32", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyUInt32(IntPtr element_handle, string property_name, out uint value);
+
+        /* int ml_pipeline_element_get_property_uint64 (ml_pipeline_element_h elem_h, const char *property_name, uint64_t *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_uint64", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyUInt64(IntPtr element_handle, string property_name, out ulong value);
+
+        /* int ml_pipeline_element_get_property_double (ml_pipeline_element_h elem_h, const char *property_name, double *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_double", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyDouble(IntPtr element_handle, string property_name, out double value);
+
+        /* int ml_pipeline_element_get_property_enum (ml_pipeline_element_h elem_h, const char *property_name, uint32_t *value); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_element_get_property_enum", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError GetPropertyEnum(IntPtr element_handle, string property_name, out uint value);
     }
 
     internal static partial class SingleShot

--- a/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
+++ b/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
@@ -35,6 +35,10 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void NewDataCallback(IntPtr data, IntPtr info, IntPtr user_data);
 
+        /* typedef int (*ml_custom_easy_invoke_cb) (const ml_tensors_data_h in, ml_tensors_data_h out, void *user_data); */
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void CustomEasyInvokeCallback(IntPtr in_data, IntPtr out_data, IntPtr user_data);
+
         /* int ml_pipeline_construct (const char *pipeline_description, ml_pipeline_state_cb cb, void *user_data, ml_pipeline_h *pipe); */
         [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_construct", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError Construct(string pipeline_description, StateChangedCallback callback, IntPtr user_data, out IntPtr pipeline_handle);
@@ -98,6 +102,14 @@ internal static partial class Interop
         /* int ml_pipeline_switch_select (ml_pipeline_switch_h switch_handle, const char *pad_name); */
         [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_switch_select", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SelectSwitchPad(IntPtr switch_handle, string pad_name);
+
+        /* int ml_pipeline_custom_easy_filter_register (const char *name, const ml_tensors_info_h in, const ml_tensors_info_h out, ml_custom_easy_invoke_cb cb, void *user_data, ml_custom_easy_filter_h *custom); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_custom_easy_filter_register", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError RegisterCustomFilter(string name, IntPtr input_info, IntPtr output_info, CustomEasyInvokeCallback callback, IntPtr user_data, out IntPtr custom_handle);
+
+        /* int ml_pipeline_custom_easy_filter_unregister (ml_custom_easy_filter_h custom); */
+        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_pipeline_custom_easy_filter_unregister", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern NNStreamerError UnregisterCustomFilter(IntPtr custom_handle);
     }
 
     internal static partial class SingleShot

--- a/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/Commons.cs
+++ b/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/Commons.cs
@@ -134,44 +134,49 @@ namespace Tizen.MachineLearning.Inference
         /// <summary>
         /// Custom filter (Independent shared object).
         /// </summary>
-        CustomFilter,
+        CustomFilter = 1,
         /// <summary>
         /// Tensorflow-lite (.tflite).
         /// </summary>
-        TensorflowLite,
+        TensorflowLite = 2,
         /// <summary>
         /// Tensorflow (.pb).
         /// </summary>
-        Tensorflow,
+        Tensorflow = 3,
         /// <summary>
         /// Neural Network Inference framework, which is developed by SR (Samsung Research).
         /// </summary>
-        NNFW,
+        NNFW = 4,
         /// <summary>
         /// Intel Movidius Neural Compute SDK (libmvnc).
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        MVNC,
+        MVNC = 5,
         /// <summary>
         /// Intel OpenVINO.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        OpenVINO,
+        OpenVINO = 6,
         /// <summary>
         /// VeriSilicon's Vivante.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        Vivante,
+        Vivante = 7,
         /// <summary>
         /// Google Coral Edge TPU (USB).
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        EdgeTPU,
+        EdgeTPU = 8,
         /// <summary>
         /// Arm Neural Network framework (support for caffe and tensorflow-lite).
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        ArmNN,
+        ArmNN = 9,
+        /// <summary>
+        /// Qualcomm SNPE (Snapdgragon Neural Processing Engine (.dlc)
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        SNPE = 10,
     }
 
     /// <summary>
@@ -193,10 +198,15 @@ namespace Tizen.MachineLearning.Inference
         /// </summary>
         CPU = 0x1000,
         /// <summary>
+        /// SIMD in CPU if possible.
+        /// <since_tizen> 8 </since_tizen>
+        /// </summary>
+        CPUSIMD = 0x1100,
+        /// <summary>
         /// NEON in CPU.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        CPUNeon = 0x1100,
+        CPUNeon = CPUSIMD,
         /// <summary>
         /// Any GPU if possible.
         /// </summary>

--- a/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/CustomFilter.cs
+++ b/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/CustomFilter.cs
@@ -1,0 +1,140 @@
+/*
+* Copyright (c) 2020 Samsung Electronics Co., Ltd. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Tizen.MachineLearning.Inference
+{
+    /// <summary>
+    /// The CustomFilter class provides interfaces to create a custom-filter in the pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Because of data translation (i.e. marshaling and unmarshaling ) between Native and .Net Layer, CustomFilter class shows lower performance than native implementation.
+    /// </remarks>
+    /// <since_tizen> 8 </since_tizen>
+    public class CustomFilter : IDisposable
+    {
+        private Interop.Pipeline.CustomEasyInvokeCallback _nativeCallback;
+        private Func<TensorsData, TensorsData> _filter;
+
+        private TensorsInfo _InInfo;
+        private TensorsInfo _OutInfo;
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Internally gets and sets the the native handle of custom filter.
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        internal IntPtr Handle { get; set; }
+
+        /// <summary>
+        /// Gets or internally sets the name of the CustomFilter
+        /// </summary>
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Creates new custom-filter with input and output tensors information.
+        /// </summary>
+        /// <param name="name">The name of custom-filter</param>
+        /// <param name="inInfo">The input tensors information</param>
+        /// <param name="outInfo">The output tensors information</param>
+        /// <param name="filter">Delegate to be called while processing the pipeline</param>
+        /// <returns>CustomFiter instance</returns>
+        /// <exception cref="NotSupportedException">Thrown when the feature is not supported.</exception>
+        /// <exception cref="ArgumentException">Thrown when the method failed due to an invalid parameter.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        public static CustomFilter Create(string name,
+            TensorsInfo inInfo, TensorsInfo outInfo, Func<TensorsData, TensorsData> filter)
+        {
+            NNStreamer.CheckNNStreamerSupport();
+
+            return new CustomFilter(name, inInfo, outInfo, filter);
+        }
+
+        /// <summary>
+        /// Releases any unmanaged resources used by this object.
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases any unmanaged resources used by this object including opened handle.
+        /// </summary>
+        /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        /// <since_tizen> 8 </since_tizen>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                // release managed objects
+            }
+
+            // release unmanaged objects
+            if (Handle != IntPtr.Zero)
+            {
+                NNStreamerError ret = Interop.Pipeline.UnregisterCustomFilter(Handle);
+                if (ret != NNStreamerError.None)
+                    Log.Error(NNStreamer.TAG, "failed to destroy CustomFilter object");
+
+                Handle = IntPtr.Zero;
+            }
+            _disposed = true;
+        }
+
+        private CustomFilter(string name, TensorsInfo inInfo, TensorsInfo outInfo, Func<TensorsData, TensorsData> filter)
+        {
+            /* Parameger check */
+            if (name == null)
+                throw NNStreamerExceptionFactory.CreateException(NNStreamerError.InvalidParameter, "Given name is null");
+
+            if (inInfo == null || outInfo == null)
+                throw NNStreamerExceptionFactory.CreateException(NNStreamerError.InvalidParameter, "Given TensorsInfo is null");
+
+            if (filter == null)
+                throw NNStreamerExceptionFactory.CreateException(NNStreamerError.InvalidParameter, "Given Callback interface is null");
+
+            _nativeCallback = (in_data_handle, out_data_handle, _) =>
+            {
+                TensorsData inData = TensorsData.CreateFromNativeHandle(in_data_handle, IntPtr.Zero, true, false);
+                TensorsData outData = _filter(inData);
+                out_data_handle = outData.GetHandle();
+            };
+
+            IntPtr handle = IntPtr.Zero;
+
+            /* Create custom filter callback */
+            NNStreamerError ret = Interop.Pipeline.RegisterCustomFilter(name,
+                inInfo.GetTensorsInfoHandle(), outInfo.GetTensorsInfoHandle(), _nativeCallback, IntPtr.Zero, out handle);
+            NNStreamer.CheckException(ret, "Failed to create custom filter function: " + name);
+
+            /* Set internal member */
+            _InInfo = inInfo;
+            _OutInfo = outInfo;
+            _filter = filter;
+
+            Name = name;
+            Handle = handle;
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
This PR newly add `CustomFilter` class and more functionality  to MachineLearning module.
Detailed items are as below.

* Add SNPE(i.e. Snapdgragon Neural Processing Engine) to NNFWType enum.
* Add CPUSIMD to HWType enum.
* Add CustomFilter class to easily manipulate the tensors data as a simple user-level method.
* Add the property getter/setter of the node in NNStreamer pipeline.


### API Changes ###
* ACR: TCSACR-365

### Submit History ###
#### Submit v2
* Remove the code which throws OutOfMemoryException
* Update the wrong API version and comments.
* Use 'CPUNeon = CPUSIMD' since both of them have the same enum value.
* Use predefined delegate `Func` instead of `delegate`
* Use the name 'Create()' of `CustomFilter` class instead of `Register()` since it is more natural.
* Support generic type for property getter function of the node in NNStreamer pipeline.
#### Submit v1
* First draft
