### PR TITLE
[NUI] Update MeasureCallback interface for latest Dali::Toolkit

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -94,8 +94,8 @@ namespace Tizen.NUI
                 width = x;
                 height = y;
             }
-            float width;
-            float height;
+            public float width;
+            public float height;
         };
 
         /// <summary>
@@ -230,8 +230,8 @@ namespace Tizen.NUI
             SetChildValue(view, FlexGrowProperty, value);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        internal delegate MeasuredSize ChildMeasureCallback(global::System.IntPtr child, float width, int measureModeWidth, float height, int measureModeHeight);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void ChildMeasureCallback( global::System.IntPtr child, float width, int measureModeWidth, float height, int measureModeHeight, out MeasuredSize measureSize );
 
         event ChildMeasureCallback measureChildDelegate; // Stores a delegate to the child measure callback. Used for all children of this FlexLayout.
 
@@ -589,7 +589,7 @@ namespace Tizen.NUI
             Absolute
         }
 
-        private MeasuredSize measureChild(global::System.IntPtr childPtr, float width, int measureModeWidth, float height, int measureModeHeight)
+        private void measureChild(global::System.IntPtr childPtr, float width, int measureModeWidth, float height, int measureModeHeight, out MeasuredSize measureSize)
         {
             // We need to measure child layout
             View child = Registry.GetManagedBaseHandleFromNativePtr(childPtr) as View;
@@ -612,7 +612,8 @@ namespace Tizen.NUI
 
             childLayout.Measure(childWidthMeasureSpec, childHeightMeasureSpec);
 
-            return new MeasuredSize(childLayout.MeasuredWidth.Size.AsRoundedValue(), childLayout.MeasuredHeight.Size.AsRoundedValue());
+            measureSize.width = childLayout.MeasuredWidth.Size.AsRoundedValue();
+            measureSize.height = childLayout.MeasuredHeight.Size.AsRoundedValue();
         }
 
         void InsertChild(LayoutItem child)


### PR DESCRIPTION
Making MeasureCallback return a struct is causing the .NET runtime on
Windows 10 messes up with argument values. We changed the signature of
MeasureCallback on Dali::Toolkit to make the return value be an out
parameter.

The detailed explanation of what's the problem can be found at [1].

Moreover, we declare MeasureCallback as Cdecl, as it is declared this
way in the C++ header file.

[1] https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/242665/
