### PR TITLE
[NUI] Add direction & displacement into ScrollOutOfBound event.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -62,39 +62,52 @@ namespace Tizen.NUI.Components
     public class ScrollOutOfBoundEventArgs : EventArgs
     {
         /// <summary>
-        /// The bound to be scrolled out of.
+        /// The direction to be touched.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public enum Bound
+        public enum Direction
         {
             /// <summary>
-            /// Top bound.
+            /// Upwards.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
-            Top,
+            Up,
 
             /// <summary>
-            /// Bottom bound.
+            /// Downwards.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
-            Bottom
+            Down,
         }
 
         /// <summary>
-        /// Default constructor.
+        /// Constructor.
         /// </summary>
-        /// <param name="bound">Current scrollable bound</param>
+        /// <param name="direction">Current pan direction</param>
+        /// <param name="displacement">Current total displacement</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ScrollOutOfBoundEventArgs(Bound bound)
+        public ScrollOutOfBoundEventArgs(Direction direction, float displacement)
         {
-            ScrollableBound = bound;
+            PanDirection = direction;
+            Displacement = displacement;
         }
 
         /// <summary>
-        /// Current position of ContentContainer.
+        /// Current pan direction of ContentContainer.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Bound ScrollableBound
+        public Direction PanDirection
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Current total displacement of ContentContainer.
+        /// if its value is greater than 0, it is at the top/left;
+        /// if less than 0, it is at the bottom/right.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float Displacement
         {
             get;
         }
@@ -1041,12 +1054,12 @@ namespace Tizen.NUI.Components
             isVerticalShadowShown = false;
         }
 
-        private void DragVerticalShadow(float displacement)
+        private void DragVerticalShadow(float totalPanDisplacement, float panDisplacement)
         {
             if (ScrollingDirection != Direction.Vertical)
                 return;
 
-            if ((int)displacement > 0) // downwards
+            if (totalPanDisplacement > 0) // downwards
             {
                 // check if reaching at the top.
                 if ((int)finalTargetPosition != 0)
@@ -1055,12 +1068,16 @@ namespace Tizen.NUI.Components
                 // save start displacement, and re-calculate displacement.
                 if (!isVerticalShadowShown)
                 {
-                    startShowShadowDisplacement = displacement;
-                    OnScrollOutOfBound(ScrollOutOfBoundEventArgs.Bound.Top);
+                    startShowShadowDisplacement = totalPanDisplacement;
                 }
                 isVerticalShadowShown = true;
 
-                float newDisplacement = (int)displacement < (int)startShowShadowDisplacement ? 0 : displacement - startShowShadowDisplacement;
+                // trigger event
+                ScrollOutOfBoundEventArgs.Direction direction = panDisplacement > 0 ?
+                    ScrollOutOfBoundEventArgs.Direction.Down : ScrollOutOfBoundEventArgs.Direction.Up;
+                OnScrollOutOfBound(direction, totalPanDisplacement);
+
+                float newDisplacement = (int)totalPanDisplacement < (int)startShowShadowDisplacement ? 0 : totalPanDisplacement - startShowShadowDisplacement;
 
                 // scale limit of width is 60%.
                 float widthScale = newDisplacement / verticalShadowScaleHeightLimit;
@@ -1069,7 +1086,7 @@ namespace Tizen.NUI.Components
                 // scale limit of height is 300%.
                 verticalTopShadowView.SizeHeight = newDisplacement > verticalShadowScaleHeightLimit ? verticalShadowScaleHeightLimit : newDisplacement;
             }
-            else if ((int)displacement < 0) // upwards
+            else if (totalPanDisplacement < 0) // upwards
             {
                 // check if reaching at the bottom.
                 if (-(int)finalTargetPosition != (int)maxScrollDistance)
@@ -1078,12 +1095,16 @@ namespace Tizen.NUI.Components
                 // save start displacement, and re-calculate displacement.
                 if (!isVerticalShadowShown)
                 {
-                    startShowShadowDisplacement = displacement;
-                    OnScrollOutOfBound(ScrollOutOfBoundEventArgs.Bound.Bottom);
+                    startShowShadowDisplacement = totalPanDisplacement;
                 }
                 isVerticalShadowShown = true;
 
-                float newDisplacement = (int)startShowShadowDisplacement < (int)displacement ? 0 : startShowShadowDisplacement - displacement;
+                // trigger event
+                ScrollOutOfBoundEventArgs.Direction direction = panDisplacement > 0 ?
+                    ScrollOutOfBoundEventArgs.Direction.Down : ScrollOutOfBoundEventArgs.Direction.Up;
+                OnScrollOutOfBound(direction, totalPanDisplacement);
+
+                float newDisplacement = (int)startShowShadowDisplacement < (int)totalPanDisplacement ? 0 : startShowShadowDisplacement - totalPanDisplacement;
 
                 // scale limit of width is 60%.
                 float widthScale = newDisplacement / verticalShadowScaleHeightLimit;
@@ -1142,9 +1163,9 @@ namespace Tizen.NUI.Components
             isVerticalShadowShown = false;
         }
 
-        private void OnScrollOutOfBound(ScrollOutOfBoundEventArgs.Bound bound)
+        private void OnScrollOutOfBound(ScrollOutOfBoundEventArgs.Direction direction, float displacement)
         {
-            ScrollOutOfBoundEventArgs args = new ScrollOutOfBoundEventArgs(bound);
+            ScrollOutOfBoundEventArgs args = new ScrollOutOfBoundEventArgs(direction, displacement);
             ScrollOutOfBound?.Invoke(this, args);
         }
 
@@ -1188,7 +1209,7 @@ namespace Tizen.NUI.Components
                         ScrollBy(panGesture.Displacement.Y, false);
                     }
                     totalDisplacementForPan += panGesture.Displacement.Y;
-                    DragVerticalShadow(totalDisplacementForPan);
+                    DragVerticalShadow(totalDisplacementForPan, panGesture.Displacement.Y);
                 }
                 Debug.WriteLineIf(LayoutDebugScrollableBase, "OnPanGestureDetected Continue totalDisplacementForPan:" + totalDisplacementForPan);
             }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableBaseOutOfBoundSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableBaseOutOfBoundSample.cs
@@ -35,6 +35,7 @@ namespace Tizen.NUI.Samples
                 Position = new Position(300, 100),
                 Size = new Size(400, 300),
                 ScrollingDirection = Components.ScrollableBase.Direction.Vertical,
+                EnableOverShootingEffect = true,
             };
             mScrollableBase.ScrollOutOfBound += OnScrollOutOfBound;
 
@@ -63,13 +64,19 @@ namespace Tizen.NUI.Samples
 
         private void OnScrollOutOfBound(object sender, Components.ScrollOutOfBoundEventArgs e)
         {
-            if (e.ScrollableBound == Components.ScrollOutOfBoundEventArgs.Bound.Top)
+            if (e.Displacement > 100)
             {
-                items[0].Text = "Reached at the top.";
+                if (e.PanDirection == Components.ScrollOutOfBoundEventArgs.Direction.Down)
+                {
+                    items[0].Text = $"Reached at the top, panned displacement is {e.Displacement}.";
+                }
             }
-            else
+            else if (0 - e.Displacement > 100)
             {
-                items[4].Text = "Reached at the bottom.";
+                if (e.PanDirection == Components.ScrollOutOfBoundEventArgs.Direction.Up)
+                {
+                    items[4].Text = $"Reached at the bottom, panned displacement is {e.Displacement}.";
+                }
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
This patch is to trigger ScrollOutOfBound event as pan gesture state,
and add pan direction & displacement into ScrollOutOfBound event.
Bound of ScrollOutOfBoundEventArgs is removed, because displacement
can be used for checking Top/Bottom.

### API Changes ###
none