### PR TITLE
[NUI] Add BindableProperties for Style class

### DIFF
--- a/src/Tizen.NUI.Components/Style/LoadingStyle.cs
+++ b/src/Tizen.NUI.Components/Style/LoadingStyle.cs
@@ -26,6 +26,43 @@ namespace Tizen.NUI.Components
     /// <since_tizen> 8 </since_tizen>
     public class LoadingStyle : ControlStyle
     {
+        /// <summary>The FrameRateSelector bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty FrameRateSelectorProperty = BindableProperty.Create("FrameRateSelector", typeof(Selector<int?>), typeof(LoadingStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((LoadingStyle)bindable).frameRate = ((Selector<int?>)newValue)?.Clone();
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((LoadingStyle)bindable).frameRate;
+        });
+
+        /// <summary>The LoadingSize bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty LoadingSizeProperty = BindableProperty.Create(nameof(LoadingSize), typeof(Size), typeof(LoadingStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((LoadingStyle)bindable).loadingSize = newValue == null ? null : new Size((Size)newValue);
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((LoadingStyle)bindable).loadingSize;
+        });
+
+        /// <summary>The Images bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ImagesProperty = BindableProperty.Create(nameof(Images), typeof(string[]), typeof(LoadingStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((LoadingStyle)bindable).images = (string[])((string[])newValue)?.Clone();
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((LoadingStyle)bindable).images;
+        });
+
+        private Selector<int?> frameRate;
+        private Size loadingSize;
+        private string[] images;
+
         static LoadingStyle() { }
 
         /// <summary>
@@ -52,19 +89,31 @@ namespace Tizen.NUI.Components
         /// Gets or sets loading image resources.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        public string[] Images { get; set; }
+        public string[] Images
+        {
+            get => (string[])GetValue(ImagesProperty);
+            set => SetValue(ImagesProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets loading image size.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        public Size LoadingSize { get; set; }
+        public Size LoadingSize
+        {
+            get => (Size)GetValue(LoadingSizeProperty);
+            set => SetValue(LoadingSizeProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets loading frame per second.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        public Selector<int?> FrameRate { get; set; } = new Selector<int?>();
+        public Selector<int?> FrameRate
+        {
+            get => (Selector<int?>)GetValue(FrameRateSelectorProperty);
+            set => SetValue(FrameRateSelectorProperty, value);
+        }
 
         /// <summary>
         /// Style's clone function.
@@ -74,24 +123,6 @@ namespace Tizen.NUI.Components
         public override void CopyFrom(BindableObject bindableObject)
         {
             base.CopyFrom(bindableObject);
-
-            LoadingStyle loadingStyle = bindableObject as LoadingStyle;
-
-            if (null != loadingStyle)
-            {
-                if (null != loadingStyle.FrameRate)
-                {
-                    FrameRate?.Clone(loadingStyle.FrameRate);
-                }
-                if (null != loadingStyle.LoadingSize)
-                {
-                    LoadingSize = loadingStyle.LoadingSize;
-                }
-                if (null != loadingStyle.Images)
-                {
-                    Images = loadingStyle.Images;
-                }
-            }
         }
     }
 }

--- a/src/Tizen.NUI.Components/Style/PaginationStyle.cs
+++ b/src/Tizen.NUI.Components/Style/PaginationStyle.cs
@@ -26,6 +26,43 @@ namespace Tizen.NUI.Components
     /// <since_tizen> 8 </since_tizen>
     public class PaginationStyle : ControlStyle
     {
+        /// <summary>The IndicatorSize bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IndicatorSizeProperty = BindableProperty.Create(nameof(IndicatorSize), typeof(Size), typeof(PaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((PaginationStyle)bindable).indicatorSize = newValue == null ? null : new Size((Size)newValue);
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((PaginationStyle)bindable).indicatorSize;
+        });
+
+        /// <summary>The IndicatorImageUrlSelector bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IndicatorImageUrlSelectorProperty = BindableProperty.Create("IndicatorImageUrlSelector", typeof(Selector<string>), typeof(PaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((PaginationStyle)bindable).indicatorImageUrl = ((Selector<string>)newValue)?.Clone();
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((PaginationStyle)bindable).indicatorImageUrl;
+        });
+
+        /// <summary>The IndicatorSpacing bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IndicatorSpacingProperty = BindableProperty.Create(nameof(IndicatorSpacing), typeof(int?), typeof(PaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((PaginationStyle)bindable).indicatorSpacing = (int?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((PaginationStyle)bindable).indicatorSpacing;
+        });
+
+        private Size indicatorSize;
+        private Selector<string> indicatorImageUrl;
+        private int? indicatorSpacing;
+
         static PaginationStyle() { }
 
         /// <summary>
@@ -50,19 +87,31 @@ namespace Tizen.NUI.Components
         /// Gets or sets the size of the indicator.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        public Size IndicatorSize { get; set; }
+        public Size IndicatorSize
+        {
+            get => (Size)GetValue(IndicatorSizeProperty);
+            set => SetValue(IndicatorSizeProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets the resource of indicator.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        public Selector<string> IndicatorImageUrl { get; set; } = new Selector<string>();
+        public Selector<string> IndicatorImageUrl
+        {
+            get => (Selector<string>)GetValue(IndicatorImageUrlSelectorProperty);
+            set => SetValue(IndicatorImageUrlSelectorProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets the space of the indicator.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        public int IndicatorSpacing { get; set; }
+        public int IndicatorSpacing
+        {
+            get => ((int?)GetValue(IndicatorSpacingProperty)) ?? 0;
+            set => SetValue(IndicatorSpacingProperty, value);
+        }
 
         /// <summary>
         /// Retrieves a copy of PaginationStyle.
@@ -72,20 +121,6 @@ namespace Tizen.NUI.Components
         public override void CopyFrom(BindableObject bindableObject)
         {
             base.CopyFrom(bindableObject);
-
-            PaginationStyle paginationStyle = bindableObject as PaginationStyle;
-            if (null != paginationStyle)
-            {
-                if (null != paginationStyle.IndicatorSize)
-                {
-                    IndicatorSize = new Size(paginationStyle.IndicatorSize.Width, paginationStyle.IndicatorSize.Height);
-                }
-                if (null != paginationStyle.IndicatorImageUrl)
-                {
-                    IndicatorImageUrl?.Clone(paginationStyle.IndicatorImageUrl);
-                }
-                IndicatorSpacing = paginationStyle.IndicatorSpacing;
-            }
         }
     }
 }

--- a/src/Tizen.NUI.Components/Style/ToastStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ToastStyle.cs
@@ -26,6 +26,19 @@ namespace Tizen.NUI.Components
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ToastStyle : ControlStyle
     {
+        /// <summary>The Duration bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty DurationProperty = BindableProperty.Create(nameof(Duration), typeof(uint?), typeof(ToastStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((ToastStyle)bindable).duration = (uint?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((ToastStyle)bindable).duration;
+        });
+
+        private uint? duration;
+
         static ToastStyle() { }
 
         /// <summary>
@@ -52,7 +65,11 @@ namespace Tizen.NUI.Components
         /// Gets or sets toast show duration time.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint? Duration { get; set; }
+        public uint? Duration
+        {
+            get => (uint?)GetValue(DurationProperty);
+            set => SetValue(DurationProperty, value);
+        }
 
         /// <summary>
         /// Text's Style.
@@ -75,7 +92,6 @@ namespace Tizen.NUI.Components
                 {
                     Text?.CopyFrom(toastStyle.Text);
                 }
-                Duration = toastStyle.Duration;
             }
         }
 

--- a/src/Tizen.NUI.Wearable/src/public/WearableStyle/CircularPaginationStyle.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WearableStyle/CircularPaginationStyle.cs
@@ -29,6 +29,43 @@ namespace Tizen.NUI.Wearable
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class CircularPaginationStyle : ControlStyle
     {
+        /// <summary>The IndicatorSize bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IndicatorSizeProperty = BindableProperty.Create(nameof(IndicatorSize), typeof(Size), typeof(CircularPaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((CircularPaginationStyle)bindable).indicatorSize = newValue == null ? null : new Size((Size)newValue);
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((CircularPaginationStyle)bindable).indicatorSize;
+        });
+
+        /// <summary>The IndicatorImageUrlSelector bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IndicatorImageUrlSelectorProperty = BindableProperty.Create("IndicatorImageUrlSelector", typeof(Selector<string>), typeof(CircularPaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((CircularPaginationStyle)bindable).indicatorImageUrl = ((Selector<string>)newValue)?.Clone();
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((CircularPaginationStyle)bindable).indicatorImageUrl;
+        });
+
+        /// <summary>The CenterIndicatorImageUrlSelector bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty CenterIndicatorImageUrlSelectorProperty = BindableProperty.Create("CenterIndicatorImageUrlSelector", typeof(Selector<string>), typeof(CircularPaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((CircularPaginationStyle)bindable).centerIndicatorImageUrl = ((Selector<string>)newValue)?.Clone();
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((CircularPaginationStyle)bindable).centerIndicatorImageUrl;
+        });
+
+        private Size indicatorSize;
+        private Selector<string> indicatorImageUrl;
+        private Selector<string> centerIndicatorImageUrl;
+
         static CircularPaginationStyle() { }
 
         /// <summary>
@@ -61,7 +98,11 @@ namespace Tizen.NUI.Wearable
         /// <since_tizen> 8 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Size IndicatorSize { get; set; }
+        public Size IndicatorSize
+        {
+            get => (Size)GetValue(IndicatorSizeProperty);
+            set => SetValue(IndicatorSizeProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets the resource of indicator.
@@ -69,7 +110,11 @@ namespace Tizen.NUI.Wearable
         /// <since_tizen> 8 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Selector<string> IndicatorImageURL { get; set; } = new Selector<string>();
+        public Selector<string> IndicatorImageURL
+        {
+            get => (Selector<string>)GetValue(IndicatorImageUrlSelectorProperty);
+            set => SetValue(IndicatorImageUrlSelectorProperty, value);
+        }
 
         /// <summary>
         /// Gets or sets the resource of the center indicator.
@@ -77,34 +122,10 @@ namespace Tizen.NUI.Wearable
         /// <since_tizen> 8 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Selector<string> CenterIndicatorImageURL { get; set; } = new Selector<string>();
-
-        /// <summary>
-        /// Retrieves a copy of CircularPaginationStyle.
-        /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void CopyFrom(BindableObject bindableObject)
+        public Selector<string> CenterIndicatorImageURL
         {
-            base.CopyFrom(bindableObject);
-
-            CircularPaginationStyle circularPaginationStyle = bindableObject as CircularPaginationStyle;
-            if (null != circularPaginationStyle)
-            {
-                if (null != circularPaginationStyle.IndicatorSize)
-                {
-                    IndicatorSize = new Size(circularPaginationStyle.IndicatorSize.Width, circularPaginationStyle.IndicatorSize.Height);
-                }
-                if (null != circularPaginationStyle.IndicatorImageURL)
-                {
-                    IndicatorImageURL?.Clone(circularPaginationStyle.IndicatorImageURL);
-                }
-                if (null != circularPaginationStyle.CenterIndicatorImageURL)
-                {
-                    CenterIndicatorImageURL?.Clone(circularPaginationStyle.CenterIndicatorImageURL);
-                }
-            }
+            get => (Selector<string>)GetValue(CenterIndicatorImageUrlSelectorProperty);
+            set => SetValue(CenterIndicatorImageUrlSelectorProperty, value);
         }
 
         private void Initialize()

--- a/src/Tizen.NUI.Wearable/src/public/WearableStyle/PopupStyle.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WearableStyle/PopupStyle.cs
@@ -27,6 +27,19 @@ namespace Tizen.NUI.Wearable
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class PopupStyle : ControlStyle
     {
+        /// <summary>Bindable property of WrapContent</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty WrapContentProperty = BindableProperty.Create(nameof(WrapContent), typeof(bool?), typeof(PopupStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((PopupStyle)bindable).wrapContent = (bool?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((PopupStyle)bindable).wrapContent;
+        });
+
+        private bool? wrapContent;
+
         static PopupStyle() { }
 
         /// <summary>
@@ -58,26 +71,8 @@ namespace Tizen.NUI.Wearable
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool? WrapContent
         {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Retrieves a copy of PopupStyle.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void CopyFrom(BindableObject bindableObject)
-        {
-            base.CopyFrom(bindableObject);
-
-            PopupStyle popupStyle = bindableObject as PopupStyle;
-            if (null != popupStyle)
-            {
-                if (null != popupStyle.WrapContent)
-                {
-                    WrapContent = popupStyle.WrapContent;
-                }
-            }
+            get => (bool?)GetValue(WrapContentProperty);
+            set => SetValue(WrapContentProperty, value);            
         }
 
         private void initSubStyle()


### PR DESCRIPTION
Also, this patch remove duplicated assignment of properties in
`BindableObject.CopyFrom`.

Co-authored-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
