### PR TITLE
[Build] Fix wrong relative path in maketfm.py

### DIFF
--- a/packaging/maketfm.py
+++ b/packaging/maketfm.py
@@ -3,7 +3,8 @@ import xml.etree.ElementTree as ET
 
 scrpit_dir = os.path.dirname(os.path.abspath(__file__))
 spec_dir = os.path.join(scrpit_dir, "csapi-tizenfx.spec")
-tree = ET.parse("../pkg/Tizen.NET/Tizen.NET.nuspec")
+nuspec_file = os.path.join(scrpit_dir, "../pkg/Tizen.NET/Tizen.NET.nuspec")
+tree = ET.parse(nuspec_file)
 root = tree.getroot()
 
 tfm_list = []


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
