### PR TITLE
[NUI] fix ThemeResourceSample build error

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ThemeResourceSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ThemeResourceSample.cs
@@ -8,9 +8,9 @@ namespace Tizen.NUI.Samples
     {
         public void Activate()
         {
-            string resourceDefault = System.IO.Path.Combine("res", "resSampleThemeResourceDefault.xaml");
-            string resourceDark = System.IO.Path.Combine("res", "SampleThemeResourceDark.xaml");
-            Theme sampleTheme = new Theme(System.IO.Path.Combine("res", "SampleTheme.xaml"), resourceDefault);
+            string resourceDefault = global::System.IO.Path.Combine("res", "resSampleThemeResourceDefault.xaml");
+            string resourceDark = global::System.IO.Path.Combine("res", "SampleThemeResourceDark.xaml");
+            Theme sampleTheme = new Theme(global::System.IO.Path.Combine("res", "SampleTheme.xaml"), resourceDefault);
             ThemeManager.ApplyTheme(sampleTheme);
 
             View root = new View();


### PR DESCRIPTION
This patch will fix build error caused by conflict between global::System.XXX
and Tizen.System.XXX namespace.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
