### PR TITLE
[ElmSharp] Fix elm_transit_paused_get to return boolean correctly

### DIFF
--- a/src/ElmSharp/Interop/Interop.Elementary.cs
+++ b/src/ElmSharp/Interop/Interop.Elementary.cs
@@ -734,6 +734,7 @@ internal static partial class Interop
         internal static extern void elm_transit_paused_set(IntPtr transit, bool paused);
 
         [DllImport(Libraries.Elementary)]
+        [return : MarshalAs(UnmanagedType.U1)]
         internal static extern bool elm_transit_paused_get(IntPtr transit);
 
         [DllImport(Libraries.Elementary)]


### PR DESCRIPTION
Interop.Elementary.elm_transit_paused_get always returns true although
elm_transit_paused_get actually returns EINA_FALSE.

Since C and C# use 4 bytes for boolean but C++ uses 1 byte for boolean,
this may cause that the boolean return value is not passed correctly.

To resolve this issue, [return: MarshalAs(UnmanagedType.U1)] is inserted
to the declaration of elm_transit_paused_get in Interop.Elementary.cs.

This patch refers 98c70851b1b1d640295768e6050c90ed61889e7c

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
