### PR TITLE
[ElmSharp] Fix elm_more_option_open_get to return bool correctly

### DIFF
--- a/src/ElmSharp.Wearable/Interop/Interop.Eext.MoreOption.cs
+++ b/src/ElmSharp.Wearable/Interop/Interop.Eext.MoreOption.cs
@@ -73,6 +73,7 @@ internal static partial class Interop
         internal static extern IntPtr eext_more_option_items_get(IntPtr obj);
 
         [DllImport(Libraries.Eext)]
+        [return: MarshalAs(UnmanagedType.U1)]
         internal static extern bool eext_more_option_opened_get(IntPtr obj);
 
         [DllImport(Libraries.Eext)]


### PR DESCRIPTION
### Description of Change ###
`Interop.Elementary.eext_more_option_opened_get` always returns true although `elm_transit_paused_get` actually returns EINA_FALSE.

Since C and C# use 4 bytes for boolean but C++ uses 1 byte for boolean, this may cause that the boolean return value is not passed correctly.

To resolve this issue,` [return: MarshalAs(UnmanagedType.U1)] `is inserted to the declaration of `eext_more_option_opened_get`.

### API Changes ###
None