### PR TITLE
Tizen.Peripheral move all classes to it's namespaces.

### DIFF
--- a/internals/src/Tizen.Peripheral/Tizen.Peripheral/Adc.cs
+++ b/internals/src/Tizen.Peripheral/Tizen.Peripheral/Adc.cs
@@ -17,13 +17,13 @@
 using System;
 using NativeAdc = Interop.Peripheral.Adc;
 
-namespace Tizen.Peripheral
+namespace Tizen.Peripheral.Adc
 {
     /// <summary>
     /// The class allows applications to use the platform ADC peripheral.
     /// </summary>
     /// <privilege>http://tizen.org/privilege/peripheralio</privilege>
-    public class Adc : IDisposable
+    public class AdcChannel : IDisposable
     {
         /// <summary>
         /// Native handle to ADC.
@@ -36,7 +36,7 @@ namespace Tizen.Peripheral
         /// </summary>
         /// <param name="device">The ADC device number.</param>
         /// <param name="channel">The ADC channel number to control.</param>
-        public Adc(int device, int channel)
+        public AdcChannel(int device, int channel)
         {
             var ret = NativeAdc.Open(device, channel, out IntPtr handle);
             if (ret != Internals.Errors.ErrorCode.None)
@@ -48,7 +48,7 @@ namespace Tizen.Peripheral
         /// <summary>
         /// Closes the ADC pin.
         /// </summary>
-        ~Adc()
+        ~AdcChannel()
         {
             Dispose(false);
         }

--- a/internals/src/Tizen.Peripheral/Tizen.Peripheral/Gpio.cs
+++ b/internals/src/Tizen.Peripheral/Tizen.Peripheral/Gpio.cs
@@ -87,7 +87,7 @@ namespace Tizen.Peripheral.Gpio
     /// The class allows applications to use the platform Digital Pins as Input/Output.
     /// </summary>
     /// <privilege>http://tizen.org/privilege/peripheralio</privilege>
-    public class Gpio : IDisposable
+    public class GpioPin : IDisposable
     {
 
         private GpioChangePolarity _polarityType;
@@ -109,7 +109,7 @@ namespace Tizen.Peripheral.Gpio
         /// </summary>
         /// <param name="pinNumber">The GPIO pin number.</param>
         /// <param name="mode">GPIO direction.</param>
-        public Gpio(int pinNumber, GpioPinDriveMode mode)
+        public GpioPin(int pinNumber, GpioPinDriveMode mode)
         {
             var ret = NativeGpio.Open(pinNumber, out IntPtr handle);
             if (ret != ErrorCode.None)
@@ -152,7 +152,7 @@ namespace Tizen.Peripheral.Gpio
         /// <summary>
         /// Closes the GPIO pin.
         /// </summary>
-        ~Gpio()
+        ~GpioPin()
         {
             Dispose(false);
         }

--- a/internals/src/Tizen.Peripheral/Tizen.Peripheral/I2c.cs
+++ b/internals/src/Tizen.Peripheral/Tizen.Peripheral/I2c.cs
@@ -17,13 +17,13 @@
 using System;
 using NativeI2c = Interop.Peripheral.I2c;
 
-namespace Tizen.Peripheral
+namespace Tizen.Peripheral.I2c
 {
     /// <summary>
     /// The class allows applications to communicate via i2c platform's bus.
     /// </summary>
     /// <privilege>http://tizen.org/privilege/peripheralio</privilege>
-    public class I2c : IDisposable
+    public class I2cDevice : IDisposable
     {
         /// <summary>
         /// Native handle to I2c.
@@ -36,7 +36,7 @@ namespace Tizen.Peripheral
         /// </summary>
         /// <param name="bus">The I2C bus number that the slave device is connected.</param>
         /// <param name="address">The address of the slave device.</param>
-        public I2c(int bus, int address)
+        public I2cDevice(int bus, int address)
         {
             var ret = NativeI2c.Open(bus, address, out IntPtr handle);
             if (ret != Internals.Errors.ErrorCode.None)
@@ -48,7 +48,7 @@ namespace Tizen.Peripheral
         /// <summary>
         /// Closes the connection to the I2C slave device.
         /// </summary>
-        ~I2c()
+        ~I2cDevice()
         {
             Dispose(false);
         }

--- a/internals/src/Tizen.Peripheral/Tizen.Peripheral/Pwm.cs
+++ b/internals/src/Tizen.Peripheral/Tizen.Peripheral/Pwm.cs
@@ -39,7 +39,7 @@ namespace Tizen.Peripheral.Pwm
     /// The class allows applications to use the platform PWM peripheral.
     /// </summary>
     /// <privilege>http://tizen.org/privilege/peripheralio</privilege>
-    public class Pwm : IDisposable
+    public class PwmPin : IDisposable
     {
 
         //TODO provide default values.
@@ -59,7 +59,7 @@ namespace Tizen.Peripheral.Pwm
         /// </summary>
         /// <param name="chip">The PWM chip number.</param>
         /// <param name="pin">The PWM pin (channel) number to control.</param>
-        public Pwm(int chip, int pin)
+        public PwmPin(int chip, int pin)
         {
             var ret = NativePwm.Open(chip, pin, out IntPtr handle);
             if (ret != Internals.Errors.ErrorCode.None)
@@ -71,7 +71,7 @@ namespace Tizen.Peripheral.Pwm
         /// <summary>
         /// Closes the PWM pin.
         /// </summary>
-        ~Pwm()
+        ~PwmPin()
         {
             Dispose(false);
         }

--- a/internals/src/Tizen.Peripheral/Tizen.Peripheral/Spi.cs
+++ b/internals/src/Tizen.Peripheral/Tizen.Peripheral/Spi.cs
@@ -68,7 +68,7 @@ namespace Tizen.Peripheral.Spi
     /// The class allows applications to communicate via SPI platform's bus.
     /// </summary>
     /// <privilege>http://tizen.org/privilege/peripheralio</privilege>
-    public class Spi : IDisposable
+    public class SpiDevice : IDisposable
     {
 
         //TODO Provide default values.
@@ -88,7 +88,7 @@ namespace Tizen.Peripheral.Spi
         /// </summary>
         /// <param name="bus">The SPI bus number.</param>
         /// <param name="chip">The SPI chip select number.</param>
-        public Spi(int bus, int chip)
+        public SpiDevice(int bus, int chip)
         {
             var ret = NativeSpi.Open(bus, chip, out IntPtr handle);
             if (ret != Internals.Errors.ErrorCode.None)
@@ -100,7 +100,7 @@ namespace Tizen.Peripheral.Spi
         /// <summary>
         /// Closes the SPI slave device.
         /// </summary>
-        ~Spi()
+        ~SpiDevice()
         {
             Dispose(false);
         }

--- a/internals/src/Tizen.Peripheral/Tizen.Peripheral/Uart.cs
+++ b/internals/src/Tizen.Peripheral/Tizen.Peripheral/Uart.cs
@@ -155,7 +155,7 @@ namespace Tizen.Peripheral.Uart
     /// The class allows applications to communicate via UART platform's bus.
     /// </summary>
     /// <privilege>http://tizen.org/privilege/peripheralio</privilege>
-    public class Uart : IDisposable
+    public class SerialPort : IDisposable
     {
         private BaudRate _baudRate;
         private DataBits _dataBits;
@@ -174,7 +174,7 @@ namespace Tizen.Peripheral.Uart
         /// Opens the UART slave device.
         /// </summary>
         /// <param name="port">The UART port number that the slave device is connected.</param>
-        public Uart(int port)
+        public SerialPort(int port)
         {
             var ret = NativeUart.Open(port, out IntPtr handle);
             if (ret != Internals.Errors.ErrorCode.None)
@@ -186,7 +186,7 @@ namespace Tizen.Peripheral.Uart
         /// <summary>
         /// Closes the UART slave device.
         /// </summary>
-        ~Uart()
+        ~SerialPort()
         {
             Dispose(false);
         }


### PR DESCRIPTION
Signed-off-by: Ernest Borowski <e.borowski@samsung.com>

### Description of Change ###
Move all classes to it's own namespaces.


### API Changes ###
Rename classes:
Adc -> AdcChannel
Gpio -> GpioPin
I2c -> I2cDevice
Spi -> SpiDevice
Pwm -> PwmPin
Uart -> SerialPort

Move class:
1.
```csharp
  public class Tizen.Peripheral.I2cDevice (class):
        public I2cDevice(int bus, int address) (constructor);
        public void Close() (method);
        public void Read(byte[] dataOut) (method);
        public void Write(byte[] data) (method);
        public byte ReadRegisterByte(byte register) (method);
        public void WriteRegisterByte(byte register, byte data) (method);
        public ushort ReadRegisterWord(byte register) (method);
        public void WriteRegisterWord(byte register, ushort data) (method);
        public void Dispose() (method);
```
to `Tizen.Peripheral.I2c` namespace
2. 
```csharp
    public class Tizen.Peripheral.AdcChannel : IDisposable (class):
        public AdcChannel(int device, int channel) (constructor);
        public uint ReadValue() (method);
        public void Close() (method);
        public void Dispose() (method);
```
to `Tizen.Peripheral.Adc` namespace