### PR TITLE
[NUI] Add Animation Finished callback debug log temporarily

### DIFF
--- a/src/Tizen.NUI/src/public/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation.cs
@@ -1318,11 +1318,14 @@ namespace Tizen.NUI
 
         private void OnFinished(IntPtr data)
         {
+            Tizen.Log.Error("NUI", $"[TEMP]OnFinished() START");
             if (_animationFinishedEventHandler != null)
             {
                 //here we send all data to user event handlers
                 _animationFinishedEventHandler(this, null);
+                Tizen.Log.Error("NUI", $"[TEMP]OnFinished() handler is invoked! should be shown!");
             }
+            Tizen.Log.Error("NUI", $"[TEMP]OnFinished() END");
         }
 
         private void OnProgressReached(IntPtr data)


### PR DESCRIPTION
### Description of Change ###
[NUI] Add Animation Finished callback debug log temporarily

- To do debugging for the rare case when Finished event handler is not called.

### API Changes ###
none