### PR TITLE
[NUI] Fix bulid warnings in Shadow

### DIFF
--- a/src/Tizen.NUI/src/public/ViewProperty/ImageShadow.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/ImageShadow.cs
@@ -57,11 +57,16 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Constructor
+        /// Create a Shadow from a propertyMap.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         internal ImageShadow(PropertyMap propertyMap) : base(propertyMap)
         {
+            Border = noBorder;
+            propertyMap.Find(ImageVisualProperty.Border)?.Get(Border);
+
+            string url = null;
+            propertyMap.Find(ImageVisualProperty.URL)?.Get(out url);
+            Url = url;
         }
 
         /// <summary>
@@ -153,25 +158,6 @@ namespace Tizen.NUI
             map[ImageVisualProperty.URL] = PropertyValue.CreateWithGuard(Url);
 
             return map;
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool SetPropertyMap(PropertyMap propertyMap)
-        {
-            if (!base.SetPropertyMap(propertyMap))
-            {
-                return false;
-            }
-
-            Border = noBorder;
-            propertyMap.Find(ImageVisualProperty.Border)?.Get(Border);
-
-            string url = null;
-            propertyMap.Find(ImageVisualProperty.URL)?.Get(out url);
-            Url = url;
-
-            return true;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/ViewProperty/Shadow.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/Shadow.cs
@@ -60,11 +60,16 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Create a Shadow from a propertyMap.
+        /// Create a Shadow from a property map.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         internal Shadow(PropertyMap propertyMap) : base(propertyMap)
         {
+            Color = noColor;
+            propertyMap.Find(ColorVisualProperty.MixColor)?.Get(Color);
+
+            float blurRadius = 0;
+            propertyMap.Find(ColorVisualProperty.BlurRadius)?.Get(out blurRadius);
+            BlurRadius = blurRadius;
         }
 
         /// <summary>
@@ -136,25 +141,6 @@ namespace Tizen.NUI
             map[ColorVisualProperty.BlurRadius] = new PropertyValue(BlurRadius < 0 ? 0 : BlurRadius);
 
             return map;
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool SetPropertyMap(PropertyMap propertyMap)
-        {
-            if (!base.SetPropertyMap(propertyMap))
-            {
-                return false;
-            }
-
-            Color = noColor;
-            propertyMap.Find(ColorVisualProperty.MixColor)?.Get(Color);
-
-            float blurRadius = 0;
-            propertyMap.Find(ColorVisualProperty.BlurRadius)?.Get(out blurRadius);
-            BlurRadius = blurRadius;
-
-            return true;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
@@ -16,10 +16,10 @@
  */
 
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Tizen.NUI
 {
-
     /// <summary>
     /// The property map class that has transform property for one of its items.
     /// This class can be used to convert visual properties to map.
@@ -49,19 +49,31 @@ namespace Tizen.NUI
             Extents = extents == null ? null : new Vector2(extents);
         }
 
-        /// <summary></summary>
+        /// <summary>
+        /// Create a Shadow from a property map.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal protected ShadowBase(PropertyMap propertyMap)
+        protected ShadowBase(PropertyMap propertyMap)
         {
+            Debug.Assert(propertyMap != null);
+
             Offset = noOffset;
             Extents = noExtents;
 
-            if (propertyMap == null)
+            var transformProperty = propertyMap.Find(Visual.Property.Transform);
+
+            if (transformProperty == null)
             {
+                // No transform map
                 return;
             }
 
-            SetPropertyMap(propertyMap);
+            var transformMap = new PropertyMap();
+
+            if (transformProperty.Get(transformMap))
+            {
+                SetTransformMap(transformMap);
+            }
         }
 
         /// <summary>
@@ -87,14 +99,18 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Vector2 Extents { get; set; }
 
-        /// <summary></summary>
+        /// <summary>
+        /// Equality operator.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool operator ==(ShadowBase shadow1, ShadowBase shadow2)
         {
             return object.ReferenceEquals(shadow1, null) ? object.ReferenceEquals(shadow2, null) : shadow1.Equals(shadow2);
         }
 
-        /// <summary></summary>
+        /// <summary>
+        /// Inequality operator.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool operator !=(ShadowBase shadow1, ShadowBase shadow2)
         {
@@ -105,11 +121,11 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object other)
         {
-            if ((other == null) || ! this.GetType().Equals(other.GetType())) 
+            if ((other == null) || ! GetType().Equals(other.GetType()))
             {
                 return false;
             }
-            
+
             var otherShadow = (ShadowBase)other;
 
             if (!((Offset == null) ? otherShadow.Offset == null : Offset.Equals(otherShadow.Offset)))
@@ -117,7 +133,7 @@ namespace Tizen.NUI
                 return false;
             }
 
-            return ((Extents == null) ? otherShadow.Extents == null : Extents.Equals(otherShadow.Extents));
+            return (Extents == null) ? otherShadow.Extents == null : Extents.Equals(otherShadow.Extents);
         }
 
         /// <inheritdoc/>
@@ -154,6 +170,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Extract a property map.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual PropertyMap GetPropertyMap()
@@ -161,34 +178,6 @@ namespace Tizen.NUI
             PropertyMap map = new PropertyMap();
 
             return map;
-        }
-
-        /// <summary>
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool SetPropertyMap(PropertyMap propertyMap)
-        {
-            if (propertyMap == null)
-            {
-                return false;
-            }
-
-            var transformProperty = propertyMap.Find(Visual.Property.Transform);
-
-            if (transformProperty == null)
-            {
-                // No transform map
-                return true;
-            }
-
-            var transformMap = new PropertyMap();
-
-            if (transformProperty.Get(transformMap))
-            {
-                SetTransformMap(transformMap);
-            }
-
-            return true;
         }
 
         private PropertyValue GetTransformMap()
@@ -212,9 +201,6 @@ namespace Tizen.NUI
             return new PropertyValue(transformMap);
         }
 
-        /// <summary>
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         private void SetTransformMap(PropertyMap transformMap)
         {
             if (transformMap == null)


### PR DESCRIPTION
This patch fixes following build warnings and coding recommandations for Shadow.

* Fill missing API descriptions.
* Do not call overridable methods in constructors. (CA2214)
* Remove trailing white spaces.
* Remove unnecessary parentheses. (IDE0047)

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
