### PR TITLE
Revert "[NUI] Provide binding after WheelEvent class pimpling (#1927)"

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Wheel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Wheel.cs
@@ -12,13 +12,7 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr new_Wheel__SWIG_0();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Wheel__SWIG_1")]
-            public static extern global::System.IntPtr new_Wheel__SWIG_1(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_Assign")]
-            public static extern global::System.IntPtr Wheel_Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_New")]
-            public static extern global::System.IntPtr Wheel_New(int jarg1, int jarg2, uint jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, int jarg5, uint jarg6);
+            public static extern global::System.IntPtr new_Wheel__SWIG_1(int jarg1, int jarg2, uint jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, int jarg5, uint jarg6);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Wheel")]
             public static extern void delete_Wheel(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -32,20 +26,38 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_IsAltModifier")]
             public static extern bool Wheel_IsAltModifier(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_type_set")]
+            public static extern void Wheel_type_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_type_get")]
             public static extern int Wheel_type_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_direction_set")]
+            public static extern void Wheel_direction_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_direction_get")]
             public static extern int Wheel_direction_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_modifiers_set")]
+            public static extern void Wheel_modifiers_set(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_modifiers_get")]
             public static extern uint Wheel_modifiers_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_point_set")]
+            public static extern void Wheel_point_set(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_point_get")]
             public static extern global::System.IntPtr Wheel_point_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_delta_get")]
-            public static extern int Wheel_delta_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_z_set")]
+            public static extern void Wheel_z_set(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_z_get")]
+            public static extern int Wheel_z_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_timeStamp_set")]
+            public static extern void Wheel_timeStamp_set(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_timeStamp_get")]
             public static extern uint Wheel_timeStamp_get(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -70,9 +82,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_StageWheelSignal")]
             public static extern void delete_StageWheelSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Wheel_SWIGUpcast")]
-            public static extern global::System.IntPtr Wheel_SWIGUpcast(global::System.IntPtr jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Wheel.cs
+++ b/src/Tizen.NUI/src/public/Wheel.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2019 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  *
  */
 using System.ComponentModel;
-using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
 {
@@ -48,7 +47,7 @@ namespace Tizen.NUI
         /// <param name="z">The offset of rolling (positive value means roll down or clockwise, and negative value means roll up or counter-clockwise).</param>
         /// <param name="timeStamp">The time the wheel is being rolled.</param>
         /// <since_tizen> 3 </since_tizen>
-        public Wheel(Wheel.WheelType type, int direction, uint modifiers, Vector2 point, int z, uint timeStamp) : this(Interop.Wheel.Wheel_New((int)type, direction, modifiers, Vector2.getCPtr(point), z, timeStamp), true)
+        public Wheel(Wheel.WheelType type, int direction, uint modifiers, Vector2 point, int z, uint timeStamp) : this(Interop.Wheel.new_Wheel__SWIG_1((int)type, direction, modifiers, Vector2.getCPtr(point), z, timeStamp), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -150,6 +149,11 @@ namespace Tizen.NUI
 
         private Wheel.WheelType type
         {
+            set
+            {
+                Interop.Wheel.Wheel_type_set(swigCPtr, (int)value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
             get
             {
                 Wheel.WheelType ret = (Wheel.WheelType)Interop.Wheel.Wheel_type_get(swigCPtr);
@@ -160,6 +164,11 @@ namespace Tizen.NUI
 
         private int direction
         {
+            set
+            {
+                Interop.Wheel.Wheel_direction_set(swigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
             get
             {
                 int ret = Interop.Wheel.Wheel_direction_get(swigCPtr);
@@ -170,6 +179,11 @@ namespace Tizen.NUI
 
         private uint modifiers
         {
+            set
+            {
+                Interop.Wheel.Wheel_modifiers_set(swigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
             get
             {
                 uint ret = Interop.Wheel.Wheel_modifiers_get(swigCPtr);
@@ -180,6 +194,11 @@ namespace Tizen.NUI
 
         private Vector2 point
         {
+            set
+            {
+                Interop.Wheel.Wheel_point_set(swigCPtr, Vector2.getCPtr(value));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
             get
             {
                 global::System.IntPtr cPtr = Interop.Wheel.Wheel_point_get(swigCPtr);
@@ -191,9 +210,14 @@ namespace Tizen.NUI
 
         private int z
         {
+            set
+            {
+                Interop.Wheel.Wheel_z_set(swigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
             get
             {
-                int ret = Interop.Wheel.Wheel_delta_get(swigCPtr);
+                int ret = Interop.Wheel.Wheel_z_get(swigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
@@ -201,6 +225,11 @@ namespace Tizen.NUI
 
         private uint timeStamp
         {
+            set
+            {
+                Interop.Wheel.Wheel_timeStamp_set(swigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
             get
             {
                 uint ret = Interop.Wheel.Wheel_timeStamp_get(swigCPtr);


### PR DESCRIPTION
This reverts commit fb31cb7e5cd8d7ff50d74316227002d619940860.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
