### PR TITLE
[NUI] rename from styleSheet to styleName

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -94,22 +94,22 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Construct with styleSheet
+        /// Construct with style name
         /// </summary>
-        /// <param name="styleSheet">StyleSheet to be applied</param>
+        /// <param name="styleName">The name of style in the current theme to be applied</param>
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Control(string styleSheet) : base()
+        public Control(string styleName) : base()
         {
-            ViewStyle viewStyle = StyleManager.Instance.GetViewStyle(styleSheet);
+            ViewStyle viewStyle = StyleManager.Instance.GetViewStyle(styleName);
             if (viewStyle == null)
             {
-                throw new InvalidOperationException($"There is no style {styleSheet}");
+                throw new InvalidOperationException($"There is no style {styleName}");
             }
 
             ApplyStyle(viewStyle);
-            this.StyleName = styleSheet;
+            this.StyleName = styleName;
 
             Initialize();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -227,6 +227,7 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The StyleName, type string.
+        /// The value indicates DALi style name defined in json theme file.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public string StyleName

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI.BaseComponents
     public partial class View
     {
         /// <summary>
-        /// StyleNameProperty
+        /// StyleNameProperty (DALi json)
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty StyleNameProperty = BindableProperty.Create("StyleName", typeof(string), typeof(View), string.Empty, propertyChanged: (bindable, oldValue, newValue) =>


### PR DESCRIPTION
Since `StyleSheet` is used in Dali with the JSON file format, this rename will
avoid name confusion.

Co-authored-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
