### PR TITLE
[NUI] Fix Components.Switch Thumb animation defect

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
@@ -49,11 +49,13 @@ namespace Tizen.NUI.Components.Extension
 
             if (slidingAnimation.State == Animation.States.Playing)
             {
+                slidingAnimation.EndAction = Animation.EndActions.StopFinal;
                 slidingAnimation.Stop();
             }
 
             slidingAnimation.Clear();
             slidingAnimation.AnimateTo(thumb, "PositionX", track.Size.Width - thumb.Size.Width - thumb.Position.X);
+            slidingAnimation.EndAction = Animation.EndActions.StopFinal;
             slidingAnimation.Play();
         }
 


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix Components.Switch Thumb animation defect

- Fix https://code.sec.samsung.net/jira/browse/TDAF-1171
- When the switch thumb is animated, sometimes it's position is fixed so stucked in the middle of track
- Change EndAction of animation as StopFinal

### API Changes ###
none