### PR TITLE
[NUI] Switch do not animate on selection when it is not on Window

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
@@ -53,10 +53,19 @@ namespace Tizen.NUI.Components.Extension
                 slidingAnimation.Stop();
             }
 
-            slidingAnimation.Clear();
-            slidingAnimation.AnimateTo(thumb, "PositionX", switchButton.IsSelected ? track.Size.Width - thumb.Size.Width : 0);
-            slidingAnimation.EndAction = Animation.EndActions.StopFinal;
-            slidingAnimation.Play();
+            float destinationPosX = switchButton.IsSelected ? track.Size.Width - thumb.Size.Width : 0;
+
+            if (switchButton.IsOnWindow)
+            {
+                slidingAnimation.Clear();
+                slidingAnimation.AnimateTo(thumb, "PositionX", destinationPosX);
+                slidingAnimation.EndAction = Animation.EndActions.StopFinal;
+                slidingAnimation.Play();
+            }
+            else
+            {
+                thumb.PositionX = destinationPosX;
+            }
         }
 
         public override void OnDispose(Button button)


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
