### PR TITLE
[NUI] correct logical operator in enum validation

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -383,7 +383,7 @@ namespace Tizen.NUI
             get => (FlexWrapType)Interop.FlexLayout.FlexLayout_GetFlexWrap(swigCPtr);
             set
             {
-                if (value != FlexWrapType.NoWrap || value != FlexWrapType.Wrap)
+                if (value != FlexWrapType.NoWrap && value != FlexWrapType.Wrap)
                     throw new InvalidEnumArgumentException(nameof(WrapType));
 
                 Interop.FlexLayout.FlexLayout_SetFlexWrap(swigCPtr, (int)value);

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -236,7 +236,7 @@ namespace Tizen.NUI
             set
             {
                 if (gridOrientation == value) return;
-                if (value != Orientation.Horizontal || value != Orientation.Vertical)
+                if (value != Orientation.Horizontal && value != Orientation.Vertical)
                     throw new InvalidEnumArgumentException(nameof(GridOrientation));
 
                 gridOrientation = value;


### PR DESCRIPTION
Test Code:
```cs
FlexLayout flexLayout = new FlexLayout();
flexLayout.WrapType = FlexLayout.FlexWrapType.Wrap;
```

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
