### PR TITLE
[NUI] No need to do Registry.GetManagedBaseHandleFromNativePtr().

### DIFF
--- a/src/Tizen.NUI/src/public/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Gesture.cs
@@ -195,11 +195,7 @@ namespace Tizen.NUI
 
         internal static Gesture GetGestureFromPtr(global::System.IntPtr cPtr)
         {
-            Gesture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Gesture;
-            if (ret == null)
-            {
-                ret = new Gesture(cPtr, false);
-            }
+            Gesture ret = new Gesture(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Hover.cs
+++ b/src/Tizen.NUI/src/public/Hover.cs
@@ -159,12 +159,7 @@ namespace Tizen.NUI
 
         internal static Hover GetHoverFromPtr(global::System.IntPtr cPtr)
         {
-            Hover ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Hover;
-            if (ret == null)
-            {
-                ret = new Hover(cPtr, false);
-            }
-
+            Hover ret = new Hover(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Key.cs
+++ b/src/Tizen.NUI/src/public/Key.cs
@@ -324,11 +324,7 @@ namespace Tizen.NUI
 
         internal static Key GetKeyFromPtr(global::System.IntPtr cPtr)
         {
-            Key ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Key;
-            if (ret == null)
-            {
-                ret = new Key(cPtr, false);
-            }
+            Key ret = new Key(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/LongPressGesture.cs
+++ b/src/Tizen.NUI/src/public/LongPressGesture.cs
@@ -135,11 +135,7 @@ namespace Tizen.NUI
 
         internal static LongPressGesture GetLongPressGestureFromPtr(global::System.IntPtr cPtr)
         {
-            LongPressGesture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as LongPressGesture;
-            if (ret == null)
-            {
-                ret = new LongPressGesture(cPtr, false);
-            }
+            LongPressGesture ret = new LongPressGesture(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/PanGesture.cs
+++ b/src/Tizen.NUI/src/public/PanGesture.cs
@@ -326,11 +326,7 @@ namespace Tizen.NUI
 
         internal static PanGesture GetPanGestureFromPtr(global::System.IntPtr cPtr)
         {
-            PanGesture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as PanGesture;
-            if (ret == null)
-            {
-                ret = new PanGesture(cPtr, false);
-            }
+            PanGesture ret = new PanGesture(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/PinchGesture.cs
+++ b/src/Tizen.NUI/src/public/PinchGesture.cs
@@ -163,11 +163,7 @@ namespace Tizen.NUI
 
         internal static PinchGesture GetPinchGestureFromPtr(global::System.IntPtr cPtr)
         {
-            PinchGesture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as PinchGesture;
-            if (ret == null)
-            {
-                ret = new PinchGesture(cPtr, false);
-            }
+            PinchGesture ret = new PinchGesture(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/RotationGesture.cs
+++ b/src/Tizen.NUI/src/public/RotationGesture.cs
@@ -137,11 +137,7 @@ namespace Tizen.NUI
 
         internal static RotationGesture GetRotationGestureFromPtr(global::System.IntPtr cPtr)
         {
-            RotationGesture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as RotationGesture;
-            if (ret == null)
-            {
-                ret = new RotationGesture(cPtr, false);
-            }
+            RotationGesture ret = new RotationGesture(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/TapGesture.cs
+++ b/src/Tizen.NUI/src/public/TapGesture.cs
@@ -161,11 +161,7 @@ namespace Tizen.NUI
         /// <returns>The TapGesture object.</returns>
         internal static TapGesture GetTapGestureFromPtr(global::System.IntPtr cPtr)
         {
-            TapGesture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TapGesture;
-            if (ret == null)
-            {
-                ret = new TapGesture(cPtr, false);
-            }
+            TapGesture ret = new TapGesture(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Wheel.cs
+++ b/src/Tizen.NUI/src/public/Wheel.cs
@@ -253,11 +253,7 @@ namespace Tizen.NUI
 
         internal static Wheel GetWheelFromPtr(global::System.IntPtr cPtr)
         {
-            Wheel ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Wheel;
-            if (ret == null)
-            {
-                ret = new Wheel(cPtr, false);
-            }
+            Wheel ret = new Wheel(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
No need to do Registry.GetManagedBaseHandleFromNativePtr().

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: NONE

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
