### PR TITLE
[NUI] Introduce CornerRadiusPolicy to View

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1028,9 +1028,9 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        internal override void UpdateCornerRadius(float value)
+        internal override void ApplyCornerRadius()
         {
-            base.UpdateCornerRadius(value);
+            base.ApplyCornerRadius();
 
             UpdateImage(0, null);
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -84,6 +84,7 @@ namespace Tizen.NUI.BaseComponents
         private Selector<Color> backgroundColorSelector;
         private Selector<Rectangle> backgroundImageBorderSelector;
         private Selector<Color> colorSelector;
+        private VisualTransformPolicyType? cornerRadiusPolicy;
 
         static ViewStyle() { }
 
@@ -674,6 +675,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (Selector<float?>)GetValue(CornerRadiusProperty);
             set => SetValue(CornerRadiusProperty, value);
+        }
+
+        /// <summary>
+        /// Whether the CornerRadius property value is relative (percentage [0.0f to 1.0f] of the view size) or absolute (in world units).
+        /// It is absolute by default.
+        /// When the policy is relative, the corner radius is relative to the smaller of the view's width and height.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VisualTransformPolicyType? CornerRadiusPolicy
+        {
+            get => (VisualTransformPolicyType?)GetValue(CornerRadiusPolicyProperty);
+            set => SetValue(CornerRadiusPolicyProperty, value);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -868,6 +868,13 @@ namespace Tizen.NUI.BaseComponents
             return viewStyle.cornerRadius;
         });
 
+        /// <summary> A BindableProperty for CornerRadiusPolicy </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty CornerRadiusPolicyProperty = BindableProperty.Create(nameof(CornerRadiusPolicy), typeof(VisualTransformPolicyType?), typeof(ViewStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).cornerRadiusPolicy = (VisualTransformPolicyType?)newValue,
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).cornerRadiusPolicy
+        );
+
         /// <summary>
         /// EnableControlState property
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -447,6 +447,18 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Whether the CornerRadius property value is relative (percentage [0.0f to 1.0f] of the view size) or absolute (in world units).
+        /// It is absolute by default.
+        /// When the policy is relative, the corner radius is relative to the smaller of the view's width and height.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VisualTransformPolicyType CornerRadiusPolicy
+        {
+            get => (VisualTransformPolicyType)GetValue(CornerRadiusPolicyProperty);
+            set => SetValue(CornerRadiusPolicyProperty, value);
+        }
+
+        /// <summary>
         /// The current state of the view.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1567,12 +1567,32 @@ namespace Tizen.NUI.BaseComponents
         public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(View), default(float), propertyChanged: (bindable, oldValue, newValue) =>
         {
             var view = (View)bindable;
-            view.UpdateCornerRadius((float)newValue);
+            (view.backgroundExtraData ?? (view.backgroundExtraData = new BackgroundExtraData())).CornerRadius = (float)newValue;
+            view.ApplyCornerRadius();
         },
         defaultValueCreator: (bindable) =>
         {
             var view = (View)bindable;
             return view.backgroundExtraData == null ? 0 : view.backgroundExtraData.CornerRadius;
+        });
+
+        /// <summary>
+        /// CornerRadiusPolicy Property
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty CornerRadiusPolicyProperty = BindableProperty.Create(nameof(CornerRadiusPolicy), typeof(VisualTransformPolicyType), typeof(View), VisualTransformPolicyType.Absolute, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var view = (View)bindable;
+            (view.backgroundExtraData ?? (view.backgroundExtraData = new BackgroundExtraData())).CornerRadiusPolicy = (VisualTransformPolicyType)newValue;
+            if (view.backgroundExtraData.CornerRadius != 0)
+            {
+                view.ApplyCornerRadius();
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var view = (View)bindable;
+            return view.backgroundExtraData == null ? VisualTransformPolicyType.Absolute : view.backgroundExtraData.CornerRadiusPolicy;
         });
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1068,27 +1068,34 @@ namespace Tizen.NUI.BaseComponents
             return (ResourceLoadingStatusType)Interop.View.View_GetVisualResourceStatus(this.swigCPtr, Property.BACKGROUND);
         }
 
-        internal virtual void UpdateCornerRadius(float value)
+        /// TODO open as a protected level
+        internal virtual void ApplyCornerRadius()
         {
-            if (value != 0)
-            {
-                (backgroundExtraData ?? (backgroundExtraData = new BackgroundExtraData())).CornerRadius = value;
-            }
+            if (backgroundExtraData == null) return;
 
-            Tizen.NUI.PropertyMap backgroundMap = new Tizen.NUI.PropertyMap();
+            // Apply to the background visual
+            PropertyMap backgroundMap = new PropertyMap();
             PropertyValue background = Tizen.NUI.Object.GetProperty(swigCPtr, View.Property.BACKGROUND);
-            background?.Get(backgroundMap);
-
-            if (!backgroundMap.Empty())
+            if (background.Get(backgroundMap) && !backgroundMap.Empty())
             {
-                backgroundMap[Visual.Property.CornerRadius] = new PropertyValue(value);
-                PropertyValue setValue = new Tizen.NUI.PropertyValue(backgroundMap);
-                Tizen.NUI.Object.SetProperty(swigCPtr, View.Property.BACKGROUND, setValue);
-                setValue?.Dispose();
+                backgroundMap[Visual.Property.CornerRadius] = new PropertyValue(backgroundExtraData.CornerRadius);
+                backgroundMap[Visual.Property.CornerRadiusPolicy] = new PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
+                Tizen.NUI.Object.SetProperty(swigCPtr, View.Property.BACKGROUND, new PropertyValue(backgroundMap));
             }
-            UpdateShadowCornerRadius(value);
-            backgroundMap?.Dispose();
-            background?.Dispose();
+            backgroundMap.Dispose();
+            background.Dispose();
+
+            // Apply to the shadow visual
+            PropertyMap shadowMap = new PropertyMap();
+            PropertyValue shadow = Tizen.NUI.Object.GetProperty(swigCPtr, View.Property.SHADOW);
+            if (shadow.Get(shadowMap) && !shadowMap.Empty())
+            {
+                shadowMap[Visual.Property.CornerRadius] = new PropertyValue(backgroundExtraData.CornerRadius);
+                shadowMap[Visual.Property.CornerRadiusPolicy] = new PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
+                Tizen.NUI.Object.SetProperty(swigCPtr, View.Property.SHADOW, new PropertyValue(shadowMap));
+            }
+            shadowMap.Dispose();
+            shadow.Dispose();
         }
 
         internal void UpdateStyle()
@@ -1386,24 +1393,6 @@ namespace Tizen.NUI.BaseComponents
         private void OnSizeModeFactorChanged(float x, float y, float z)
         {
             SizeModeFactor = new Vector3(x, y, z);
-        }
-
-        private void UpdateShadowCornerRadius(float value)
-        {
-            // TODO Update corner radius property only whe DALi supports visual property update.
-            PropertyMap map = new PropertyMap();
-
-            PropertyValue shadowVal = Tizen.NUI.Object.GetProperty(swigCPtr, View.Property.SHADOW);
-            if (shadowVal.Get(map) && !map.Empty())
-            {
-                map[Visual.Property.CornerRadius] = new PropertyValue(value);
-
-                PropertyValue setValue = new PropertyValue(map);
-                Tizen.NUI.Object.SetProperty(swigCPtr, View.Property.SHADOW, setValue);
-                setValue?.Dispose();
-            }
-            map?.Dispose();
-            shadowVal?.Dispose();
         }
 
         private bool EmptyOnTouch(object target, TouchEventArgs args)

--- a/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
@@ -44,6 +44,11 @@ namespace Tizen.NUI
         /// <summary></summary>
         internal float CornerRadius { get; set; }
 
+        /// <summary>
+        /// Whether the CornerRadius value is relative (percentage [0.0f to 1.0f] of the view size) or absolute (in world units).
+        /// </summary>
+        internal VisualTransformPolicyType CornerRadiusPolicy { get; set; } = VisualTransformPolicyType.Absolute;
+
         internal bool Empty()
         {
             return CornerRadius == 0 && Rectangle.IsNullOrZero(BackgroundImageBorder);

--- a/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
@@ -162,9 +162,8 @@ namespace Tizen.NUI
             if (attachedView.CornerRadius > 0)
             {
                 map[Visual.Property.CornerRadius] = new PropertyValue(attachedView.CornerRadius);
+                map[Visual.Property.CornerRadiusPolicy] = new PropertyValue((int)attachedView.CornerRadiusPolicy);
             }
-
-            map[Visual.Property.Transform] = GetTransformMap();
 
             return new PropertyValue(map);
         }
@@ -176,6 +175,8 @@ namespace Tizen.NUI
         protected virtual PropertyMap GetPropertyMap()
         {
             PropertyMap map = new PropertyMap();
+
+            map[Visual.Property.Transform] = GetTransformMap();
 
             return map;
         }

--- a/src/Tizen.NUI/src/public/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/VisualConstants.cs
@@ -493,6 +493,12 @@ namespace Tizen.NUI
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             public static readonly int CornerRadius = NDalic.VISUAL_PROPERTY_MIX_COLOR + 3;
+            /// <summary>
+            /// The corner radius policy of the visual.
+            /// Whether the corner radius value is relative (percentage [0.0f to 1.0f] of the visual size) or absolute (in world units).
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public static readonly int CornerRadiusPolicy = NDalic.VISUAL_PROPERTY_MIX_COLOR + 4;
         }
 
         /// <summary>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ControlSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ControlSample.cs
@@ -35,10 +35,17 @@ namespace Tizen.NUI.Samples
                     Color = new Color(0.2f, 0.2f, 0.2f, 0.3f),
                     Offset = new Vector2(5, 5),
                 },
-                CornerRadius = 26f,
+                CornerRadius = 0.5f,
+                CornerRadiusPolicy = VisualTransformPolicyType.Relative,
             };
 
             root.Add(control);
+
+            var animation = new Animation(2000);
+            animation.AnimateTo(control, "SizeWidth", 200, 0, 1000);
+            animation.AnimateTo(control, "SizeWidth", 100, 1000, 2000);
+            animation.Looping = true;
+            animation.Play();
         }
 
         public void Deactivate()


### PR DESCRIPTION
The CornerRadiusPolicy indicates whether the CornerRadius value is relative or absolute.
The default policy is absolute, which means the CornerRadius is an absolute float length.
If the policy is relative, the CornerRadius can have percentage value between 0.0f to 1.0f,
that is relative to the smaller of view's width and height.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
