### PR TITLE
[NUI] Remove OnAccessibilityTouch binding

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewImplSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewImplSignal.cs
@@ -122,12 +122,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnAccessibilityPanSwigExplicitViewImpl")]
             public static extern bool ViewImpl_OnAccessibilityPanSwigExplicitViewImpl(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnAccessibilityTouch")]
-            public static extern bool ViewImpl_OnAccessibilityTouch(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnAccessibilityTouchSwigExplicitViewImpl")]
-            public static extern bool ViewImpl_OnAccessibilityTouchSwigExplicitViewImpl(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnAccessibilityValueChange")]
             public static extern bool ViewImpl_OnAccessibilityValueChange(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 

--- a/src/Tizen.NUI/src/internal/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewImpl.cs
@@ -391,13 +391,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal virtual bool OnAccessibilityTouch(SWIGTYPE_p_Dali__TouchEvent touchEvent)
-        {
-            bool ret = (SwigDerivedClassHasMethod("OnAccessibilityTouch", swigMethodTypes27) ? Interop.ViewImplSignal.ViewImpl_OnAccessibilityTouchSwigExplicitViewImpl(swigCPtr, SWIGTYPE_p_Dali__TouchEvent.getCPtr(touchEvent)) : Interop.ViewImplSignal.ViewImpl_OnAccessibilityTouch(swigCPtr, SWIGTYPE_p_Dali__TouchEvent.getCPtr(touchEvent)));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public virtual bool OnAccessibilityValueChange(bool isIncrease)
         {
             bool ret = (SwigDerivedClassHasMethod("OnAccessibilityValueChange", swigMethodTypes28) ? Interop.ViewImplSignal.ViewImpl_OnAccessibilityValueChangeSwigExplicitViewImpl(swigCPtr, isIncrease) : Interop.ViewImplSignal.ViewImpl_OnAccessibilityValueChange(swigCPtr, isIncrease));
@@ -532,8 +525,6 @@ namespace Tizen.NUI
                 swigDelegate25 = new SwigDelegateViewImpl_25(SwigDirectorOnAccessibilityActivated);
             if (SwigDerivedClassHasMethod("OnAccessibilityPan", swigMethodTypes26))
                 swigDelegate26 = new SwigDelegateViewImpl_26(SwigDirectorOnAccessibilityPan);
-            if (SwigDerivedClassHasMethod("OnAccessibilityTouch", swigMethodTypes27))
-                swigDelegate27 = new SwigDelegateViewImpl_27(SwigDirectorOnAccessibilityTouch);
             if (SwigDerivedClassHasMethod("OnAccessibilityValueChange", swigMethodTypes28))
                 swigDelegate28 = new SwigDelegateViewImpl_28(SwigDirectorOnAccessibilityValueChange);
             if (SwigDerivedClassHasMethod("OnAccessibilityZoom", swigMethodTypes29))
@@ -560,7 +551,7 @@ namespace Tizen.NUI
                 swigDelegate39 = new SwigDelegateViewImpl_39(SwigDirectorSignalConnected);
             if (SwigDerivedClassHasMethod("SignalDisconnected", swigMethodTypes40))
                 swigDelegate40 = new SwigDelegateViewImpl_40(SwigDirectorSignalDisconnected);
-            Interop.ViewImpl.ViewImpl_director_connect(swigCPtr, swigDelegate0, swigDelegate1, swigDelegate2, swigDelegate3, swigDelegate4, swigDelegate5, swigDelegate6, swigDelegate7, swigDelegate8, swigDelegate9, swigDelegate10, swigDelegate11, swigDelegate12, swigDelegate13, swigDelegate14, swigDelegate15, swigDelegate16, swigDelegate17, swigDelegate18, swigDelegate19, swigDelegate20, swigDelegate21, swigDelegate24, swigDelegate25, swigDelegate26, swigDelegate27, swigDelegate28, swigDelegate29, swigDelegate30, swigDelegate31, swigDelegate32, swigDelegate33, swigDelegate34, swigDelegate35, swigDelegate36, swigDelegate37, swigDelegate38, swigDelegate39, swigDelegate40);
+            Interop.ViewImpl.ViewImpl_director_connect(swigCPtr, swigDelegate0, swigDelegate1, swigDelegate2, swigDelegate3, swigDelegate4, swigDelegate5, swigDelegate6, swigDelegate7, swigDelegate8, swigDelegate9, swigDelegate10, swigDelegate11, swigDelegate12, swigDelegate13, swigDelegate14, swigDelegate15, swigDelegate16, swigDelegate17, swigDelegate18, swigDelegate19, swigDelegate20, swigDelegate21, swigDelegate24, swigDelegate25, swigDelegate26, null, swigDelegate28, swigDelegate29, swigDelegate30, swigDelegate31, swigDelegate32, swigDelegate33, swigDelegate34, swigDelegate35, swigDelegate36, swigDelegate37, swigDelegate38, swigDelegate39, swigDelegate40);
         }
 
 
@@ -716,11 +707,6 @@ namespace Tizen.NUI
         private bool SwigDirectorOnAccessibilityPan(global::System.IntPtr gesture)
         {
             return OnAccessibilityPan(new PanGesture(gesture, true));
-        }
-
-        private bool SwigDirectorOnAccessibilityTouch(global::System.IntPtr touchEvent)
-        {
-            return OnAccessibilityTouch(new SWIGTYPE_p_Dali__TouchEvent(touchEvent, false));
         }
 
         private bool SwigDirectorOnAccessibilityValueChange(bool isIncrease)
@@ -898,7 +884,6 @@ namespace Tizen.NUI
         private SwigDelegateViewImpl_24 swigDelegate24;
         private SwigDelegateViewImpl_25 swigDelegate25;
         private SwigDelegateViewImpl_26 swigDelegate26;
-        private SwigDelegateViewImpl_27 swigDelegate27;
         private SwigDelegateViewImpl_28 swigDelegate28;
         private SwigDelegateViewImpl_29 swigDelegate29;
         private SwigDelegateViewImpl_30 swigDelegate30;

--- a/src/Tizen.NUI/src/internal/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewWrapperImpl.cs
@@ -70,8 +70,6 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public delegate bool OnAccessibilityPanDelegate(PanGesture gestures);
         /// <since_tizen> 3 </since_tizen>
-        public delegate bool OnAccessibilityTouchDelegate(Touch touch);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool OnAccessibilityValueChangeDelegate(bool isIncrease);
         /// <since_tizen> 3 </since_tizen>
         public delegate bool OnAccessibilityZoomDelegate();
@@ -118,7 +116,6 @@ namespace Tizen.NUI
         public new OnStyleChangeDelegate OnStyleChange;
         public new OnAccessibilityActivatedDelegate OnAccessibilityActivated;
         public new OnAccessibilityPanDelegate OnAccessibilityPan;
-        public new OnAccessibilityTouchDelegate OnAccessibilityTouch;
         public new OnAccessibilityValueChangeDelegate OnAccessibilityValueChange;
         public new OnAccessibilityZoomDelegate OnAccessibilityZoom;
         public OnFocusGainedDelegate OnFocusGained;
@@ -284,7 +281,6 @@ namespace Tizen.NUI
             Delegate24 = new DelegateViewWrapperImpl_24(DirectorOnStyleChange);
             Delegate25 = new DelegateViewWrapperImpl_25(DirectorOnAccessibilityActivated);
             Delegate26 = new DelegateViewWrapperImpl_26(DirectorOnAccessibilityPan);
-            Delegate27 = new DelegateViewWrapperImpl_27(DirectorOnAccessibilityTouch);
             Delegate28 = new DelegateViewWrapperImpl_28(DirectorOnAccessibilityValueChange);
             Delegate29 = new DelegateViewWrapperImpl_29(DirectorOnAccessibilityZoom);
             Delegate30 = new DelegateViewWrapperImpl_30(DirectorOnFocusGained);
@@ -296,7 +292,7 @@ namespace Tizen.NUI
             Delegate36 = new DelegateViewWrapperImpl_36(DirectorOnPan);
             Delegate37 = new DelegateViewWrapperImpl_37(DirectorOnTap);
             Delegate38 = new DelegateViewWrapperImpl_38(DirectorOnLongPress);
-            Interop.ViewWrapperImpl.ViewWrapperImpl_director_connect(swigCPtr, Delegate0, Delegate1, Delegate2, Delegate3, Delegate4, Delegate5, Delegate6, Delegate7, Delegate8, Delegate9, Delegate10, Delegate11, Delegate12, Delegate13, Delegate14, Delegate15, Delegate16, Delegate17, Delegate18, Delegate19, Delegate20, Delegate21, Delegate24, Delegate25, Delegate26, Delegate27, Delegate28, Delegate29, Delegate30, Delegate31, Delegate32, Delegate33, Delegate34, Delegate35, Delegate36, Delegate37, Delegate38, null, null);
+            Interop.ViewWrapperImpl.ViewWrapperImpl_director_connect(swigCPtr, Delegate0, Delegate1, Delegate2, Delegate3, Delegate4, Delegate5, Delegate6, Delegate7, Delegate8, Delegate9, Delegate10, Delegate11, Delegate12, Delegate13, Delegate14, Delegate15, Delegate16, Delegate17, Delegate18, Delegate19, Delegate20, Delegate21, Delegate24, Delegate25, Delegate26, null, Delegate28, Delegate29, Delegate30, Delegate31, Delegate32, Delegate33, Delegate34, Delegate35, Delegate36, Delegate37, Delegate38, null, null);
         }
 
         private void DirectorOnSceneConnection(int depth)
@@ -453,11 +449,6 @@ namespace Tizen.NUI
         private bool DirectorOnAccessibilityPan(global::System.IntPtr gesture)
         {
             return OnAccessibilityPan(new PanGesture(gesture, false));
-        }
-
-        private bool DirectorOnAccessibilityTouch(global::System.IntPtr touch)
-        {
-            return OnAccessibilityTouch(new Touch(touch, false));
         }
 
         private bool DirectorOnAccessibilityValueChange(bool isIncrease)
@@ -633,7 +624,6 @@ namespace Tizen.NUI
         private DelegateViewWrapperImpl_24 Delegate24;
         private DelegateViewWrapperImpl_25 Delegate25;
         private DelegateViewWrapperImpl_26 Delegate26;
-        private DelegateViewWrapperImpl_27 Delegate27;
         private DelegateViewWrapperImpl_28 Delegate28;
         private DelegateViewWrapperImpl_29 Delegate29;
         private DelegateViewWrapperImpl_30 Delegate30;

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -478,16 +478,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// This method should be overridden by deriving classes when they wish to respond the accessibility.
-        /// </summary>
-        /// <param name="touch">The touch gesture.</param>
-        /// <returns>True if the touch event has been consumed by this control.</returns>
-        internal virtual bool OnAccessibilityTouch(Touch touch)
-        {
-            return false;
-        }
-
-        /// <summary>
         /// This method should be overridden by deriving classes when they wish to respond the accessibility up and down action (i.e., value change of slider control).
         /// </summary>
         /// <param name="isIncrease">Whether the value should be increased or decreased.</param>
@@ -759,7 +749,6 @@ namespace Tizen.NUI.BaseComponents
             viewWrapperImpl.OnStyleChange = new ViewWrapperImpl.OnStyleChangeDelegate(OnStyleChange);
             viewWrapperImpl.OnAccessibilityActivated = new ViewWrapperImpl.OnAccessibilityActivatedDelegate(OnAccessibilityActivated);
             viewWrapperImpl.OnAccessibilityPan = new ViewWrapperImpl.OnAccessibilityPanDelegate(OnAccessibilityPan);
-            viewWrapperImpl.OnAccessibilityTouch = new ViewWrapperImpl.OnAccessibilityTouchDelegate(OnAccessibilityTouch);
             viewWrapperImpl.OnAccessibilityValueChange = new ViewWrapperImpl.OnAccessibilityValueChangeDelegate(OnAccessibilityValueChange);
             viewWrapperImpl.OnAccessibilityZoom = new ViewWrapperImpl.OnAccessibilityZoomDelegate(OnAccessibilityZoom);
             viewWrapperImpl.OnFocusGained = new ViewWrapperImpl.OnFocusGainedDelegate(OnFocusGained);


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- Currently OnAccessibilityTouch is unused and unnecessary in AccessibilityManager.
 So, removed the internal API and its C# binding not to make confused.


### API Changes ###
- N/A