### PR TITLE
[NUI] Do not make error message when the profile theme file is not found

### DIFF
--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -19,6 +19,7 @@ using TizenSystemInformation.Tizen.System;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using Tizen.NUI.Xaml;
 using Tizen.NUI.BaseComponents;
 
@@ -304,6 +305,12 @@ namespace Tizen.NUI
             foreach (var project in nuiThemeProjects)
             {
                 string path = StyleManager.FrameworkResourcePath + "/Theme/" + project + "_" + id + ".xaml";
+
+                if (!File.Exists(path))
+                {
+                    Tizen.Log.Info("NUI", $"\"{path}\" is not found in this profile.\n");
+                    continue;
+                }
 
                 try
                 {


### PR DESCRIPTION
In some profile, not all 3 theme files exists.
So the patch checks file existance not to make error messages.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
