### PR TITLE
[Bluetooth][Non-ACR] Fix Track data converting logic

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothAvrcpControlImpl.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothAvrcpControlImpl.cs
@@ -146,16 +146,24 @@ namespace Tizen.Network.Bluetooth
         {
             _trackInfoChangedCallback = (ref TrackInfoStruct track_info, IntPtr userdata) =>
             {
-                _trackInfoChanged?.Invoke(null, new TrackInfoChangedEventArgs(new Track()
-                {
-                    Album = track_info.Album,
-                    Artist = track_info.Artist,
-                    Genre = track_info.Genre,
-                    Title = track_info.Title,
-                    TotalTracks = track_info.total_tracks,
-                    TrackNum = track_info.number,
-                    Duration = track_info.duration
-                }));
+                Track track = new Track();
+                track.Album = Marshal.PtrToStringAnsi(track_info.Album);
+                track.Artist = Marshal.PtrToStringAnsi(track_info.Artist);
+                track.Genre = Marshal.PtrToStringAnsi(track_info.Genre);
+                track.Title = Marshal.PtrToStringAnsi(track_info.Title);
+                track.TotalTracks = track_info.total_tracks;
+                track.TrackNum = track_info.number;
+                track.Duration = track_info.duration;
+
+                Log.Debug(Globals.LogTag, "Album: " + track.Album
+                    + ", Artist: " + track.Artist
+                    + ", Genre: " + track.Genre
+                    + ", Title: " + track.Title
+                    + ", TotalTracks: " + track.TotalTracks
+                    + ", TrackNum: " + track.TrackNum
+                    + ", Duration: " + track.Duration);
+
+                _trackInfoChanged?.Invoke(null, new TrackInfoChangedEventArgs(track));
             };
             int ret = Interop.Bluetooth.SetTrackInfoChangedCallback(_trackInfoChangedCallback, IntPtr.Zero);
             if (ret != (int)BluetoothError.None)
@@ -307,8 +315,8 @@ namespace Tizen.Network.Bluetooth
 
         internal Track GetTrackInfo()
         {
-            Track trackdata = new Track();
-            TrackInfoStruct trackinfo;
+            Track track = new Track();
+            TrackInfoStruct track_info;
             IntPtr infoptr;
 
             int ret = Interop.Bluetooth.GetTrackInfo(out infoptr);
@@ -318,14 +326,22 @@ namespace Tizen.Network.Bluetooth
                 BluetoothErrorFactory.ThrowBluetoothException(ret);
             }
 
-            trackinfo = (TrackInfoStruct)Marshal.PtrToStructure(infoptr, typeof(TrackInfoStruct));
-            trackdata.Album = trackinfo.Album;
-            trackdata.Artist = trackinfo.Artist;
-            trackdata.Genre = trackinfo.Genre;
-            trackdata.Title = trackinfo.Title;
-            trackdata.TotalTracks = trackinfo.total_tracks;
-            trackdata.TrackNum = trackinfo.number;
-            trackdata.Duration = trackinfo.duration;
+            track_info = (TrackInfoStruct)Marshal.PtrToStructure(infoptr, typeof(TrackInfoStruct));
+            track.Album = Marshal.PtrToStringAnsi(track_info.Album);
+            track.Artist = Marshal.PtrToStringAnsi(track_info.Artist);
+            track.Genre = Marshal.PtrToStringAnsi(track_info.Genre);
+            track.Title = Marshal.PtrToStringAnsi(track_info.Title);
+            track.TotalTracks = track_info.total_tracks;
+            track.TrackNum = track_info.number;
+            track.Duration = track_info.duration;
+
+            Log.Debug(Globals.LogTag, "Album: " + track.Album
+                + ", Artist: " + track.Artist
+                + ", Genre: " + track.Genre
+                + ", Title: " + track.Title
+                + ", TotalTracks: " + track.TotalTracks
+                + ", TrackNum: " + track.TrackNum
+                + ", Duration: " + track.Duration);
 
             ret = Interop.Bluetooth.FreeTrackInfo(infoptr);
             if (ret != (int)BluetoothError.None)
@@ -334,7 +350,7 @@ namespace Tizen.Network.Bluetooth
                 BluetoothErrorFactory.ThrowBluetoothException(ret);
             }
 
-            return trackdata;
+            return track;
         }
 
         internal void SendPlayerCommand(PlayerCommand command)

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothEventArgs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothEventArgs.cs
@@ -1045,7 +1045,7 @@ namespace Tizen.Network.Bluetooth
     /// <since_tizen> 8 </since_tizen>
     public class TrackInfoChangedEventArgs : EventArgs
     {
-        private Track _track = new Track();
+        private Track _track;
         internal TrackInfoChangedEventArgs(Track Data)
         {
             _track = Data;

--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
@@ -136,7 +136,7 @@ namespace Tizen.Network.Bluetooth
 
         internal IntPtr ManufacturerData;
     }
-    
+
     [NativeStruct("bt_device_sdp_info_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct BluetoothDeviceSdpStruct
@@ -225,17 +225,14 @@ namespace Tizen.Network.Bluetooth
         internal IntPtr data;
     }
 
+    [NativeStruct("bt_avrcp_metadata_attributes_info_s", Include="bluetooth_type.h", PkgConfig="capi-network-bluetooth")]
     [StructLayout(LayoutKind.Sequential)]
     internal struct TrackInfoStruct
     {
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
-        internal string Title;
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
-        internal string Artist;
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
-        internal string Album;
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
-        internal string Genre;
+        internal IntPtr Title;
+        internal IntPtr Artist;
+        internal IntPtr Album;
+        internal IntPtr Genre;
         internal uint total_tracks;
         internal uint number;
         internal uint duration;


### PR DESCRIPTION
I/DOTNET_LAUNCHER( 1322): System.Runtime.InteropServices.COMException
 (0x8007007A): The data area passed to a system call is too small.
 (0x8007007A) at System.StubHelpers.ValueClassMarshaler.ConvertToNative
 (IntPtr dst, IntPtr src, IntPtr pMT, CleanupWorkListElement& pCleanupWorkList)

Signed-off-by: Wootak Jung <wootak.jung@samsung.com>