### PR TITLE
[NUI] Bug fixed about TextPageUtil

### DIFF
--- a/src/Tizen.NUI/src/public/Utility/TextPageUtil.cs
+++ b/src/Tizen.NUI/src/public/Utility/TextPageUtil.cs
@@ -101,6 +101,7 @@ namespace Tizen.NUI.Utility
       int cutOffIndex = 0;
 
       // init
+      totalPageCnt = 0;
       pageList = new List<PageData>();
       tagList = new List<TagData>();
       characterList = new List<char>();
@@ -150,7 +151,7 @@ namespace Tizen.NUI.Utility
             pageList.Add(pageData);
           }
           totalPageCnt++;
-          if(offset <= 0 ) break;
+          if(offset <= 0 || remainLength <= 0 ) break;
       }
 
       textParameters.Dispose();


### PR DESCRIPTION
add check remainLength and init totalPageCnt value

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: NONE

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
