### PR TITLE
[NUI] Make Selector.StateValueList public temporarily

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI.BaseComponents
         /// The list for adding state-value pair.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        List<StateValuePair<T>> StateValueList { get; set; } = new List<StateValuePair<T>>();
+        public List<StateValuePair<T>> StateValueList { get; set; } = new List<StateValuePair<T>>();
 
         /// <summary>
         /// Adds the specified state and value.


### PR DESCRIPTION
This will fix DA-NUI build error.
Please revert this patch after the DA build error is fixed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
