### PR TITLE
[NUI] Fix not to get framework path via StyleManager

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -697,7 +697,7 @@ namespace Tizen.NUI.Components
             //Show vertical shadow on the top (or bottom) of the scrollable when panning down (or up).
             verticalTopShadowView = new View
             {
-                BackgroundImage = Tizen.NUI.StyleManager.FrameworkResourcePath + "nui_component_default_scroll_over_shooting_top.png",
+                BackgroundImage = Tizen.NUI.FrameworkInformation.ResourcePath + "nui_component_default_scroll_over_shooting_top.png",
                 Opacity = 1.0f,
                 SizeHeight = 0.0f,
                 PositionUsesPivotPoint = true,
@@ -706,7 +706,7 @@ namespace Tizen.NUI.Components
             };
             verticalBottomShadowView = new View
             {
-                BackgroundImage = Tizen.NUI.StyleManager.FrameworkResourcePath + "nui_component_default_scroll_over_shooting_bottom.png",
+                BackgroundImage = Tizen.NUI.FrameworkInformation.ResourcePath + "nui_component_default_scroll_over_shooting_bottom.png",
                 Opacity = 1.0f,
                 SizeHeight = 0.0f,
                 PositionUsesPivotPoint = true,

--- a/src/Tizen.NUI.Wearable/src/public/WearableStyle/CircularPaginationStyle.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WearableStyle/CircularPaginationStyle.cs
@@ -130,13 +130,13 @@ namespace Tizen.NUI.Wearable
             IndicatorSize = new Size(10, 10);
             IndicatorImageURL = new Selector<string>()
             {
-                Normal = Tizen.NUI.StyleManager.FrameworkResourcePath + "nui_component_default_pagination_normal_dot.png",
-                Selected = Tizen.NUI.StyleManager.FrameworkResourcePath + "nui_component_default_pagination_focus_dot.png",
+                Normal = Tizen.NUI.FrameworkInformation.ResourcePath + "nui_component_default_pagination_normal_dot.png",
+                Selected = Tizen.NUI.FrameworkInformation.ResourcePath + "nui_component_default_pagination_focus_dot.png",
             };
             CenterIndicatorImageURL = new Selector<string>()
             {
-                Normal = Tizen.NUI.StyleManager.FrameworkResourcePath + "nui_wearable_circular_pagination_center_normal_dot.png",
-                Selected = Tizen.NUI.StyleManager.FrameworkResourcePath + "nui_wearable_circular_pagination_center_focus_dot.png",
+                Normal = Tizen.NUI.FrameworkInformation.ResourcePath + "nui_wearable_circular_pagination_center_normal_dot.png",
+                Selected = Tizen.NUI.FrameworkInformation.ResourcePath + "nui_wearable_circular_pagination_center_focus_dot.png",
             };
         }
     }

--- a/src/Tizen.NUI/src/public/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/NUIConstants.cs
@@ -1805,4 +1805,13 @@ namespace Tizen.NUI
         /// </summary>
         NoThirdParty
     }
+
+    /// <summary>
+    /// TODO This is to get TizenFX resource path. It needs to be fixed to use application framework API in the future.
+    /// Internal use only. Do not open this API.
+    /// </summary>
+    internal struct FrameworkInformation
+    {
+        public readonly static string ResourcePath = "/usr/share/dotnet.tizen/framework/res/";
+    }
 }

--- a/src/Tizen.NUI/src/public/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/StyleManager.cs
@@ -37,13 +37,6 @@ namespace Tizen.NUI
         private StyleChangedCallbackDelegate _styleManagerStyleChangedCallbackDelegate;
 
         /// <summary>
-        /// Internal use only. Do not open this API.
-        /// This is to get TizenFX resource path. It needs to be fixed to use application framework API in the future.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public readonly static string FrameworkResourcePath = "/usr/share/dotnet.tizen/framework/res/";
-
-        /// <summary>
         /// Creates a StyleManager handle.<br />
         /// This can be initialized with StyleManager::Get().<br />
         /// </summary>

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -309,7 +309,7 @@ namespace Tizen.NUI
 
             foreach (var project in nuiThemeProjects)
             {
-                string path = StyleManager.FrameworkResourcePath + "/Theme/" + project + "_" + id + ".xaml";
+                string path = FrameworkInformation.ResourcePath + "/Theme/" + project + "_" + id + ".xaml";
 
                 if (!File.Exists(path))
                 {

--- a/src/Tizen.NUI/src/public/Xaml/MarkupExtensions/NUIResourcePathExtension.cs
+++ b/src/Tizen.NUI/src/public/Xaml/MarkupExtensions/NUIResourcePathExtension.cs
@@ -22,7 +22,7 @@ namespace Tizen.NUI.Xaml
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public string ProvideValue(IServiceProvider serviceProvider) => StyleManager.FrameworkResourcePath + FilePath;
+        public string ProvideValue(IServiceProvider serviceProvider) => FrameworkInformation.ResourcePath + FilePath;
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
StyleManager uses dali singleton service which is not initialized in PreLoad().
Previously in Preload(), ThemeManager got framework resource path via static constant in StyleManager,
which leaded to initialize StyleManager instance that is not valid in PreLoad().

So this patch moved framework resource path constant to the constant file.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
