### PR TITLE
[WiFi] Use cloned apHandle

### DIFF
--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/ConnectionStateChangedEventArgs.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/ConnectionStateChangedEventArgs.cs
@@ -30,7 +30,9 @@ namespace Tizen.Network.WiFi
         internal ConnectionStateChangedEventArgs(WiFiConnectionState s, IntPtr apHandle)
         {
             _state = s;
-            _ap = new WiFiAP(apHandle);
+            IntPtr clonedHandle;
+            Interop.WiFi.AP.Clone(out clonedHandle, apHandle);
+            _ap = new WiFiAP(clonedHandle);
         }
 
         /// <summary>


### PR DESCRIPTION
The parameter, apHandle of ConnectionStateChangedEventArgs() is freed by caller (native api).
Therefore, cloned handle should be used to create new WiFiAP instance.