### PR TITLE
[NUI] Fill missing descriptions and fix build warnings for Theme

### DIFF
--- a/src/Tizen.NUI/src/public/Theme/Theme.cs
+++ b/src/Tizen.NUI/src/public/Theme/Theme.cs
@@ -15,7 +15,6 @@
  *
  */
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
@@ -26,7 +25,18 @@ using Tizen.NUI.Xaml;
 
 namespace Tizen.NUI
 {
-    /// <summary></summary>
+    /// <summary>
+    /// <para>
+    /// Basically, the Theme is a dictionary of <seealso cref="ViewStyle"/>s that can decorate NUI <seealso cref="View"/>s.
+    /// Each ViewStyle item is identified by a string key that can be matched the <seealso cref="View.StyleName"/>.
+    /// </para>
+    /// <para>
+    /// The main purpose of providing Theme is to separate style details from the structure.
+    /// Managing style separately makes it easier to customize the look of application by user context.
+    /// Also since a Theme can be created from xaml file, it can be treated as a resource.
+    /// This enables sharing styles with other applications.
+    /// </para>
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Theme : BindableObject, IResourcesProvider
     {
@@ -68,7 +78,7 @@ namespace Tizen.NUI
         {
             if (string.IsNullOrEmpty(xamlFile))
             {
-                throw new ArgumentNullException("The xaml file path cannot be null or empty string", nameof(xamlFile));
+                throw new ArgumentNullException(nameof(xamlFile), "The xaml file path cannot be null or empty string");
             }
 
             LoadFromXaml(xamlFile);
@@ -80,7 +90,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="xamlFile">An absolute path to the xaml file.</param>
         /// <param name="themeResource">An absolute path to the theme resource file.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the given xamlFile is null or empty string.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the given xamlFile or themeResource is null or empty string.</exception>
         /// <exception cref="System.IO.IOException">Thrown when there are file IO problems.</exception>
         /// <exception cref="Exception">Thrown when the content of the xaml file is not valid xaml form.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -98,7 +108,9 @@ namespace Tizen.NUI
             this.xamlFile = xamlFile;
         }
 
-        /// <summary></summary>
+        /// <summary>
+        /// The string key to identify the Theme.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string Id { get; set; }
 
@@ -209,10 +221,11 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="viewType">The type of View.</param>
         /// <returns>Founded style instance.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the given viewType is null.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ViewStyle GetStyle(Type viewType)
         {
-            var currentType = viewType;
+            var currentType = viewType ?? throw new ArgumentNullException(nameof(viewType));
             ViewStyle resultStyle = null;
 
             do

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -20,12 +20,20 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
-using Tizen.NUI.Xaml;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
 {
-    /// <summary></summary>
+    /// <summary>
+    /// This static module provides methods that can manage NUI <seealso cref="Theme"/>.
+    /// </summary>
+    /// <example>
+    /// To apply custom theme to the application, try <seealso cref="ApplyTheme(Theme)"/>.
+    /// <code>
+    /// var customTheme = new Theme(res + "customThemeFile.xaml");
+    /// ThemeManager.ApplyTheme(customTheme);
+    /// </code>
+    /// </example>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class ThemeManager
     {
@@ -60,12 +68,13 @@ namespace Tizen.NUI
         private static Theme defaultTheme;
         private static bool isLoadingDefault = false;
         private static Profile? currentProfile;
-        private static List<Theme> builtinThemes = new List<Theme>(); // Themes provided by framework.
+        private static readonly List<Theme> builtinThemes = new List<Theme>(); // Themes provided by framework.
         internal static List<Theme> customThemes = new List<Theme>(); // Themes registered by user.
 
         static ThemeManager() {}
 
         /// <summary>
+        /// An event invoked after the theme has changed by <seealso cref="ApplyTheme(Theme)"/>.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static event EventHandler<ThemeChangedEventArgs> ThemeChanged;
@@ -77,14 +86,7 @@ namespace Tizen.NUI
 
         internal static Theme CurrentTheme
         {
-            get
-            {
-                if (currentTheme == null)
-                {
-                    currentTheme = DefaultTheme;
-                }
-                return currentTheme;
-            }
+            get =>  currentTheme ?? (currentTheme = DefaultTheme);
             set
             {
                 currentTheme = value;
@@ -125,6 +127,9 @@ namespace Tizen.NUI
                     }
                     catch
                     {
+                        // Note
+                        // Do not rethrow exception.
+                        // In some machine, profile may not exits.
                         Tizen.Log.Info("NUI", "Unknown device profile\n");
                     }
                     finally
@@ -156,7 +161,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void ApplyFallbackTheme(Theme fallbackTheme)
         {
-            DefaultTheme = fallbackTheme ?? throw new ArgumentNullException("Invalid theme.");
+            DefaultTheme = fallbackTheme ?? throw new ArgumentNullException(nameof(fallbackTheme));
         }
 
         /// <summary>
@@ -169,7 +174,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void ApplyTheme(Theme theme)
         {
-            var newTheme = (Theme)theme?.Clone() ?? throw new ArgumentNullException("Invalid theme.");
+            var newTheme = (Theme)theme?.Clone() ?? throw new ArgumentNullException(nameof(theme));
 
             if (string.IsNullOrEmpty(newTheme.Id))
             {
@@ -180,21 +185,24 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// <para>
         /// Note that this API is to support legacy Tizen.NUI.Components.StyleManager.
         /// Please use <seealso cref="ApplyTheme(Theme)"/> instead.
-        ///
+        /// </para>
+        /// <para>
         /// Apply theme to the NUI using theme id.
         /// The id of theme should be either a registered custom theme or a built-in theme.
         /// You can register custom theme using <seealso cref="RegisterTheme(Theme)"/>.
         /// This will change the appreance of the existing components with property <seealso cref="View.ThemeChangeSensitive"/> on.
         /// This also affects all components created afterwards.
+        /// </para>
         /// </summary>
         /// <param name="themeId">The theme Id.</param>
         /// <exception cref="ArgumentNullException">Thrown when the given themeId is null.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void ApplyTheme(string themeId)
         {
-            if (themeId == null) throw new ArgumentNullException("Invalid themeId");
+            if (themeId == null) throw new ArgumentNullException(nameof(themeId));
 
             int index = customThemes.FindIndex(x => x.Id.Equals(themeId, StringComparison.OrdinalIgnoreCase));
             if (index >= 0)
@@ -202,7 +210,7 @@ namespace Tizen.NUI
                 CurrentTheme = customThemes[index];
                 return;
             }
-            
+
             index = builtinThemes.FindIndex(x => string.Equals(x.Id, themeId, StringComparison.OrdinalIgnoreCase));
             if (index >= 0)
             {
@@ -215,16 +223,17 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Note that this API is to support legacy Tizen.NUI.Components.StyleManager.
-        ///
-        /// Register a custom theme that can be used as an id when calling <seealso cref="ApplyTheme(string)"/>.
+        /// <para> Note that this API is to support legacy Tizen.NUI.Components.StyleManager. </para>
+        /// <para> Register a custom theme that can be used as an id when calling <seealso cref="ApplyTheme(string)"/>. </para>
         /// </summary>
         /// <param name="theme">The theme instance.</param>
-        /// <exception cref="ArgumentException">Thrown when the given theme is null or invalid.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the given theme is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the given theme id is invalid.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void RegisterTheme(Theme theme)
         {
-            if (theme == null || string.IsNullOrEmpty(theme.Id)) throw new ArgumentException("Invalid theme.");
+            if (theme == null) throw new ArgumentNullException(nameof(theme));
+            if (string.IsNullOrEmpty(theme.Id)) throw new ArgumentException("Invalid theme id.");
 
             int index = customThemes.FindIndex(x => x.Id.Equals(theme.Id, StringComparison.OrdinalIgnoreCase));
             if (index >= 0)
@@ -246,7 +255,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ViewStyle GetStyle(string styleName)
         {
-            if (styleName == null) throw new ArgumentNullException("Invalid style name");
+            if (styleName == null) throw new ArgumentNullException(nameof(styleName));
 
             if (!ThemeApplied) return null;
 
@@ -261,7 +270,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ViewStyle GetStyle(Type viewType)
         {
-            if (viewType == null) throw new ArgumentNullException("Invalid viewType");
+            if (viewType == null) throw new ArgumentNullException(nameof(viewType));
 
             if (!ThemeApplied) return null;
 
@@ -276,7 +285,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static Theme GetBuiltinTheme(string themeId)
         {
-            if (themeId == null) throw new ArgumentNullException("Invalid themeId");
+            if (themeId == null) throw new ArgumentNullException(nameof(themeId));
 
             Theme result = null;
             int index = builtinThemes.FindIndex(x => string.Equals(x.Id, themeId, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
This patch fixes build warnings and Roslynator suggestions in Theme and ThemeManager.

CA2208 Instantiate argument exceptions correctly
CA1062 Validate arguments of public methods
IDE0044 Add readonly modifier
IDE0005 Remove unnecessary import
RCS1171 Simplify lazy initialization

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
