### PR TITLE
[NUI] fix CA1801 build warnings from auto-generated codes by SWIG

### DIFF
--- a/src/Tizen.NUI/src/internal/Any.cs
+++ b/src/Tizen.NUI/src/internal/Any.cs
@@ -60,7 +60,7 @@ namespace Tizen.NUI
 
         public new SWIGTYPE_p_std__type_info GetType()
         {
-            SWIGTYPE_p_std__type_info ret = new SWIGTYPE_p_std__type_info(Interop.Any.Any_GetType(swigCPtr), false);
+            SWIGTYPE_p_std__type_info ret = new SWIGTYPE_p_std__type_info(Interop.Any.Any_GetType(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -100,7 +100,7 @@ namespace Tizen.NUI
             /// <since_tizen> 3 </since_tizen>
             public new SWIGTYPE_p_std__type_info GetType()
             {
-                SWIGTYPE_p_std__type_info ret = new SWIGTYPE_p_std__type_info(Interop.Any.Any_AnyContainerBase_GetType(swigCPtr), false);
+                SWIGTYPE_p_std__type_info ret = new SWIGTYPE_p_std__type_info(Interop.Any.Any_AnyContainerBase_GetType(swigCPtr));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
@@ -110,7 +110,7 @@ namespace Tizen.NUI
             {
                 get
                 {
-                    SWIGTYPE_p_std__type_info ret = new SWIGTYPE_p_std__type_info(Interop.Any.Any_AnyContainerBase_mType_get(swigCPtr), false);
+                    SWIGTYPE_p_std__type_info ret = new SWIGTYPE_p_std__type_info(Interop.Any.Any_AnyContainerBase_mType_get(swigCPtr));
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -127,7 +127,7 @@ namespace Tizen.NUI
                 get
                 {
                     global::System.IntPtr cPtr = Interop.Any.Any_AnyContainerBase_mCloneFunc_get(swigCPtr);
-                    SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase(cPtr, false);
+                    SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase(cPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }
@@ -144,7 +144,7 @@ namespace Tizen.NUI
                 get
                 {
                     global::System.IntPtr cPtr = Interop.Any.Any_AnyContainerBase_mDeleteFunc_get(swigCPtr);
-                    SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void(cPtr, false);
+                    SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void(cPtr);
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                     return ret;
                 }

--- a/src/Tizen.NUI/src/internal/AsyncImageLoader.cs
+++ b/src/Tizen.NUI/src/internal/AsyncImageLoader.cs
@@ -94,7 +94,7 @@ namespace Tizen.NUI
 
         public SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t ImageLoadedSignal()
         {
-            SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t(Interop.AsyncImageLoader.AsyncImageLoader_ImageLoadedSignal(swigCPtr), false);
+            SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t(Interop.AsyncImageLoader.AsyncImageLoader_ImageLoadedSignal(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/CreateWidgetFunction.cs
+++ b/src/Tizen.NUI/src/internal/CreateWidgetFunction.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal CreateWidgetFunction(global::System.IntPtr cPtr, bool futureUse)
+        internal CreateWidgetFunction(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/ItemView.cs
+++ b/src/Tizen.NUI/src/internal/ItemView.cs
@@ -206,14 +206,14 @@ namespace Tizen.NUI
 
         internal SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t GetLayout(uint layoutIndex)
         {
-            SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t ret = new SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(Interop.ItemView.ItemView_GetLayout(swigCPtr, layoutIndex), true);
+            SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t ret = new SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(Interop.ItemView.ItemView_GetLayout(swigCPtr, layoutIndex));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         internal SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t GetActiveLayout()
         {
-            SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t ret = new SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(Interop.ItemView.ItemView_GetActiveLayout(swigCPtr), true);
+            SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t ret = new SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(Interop.ItemView.ItemView_GetActiveLayout(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/KeyInputFocusManager.cs
+++ b/src/Tizen.NUI/src/internal/KeyInputFocusManager.cs
@@ -65,7 +65,7 @@ namespace Tizen.NUI
 
         internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t KeyInputFocusChangedSignal()
         {
-            SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t(Interop.KeyInputFocusManager.KeyInputFocusManager_KeyInputFocusChangedSignal(swigCPtr), false);
+            SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t(Interop.KeyInputFocusManager.KeyInputFocusManager_KeyInputFocusChangedSignal(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/Matrix.cs
+++ b/src/Tizen.NUI/src/internal/Matrix.cs
@@ -188,7 +188,7 @@ namespace Tizen.NUI
         public SWIGTYPE_p_float AsFloat()
         {
             global::System.IntPtr cPtr = Interop.Matrix.Matrix_AsFloat__SWIG_0(swigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr, false);
+            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/Matrix3.cs
+++ b/src/Tizen.NUI/src/internal/Matrix3.cs
@@ -102,7 +102,7 @@ namespace Tizen.NUI
         public SWIGTYPE_p_float AsFloat()
         {
             global::System.IntPtr cPtr = Interop.Matrix.Matrix3_AsFloat__SWIG_0(swigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr, false);
+            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/NDalic.cs
+++ b/src/Tizen.NUI/src/internal/NDalic.cs
@@ -535,7 +535,7 @@ namespace Tizen.NUI
 
         internal static SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t NewItemLayout(DefaultItemLayoutType type)
         {
-            SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t ret = new SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(Interop.NDalic.NewItemLayout((int)type), true);
+            SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t ret = new SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(Interop.NDalic.NewItemLayout((int)type));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/RenderTask.cs
@@ -59,7 +59,7 @@ namespace Tizen.NUI
             get
             {
                 global::System.IntPtr cPtr = Interop.RenderTask.RenderTask_DEFAULT_SCREEN_TO_FRAMEBUFFER_FUNCTION_get();
-                SWIGTYPE_p_f_r_Dali__Vector2__bool ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_Dali__Vector2__bool(cPtr, false);
+                SWIGTYPE_p_f_r_Dali__Vector2__bool ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_Dali__Vector2__bool(cPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
@@ -70,7 +70,7 @@ namespace Tizen.NUI
             get
             {
                 global::System.IntPtr cPtr = Interop.RenderTask.RenderTask_FULLSCREEN_FRAMEBUFFER_FUNCTION_get();
-                SWIGTYPE_p_f_r_Dali__Vector2__bool ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_Dali__Vector2__bool(cPtr, false);
+                SWIGTYPE_p_f_r_Dali__Vector2__bool ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_Dali__Vector2__bool(cPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
@@ -239,7 +239,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_f_r_Dali__Vector2__bool GetScreenToFrameBufferFunction()
         {
             global::System.IntPtr cPtr = Interop.RenderTask.RenderTask_GetScreenToFrameBufferFunction(swigCPtr);
-            SWIGTYPE_p_f_r_Dali__Vector2__bool ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_Dali__Vector2__bool(cPtr, false);
+            SWIGTYPE_p_f_r_Dali__Vector2__bool ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_r_Dali__Vector2__bool(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_CallbackBase.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_CallbackBase.cs
@@ -17,7 +17,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_CallbackBase(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_CallbackBase(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CallbackBase.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CallbackBase.cs
@@ -17,7 +17,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__CallbackBase(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__CallbackBase(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Constraint.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Constraint.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Constraint(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Constraint(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CustomActorImpl__Extension.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CustomActorImpl__Extension.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__CustomActorImpl__Extension(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__CustomActorImpl__Extension(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__FunctorDelegate.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__FunctorDelegate.cs
@@ -17,7 +17,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__FunctorDelegate(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__FunctorDelegate(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__Texture.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__Texture.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Internal__Texture(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Internal__Texture(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__TypeRegistry.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Internal__TypeRegistry.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Internal__TypeRegistry(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Internal__TypeRegistry(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__IntrusivePtrT_Dali__Toolkit__ItemLayout_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__RectT_unsigned_int_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__RectT_unsigned_int_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__RectT_unsigned_int_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__RectT_unsigned_int_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__RenderSurface.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__RenderSurface.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__RenderSurface(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__RenderSurface(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Actor_Dali__TouchEvent_const_RF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Actor_Dali__TouchEvent_const_RF_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__SignalT_bool_fDali__Actor_Dali__TouchEvent_const_RF_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__SignalT_bool_fDali__Actor_Dali__TouchEvent_const_RF_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Actor_bool_Dali__DevelActor__VisibilityChange__TypeF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Actor_bool_Dali__DevelActor__VisibilityChange__TypeF_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Actor_bool_Dali__DevelActor__VisibilityChange__TypeF_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Actor_bool_Dali__DevelActor__VisibilityChange__TypeF_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__Control_Dali__Toolkit__ControlF_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__SignalT_void_fuint32_t_Dali__PixelDataF_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__ClampState.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__ClampState.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Toolkit__ClampState(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Toolkit__ClampState(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Toolkit__Internal__AsyncImageLoader(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Control__Extension.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Control__Extension.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Toolkit__Internal__Control__Extension(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Toolkit__Internal__Control__Extension(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Toolkit__Internal__TransitionData(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Toolkit__Internal__Visual__Base(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__ItemFactory__Extension.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Toolkit__ItemFactory__Extension.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Toolkit__ItemFactory__Extension(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Toolkit__ItemFactory__Extension(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__VectorT_uint32_t_TypeTraitsT_uint32_t_t__IS_TRIVIAL_TYPE__true_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__VectorT_uint32_t_TypeTraitsT_uint32_t_t__IS_TRIVIAL_TYPE__true_t.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__VectorT_uint32_t_TypeTraitsT_uint32_t_t__IS_TRIVIAL_TYPE__true_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__VectorT_uint32_t_TypeTraitsT_uint32_t_t__IS_TRIVIAL_TYPE__true_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Widget__Impl.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__Widget__Impl.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_Dali__Widget__Impl(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_Dali__Widget__Impl(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_FunctorDelegate.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_FunctorDelegate.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_FunctorDelegate(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_FunctorDelegate(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_KeyboardFocusManager.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_KeyboardFocusManager.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_KeyboardFocusManager(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_KeyboardFocusManager(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_PropertyInputContainer.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_PropertyInputContainer.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_PropertyInputContainer(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_PropertyInputContainer(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_bundle.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_bundle.cs
@@ -32,7 +32,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_bundle(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_bundle(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_double.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_double.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_double(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_double(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_float__float.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_float__float.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_float__float(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_float__float(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_Dali__Property__Index__Dali__Property__Value.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_Dali__Property__Index__Dali__Property__Value.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_p_Dali__BaseObject_Dali__Property__Index__Dali__Property__Value(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_p_Dali__BaseObject_Dali__Property__Index__Dali__Property__Value(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_int_r_q_const__Dali__Property__Value__void.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_int_r_q_const__Dali__Property__Value__void.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_p_Dali__BaseObject_int_r_q_const__Dali__Property__Value__void(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_p_Dali__BaseObject_int_r_q_const__Dali__Property__Value__void(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_p_Dali__ConnectionTrackerInterface.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_p_Dali__ConnectionTrackerInterface.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_p_Dali__BaseObject_p_Dali__ConnectionTrackerInterface_r_q_const__std__string_p_Dali__FunctorDelegate__bool(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_p_Dali__BaseObject_p_Dali__ConnectionTrackerInterface_r_q_const__std__string_p_Dali__FunctorDelegate__bool(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_r_q_const__std__string_r_q_const__Dali__Property__Map__bool.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_Dali__BaseObject_r_q_const__std__string_r_q_const__Dali__Property__Map__bool.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_p_Dali__BaseObject_r_q_const__std__string_r_q_const__Dali__Property__Map__bool(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_p_Dali__BaseObject_r_q_const__std__string_r_q_const__Dali__Property__Map__bool(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_r_Dali__Vector2__bool.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_r_Dali__Vector2__bool.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_r_Dali__Vector2__bool(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_r_Dali__Vector2__bool(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_r_q_const__Dali__Vector3__float.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_f_r_q_const__Dali__Vector3__float.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_f_r_q_const__Dali__Vector3__float(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_f_r_q_const__Dali__Vector3__float(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_float.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_float.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_float(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_float(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_int.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_int.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_int(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_int(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_p_Dali__TextAbstraction__VectorBlob.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_p_Dali__TextAbstraction__VectorBlob.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_p_Dali__TextAbstraction__VectorBlob(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_p_Dali__TextAbstraction__VectorBlob(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_std__type_info.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_std__type_info.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_std__type_info(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_std__type_info(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_std__vectorT_Dali__TextAbstraction__FontDescription_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_std__vectorT_Dali__TextAbstraction__FontDescription_t.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_std__vectorT_Dali__TextAbstraction__FontDescription_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_std__vectorT_Dali__TextAbstraction__FontDescription_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_time_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_time_t.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_time_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_time_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_tm.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_tm.cs
@@ -21,7 +21,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_tm(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_tm(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_uint16_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_uint16_t.cs
@@ -21,7 +21,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_uint16_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_uint16_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_uint8_t.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_uint8_t.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_uint8_t(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_uint8_t(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_unsigned_char.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_unsigned_char.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_unsigned_char(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_unsigned_char(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_unsigned_int.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_unsigned_int.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_unsigned_int(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_unsigned_int(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_unsigned_short.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_unsigned_short.cs
@@ -14,7 +14,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal SWIGTYPE_p_unsigned_short(global::System.IntPtr cPtr, bool futureUse)
+        internal SWIGTYPE_p_unsigned_short(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/VectorUnsignedChar.cs
+++ b/src/Tizen.NUI/src/internal/VectorUnsignedChar.cs
@@ -54,7 +54,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_unsigned_char Begin()
         {
             global::System.IntPtr cPtr = Interop.VectorUnsignedChar.VectorUnsignedChar_Begin(swigCPtr);
-            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr, false);
+            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -62,14 +62,14 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_unsigned_char End()
         {
             global::System.IntPtr cPtr = Interop.VectorUnsignedChar.VectorUnsignedChar_End(swigCPtr);
-            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr, false);
+            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         internal SWIGTYPE_p_unsigned_char ValueOfIndex(uint index)
         {
-            SWIGTYPE_p_unsigned_char ret = new SWIGTYPE_p_unsigned_char(Interop.VectorUnsignedChar.VectorUnsignedChar_ValueOfIndex__SWIG_0(swigCPtr, index), false);
+            SWIGTYPE_p_unsigned_char ret = new SWIGTYPE_p_unsigned_char(Interop.VectorUnsignedChar.VectorUnsignedChar_ValueOfIndex__SWIG_0(swigCPtr, index));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -113,7 +113,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_unsigned_char Erase(byte[] iterator)
         {
             global::System.IntPtr cPtr = Interop.VectorUnsignedChar.VectorUnsignedChar_Erase__SWIG_0(swigCPtr, iterator);
-            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr, false);
+            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -121,7 +121,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_unsigned_char Erase(byte[] first, SWIGTYPE_p_unsigned_char last)
         {
             global::System.IntPtr cPtr = Interop.VectorUnsignedChar.VectorUnsignedChar_Erase__SWIG_1(swigCPtr, first, SWIGTYPE_p_unsigned_char.getCPtr(last));
-            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr, false);
+            SWIGTYPE_p_unsigned_char ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_char(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewImpl.cs
@@ -724,12 +724,12 @@ namespace Tizen.NUI
 
         private void SwigDirectorSignalConnected(global::System.IntPtr slotObserver, global::System.IntPtr callback)
         {
-            SignalConnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback, false));
+            SignalConnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback));
         }
 
         private void SwigDirectorSignalDisconnected(global::System.IntPtr slotObserver, global::System.IntPtr callback)
         {
-            SignalDisconnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback, false));
+            SignalDisconnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback));
         }
 
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.NUI/src/internal/WidgetApplication.cs
+++ b/src/Tizen.NUI/src/internal/WidgetApplication.cs
@@ -91,7 +91,7 @@ namespace Tizen.NUI
             _createWidgetFunctionDelegateList.Add(newDelegate);
 
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(newDelegate);
-            CreateWidgetFunction createWidgetFunction = new CreateWidgetFunction(ip, true);
+            CreateWidgetFunction createWidgetFunction = new CreateWidgetFunction(ip);
 
             Interop.WidgetApplication.WidgetApplication_RegisterWidgetCreatingFunction(swigCPtr, ref widgetName, CreateWidgetFunction.getCPtr(createWidgetFunction));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/WidgetImpl.cs
+++ b/src/Tizen.NUI/src/internal/WidgetImpl.cs
@@ -350,12 +350,12 @@ namespace Tizen.NUI
 
         private void SwigDirectorSignalConnected(global::System.IntPtr slotObserver, global::System.IntPtr callback)
         {
-            SignalConnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback, false));
+            SignalConnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback));
         }
 
         private void SwigDirectorSignalDisconnected(global::System.IntPtr slotObserver, global::System.IntPtr callback)
         {
-            SignalDisconnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback, false));
+            SignalDisconnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback));
         }
 
         public delegate void SwigDelegateWidgetImpl_0(string contentInfo, global::System.IntPtr window);

--- a/src/Tizen.NUI/src/internal/WidgetImplPtr.cs
+++ b/src/Tizen.NUI/src/internal/WidgetImplPtr.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     {
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal WidgetImplPtr(global::System.IntPtr cPtr, bool futureUse)
+        internal WidgetImplPtr(global::System.IntPtr cPtr)
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }

--- a/src/Tizen.NUI/src/internal/doublep.cs
+++ b/src/Tizen.NUI/src/internal/doublep.cs
@@ -50,7 +50,7 @@ namespace Tizen.NUI
         public SWIGTYPE_p_double cast()
         {
             global::System.IntPtr cPtr = Interop.doublep.doublep_cast(swigCPtr);
-            SWIGTYPE_p_double ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_double(cPtr, false);
+            SWIGTYPE_p_double ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_double(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/floatp.cs
+++ b/src/Tizen.NUI/src/internal/floatp.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI
         public SWIGTYPE_p_float cast()
         {
             global::System.IntPtr cPtr = Interop.floatp.floatp_cast(swigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr, false);
+            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/intp.cs
+++ b/src/Tizen.NUI/src/internal/intp.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI
         public SWIGTYPE_p_int cast()
         {
             global::System.IntPtr cPtr = Interop.intp.intp_cast(swigCPtr);
-            SWIGTYPE_p_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_int(cPtr, false);
+            SWIGTYPE_p_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_int(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/uintp.cs
+++ b/src/Tizen.NUI/src/internal/uintp.cs
@@ -52,7 +52,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_unsigned_int cast()
         {
             global::System.IntPtr cPtr = Interop.uintp.uintp_cast(swigCPtr);
-            SWIGTYPE_p_unsigned_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_int(cPtr, false);
+            SWIGTYPE_p_unsigned_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_int(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/ushortp.cs
+++ b/src/Tizen.NUI/src/internal/ushortp.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI
         public SWIGTYPE_p_unsigned_short cast()
         {
             global::System.IntPtr cPtr = Interop.ushortp.ushortp_cast(swigCPtr);
-            SWIGTYPE_p_unsigned_short ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_short(cPtr, false);
+            SWIGTYPE_p_unsigned_short ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_short(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
@@ -1038,7 +1038,7 @@ namespace Tizen.NUI.Accessibility
 
         internal SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t ActionScrollSignal()
         {
-            SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t ret = new SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t(Interop.AccessibilityManager.AccessibilityManager_ActionScrollSignal(swigCPtr), false);
+            SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t ret = new SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t(Interop.AccessibilityManager.AccessibilityManager_ActionScrollSignal(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/AlphaFunction.cs
+++ b/src/Tizen.NUI/src/public/AlphaFunction.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="func">User defined fuction. It must be a method formatted as float alphafunction(float progress)</param>
         /// <since_tizen> 3 </since_tizen>
-        public AlphaFunction(global::System.Delegate func) : this(Interop.AlphaFunction.new_AlphaFunction__SWIG_2(SWIGTYPE_p_f_float__float.getCPtr(new SWIGTYPE_p_f_float__float(System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func), true))), true)
+        public AlphaFunction(global::System.Delegate func) : this(Interop.AlphaFunction.new_AlphaFunction__SWIG_2(SWIGTYPE_p_f_float__float.getCPtr(new SWIGTYPE_p_f_float__float(System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func)))), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -316,7 +316,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_f_float__float GetCustomFunction()
         {
             global::System.IntPtr cPtr = Interop.AlphaFunction.AlphaFunction_GetCustomFunction(swigCPtr);
-            SWIGTYPE_p_f_float__float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_float__float(cPtr, false);
+            SWIGTYPE_p_f_float__float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_f_float__float(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1234,7 +1234,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t InputStyleChangedSignal()
         {
-            SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t(Interop.TextEditor.TextEditor_InputStyleChangedSignal(swigCPtr), false);
+            SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t(Interop.TextEditor.TextEditor_InputStyleChangedSignal(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1362,7 +1362,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t InputStyleChangedSignal()
         {
-            SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t(Interop.TextField.TextField_InputStyleChangedSignal(swigCPtr), false);
+            SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t(Interop.TextField.TextField_InputStyleChangedSignal(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Vector2.cs
+++ b/src/Tizen.NUI/src/public/Vector2.cs
@@ -521,7 +521,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_float AsFloat()
         {
             global::System.IntPtr cPtr = Interop.Vector2.Vector2_AsFloat__SWIG_0(swigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr, false);
+            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Vector3.cs
+++ b/src/Tizen.NUI/src/public/Vector3.cs
@@ -733,7 +733,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_float AsFloat()
         {
             global::System.IntPtr cPtr = Interop.Vector3.Vector3_AsFloat__SWIG_0(swigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr, false);
+            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Vector4.cs
+++ b/src/Tizen.NUI/src/public/Vector4.cs
@@ -769,7 +769,7 @@ namespace Tizen.NUI
         internal SWIGTYPE_p_float AsFloat()
         {
             global::System.IntPtr cPtr = Interop.Vector4.Vector4_AsFloat__SWIG_0(swigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr, false);
+            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/WatchTime.cs
+++ b/src/Tizen.NUI/src/public/WatchTime.cs
@@ -210,14 +210,14 @@ namespace Tizen.NUI
 
         internal SWIGTYPE_p_tm GetUtcTime()
         {
-            SWIGTYPE_p_tm ret = new SWIGTYPE_p_tm(Interop.Watch.WatchTime_GetUtcTime(swigCPtr), true);
+            SWIGTYPE_p_tm ret = new SWIGTYPE_p_tm(Interop.Watch.WatchTime_GetUtcTime(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         internal SWIGTYPE_p_time_t GetUtcTimeStamp()
         {
-            SWIGTYPE_p_time_t ret = new SWIGTYPE_p_time_t(Interop.Watch.WatchTime_GetUtcTimeStamp(swigCPtr), true);
+            SWIGTYPE_p_time_t ret = new SWIGTYPE_p_time_t(Interop.Watch.WatchTime_GetUtcTimeStamp(swigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
### Description of Change ###
The 'futureUse' parameter is never being used through the whole code.
It removes 'futureUse' parameter from functions.