### PR TITLE
[NUI] Add defensive code for ViewSignal Disconnect()

### DIFF
--- a/src/Tizen.NUI/src/internal/ViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/ViewSignal.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
  */
+
+using global::System.Threading;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
@@ -83,10 +85,25 @@ namespace Tizen.NUI
 
         public void Disconnect(System.Delegate func)
         {
-            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            try
             {
-                Interop.ActorSignal.ActorSignal_Disconnect(swigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+                {
+                    Interop.ActorSignal.ActorSignal_Disconnect(swigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                }
+            }
+            catch (global::System.Exception ex)
+            {
+                Tizen.Log.Fatal("NUI", $"[ERROR] excpetion! {ex}: {ex.Message}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] current threadID : {Thread.CurrentThread.ManagedThreadId}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] back trace!");
+                global::System.Diagnostics.StackTrace st = new global::System.Diagnostics.StackTrace(true);
+                for (int i = 0; i < st.FrameCount; i++)
+                {
+                    global::System.Diagnostics.StackFrame sf = st.GetFrame(i);
+                    Tizen.Log.Fatal("NUI", " Method " + sf.GetMethod());
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -211,6 +211,7 @@ namespace Tizen.NUI.BaseComponents
                 if (_onRelayoutEventHandler == null && OnRelayoutSignal().Empty() == false)
                 {
                     this.OnRelayoutSignal().Disconnect(_onRelayoutEventCallback);
+                    _onRelayoutEventCallback = null;
                 }
 
             }
@@ -331,6 +332,7 @@ namespace Tizen.NUI.BaseComponents
                 if (_onWindowEventHandler == null && OnWindowSignal().Empty() == false)
                 {
                     this.OnWindowSignal().Disconnect(_onWindowEventCallback);
+                    _onWindowEventCallback = null;
                 }
             }
         }
@@ -360,6 +362,7 @@ namespace Tizen.NUI.BaseComponents
                 if (_offWindowEventHandler == null && OffWindowSignal().Empty() == false)
                 {
                     this.OffWindowSignal().Disconnect(_offWindowEventCallback);
+                    _offWindowEventCallback = null;
                 }
             }
         }
@@ -447,6 +450,7 @@ namespace Tizen.NUI.BaseComponents
                 if (_resourcesLoadedEventHandler == null && ResourcesLoadedSignal().Empty() == false)
                 {
                     this.ResourcesLoadedSignal().Disconnect(_ResourcesLoadedCallback);
+                    _ResourcesLoadedCallback = null;
                 }
             }
         }
@@ -470,6 +474,7 @@ namespace Tizen.NUI.BaseComponents
                 if (_backgroundResourceLoadedEventHandler == null && ResourcesLoadedSignal().Empty() == false)
                 {
                     this.ResourcesLoadedSignal().Disconnect(_backgroundResourceLoadedCallback);
+                    _backgroundResourceLoadedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1061,16 +1061,19 @@ namespace Tizen.NUI.BaseComponents
             if (_onRelayoutEventCallback != null)
             {
                 this.OnRelayoutSignal().Disconnect(_onRelayoutEventCallback);
+                _onRelayoutEventCallback = null;
             }
 
             if (_offWindowEventCallback != null)
             {
                 this.OffWindowSignal().Disconnect(_offWindowEventCallback);
+                _offWindowEventCallback = null;
             }
 
             if (_onWindowEventCallback != null)
             {
                 this.OnWindowSignal().Disconnect(_onWindowEventCallback);
+                _onWindowEventCallback = null;
             }
 
             if (_wheelEventCallback != null)
@@ -1091,6 +1094,7 @@ namespace Tizen.NUI.BaseComponents
             if (_ResourcesLoadedCallback != null)
             {
                 this.ResourcesLoadedSignal().Disconnect(_ResourcesLoadedCallback);
+                _ResourcesLoadedCallback = null;
             }
 
             if (_offWindowEventCallback != null)
@@ -1141,6 +1145,7 @@ namespace Tizen.NUI.BaseComponents
             if (_backgroundResourceLoadedCallback != null)
             {
                 this.ResourcesLoadedSignal().Disconnect(_backgroundResourceLoadedCallback);
+                _backgroundResourceLoadedCallback = null;
             }
 
             if (_onWindowSendEventCallback != null)


### PR DESCRIPTION
### Description of Change ###
[NUI] Add defensive code for ViewSignal Disconnect()

- the following exception couldn't be reproduced so this defensive code is added.
Exception !!! : [com.samsung.tv.csfs] [] EXCEPTION Exception !!!: System.NullReferenceException: Object reference not set to an instance of an object.
at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate[TDelegate](TDelegate d)
at Tizen.NUI.ViewSignal.Disconnect(Delegate func)
at Tizen.NUI.BaseComponents.View.DisConnectFromSignals()
at Tizen.NUI.BaseComponents.View.Dispose(DisposeTypes type)
at Tizen.TV.FLUX.FluxView.Dispose(DisposeTypes type)

- Add back trace and thread check in ViewSignal.Disconnect().
- Add null setting in callback delegate.

### API Changes ###
none