### PR TITLE
[NUI] Adjust ScrollingEventThreshold to cover larger sized ContentCon…

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -112,7 +112,7 @@ namespace Tizen.NUI.Components
         private int mScrollDuration = 125;
         private int mPageWidth = 0;
         private float mPageFlickThreshold = 0.4f;
-        private float mScrollingEventThreshold = 0.00001f;
+        private float mScrollingEventThreshold = 0.001f;
 
         private class ScrollableBaseCustomLayout : LayoutGroup
         {
@@ -474,7 +474,10 @@ namespace Tizen.NUI.Components
         public float DecelerationThreshold { get; set; } = 0.1f;
 
         /// <summary>
-        /// Scrolling event will be thrown when this amount of scroll positino is changed.
+        /// Scrolling event will be thrown when this amount of scroll position is changed.
+        /// If this threshold becomes smaller, the tracking detail increases but the scrolling range that can be tracked becomes smaller.
+        /// If large sized ContentContainer is required, please use larger threshold value.
+        /// Default ScrollingEventThreshold value is 0.001f.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public float ScrollingEventThreshold

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.code-workspace
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.code-workspace
@@ -5,6 +5,12 @@
 		},
 		{
 			"path": "../../../src/Tizen.NUI"
+		},
+		{
+			"path": "../../../src/Tizen.NUI.Components"
+		},
+		{
+			"path": "../../../../../DALi"
 		}
 	],
 	"settings": {}


### PR DESCRIPTION
…tainer.

 - Current default value is 0.00001f and it is too small to track large scale scrolling range.
 - This patch updates it to reasonable size and adds guide comment.

Signed-off-by: Seungho Baek <sbsh.baek@samsung.com>