### PR TITLE
[NUI] fix a CA2200 warning

### DIFF
--- a/src/Tizen.NUI/src/internal/Xaml/RegisterXNamesVisitor.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/RegisterXNamesVisitor.cs
@@ -32,7 +32,7 @@ namespace Tizen.NUI.Xaml
             catch (ArgumentException ae)
             {
                 if (ae.ParamName != "name")
-                    throw ae;
+                    throw;
                 throw new XamlParseException($"An element with the name \"{(string)node.Value}\" already exists in this NameScope", node);
             }
             var element = Values[parentNode] as Element;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
fix a CA2200 warning from RegisterXNamesVisitor.cs

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
