### PR TITLE
[NUI] Use weak reference for theme changed event

### DIFF
--- a/src/Tizen.NUI/src/internal/WeakEvent.cs
+++ b/src/Tizen.NUI/src/internal/WeakEvent.cs
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Tizen.NUI
+{
+    internal class WeakEvent<T>
+    {
+        private List<WeakHandler<T>> handlers = new List<WeakHandler<T>>();
+
+        public void Add(T handler)
+        {
+            handlers.Add(new WeakHandler<T>(handler));
+        }
+
+        public void Remove(T handler)
+        {
+            handlers.RemoveAll(item => !item.IsAlive || item.Equals(handler));
+        }
+
+        public void Invoke(object sender, EventArgs args)
+        {
+            var copied = handlers.ToArray();
+            foreach (var item in copied)
+            {
+                if (item.IsAlive)
+                {
+                    item.Invoke(sender, args);
+                    continue;
+                }
+                handlers.Remove(item);
+            }
+        }
+
+        internal class WeakHandler<T>
+        {
+            private WeakReference weakReference;
+            private MethodInfo methodInfo;
+
+            public WeakHandler(T handler)
+            {
+                Delegate d = (Delegate)(object)handler;
+                if (d.Target != null) weakReference = new WeakReference(d.Target);
+                methodInfo = d.Method;
+            }
+
+            public bool Equals(T handler)
+            {
+                Delegate other = (Delegate)(object)handler;
+                return other != null && other.Target == weakReference?.Target && other.Method.Equals(methodInfo);
+            }
+
+            public bool IsAlive => weakReference == null || weakReference.IsAlive;
+
+            public void Invoke(params object[] args)
+            {
+                if (weakReference == null)
+                {
+                    Delegate.CreateDelegate(typeof(T), methodInfo).DynamicInvoke(args);
+                }
+                else
+                {
+                    Delegate.CreateDelegate(typeof(T), weakReference.Target, methodInfo).DynamicInvoke(args);
+                }
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1622,11 +1622,11 @@ namespace Tizen.NUI.BaseComponents
 
             if (view.themeChangeSensitive)
             {
-                ThemeManager.ThemeChangedInternal += view.OnThemeChanged;
+                ThemeManager.ThemeChangedInternal.Add(view.OnThemeChanged);
             }
             else
             {
-                ThemeManager.ThemeChangedInternal -= view.OnThemeChanged;
+                ThemeManager.ThemeChangedInternal.Remove(view.OnThemeChanged);
             }
         },
         defaultValueCreator: (bindable) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1083,7 +1083,7 @@ namespace Tizen.NUI.BaseComponents
                 selectorData?.Reset(this);
                 if (themeChangeSensitive)
                 {
-                    ThemeManager.ThemeChangedInternal -= OnThemeChanged;
+                    ThemeManager.ThemeChangedInternal.Remove(OnThemeChanged);
                 }
             }
 

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using Tizen.NUI.Xaml;
+using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
@@ -73,7 +74,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Internal one should be called before calling public ThemeChanged
         /// </summary>
-        internal static event EventHandler<ThemeChangedEventArgs> ThemeChangedInternal;
+        internal static WeakEvent<EventHandler<ThemeChangedEventArgs>> ThemeChangedInternal = new WeakEvent<EventHandler<ThemeChangedEventArgs>>();
 
         internal static Theme CurrentTheme
         {
@@ -330,7 +331,7 @@ namespace Tizen.NUI
 
         private static void NotifyThemeChanged()
         {
-            ThemeChangedInternal?.Invoke(null, new ThemeChangedEventArgs(CurrentTheme?.Id));
+            ThemeChangedInternal.Invoke(null, new ThemeChangedEventArgs(CurrentTheme?.Id));
             ThemeChanged?.Invoke(null, new ThemeChangedEventArgs(CurrentTheme?.Id));
         }
     }


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
