### PR TITLE
[NUI] Restore Size2D's minus value as zero when Layout is null

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -745,6 +745,13 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 Size2D temp = (Size2D)GetValue(Size2DProperty);
+
+                if (this.Layout == null)
+                {
+                    if (temp.Width < 0) { temp.Width = 0; }
+                    if (temp.Height < 0) { temp.Height = 0; }
+                }
+
                 return new Size2D(OnSize2DChanged, temp.Width, temp.Height);
             }
             set


### PR DESCRIPTION
### Description of Change ###
[NUI] Restore Size2D's minus value as zero when Layout is null
- to back out this patch : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/226385/  
- Size2D is also used to set Layout size specification so it can be minus value.
- TV FLUX discards minus value of Size2D.Width or Size2D.Height so Size2D's values need be restored as zero when NUI.Layout is NULL
- TV FLUX also has it's own Layout, so NUI needs to maintain its behaviour.

### API Changes ###
none