### PR TITLE
Revert "[NUI] Add ControlStateTypeConverter for xaml (#2002)"

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
@@ -26,7 +26,6 @@ namespace Tizen.NUI.BaseComponents
     /// Class for describing the states of the view.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Binding.TypeConverter(typeof(ControlStateTypeConverter))]
     public class ControlState : IEquatable<ControlState>
     {
         private static readonly Dictionary<string, ControlState> stateDictionary = new Dictionary<string, ControlState>();
@@ -91,7 +90,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsCombined => stateList.Count > 1;
 
-        private ControlState() { }
+        /// <summary>
+        /// Default Contructor. Please use <see cref="Create(string)"/> or <see cref="Create(ControlState[])"/> instead.
+        /// </summary>
+        // Do not open this constructor. This is only for xaml support.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ControlState() { }
 
         private ControlState(string name) : this() => this.name = name;
 
@@ -255,7 +259,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 return ReferenceEquals(lhs, rhs) ? Normal : lhs;
             }
-
+            
             var rest = lhs.stateList.Except(rhs.stateList);
 
             if (rest.Count() == 0)
@@ -272,26 +276,76 @@ namespace Tizen.NUI.BaseComponents
             newState.stateList.AddRange(rest);
             return newState;
         }
+    }
 
-        class ControlStateTypeConverter : Binding.TypeConverter
+    /// <summary>
+    /// The Key/Value pair structure. this is mutable to support for xaml.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct StateValuePair<T> : IEquatable<StateValuePair<T>>
+    {
+        /// <summary>
+        /// The constructor with the specified state and value.
+        /// </summary>
+        /// <param name="state">The state</param>
+        /// <param name="value">The value associated with state.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public StateValuePair(ControlState state, T value)
         {
-            public override object ConvertFromInvariantString(string value)
-            {
-                if (value != null)
-                {
-                    value = value.Trim();
-
-                    ControlState convertedState = new ControlState();
-                    string[] parts = value.Split(',');
-                    foreach (string part in parts)
-                    {
-                        convertedState += Create(part);
-                    }
-                    return convertedState;
-                }
-
-                throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(ControlState)}");
-            }
+            State = state;
+            Value = value;
         }
+
+        /// <summary>
+        /// The state
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ControlState State { get; set; }
+        /// <summary>
+        /// The value associated with state.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public T Value { get; set; }
+
+        ///  <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Equals(StateValuePair<T> other) => (Value.Equals(other.Value)) && (State == other.State);
+
+        ///  <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            if (!(obj is StateValuePair<T>))
+                return false;
+
+            return Equals((StateValuePair<T>)obj);
+        }
+
+        ///  <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => (State.GetHashCode() * 397) ^ Value.GetHashCode();
+
+
+        /// <summary>
+        /// Compares whether the two StateValuePair are different or not.
+        /// </summary>
+        /// <param name="lhs">A <see cref="StateValuePair{T}"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="StateValuePair{T}"/> on the right hand side.</param>
+        /// <returns>true if the StateValuePair are equal; otherwise, false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator ==(StateValuePair<T> lhs, StateValuePair<T> rhs) => lhs.Equals(rhs);
+
+        /// <summary>
+        /// Compares whether the two StateValuePair are same or not.
+        /// </summary>
+        /// <param name="lhs">A <see cref="StateValuePair{T}"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="StateValuePair{T}"/> on the right hand side.</param>
+        /// <returns>true if the StateValuePair are not equal; otherwise, false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !=(StateValuePair<T> lhs, StateValuePair<T> rhs) => !(lhs == rhs);
+
+        ///  <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => $"[{State}, {Value}]";
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -36,7 +36,7 @@ namespace Tizen.NUI.BaseComponents
         /// The list for adding state-value pair.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IList<SelectorItem<T>> StateValueList { get; private set; } = new List<SelectorItem<T>>();
+        public IList<StateValuePair<T>> StateValueList { get; private set; } = new List<StateValuePair<T>>();
 
         /// <summary>
         /// Adds the specified state and value to the <see cref="StateValueList"/>.
@@ -44,14 +44,14 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="state">The state.</param>
         /// <param name="value">The value associated with state.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Add(ControlState state, T value) => StateValueList.Add(new SelectorItem<T>(state, value));
+        public void Add(ControlState state, T value) => StateValueList.Add(new StateValuePair<T>(state, value));
 
         /// <summary>
         /// Adds the specified state and value to the <see cref="StateValueList"/>.
         /// </summary>
         /// <param name="stateValuePair"></param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Add(SelectorItem<T> stateValuePair) => StateValueList.Add(stateValuePair);
+        public void Add(StateValuePair<T> stateValuePair) => StateValueList.Add(stateValuePair);
 
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -100,7 +100,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Normal
         {
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.Normal).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.Normal).Value;
             set => Add(ControlState.Normal, value);
         }
         /// <summary>
@@ -112,7 +112,7 @@ namespace Tizen.NUI.BaseComponents
         public T Pressed
         {
 
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.Pressed).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.Pressed).Value;
             set => Add(ControlState.Pressed, value);
         }
         /// <summary>
@@ -123,7 +123,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Focused
         {
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.Focused).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.Focused).Value;
             set => Add(ControlState.Focused, value);
         }
         /// <summary>
@@ -134,7 +134,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Selected
         {
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.Selected).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.Selected).Value;
             set => Add(ControlState.Selected, value);
         }
         /// <summary>
@@ -146,7 +146,7 @@ namespace Tizen.NUI.BaseComponents
         public T Disabled
         {
 
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.Disabled).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.Disabled).Value;
             set => Add(ControlState.Disabled, value);
         }
         /// <summary>
@@ -157,7 +157,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T DisabledFocused
         {
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.DisabledFocused).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.DisabledFocused).Value;
             set => Add(ControlState.DisabledFocused, value);
         }
         /// <summary>
@@ -167,7 +167,7 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         public T SelectedFocused
         {
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.SelectedFocused).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.SelectedFocused).Value;
             set => Add(ControlState.SelectedFocused, value);
         }
         /// <summary>
@@ -179,7 +179,7 @@ namespace Tizen.NUI.BaseComponents
         public T DisabledSelected
         {
 
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.DisabledSelected).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.DisabledSelected).Value;
             set => Add(ControlState.DisabledSelected, value);
         }
 
@@ -191,7 +191,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public T Other
         {
-            get => ((List<SelectorItem<T>>)StateValueList).FindLast(x => x.State == ControlState.Other).Value;
+            get => ((List<StateValuePair<T>>)StateValueList).FindLast(x => x.State == ControlState.Other).Value;
             set => Add(ControlState.Other, value);
         }
         /// <summary>
@@ -212,7 +212,7 @@ namespace Tizen.NUI.BaseComponents
 
             result = default;
 
-            int index = ((List<SelectorItem<T>>)StateValueList).FindLastIndex(x => x.State == state);
+            int index = ((List<StateValuePair<T>>)StateValueList).FindLastIndex(x => x.State == state);
             if (index >= 0)
             {
                 result = StateValueList[index].Value;
@@ -221,7 +221,7 @@ namespace Tizen.NUI.BaseComponents
 
             if (state.IsCombined)
             {
-                index = ((List<SelectorItem<T>>)StateValueList).FindLastIndex(x => state.Contains(x.State));
+                index = ((List<StateValuePair<T>>)StateValueList).FindLastIndex(x => state.Contains(x.State));
                 if (index >= 0)
                 {
                     result = StateValueList[index].Value;
@@ -229,7 +229,7 @@ namespace Tizen.NUI.BaseComponents
                 }
             }
 
-            index = ((List<SelectorItem<T>>)StateValueList).FindLastIndex(x => x.State == ControlState.Other);
+            index = ((List<StateValuePair<T>>)StateValueList).FindLastIndex(x => x.State == ControlState.Other);
             if (index >= 0)
             {
                 result = StateValueList[index].Value;
@@ -286,12 +286,12 @@ namespace Tizen.NUI.BaseComponents
             if (cloneable)
             {
                 All = (T)((ICloneable)other.All)?.Clone();
-                StateValueList = ((List<SelectorItem<T>>)other.StateValueList).ConvertAll(m => new SelectorItem<T>(m.State, (T)((ICloneable)m.Value)?.Clone()));
+                StateValueList = ((List<StateValuePair<T>>)other.StateValueList).ConvertAll(m => new StateValuePair<T>(m.State, (T)((ICloneable)m.Value)?.Clone()));
             }
             else
             {
                 All = other.All;
-                StateValueList = ((List<SelectorItem<T>>)other.StateValueList).ConvertAll(m => m);
+                StateValueList = ((List<StateValuePair<T>>)other.StateValueList).ConvertAll(m => m);
             }
         }
 
@@ -427,48 +427,6 @@ namespace Tizen.NUI.BaseComponents
         }
     }
 
-
-    /// <summary>
-    /// The selector item that have Key-Value pair. it can be added to <see cref="Selector{T}.StateValueList"/>.
-    /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public class SelectorItem<T>
-    {
-        /// <summary>
-        /// The default constructor.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public SelectorItem() {}
-
-        /// <summary>
-        /// The constructor with the specified state and value.
-        /// </summary>
-        /// <param name="state">The state</param>
-        /// <param name="value">The value associated with state.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public SelectorItem(ControlState state, T value)
-        {
-            State = state;
-            Value = value;
-        }
-
-        /// <summary>
-        /// The state
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ControlState State { get; set; }
-
-        /// <summary>
-        /// The value associated with state.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public T Value { get; set; }
-
-        ///  <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override string ToString() => $"[{State}, {Value}]";
-    }
-
     /// <summary>
     /// Extension class for <see cref="Selector{T}"/>.
     /// </summary>
@@ -482,9 +440,9 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="state">The state.</param>
         /// <param name="value">The value associated with state.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void Add<T>(this IList<SelectorItem<T>> list, ControlState state, T value)
+        public static void Add<T>(this IList<StateValuePair<T>> list, ControlState state, T value)
         {
-            list.Add(new SelectorItem<T>(state, value));
+            list.Add(new StateValuePair<T>(state, value));
         }
     }
 }


### PR DESCRIPTION
This reverts commit 87dc2534f824b8c35a6961a32a15dfd3a85131a5.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
