### PR TITLE
[NUI] Make Scrollable finish when Gesture.StateType is Cancelled

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -967,7 +967,7 @@ namespace Tizen.NUI.Components
                 }
                 Debug.WriteLineIf(LayoutDebugScrollableBase, "OnPanGestureDetected Continue totalDisplacementForPan:" + totalDisplacementForPan);
             }
-            else if (panGesture.State == Gesture.StateType.Finished)
+            else if (panGesture.State == Gesture.StateType.Finished || panGesture.State == Gesture.StateType.Cancelled)
             {
                 OnScrollDragEnded();
                 StopScroll(); // Will replace previous animation so will stop existing one.


### PR DESCRIPTION
 - Current implementation, the scroll of ScrollableBase will be finished only when Gesture.StateType is Finished.
 - However, by the hw, it can be Cancelled.

Signed-off-by: seungho <seungho@seungho.tn.corp.samsungelectronics.net>