### PR TITLE
[Build] Install Tizen.Peripheral to all profiles temporarily

### DIFF
--- a/internals/src/Tizen.Peripheral/Tizen.Peripheral.csproj
+++ b/internals/src/Tizen.Peripheral/Tizen.Peripheral.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!--
     <SupportedProfiles>mobile,wearable</SupportedProfiles>
+    -->
 </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Install Tizen.Peripheral to all profiles temporarily, 
TizenFX does not support dummy assemblies for internal modules now.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
