### PR TITLE
Revert "[NUI] Provide binding after HoverEvent class pimpling (#1917)"

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Hover.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Hover.cs
@@ -12,37 +12,28 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr new_Hover__SWIG_0();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Hover__SWIG_1")]
-            public static extern global::System.IntPtr new_Hover__SWIG_1(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static extern global::System.IntPtr new_Hover__SWIG_1(uint jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_Assign")]
-            public static extern global::System.IntPtr Hover_Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Hover")]
+            public static extern void delete_Hover(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetTime")]
-            public static extern uint Hover_GetTime(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_points_set")]
+            public static extern void Hover_points_set(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_points_get")]
+            public static extern global::System.IntPtr Hover_points_get(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_time_set")]
+            public static extern void Hover_time_set(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_time_get")]
+            public static extern uint Hover_time_get(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetPointCount")]
             public static extern uint Hover_GetPointCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetDeviceId")]
-            public static extern int Hover_GetDeviceId(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetState")]
-            public static extern int Hover_GetState(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetHitActor")]
-            public static extern global::System.IntPtr Hover_GetHitActor(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetLocalPosition")]
-            public static extern global::System.IntPtr Hover_GetLocalPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetScreenPosition")]
-            public static extern global::System.IntPtr Hover_GetScreenPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_SWIGUpcast")]
-            public static extern global::System.IntPtr Hover_SWIGUpcast(global::System.IntPtr jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Hover")]
-            public static extern void delete_Hover(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Hover_GetPoint")]
+            public static extern global::System.IntPtr Hover_GetPoint(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Hover.cs
+++ b/src/Tizen.NUI/src/public/Hover.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2019 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Hover(Hover other) : this(Interop.Hover.new_Hover__SWIG_1(Hover.getCPtr(other)), true)
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        /// <param name="time">The time the event occurred.</param>
+        internal Hover(uint time) : this(Interop.Hover.new_Hover__SWIG_1(time), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -54,7 +58,36 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.Hover.Hover_GetTime(swigCPtr);
+                return time;
+            }
+        }
+
+        private TouchPointContainer points
+        {
+            set
+            {
+                Interop.Hover.Hover_points_set(swigCPtr, TouchPointContainer.getCPtr(value));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            get
+            {
+                global::System.IntPtr cPtr = Interop.Hover.Hover_points_get(swigCPtr);
+                TouchPointContainer ret = (cPtr == global::System.IntPtr.Zero) ? null : new TouchPointContainer(cPtr, false);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private uint time
+        {
+            set
+            {
+                Interop.Hover.Hover_time_set(swigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            get
+            {
+                uint ret = Interop.Hover.Hover_time_get(swigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
@@ -64,45 +97,53 @@ namespace Tizen.NUI
         /// Returns the ID of the device used for the point specified.<br />
         /// Each point has a unique device ID which specifies the device used for that
         /// point. This is returned by this method.<br />
-        /// If a point is greater than GetPointCount(), then this method will return -1.<br />
         /// </summary>
         /// <param name="point">The point required.</param>
         /// <returns>The device ID of this point.</returns>
         /// <since_tizen> 3 </since_tizen>
         public int GetDeviceId(uint point)
         {
-            int ret = Interop.Hover.Hover_GetDeviceId(swigCPtr, point);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            if (point < points.Count)
+            {
+                return points[(int)point].DeviceId;
+            }
+            return -1;
         }
 
         /// <summary>
-        /// Retrieves the state of the point specified.<br />
-        /// If a point is greater than GetPointCount(), then this method will return PointState.Finished.<br />
+        /// Retrieves the state of the point specified.
         /// </summary>
         /// <param name="point">The point required.</param>
         /// <returns>The state of the point specified.</returns>
         /// <since_tizen> 3 </since_tizen>
         public PointStateType GetState(uint point)
         {
-            PointStateType ret = (PointStateType)Interop.Hover.Hover_GetState(swigCPtr, point);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            if (point < points.Count)
+            {
+                return (Tizen.NUI.PointStateType)(points[(int)point].State);
+            }
+            return PointStateType.Finished;
         }
 
         /// <summary>
-        /// Retrieves the view that was underneath the point specified.<br />
-        /// If a point is greater than GetPointCount(), then this method will return an empty handle.<br />
+        /// Retrieves the view that was underneath the point specified.
         /// </summary>
         /// <param name="point">The point required.</param>
         /// <returns>The view that was underneath the point specified.</returns>
         /// <since_tizen> 3 </since_tizen>
         public View GetHitView(uint point)
         {
-            global::System.IntPtr cPtr = Interop.Hover.Hover_GetHitActor(swigCPtr, point);
-            View ret = this.GetInstanceSafely<View>(cPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            if (point < points.Count)
+            {
+                return points[(int)point].HitView;
+            }
+            else
+            {
+                // Return a native empty handle
+                View view = new View();
+                view.Reset();
+                return view;
+            }
         }
 
         /// <summary>
@@ -113,9 +154,11 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public Vector2 GetLocalPosition(uint point)
         {
-            Vector2 ret = new Vector2(Interop.Hover.Hover_GetLocalPosition(swigCPtr, point), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            if (point < points.Count)
+            {
+                return points[(int)point].Local;
+            }
+            return new Vector2(0.0f, 0.0f);
         }
 
         /// <summary>
@@ -126,9 +169,11 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public Vector2 GetScreenPosition(uint point)
         {
-            Vector2 ret = new Vector2(Interop.Hover.Hover_GetScreenPosition(swigCPtr, point), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            if (point < points.Count)
+            {
+                return points[(int)point].Screen;
+            }
+            return new Vector2(0.0f, 0.0f);
         }
 
         /// <summary>
@@ -151,6 +196,13 @@ namespace Tizen.NUI
         internal static Hover GetHoverFromPtr(global::System.IntPtr cPtr)
         {
             Hover ret = new Hover(cPtr, false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal TouchPoint GetPoint(uint point)
+        {
+            TouchPoint ret = new TouchPoint(Interop.Hover.Hover_GetPoint(swigCPtr, point), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
This reverts commit 86de072d0845bb610130f14e9e5d593c4faaa46d.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
