### PR TITLE
[NUI] Add color constructor

### DIFF
--- a/src/Tizen.NUI/src/public/Color.cs
+++ b/src/Tizen.NUI/src/public/Color.cs
@@ -142,6 +142,19 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// The conversion constructor from an System.Drawing.Color instance.
+        /// </summary>
+        /// <param name="color">System.Drawing.Color instance</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color(global::System.Drawing.Color color) : this(Interop.Vector4.new_Vector4__SWIG_0(), true)
+        {
+            R = color.R / 255.0f;
+            G = color.G / 255.0f;
+            B = color.B / 255.0f;
+            A = color.A / 255.0f;
+        }
+
+        /// <summary>
         /// The copy constructor.
         /// </summary>
         /// <param name="other">The copy target.</param>


### PR DESCRIPTION
### Description of Change ###
Add color constructor which is initialized by System.Drawing.Color.

When we test something, we always feel our Color class has not enough
color list.

In System.Drawing.Color, there is a ton of predefined colors.
So, added new constructor which can initialized by System.Drawing.Color.

### API Changes ###
NONE