### PR TITLE
Revert "[NUI] Unsubscribe theme changed event when the view is not on…

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1622,11 +1622,11 @@ namespace Tizen.NUI.BaseComponents
 
             if (view.themeChangeSensitive)
             {
-                view.SubscribeThemeChange();
+                ThemeManager.ThemeChangedInternal += view.OnThemeChanged;
             }
             else
             {
-                view.UnsubscribeThemeChange();
+                ThemeManager.ThemeChangedInternal -= view.OnThemeChanged;
             }
         },
         defaultValueCreator: (bindable) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -33,7 +33,6 @@ namespace Tizen.NUI.BaseComponents
     {
         private MergedStyle mergedStyle = null;
         private ViewSelectorData selectorData;
-        private uint lastThemeChangeId;
         internal string styleName;
 
         internal MergedStyle _mergedStyle
@@ -1055,8 +1054,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal void UpdateStyle()
         {
-            lastThemeChangeId = ThemeManager.ChangeId;
-
             ViewStyle newStyle;
             if (styleName == null) newStyle = ThemeManager.GetStyle(GetType());
             else newStyle = ThemeManager.GetStyle(styleName);
@@ -1084,8 +1081,7 @@ namespace Tizen.NUI.BaseComponents
                 //Release your own managed resources here.
                 //You should release all of your own disposable objects here.
                 selectorData?.Reset(this);
-
-                if (themeChangeSensitive && IsOnWindow)
+                if (themeChangeSensitive)
                 {
                     ThemeManager.ThemeChangedInternal -= OnThemeChanged;
                 }
@@ -1338,50 +1334,6 @@ namespace Tizen.NUI.BaseComponents
         private bool EmptyOnTouch(object target, TouchEventArgs args)
         {
             return false;
-        }
-
-        private void OnAddedToWindowInternal(object sender, global::System.EventArgs args)
-        {
-            if (lastThemeChangeId != ThemeManager.ChangeId)
-            {
-                OnThemeChanged(null, new ThemeChangedEventArgs(ThemeManager.CurrentTheme?.Id));
-            }
-            AddedToWindow -= OnAddedToWindowInternal;
-            RemovedFromWindow += OnRemovedFromWindowInternal;
-            ThemeManager.ThemeChangedInternal += OnThemeChanged;
-        }
-
-        private void OnRemovedFromWindowInternal(object sender, global::System.EventArgs args)
-        {
-            ThemeManager.ThemeChangedInternal -= OnThemeChanged;
-            RemovedFromWindow -= OnRemovedFromWindowInternal;
-            AddedToWindow += OnAddedToWindowInternal;
-        }
-
-        private void SubscribeThemeChange()
-        {
-            if (IsOnWindow)
-            {
-                ThemeManager.ThemeChangedInternal += OnThemeChanged;
-                RemovedFromWindow += OnRemovedFromWindowInternal;
-            }
-            else
-            {
-                AddedToWindow += OnAddedToWindowInternal;
-            }
-        }
-
-        private void UnsubscribeThemeChange()
-        {
-            if (IsOnWindow)
-            {
-                ThemeManager.ThemeChangedInternal -= OnThemeChanged;
-                RemovedFromWindow -= OnRemovedFromWindowInternal;
-            }
-            else
-            {
-                AddedToWindow -= OnAddedToWindowInternal;
-            }
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -88,7 +88,6 @@ namespace Tizen.NUI
             set
             {
                 currentTheme = value;
-                ChangeId++;
                 NotifyThemeChanged();
             }
         }
@@ -109,8 +108,6 @@ namespace Tizen.NUI
         }
 
         internal static bool ThemeApplied => (CurrentTheme.Count > 0 || DefaultTheme.Count > 0);
-
-        internal static uint ChangeId { get; set; }
 
         private static Profile CurrentProfile
         {


### PR DESCRIPTION
… window"

This revert previous patch and make sure the theme changed event handler is disconnected when dispose.

This reverts commit 592900fdc380ce27df8c8fdb6de8084caffacc15.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
