### PR TITLE
[NUI] Add EnableMultiSelected to SelectGroup

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RadioButtonGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/RadioButtonGroup.cs
@@ -42,6 +42,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RadioButtonGroup() : base()
         {
+            EnableMultiSelection = false;
         }
 
         /// <summary>
@@ -83,31 +84,6 @@ namespace Tizen.NUI.Components
             if (null == radio) return;
             base.RemoveSelection(radio);
             radio.ItemGroup = null;
-        }
-
-        /// <summary>
-        /// Handle user's select action. Turn on check state of selected RadioButton,
-        /// and turn out check state of other RadioButtons in RadioButtonGroup
-        /// </summary>
-        /// <param name="selection">The selection selected by user</param>
-        /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void SelectionHandler(SelectButton selection)
-        {
-            RadioButton radio = selection as RadioButton;
-            if (!ItemGroup.Contains(radio))
-            {
-                return;
-            }
-
-            foreach (RadioButton btn in ItemGroup)
-            {
-                if (btn != null && btn != radio && btn.IsEnabled == true)
-                {
-                    btn.IsSelected = false;
-                }
-            }
         }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/SelectGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectGroup.cs
@@ -70,6 +70,12 @@ namespace Tizen.NUI.Components
         public int SelectedIndex => selectedIndex;
 
         /// <summary>
+        /// EnableMultiSelection is used to indicate if SelectGroup can select multiple SelectButtons.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool EnableMultiSelection { get; set; } = true;
+
+        /// <summary>
         /// Construct SelectionGroup
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
@@ -142,7 +148,7 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Overrides this method if want to handle behavior after pressing return key by user.
+        /// Called when the state of Selected is changed.
         /// </summary>
         /// <param name="selection">The selection selected by user</param>
         /// <since_tizen> 6 </since_tizen>
@@ -160,6 +166,18 @@ namespace Tizen.NUI.Components
                 if (args.IsSelected == true)
                 {
                     selectedIndex = selection.Index;
+
+                    if (EnableMultiSelection == false)
+                    {
+                        foreach (SelectButton btn in ItemGroup)
+                        {
+                            if ((btn != null) && (btn != selection) && (btn.IsEnabled == true) && (btn.IsSelected == true))
+                            {
+                                btn.IsSelected = false;
+                            }
+                        }
+                    }
+
                     SelectionHandler(selection);
                 }
             }


### PR DESCRIPTION
To support selecting multiple SelectButtons in SelectGroup,
bool EnableMultiSelected is added to SelectGroup.

By adding EnableMultiSelected in SelectGroup, RadioButtonGroup does not
need to implement its logic to prevent selecting multiple RadioButtons.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
