### PR TITLE
[NUI] change orientation angle in GLWindow

### DIFF
--- a/src/Tizen.NUI/src/public/GLWindow.cs
+++ b/src/Tizen.NUI/src/public/GLWindow.cs
@@ -80,19 +80,19 @@ namespace Tizen.NUI
             /// Landscape orientation. A wide view area is needed.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
-            Landscape = 1,
+            Landscape = 90,
 
             /// <summary>
             /// Portrait inverse orientation.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
-            PortraitInverse = 2,
+            PortraitInverse = 180,
 
             /// <summary>
             /// Landscape inverse orientation.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
-            LandscapeInverse = 3,
+            LandscapeInverse = 270,
 
             /// <summary>
             /// No orientation. It is for the preferred orientation
@@ -426,7 +426,7 @@ namespace Tizen.NUI
         /// Type of callback to render to frame to use native GL code.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public delegate void GLRenderFrameCallbackType();
+        public delegate int GLRenderFrameCallbackType();
 
         GLRenderFrameCallbackType GLRenderFrameCallback;
         HandleRef RenderHandlerRef;


### PR DESCRIPTION
Change orientation angle in GLWindow. It is same with NUI.Window.

### Description of Change ###
GLWindow has window orientation angle enum type. It is different to NUI.Window.
This patch is for convienent both GLWindow and NUI.Window. 
In addition, To be adjusted buffer commit by GLWindow application, the renderFrame callback function is changed.

This interface is not public, so, need not care for ACR.
