### PR TITLE
[NUI] Fix Switch bugs

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
@@ -54,7 +54,7 @@ namespace Tizen.NUI.Components.Extension
             }
 
             slidingAnimation.Clear();
-            slidingAnimation.AnimateTo(thumb, "PositionX", track.Size.Width - thumb.Size.Width - thumb.Position.X);
+            slidingAnimation.AnimateTo(thumb, "PositionX", switchButton.IsSelected ? track.Size.Width - thumb.Size.Width : 0);
             slidingAnimation.EndAction = Animation.EndActions.StopFinal;
             slidingAnimation.Play();
         }

--- a/src/Tizen.NUI.Components/res/Theme/Tizen.NUI.Components_Tizen.NUI.Theme.Common.xaml
+++ b/src/Tizen.NUI.Components/res/Theme/Tizen.NUI.Components_Tizen.NUI.Theme.Common.xaml
@@ -156,7 +156,7 @@
   <!--Switch-->
   <c:SwitchStyle x:Key="Switch" Size="96, 60">
     <c:Switch.Track>
-      <b:ImageViewStyle Size="96, 60" WidthResizePolicy="Fixed" HeightResizePolicy="Fixed" Border="30, 30, 30, 30">
+      <b:ImageViewStyle Size="96, 60" WidthResizePolicy="Fixed" HeightResizePolicy="Fixed">
         <b:ImageViewStyle.ResourceUrl>
           <b:Selector x:TypeArguments="x:String" Normal="{nx:NUIResourcePath nui_component_default_switch_track_n.png}" Selected="{nx:NUIResourcePath nui_component_default_switch_track_s.png}" Disabled="{nx:NUIResourcePath nui_component_default_switch_track_d.png}" DisabledSelected="{nx:NUIResourcePath nui_component_default_switch_track_ds.png}" />
         </b:ImageViewStyle.ResourceUrl>

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -187,8 +187,6 @@ namespace Tizen.NUI.BaseComponents
 
                 ControlStateChangeEventInternal?.Invoke(this, changeInfo);
 
-                OnControlStateChanged(changeInfo);
-
                 if (controlStatePropagation)
                 {
                     foreach (View child in Children)
@@ -196,6 +194,8 @@ namespace Tizen.NUI.BaseComponents
                         child.ControlState = value;
                     }
                 }
+
+                OnControlStateChanged(changeInfo);
 
                 ControlStateChangedEvent?.Invoke(this, changeInfo);
             }


### PR DESCRIPTION
* Change ControlState propagation sequence
* Remove setting border property in default switch style


This fixes an error of the following code,

```
protected override void OnCreate()
{
  //...
  var button = new Switch();
  button.SelectedChanged += OnSelected;
  root.Add(button);
}

void OnSelected(object target, SelectedChangedEventArgs args)
{
  if (args.IsSelected)
  {
     (target as Switch).IsSelected = false;
  }
}
```

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
