### PR TITLE
[NUI] Fix a build warning CA1827

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
@@ -285,13 +285,14 @@ namespace Tizen.NUI.BaseComponents
             }
 
             var rest = lhs.stateList.Except(rhs.stateList);
+            var count = rest.Count();
 
-            if (rest.Count() == 0)
+            if (count == 0)
             {
                 return Normal;
             }
 
-            if (rest.Count() == 1)
+            if (count == 1)
             {
                 return rest.First();
             }


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- To fix the build warning, replaced `Count()` method with `Any()` method
 https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1827


### API Changes ###
- N/A