### PR TITLE
[NUI] Remove StyleCop CA1715 warning messages

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DaliEventHandler.cs
+++ b/src/Tizen.NUI/src/internal/Common/DaliEventHandler.cs
@@ -16,6 +16,7 @@
  */
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Tizen.NUI
@@ -25,6 +26,9 @@ namespace Tizen.NUI
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [SuppressMessage("Microsoft.Naming",
+                     "CA1715:IdentifiersShouldHaveCorrectPrefix",
+                     Justification = "T, U, R are commonly used as generic type parameter names.")]
     public delegate R DaliEventHandlerWithReturnType<T, U, R>(T source, U e);
 
     /// <summary>
@@ -43,6 +47,9 @@ namespace Tizen.NUI
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [SuppressMessage("Microsoft.Naming",
+                     "CA1715:IdentifiersShouldHaveCorrectPrefix",
+                     Justification = "T, U are commonly used as generic type parameter names.")]
     public delegate void DaliEventHandler<T, U>(T source, U e);
 
     /// <summary>
@@ -50,6 +57,9 @@ namespace Tizen.NUI
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    [SuppressMessage("Microsoft.Naming",
+                     "CA1715:IdentifiersShouldHaveCorrectPrefix",
+                     Justification = "T, U, R are commonly used as generic type parameter names.")]
     public delegate R EventHandlerWithReturnType<T, U, R>(T source, U e);
 
     /// <summary>


### PR DESCRIPTION
Since T, U, R are commonly used as generic type parameter names and not
to do ACR, StyleCop CA1715 warning messages in DaliEventHandler.cs are
removed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
