### PR TITLE
[NUI] Load Tizen.NUI dependencies libs on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,17 @@ git clone https://github.com/Samsung/TizenFX.git
 cd TizenFX
 ```
 ### How to build
+#### Linux
 ```bash
 ./build.sh full
 ./build.sh pack
+```
+
+#### Windows
+On a `Git bash` shell with `dali-env` seted, run:
+```bash
+./build.sh full -p:DefineConstants=NOTIZEN
+./build.sh pack -p:DefineConstants=NOTIZEN
 ```
 
 ## Tizen Project

--- a/build.sh
+++ b/build.sh
@@ -69,7 +69,7 @@ restore() {
 }
 
 build() {
-  dotnet build --no-restore -c $CONFIGURATION /fl $@
+  dotnet build --no-restore -c $CONFIGURATION -fl $@
 }
 
 copy_artifacts() {

--- a/src/Tizen.Applications.Common/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libraries.cs
@@ -18,10 +18,15 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string AppCommon = "libcapi-appfw-app-common.so.0";
+        #if NOTIZEN
+            public const string AppCommon = "capi-appfw-app-common";
+            public const string AppManager = "capi-appfw-app-manager";
+        #else
+            public const string AppCommon = "libcapi-appfw-app-common.so.0";
+            public const string AppManager = "libcapi-appfw-app-manager.so.0";
+        #endif
         public const string AppControl = "libcapi-appfw-app-control.so.0";
         public const string AppEvent = "libcapi-appfw-event.so.0";
-        public const string AppManager = "libcapi-appfw-app-manager.so.0";
         public const string Bundle = "libbundle.so.0";
         public const string Rua = "librua.so.0";
         public const string Glib = "libglib-2.0.so.0";

--- a/src/Tizen.Log/Interop/Interop.Dlog.cs
+++ b/src/Tizen.Log/Interop/Interop.Dlog.cs
@@ -20,7 +20,11 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string Dlog = "libdlog.so.0";
+        #if NOTIZEN
+            public const string Dlog = "dlog";
+        #else
+            public const string Dlog = "libdlog.so.0";
+        #endif
     }
 
     internal static partial class Dlog

--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -20,7 +20,12 @@ namespace Tizen.NUI
 
     class NDalicPINVOKE
     {
-        public const string Lib = "libdali2-csharp-binder.so";
+        #if NOTIZEN
+            public const string Lib = "dali2-csharp-binder";
+        #else
+            public const string Lib = "libdali2-csharp-binder.so";
+        #endif
+
         protected class SWIGExceptionHelper
 		{
 			/// <since_tizen> 3 </since_tizen>
@@ -41,7 +46,7 @@ namespace Tizen.NUI
 			static ExceptionArgumentDelegate argumentDelegate = new ExceptionArgumentDelegate(SetPendingArgumentException);
 			static ExceptionArgumentDelegate argumentNullDelegate = new ExceptionArgumentDelegate(SetPendingArgumentNullException);
 			static ExceptionArgumentDelegate argumentOutOfRangeDelegate = new ExceptionArgumentDelegate(SetPendingArgumentOutOfRangeException);
-	
+
 			[global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "SWIGRegisterExceptionCallbacks_NDalic")]
 			public static extern void SWIGRegisterExceptionCallbacks_NDalic(
 										ExceptionDelegate applicationDelegate,
@@ -55,7 +60,7 @@ namespace Tizen.NUI
 										ExceptionDelegate outOfMemoryDelegate,
 										ExceptionDelegate overflowDelegate,
 										ExceptionDelegate systemExceptionDelegate);
-	
+
 			[global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "SWIGRegisterExceptionArgumentCallbacks_NDalic")]
 			public static extern void SWIGRegisterExceptionCallbacksArgument_NDalic(
 										ExceptionArgumentDelegate argumentDelegate,
@@ -105,7 +110,7 @@ namespace Tizen.NUI
 			{
 				SWIGPendingException.Set(new global::System.SystemException(message, SWIGPendingException.Retrieve()));
 			}
-	
+
 			static void SetPendingArgumentException(string message, string paramName)
 			{
 				SWIGPendingException.Set(new global::System.ArgumentException(message, paramName, SWIGPendingException.Retrieve()));
@@ -136,7 +141,7 @@ namespace Tizen.NUI
 										  outOfMemoryDelegate,
 										  overflowDelegate,
 										  systemDelegate);
-	
+
 				SWIGRegisterExceptionCallbacksArgument_NDalic(
 										  argumentDelegate,
 										  argumentNullDelegate,

--- a/src/Tizen/Interop/Interop.Dlog.cs
+++ b/src/Tizen/Interop/Interop.Dlog.cs
@@ -20,7 +20,11 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string Dlog = "libdlog.so.0";
+        #if NOTIZEN
+            public const string Dlog = "dlog";
+        #else
+            public const string Dlog = "libdlog.so.0";
+        #endif
     }
 
     internal static partial class Dlog

--- a/test/ElmSharp.Test/Log.cs
+++ b/test/ElmSharp.Test/Log.cs
@@ -7,7 +7,11 @@ namespace ElmSharp.Test
 {
     internal static class Log
     {
-        const string Library = "libdlog.so.0";
+        #if NOTIZEN
+            public const string Library = "dlog";
+        #else
+            public const string Library = "libdlog.so.0";
+        #endif
         const string TAG = "ElmSharp.Test";
 
         public static void Debug(string message,

--- a/test/ElmSharp.Wearable.Test/TC/Log.cs
+++ b/test/ElmSharp.Wearable.Test/TC/Log.cs
@@ -7,7 +7,11 @@ namespace ElmSharp.Test
 {
     internal static class Log
     {
-        const string Library = "libdlog.so.0";
+        #if NOTIZEN
+            public const string Library = "dlog";
+        #else
+            public const string Library = "libdlog.so.0";
+        #endif
         const string TAG = "ElmSharp.Test";
 
         public static void Debug(string message,


### PR DESCRIPTION
### Description of Change ###
This use `MSBuild` `-p:DefineConstants=NOTIZEN` directive to define a
Windows build, which impact the names of `Tizen.NUI` to search for.

This impacts the load of:
- `dali-csharp-binder`
- `capi-appfw-app-manager`
- `capi-appfw-app-common`
- `dlog`

We first tried to define those names at run-time, but
`DllImportAtribbuts` are `C#` `const strings`, which need to be defined
at compile-time, so it raised the need of the preprocessor directive to
select the correct name.

### API Changes ###
Now, to compile/run on Windows you shoud pass `-p:DefineConstants=NOTIZEN` to
`build.sh` while running it on `Git bash` shell:
```sh
$ ./build.sh full -p:DefineConstants=NOTIZEN
```
While maintaining the original use on Linux:
```sh
$ ./build.sh full
```