### PR TITLE
[NUI] separate layouting logic of the independent children

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2020 Samsung Electronics Co., Ltd.
+﻿/* Copyright (c) 2020 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace Tizen.NUI.Components
         private float mPageFlickThreshold = 0.4f;
         private float mScrollingEventThreshold = 0.001f;
 
-        private class ScrollableBaseCustomLayout : LayoutGroup
+        private class ScrollableBaseCustomLayout : AbsoluteLayout
         {
             protected override void OnMeasure(MeasureSpecification widthMeasureSpec, MeasureSpecification heightMeasureSpec)
             {
@@ -197,25 +197,6 @@ namespace Tizen.NUI.Components
                 {
                     scrollableBase.mPageWidth = (int)MeasuredWidth.Size.AsRoundedValue();
                     scrollableBase.OnScrollingChildRelayout(null, null);
-                }
-            }
-
-            protected override void OnLayout(bool changed, LayoutLength left, LayoutLength top, LayoutLength right, LayoutLength bottom)
-            {
-                foreach (LayoutItem childLayout in LayoutChildren)
-                {
-                    if (childLayout != null && childLayout.Owner.Name == "ContentContainer")
-                    {
-                        LayoutLength childWidth = childLayout.MeasuredWidth.Size;
-                        LayoutLength childHeight = childLayout.MeasuredHeight.Size;
-
-                        Position2D childPosition = childLayout.Owner.Position2D;
-
-                        LayoutLength childLeft = new LayoutLength(childPosition.X);
-                        LayoutLength childTop = new LayoutLength(childPosition.Y);
-
-                        childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight, true);
-                    }
                 }
             }
         } //  ScrollableBaseCustomLayout
@@ -621,7 +602,6 @@ namespace Tizen.NUI.Components
             ContentContainer = new View()
             {
                 Name = "ContentContainer",
-                ExcludeLayouting = false,
                 WidthSpecification = ScrollingDirection == Direction.Vertical ? LayoutParamPolicies.MatchParent : LayoutParamPolicies.WrapContent,
                 HeightSpecification = ScrollingDirection == Direction.Vertical ? LayoutParamPolicies.WrapContent : LayoutParamPolicies.MatchParent,
             };

--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -46,39 +46,30 @@ namespace Tizen.NUI
             MeasuredSize.StateType childWidthState = MeasuredSize.StateType.MeasuredSizeOK;
             MeasuredSize.StateType childHeightState = MeasuredSize.StateType.MeasuredSizeOK;
 
-            for (int i = 0; i < LayoutChildren.Count; i++)
+            foreach (LayoutItem childLayout in IterateLayoutChildren())
             {
-                LayoutItem childLayout = LayoutChildren[i];
-                if (childLayout != null)
+                // Get size of child with no padding, no margin. we won't support margin, padding for AbsolutLayout.
+                MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
+
+                // Determine the width and height needed by the children using their given position and size.
+                // Children could overlap so find the right most child.
+                Position2D childPosition = childLayout.Owner.Position2D;
+                float childRight = childLayout.MeasuredWidth.Size.AsDecimal() + childPosition.X;
+                float childBottom = childLayout.MeasuredHeight.Size.AsDecimal() + childPosition.Y;
+
+                if (maxWidth < childRight)
+                    maxWidth = childRight;
+
+                if (maxHeight < childBottom)
+                    maxHeight = childBottom;
+
+                if (childLayout.MeasuredWidth.State == MeasuredSize.StateType.MeasuredSizeTooSmall)
                 {
-                    // Get size of child with no padding, no margin. we won't support margin, padding for AbsolutLayout.
-                    MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
-
-                    if (childLayout.Owner.ExcludeLayouting)
-                    {
-                        continue;
-                    }
-
-                    // Determine the width and height needed by the children using their given position and size.
-                    // Children could overlap so find the right most child.
-                    Position2D childPosition = childLayout.Owner.Position2D;
-                    float childRight = childLayout.MeasuredWidth.Size.AsDecimal() + childPosition.X;
-                    float childBottom = childLayout.MeasuredHeight.Size.AsDecimal() + childPosition.Y;
-
-                    if (maxWidth < childRight)
-                        maxWidth = childRight;
-
-                    if (maxHeight < childBottom)
-                        maxHeight = childBottom;
-
-                    if (childLayout.MeasuredWidth.State == MeasuredSize.StateType.MeasuredSizeTooSmall)
-                    {
-                        childWidthState = MeasuredSize.StateType.MeasuredSizeTooSmall;
-                    }
-                    if (childLayout.MeasuredHeight.State == MeasuredSize.StateType.MeasuredSizeTooSmall)
-                    {
-                        childHeightState = MeasuredSize.StateType.MeasuredSizeTooSmall;
-                    }
+                    childWidthState = MeasuredSize.StateType.MeasuredSizeTooSmall;
+                }
+                if (childLayout.MeasuredHeight.State == MeasuredSize.StateType.MeasuredSizeTooSmall)
+                {
+                    childHeightState = MeasuredSize.StateType.MeasuredSizeTooSmall;
                 }
             }
 
@@ -99,21 +90,17 @@ namespace Tizen.NUI
         {
             // Absolute layout positions it's children at their Actor positions.
             // Children could overlap or spill outside the parent, as is the nature of absolute positions.
-            for (int i = 0; i < LayoutChildren.Count; i++)
+            foreach (LayoutItem childLayout in IterateLayoutChildren())
             {
-                LayoutItem childLayout = LayoutChildren[i];
-                if (childLayout != null)
-                {
-                    LayoutLength childWidth = childLayout.MeasuredWidth.Size;
-                    LayoutLength childHeight = childLayout.MeasuredHeight.Size;
+                LayoutLength childWidth = childLayout.MeasuredWidth.Size;
+                LayoutLength childHeight = childLayout.MeasuredHeight.Size;
 
-                    Position2D childPosition = childLayout.Owner.Position2D;
+                Position2D childPosition = childLayout.Owner.Position2D;
 
-                    LayoutLength childLeft = new LayoutLength(childPosition.X);
-                    LayoutLength childTop = new LayoutLength(childPosition.Y);
+                LayoutLength childLeft = new LayoutLength(childPosition.X);
+                LayoutLength childTop = new LayoutLength(childPosition.Y);
 
-                    childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight, true);
-                }
+                childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight, true);
             }
         }
     }

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -585,7 +585,8 @@ namespace Tizen.NUI
         {
             // We need to measure child layout
             View child = Registry.GetManagedBaseHandleFromNativePtr(childPtr) as View;
-            if (child == null)
+            // independent child will be measured in LayoutGroup.OnMeasureIndependentChildren().
+            if (child?.ExcludeLayouting ?? true)
             {
                 measureSize.width = 0;
                 measureSize.height = 0;
@@ -693,12 +694,6 @@ namespace Tizen.NUI
                 if (childHandleRef.Handle == IntPtr.Zero || Child == null)
                     continue;
 
-                if (layoutItem.Owner.ExcludeLayouting)
-                {
-                    MeasureChildWithoutPadding(layoutItem, widthMeasureSpec, heightMeasureSpec);
-                    continue;
-                }
-
                 AlignmentType flexAlignemnt = GetFlexAlignmentSelf(Child);
                 PositionType positionType = GetFlexPositionType(Child);
                 float flexAspectRatio = GetFlexAspectRatio(Child);
@@ -748,21 +743,16 @@ namespace Tizen.NUI
             // Call to FlexLayout implementation to calculate layout values for later retrieval.
             Interop.FlexLayout.FlexLayout_CalculateLayout(swigCPtr, width.AsDecimal(), height.AsDecimal(), isLayoutRtl);
 
-            int count = LayoutChildren.Count;
-            for (int childIndex = 0; childIndex < count; childIndex++)
+            for (int childIndex = 0; childIndex < LayoutChildren.Count; childIndex++)
             {
                 LayoutItem childLayout = LayoutChildren[childIndex];
-                if (childLayout != null)
+                if (!childLayout?.Owner?.ExcludeLayouting ?? false)
                 {
-                    if (!childLayout.Owner.ExcludeLayouting)
-                    {
-                        // Get the frame for the child, start, top, end, bottom.
-                        Vector4 frame = new Vector4(Interop.FlexLayout.FlexLayout_GetNodeFrame(swigCPtr, childIndex), true);
-                        childLayout.Layout(new LayoutLength(frame.X), new LayoutLength(frame.Y), new LayoutLength(frame.Z), new LayoutLength(frame.W));
-                    }
+                    // Get the frame for the child, start, top, end, bottom.
+                    Vector4 frame = new Vector4(Interop.FlexLayout.FlexLayout_GetNodeFrame(swigCPtr, childIndex), true);
+                    childLayout.Layout(new LayoutLength(frame.X), new LayoutLength(frame.Y), new LayoutLength(frame.Z), new LayoutLength(frame.W));
                 }
             }
-            LayoutForIndependentChild();
         }
     } // FLexlayout
 } // namesspace Tizen.NUI

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -397,7 +397,7 @@ namespace Tizen.NUI
         {
             InitChildrenWithExpand(MeasuredWidth.Size - Padding.Start - Padding.End, MeasuredHeight.Size - Padding.Top - Padding.Bottom);
 
-            for (int i = 0; i < gridChildren.Length; i++)
+            for (int i = 0; i < gridChildren.Count; i++)
             {
                 GridChild child = gridChildren[i];
                 View view = child.LayoutItem?.Owner;
@@ -430,8 +430,6 @@ namespace Tizen.NUI
 
                 child.LayoutItem.Layout(new LayoutLength(l), new LayoutLength(t), new LayoutLength(l + width), new LayoutLength(t + height));
             }
-
-            LayoutForIndependentChild();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -221,6 +221,7 @@ namespace Tizen.NUI
             if (needsLayout)
             {
                 OnMeasure(widthMeasureSpec, heightMeasureSpec);
+                OnMeasureIndependentChildren(widthMeasureSpec, heightMeasureSpec);
                 Flags = Flags | LayoutFlags.LayoutRequired;
                 Flags &= ~LayoutFlags.ForceLayout;
             }
@@ -280,6 +281,7 @@ namespace Tizen.NUI
             if (changed || ((Flags & LayoutFlags.LayoutRequired) == LayoutFlags.LayoutRequired))
             {
                 OnLayout(changed, left, top, right, bottom);
+                OnLayoutIndependentChildren(changed, left, top, right, bottom);
                 // Clear flag
                 Flags &= ~LayoutFlags.LayoutRequired;
             }
@@ -539,6 +541,8 @@ namespace Tizen.NUI
                                    GetDefaultSize(SuggestedMinimumHeight, heightMeasureSpec));
         }
 
+        internal virtual void OnMeasureIndependentChildren(MeasureSpecification widthMeasureSpec, MeasureSpecification heightMeasureSpec) { }
+
         /// <summary>
         /// Called from Layout() when this layout should assign a size and position to each of its children. <br />
         /// Derived classes with children should override this method and call Layout() on each of their children. <br />
@@ -550,6 +554,8 @@ namespace Tizen.NUI
         /// <param name="bottom">Bottom position, relative to parent.</param>
         /// <since_tizen> 6 </since_tizen>
         protected virtual void OnLayout(bool changed, LayoutLength left, LayoutLength top, LayoutLength right, LayoutLength bottom) { }
+
+        internal virtual void OnLayoutIndependentChildren(bool changed, LayoutLength left, LayoutLength top, LayoutLength right, LayoutLength bottom) { }
 
         /// <summary>
         /// Virtual method to allow derived classes to remove any children before it is removed from

--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -17,6 +17,7 @@
 using System;
 using Tizen.NUI.BaseComponents;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Tizen.NUI
 {
@@ -179,7 +180,6 @@ namespace Tizen.NUI
             {
                 LayoutVertical(left, top, right, bottom);
             }
-            LayoutForIndependentChild();
         }
 
 
@@ -274,7 +274,7 @@ namespace Tizen.NUI
             float alternativeMaxHeight = 0.0f;
             float weightedMaxHeight = 0.0f;
             float totalWeight = 0.0f;
-            int childrenCount = 0;
+            int childrenCount = IterateLayoutChildren().Count();
 
             // Reset measure variables
             _totalLength = 0.0f;
@@ -288,16 +288,8 @@ namespace Tizen.NUI
             // Weighted children are not measured at this phase.
             // Available space for weighted children will be calculated in the phase 2 based on totalLength value.
             // Max height of children is stored.
-            for (int i = 0; i < LayoutChildren.Count; i++)
+            foreach (LayoutItem childLayout in IterateLayoutChildren())
             {
-                LayoutItem childLayout = LayoutChildren[i];
-                if (childLayout.Owner.ExcludeLayouting)
-                {
-                    MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
-                    continue;
-                }
-
-                childrenCount++;
                 int childDesiredHeight = childLayout.Owner.HeightSpecification;
                 float childWeight = childLayout.Owner.Weight;
                 Extents childMargin = childLayout.Margin;
@@ -399,15 +391,8 @@ namespace Tizen.NUI
                 maxHeight = 0;
                 _totalLength = 0;
 
-                int numberOfChildren = LayoutChildren.Count;
-                for (int i = 0; i < numberOfChildren; ++i)
+                foreach (LayoutItem childLayout in IterateLayoutChildren())
                 {
-                    LayoutItem childLayout = LayoutChildren[i];
-                    if (childLayout.Owner.ExcludeLayouting)
-                    {
-                        continue;
-                    }
-
                     float desiredChildHeight = childLayout.Owner.HeightSpecification;
 
                     float childWeight = childLayout.Owner.Weight;
@@ -472,7 +457,7 @@ namespace Tizen.NUI
             float alternativeMaxWidth = 0.0f;
             float weightedMaxWidth = 0.0f;
             float totalWeight = 0.0f;
-            int childrenCount = 0;
+            int childrenCount = IterateLayoutChildren().Count();
 
             // Reset total length
             _totalLength = 0.0f;
@@ -488,15 +473,8 @@ namespace Tizen.NUI
             // to accumulate total used space in _totalLength.
             // Weighted children are not measured in this phase.
             // Available space for weighted children will be calculated in the phase 2 based on _totalLength value.
-            for (int i = 0; i < LayoutChildren.Count; i++)
+            foreach (LayoutItem childLayout in IterateLayoutChildren())
             {
-                LayoutItem childLayout = LayoutChildren[i];
-                if (childLayout.Owner.ExcludeLayouting)
-                {
-                    MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
-                    continue;
-                }
-
                 childrenCount++;
                 int childDesiredWidth = childLayout.Owner.WidthSpecification;
                 float childWeight = childLayout.Owner.Weight;
@@ -596,15 +574,8 @@ namespace Tizen.NUI
                 maxWidth = 0;
                 _totalLength = 0;
 
-                int numberOfChildren = LayoutChildren.Count;
-                for (int i = 0; i < numberOfChildren; ++i)
+                foreach (LayoutItem childLayout in IterateLayoutChildren())
                 {
-                    LayoutItem childLayout = LayoutChildren[i];
-                    if (childLayout.Owner.ExcludeLayouting)
-                    {
-                        continue;
-                    }
-
                     float desiredChildWidth = childLayout.Owner.WidthSpecification;
 
                     float childWeight = childLayout.Owner.Weight;
@@ -667,7 +638,8 @@ namespace Tizen.NUI
             // Space available for child
             LayoutLength childSpace = new LayoutLength(height - Padding.Top - Padding.Bottom);
 
-            int count = LayoutChildren.Count;
+            List<LayoutItem> LinearChildren = IterateLayoutChildren().ToList();
+            int count = LinearChildren.Count;
 
             switch (LinearAlignment)
             {
@@ -717,34 +689,29 @@ namespace Tizen.NUI
             {
                 int childIndex = start + dir * i;
                 // Get a reference to the childLayout at the given index
-                LayoutItem childLayout = LayoutChildren[childIndex];
-                if (childLayout != null)
-                {
-                    if (!childLayout.Owner.ExcludeLayouting)
-                    {
-                        LayoutLength childWidth = childLayout.MeasuredWidth.Size;
-                        LayoutLength childHeight = childLayout.MeasuredHeight.Size;
-                        Extents childMargin = childLayout.Margin;
+                LayoutItem childLayout = LinearChildren[childIndex];
 
-                        switch (LinearAlignment)
-                        {
-                            case Alignment.Bottom:
-                                childTop = new LayoutLength(height - Padding.Bottom - childHeight - childMargin.Bottom);
-                                break;
-                            case Alignment.CenterVertical:
-                            case Alignment.Center: // FALLTHROUGH
-                                childTop = new LayoutLength(Padding.Top + ((childSpace - childHeight).AsDecimal() / 2.0f) + childMargin.Top - childMargin.Bottom);
-                                break;
-                            case Alignment.Top: // FALLTHROUGH default
-                            default:
-                                childTop = new LayoutLength(Padding.Top + childMargin.Top);
-                                break;
-                        }
-                        childLeft += childMargin.Start;
-                        childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
-                        childLeft += childWidth + childMargin.End + ((i < count - 1) ? CellPadding.Width : 0);
-                    }
+                LayoutLength childWidth = childLayout.MeasuredWidth.Size;
+                LayoutLength childHeight = childLayout.MeasuredHeight.Size;
+                Extents childMargin = childLayout.Margin;
+
+                switch (LinearAlignment)
+                {
+                    case Alignment.Bottom:
+                        childTop = new LayoutLength(height - Padding.Bottom - childHeight - childMargin.Bottom);
+                        break;
+                    case Alignment.CenterVertical:
+                    case Alignment.Center: // FALLTHROUGH
+                        childTop = new LayoutLength(Padding.Top + ((childSpace - childHeight).AsDecimal() / 2.0f) + childMargin.Top - childMargin.Bottom);
+                        break;
+                    case Alignment.Top: // FALLTHROUGH default
+                    default:
+                        childTop = new LayoutLength(Padding.Top + childMargin.Top);
+                        break;
                 }
+                childLeft += childMargin.Start;
+                childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
+                childLeft += childWidth + childMargin.End + ((i < count - 1) ? CellPadding.Width : 0);
             }
         } // LayoutHorizontally
 
@@ -759,7 +726,8 @@ namespace Tizen.NUI
             // Space available for child
             LayoutLength childSpace = new LayoutLength(width - Padding.Start - Padding.End);
 
-            int count = LayoutChildren.Count;
+            List<LayoutItem> LinearChildren = IterateLayoutChildren().ToList();
+            int count = LinearChildren.Count;
 
             switch (LinearAlignment)
             {
@@ -781,40 +749,35 @@ namespace Tizen.NUI
 
             for (int i = 0; i < count; i++)
             {
-                LayoutItem childLayout = LayoutChildren[i];
-                if (childLayout != null)
-                {
-                    if (!childLayout.Owner.ExcludeLayouting)
-                    {
-                        LayoutLength childWidth = childLayout.MeasuredWidth.Size;
-                        LayoutLength childHeight = childLayout.MeasuredHeight.Size;
-                        Extents childMargin = childLayout.Margin;
+                LayoutItem childLayout = LinearChildren[i];
 
-                        childTop += childMargin.Top;
-                        switch (LinearAlignment)
+                LayoutLength childWidth = childLayout.MeasuredWidth.Size;
+                LayoutLength childHeight = childLayout.MeasuredHeight.Size;
+                Extents childMargin = childLayout.Margin;
+
+                childTop += childMargin.Top;
+                switch (LinearAlignment)
+                {
+                    case Alignment.Begin:
+                    default:
                         {
-                            case Alignment.Begin:
-                            default:
-                                {
-                                    childLeft = new LayoutLength(Padding.Start + childMargin.Start);
-                                    break;
-                                }
-                            case Alignment.End:
-                                {
-                                    childLeft = new LayoutLength(width - Padding.End - childWidth - childMargin.End);
-                                    break;
-                                }
-                            case Alignment.CenterHorizontal:
-                            case Alignment.Center: // FALL THROUGH
-                                {
-                                    childLeft = new LayoutLength(Padding.Start + ((childSpace - childWidth).AsDecimal() / 2.0f) + childMargin.Start - childMargin.End);
-                                    break;
-                                }
+                            childLeft = new LayoutLength(Padding.Start + childMargin.Start);
+                            break;
                         }
-                        childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
-                        childTop += childHeight + childMargin.Bottom + ((i < count - 1) ? CellPadding.Height : 0);
-                    }
+                    case Alignment.End:
+                        {
+                            childLeft = new LayoutLength(width - Padding.End - childWidth - childMargin.End);
+                            break;
+                        }
+                    case Alignment.CenterHorizontal:
+                    case Alignment.Center: // FALL THROUGH
+                        {
+                            childLeft = new LayoutLength(Padding.Start + ((childSpace - childWidth).AsDecimal() / 2.0f) + childMargin.Start - childMargin.End);
+                            break;
+                        }
                 }
+                childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
+                childTop += childHeight + childMargin.Bottom + ((i < count - 1) ? CellPadding.Height : 0);
             }
         } // LayoutVertical
 
@@ -824,12 +787,8 @@ namespace Tizen.NUI
             // ourselves. The measured height should be the max height of the children, changed
             // to accommodate the heightMeasureSpec from the parent
             MeasureSpecification uniformMeasureSpec = new MeasureSpecification(MeasuredHeight.Size, MeasureSpecification.ModeType.Exactly);
-            foreach (LayoutItem childLayout in LayoutChildren)
+            foreach (LayoutItem childLayout in IterateLayoutChildren())
             {
-                if (childLayout.Owner.ExcludeLayouting)
-                {
-                    continue;
-                }
                 int desiredChildHeight = childLayout.Owner.HeightSpecification;
                 int desiredChildWidth = childLayout.Owner.WidthSpecification;
 
@@ -851,13 +810,8 @@ namespace Tizen.NUI
         {
             // Pretend that the linear layout has an exact size.
             MeasureSpecification uniformMeasureSpec = new MeasureSpecification(MeasuredWidth.Size, MeasureSpecification.ModeType.Exactly);
-            foreach (LayoutItem childLayout in LayoutChildren)
+            foreach (LayoutItem childLayout in IterateLayoutChildren())
             {
-                if (childLayout.Owner.ExcludeLayouting)
-                {
-                    continue;
-                }
-
                 int desiredChildWidth = childLayout.Owner.WidthSpecification;
                 int desiredChildHeight = childLayout.Owner.WidthSpecification;
 


### PR DESCRIPTION
This patch introduces `IterateLayoutChildren()` method that return
an enumerable collection of the child layouts that affected by parent
layout.

Independent children will be measured in `OnMeasureIndependentChildren()`.

By using `IterateLayoutChildren()`, we can remove the codes that check
whether child layout exclude from layout flow in `OnMeasure`. and api
users don't need to check `View.ExcludeLayouting` property in custom layouts.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
