### PR TITLE
[NUI] synchronize View.ExcludeLayouting and FlexLayout.PositionType

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -47,7 +47,23 @@ namespace Tizen.NUI
         /// FlexPositionTypeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FlexPositionTypeProperty = BindableProperty.CreateAttached("FlexPositionType", typeof(PositionType), typeof(FlexLayout), PositionType.Relative, validateValue: ValidateEnum((int)PositionType.Relative, (int)PositionType.Absolute), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FlexPositionTypeProperty = BindableProperty.CreateAttached("FlexPositionType", typeof(PositionType), typeof(FlexLayout), PositionType.Relative, validateValue: ValidateEnum((int)PositionType.Relative, (int)PositionType.Absolute),
+        propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            if (bindable is View view)
+            {
+                view.ExcludeLayouting = (PositionType)newValue == PositionType.Absolute;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var view = (View)bindable;
+            if (view.ExcludeLayouting)
+                return PositionType.Absolute;
+
+            return PositionType.Relative;
+        });
+
 
         /// <summary>
         /// AspectRatioProperty
@@ -674,24 +690,19 @@ namespace Tizen.NUI
 
                 if (layoutItem.Owner.ExcludeLayouting)
                 {
-                    SetFlexPositionType(Child, PositionType.Absolute);
-                    Interop.FlexLayout.FlexLayout_SetFlexPositionType(childHandleRef, (int)PositionType.Absolute);
                     MeasureChildWithoutPadding(layoutItem, widthMeasureSpec, heightMeasureSpec);
                     continue;
                 }
-                else
-                {
-                    SetFlexPositionType(Child, PositionType.Relative);
-                    Interop.FlexLayout.FlexLayout_SetFlexPositionType(childHandleRef, (int)PositionType.Relative);
-                }
 
                 AlignmentType flexAlignemnt = GetFlexAlignmentSelf(Child);
+                PositionType positionType = GetFlexPositionType(Child);
                 float flexAspectRatio = GetFlexAspectRatio(Child);
                 float flexBasis = GetFlexBasis(Child);
                 float flexShrink = GetFlexShrink(Child);
                 float flexGrow = GetFlexGrow(Child);
 
                 Interop.FlexLayout.FlexLayout_SetFlexAlignmentSelf(childHandleRef, (int)flexAlignemnt);
+                Interop.FlexLayout.FlexLayout_SetFlexPositionType(childHandleRef, (int)positionType);
                 Interop.FlexLayout.FlexLayout_SetFlexAspectRatio(childHandleRef, flexAspectRatio);
                 Interop.FlexLayout.FlexLayout_SetFlexBasis(childHandleRef, flexBasis);
                 Interop.FlexLayout.FlexLayout_SetFlexShrink(childHandleRef, flexShrink);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Simple Test
```cs
//Default value test
bool Default_ExcludeLayouting = view.ExcludeLayouting; // False
FlexLayout.PositionType Default_FlexPositionType = FlexLayout.GetFlexPositionType(view); //Relative

// FlexPositionType test depending on ExcludeLayouting
view.ExcludeLayouting = true;
FlexLayout.PositionType FlexPositionType = FlexLayout.GetFlexPositionType(view); //Absolute

// ExcludeLayouting test depending on FlexLayout.SetFlexPositionType
FlexLayout.SetFlexPositionType(view, FlexLayout.PositionType.Relative);
bool ExcludeLayouting = view.ExcludeLayouting; // False;
```

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
