### PR TITLE
[NUI] remove default value assignment of style properties

### DIFF
--- a/src/Tizen.NUI.Components/Style/ButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ButtonStyle.cs
@@ -188,7 +188,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Extents IconPadding
         {
-            get => ((Extents)GetValue(IconPaddingProperty)) ?? (iconPadding = new Extents());
+            get => (Extents)GetValue(IconPaddingProperty);
             set => SetValue(IconPaddingProperty, value);
         }
 
@@ -198,7 +198,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Extents TextPadding
         {
-            get  => ((Extents)GetValue(TextPaddingProperty)) ?? (textPadding = new Extents());
+            get => (Extents)GetValue(TextPaddingProperty);
             set => SetValue(TextPaddingProperty, value);
         }
 

--- a/src/Tizen.NUI.Components/Style/DropDownStyle.cs
+++ b/src/Tizen.NUI.Components/Style/DropDownStyle.cs
@@ -171,7 +171,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Extents ListMargin
         {
-            get => ((Extents)GetValue(ListMarginProperty)) ?? (listMargin = new Extents(0, 0, 0, 0));
+            get => (Extents)GetValue(ListMarginProperty);
             set => SetValue(ListMarginProperty, value);
         }
 
@@ -191,7 +191,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Extents ListPadding
         {
-            get => ((Extents)GetValue(ListPaddingProperty)) ?? (listPadding = new Extents(0, 0, 0, 0));
+            get => (Extents)GetValue(ListPaddingProperty);
             set => SetValue(ListPaddingProperty, value);
         }
 

--- a/src/Tizen.NUI.Components/Style/PaginationStyle.cs
+++ b/src/Tizen.NUI.Components/Style/PaginationStyle.cs
@@ -106,7 +106,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public int IndicatorSpacing
         {
-            get => ((int?)GetValue(IndicatorSpacingProperty)) ?? 0;
+            get => (int)GetValue(IndicatorSpacingProperty);
             set => SetValue(IndicatorSpacingProperty, value);
         }
 

--- a/src/Tizen.NUI.Components/Style/SliderStyle.cs
+++ b/src/Tizen.NUI.Components/Style/SliderStyle.cs
@@ -186,7 +186,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Extents TrackPadding
         {
-            get => ((Extents)GetValue(TrackPaddingProperty)) ?? (trackPadding = new Extents(0, 0, 0, 0));
+            get => (Extents)GetValue(TrackPaddingProperty);
             set => SetValue(TrackPaddingProperty, value);
         }
 


### PR DESCRIPTION
null value is acceptable for style properties.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
