### PR TITLE
[NUI] Add internal api to create Texture using TbmSurface

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Texture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Texture.cs
@@ -46,6 +46,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Texture_GetHeight")]
             public static extern uint Texture_GetHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Texture_TbmSurface")]
+            public static extern global::System.IntPtr Texture_New__TbmSurface(IntPtr jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Texture.cs
+++ b/src/Tizen.NUI/src/public/Texture.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+using System;
 using System.ComponentModel;
 
 namespace Tizen.NUI
@@ -44,6 +45,11 @@ namespace Tizen.NUI
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
+        }
+
+        internal Texture(IntPtr tbmSurface) : this(Interop.Texture.Texture_New__TbmSurface(tbmSurface), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         internal Texture(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.Texture.Texture_SWIGUpcast(cPtr), cMemoryOwn)


### PR DESCRIPTION
Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
Create Texture using TbmSurface to draw.
This feature is added for FrameBroker.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
