### PR TITLE
[NUI] Delete unnecessary log in BaseHandle

### DIFF
--- a/src/Tizen.NUI/src/public/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/BaseHandle.cs
@@ -402,9 +402,6 @@ namespace Tizen.NUI
         {
             if (swigCPtrCopy.Handle == IntPtr.Zero)
             {
-                global::System.Diagnostics.StackTrace trace = new global::System.Diagnostics.StackTrace();
-                Tizen.Log.Error("NUI", "" + trace);
-                Tizen.Log.Error("NUI", "[ERROR] the native handle is invalid!");
                 return false;
             }
 


### PR DESCRIPTION
If Dispose is already called, the log is displayed unnecessarily.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
