### PR TITLE
[NUI] Add class SelectedChangedEventArgs to public

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -32,6 +32,17 @@ namespace Tizen.NUI.Components
     }
 
     /// <summary>
+    /// SelectedChangedEventArgs is a class to record item selected arguments which will sent to user.
+    /// </summary>
+    /// <since_tizen> 8 </since_tizen>
+    public class SelectedChangedEventArgs : EventArgs
+    {
+        /// <summary> Selected state </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public bool IsSelected { get; set; }
+    }
+
+    /// <summary>
     /// Button is one kind of common component, a button clearly describes what action will occur when the user selects it.
     /// Button may contain text or an icon.
     /// </summary>

--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -21,19 +21,6 @@ using System.ComponentModel;
 namespace Tizen.NUI.Components
 {
     /// <summary>
-    /// SelectedChangedEventArgs is a class to record item selected arguments which will sent to user.
-    /// </summary>
-    /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public class SelectedChangedEventArgs : EventArgs
-    {
-        /// <summary> Select state of SelectButton </summary>
-        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsSelected { get; set; }
-    }
-
-    /// <summary>
     /// SelectButton is base class of CheckBox and RadioButton.
     /// It can be used as selector and add into group for single-choice or multiple-choice .
     /// User can handle Navigation by adding/inserting/deleting NavigationItem.


### PR DESCRIPTION
To add Switch.SelectedChanged event with using SelectedChangedEventArgs,
SelectedChangedEventArgs is added to public.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
