### PR TITLE
[NUI] The default policy for textLabel is FillToParent

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
@@ -325,6 +325,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public TextLabelStyle()
         {
+            WidthResizePolicy = ResizePolicyType.FillToParent;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -153,6 +153,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetVisible(false);
             }
+            WidthResizePolicy = ResizePolicyType.FillToParent;
         }
 
         internal TextLabel(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(Interop.TextLabel.TextLabel_SWIGUpcast(cPtr), cMemoryOwn, viewStyle)
@@ -169,6 +170,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetVisible(false);
             }
+            WidthResizePolicy = ResizePolicyType.FillToParent;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The default policy for textLabel is FillToParent

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: NONE

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
