### PR TITLE
Revert "[NUI] Add Selector constructor with SelectorChangedCallback i…

### DIFF
--- a/src/Tizen.NUI.Components/Utils/Selector.cs
+++ b/src/Tizen.NUI.Components/Utils/Selector.cs
@@ -151,14 +151,6 @@ namespace Tizen.NUI.Components
         {
         }
 
-        internal ColorSelector(SelectorChangedCallback<Color> cb) : base(cb)
-        {
-        }
-
-        internal ColorSelector(SelectorChangedCallback<Color> cb, Selector<Color> selector) : base(cb, selector)
-        {
-        }
-
         /// <summary>
         /// Color selector clone function.
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -58,24 +58,6 @@ namespace Tizen.NUI.BaseComponents
             Clone(value);
         }
 
-        internal Selector(SelectorChangedCallback<T> cb) : this()
-        {
-            callback = cb;
-        }
-
-        internal Selector(SelectorChangedCallback<T> cb, T value) : this(value)
-        {
-            callback = cb;
-        }
-
-        internal Selector(SelectorChangedCallback<T> cb, Selector<T> value) : this(value)
-        {
-            callback = cb;
-        }
-
-        internal delegate void SelectorChangedCallback<T>(Selector<T> value);
-        private SelectorChangedCallback<T> callback = null;
-
 
         /// <summary>
         /// All State.
@@ -96,15 +78,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Normal
         {
-            get
-            {
-                return Find(x => x.State == ControlState.Normal).Value;
-            }
-            set
-            {
-                Add(ControlState.Normal, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.Normal).Value;
+            set => Add(ControlState.Normal, value);
         }
         /// <summary>
         /// Pressed State.
@@ -114,15 +89,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Pressed
         {
-            get
-            {
-                return Find(x => x.State == ControlState.Pressed).Value;
-            }
-            set
-            {
-                Add(ControlState.Pressed, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.Pressed).Value;
+            set => Add(ControlState.Pressed, value);
         }
         /// <summary>
         /// Focused State.
@@ -132,15 +100,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Focused
         {
-            get
-            {
-                return Find(x => x.State == ControlState.Focused).Value;
-            }
-            set
-            {
-                Add(ControlState.Focused, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.Focused).Value;
+            set => Add(ControlState.Focused, value);
         }
         /// <summary>
         /// Selected State.
@@ -150,15 +111,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Selected
         {
-            get
-            {
-                return Find(x => x.State == ControlState.Selected).Value;
-            }
-            set
-            {
-                Add(ControlState.Selected, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.Selected).Value;
+            set => Add(ControlState.Selected, value);
         }
         /// <summary>
         /// Disabled State.
@@ -168,15 +122,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Disabled
         {
-            get
-            {
-                return Find(x => x.State == ControlState.Disabled).Value;
-            }
-            set
-            {
-                Add(ControlState.Disabled, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.Disabled).Value;
+            set => Add(ControlState.Disabled, value);
         }
         /// <summary>
         /// DisabledFocused State.
@@ -186,15 +133,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T DisabledFocused
         {
-            get
-            {
-                return Find(x => x.State == ControlState.DisabledFocused).Value;
-            }
-            set
-            {
-                Add(ControlState.DisabledFocused, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.DisabledFocused).Value;
+            set => Add(ControlState.DisabledFocused, value);
         }
         /// <summary>
         /// SelectedFocused State.
@@ -203,15 +143,8 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         public T SelectedFocused
         {
-            get
-            {
-                return Find(x => x.State == ControlState.SelectedFocused).Value;
-            }
-            set
-            {
-                Add(ControlState.SelectedFocused, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.SelectedFocused).Value;
+            set => Add(ControlState.SelectedFocused, value);
         }
         /// <summary>
         /// DisabledSelected State.
@@ -221,15 +154,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T DisabledSelected
         {
-            get
-            {
-                return Find(x => x.State == ControlState.DisabledSelected).Value;
-            }
-            set
-            {
-                Add(ControlState.DisabledSelected, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.DisabledSelected).Value;
+            set => Add(ControlState.DisabledSelected, value);
         }
 
         /// <summary>
@@ -240,15 +166,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Other
         {
-            get
-            {
-                return Find(x => x.State == ControlState.Other).Value;
-            }
-            set
-            {
-                Add(ControlState.Other, value);
-                callback?.Invoke(this);
-            }
+            get => Find(x => x.State == ControlState.Other).Value;
+            set => Add(ControlState.Other, value);
         }
         /// <summary>
         /// Get value by State.


### PR DESCRIPTION
…nternally (#1862)"

This reverts commit 8527701bf57a40fa56a96378b962bd1ca3f10d90.

Setters of Color class properties (i.e. R, G, B, A) are going to be
deprecated.

Like Color class does, setters of Selector State are going to be
deprecated instead of adding constructor with SelectorChangedCallback.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
