### PR TITLE
[NUI] Fix not to use setter of AnimatedImageView.URLs

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AnimatedImageViewTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AnimatedImageViewTest.cs
@@ -167,12 +167,10 @@ namespace Tizen.NUI.Samples
             box2 = new Box(new Size2D(root.Size2D.Width, GetRatio(40, root.Size2D.Height)), "Image array Test", "");
             root.Add(box2);
 
-            var list = new List<string>();
             for (int i = 1; i <= 8; i++)
             {
-                list.Add(resPath + "images/AGIF/dog-anim-00" + i + ".png");
+                box2.image.URLs.Add(resPath + "images/AGIF/dog-anim-00" + i + ".png");
             }
-            box2.image.URLs = list;
             box2.image.Play();
 
             box2.but1.Clicked += But1_Clicked1;


### PR DESCRIPTION
The setter of AnimatedImageView.URLs was removed to resolve CA2227.
Therefore, the setter of AnimatedImageView.URLs in sample code is also
removed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
