### PR TITLE
[NUI] Fix CS0108

### DIFF
--- a/src/Tizen.NUI/src/internal/Camera.cs
+++ b/src/Tizen.NUI/src/internal/Camera.cs
@@ -39,7 +39,7 @@ namespace Tizen.NUI
             Interop.CameraActor.DeleteCameraActor(swigCPtr);
         }
 
-        internal class Property
+        new internal class Property
         {
             internal static readonly int TYPE = Interop.CameraActor.TypeGet();
             internal static readonly int ProjectionMode = Interop.CameraActor.ProjectionModeGet();

--- a/src/Tizen.NUI/src/public/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/InputMethodContext.cs
@@ -944,6 +944,8 @@ namespace Tizen.NUI
             /// The state if it owns memory
             /// </summary>
             /// <since_tizen> 5 </since_tizen>
+            //ToDo : raise ACR as [Obsolete("This has been deprecated in API9 and will be removed in API11. Please use swigCMemOwn which is declared in parent class")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "<Pending>")]
             protected bool swigCMemOwn;
             private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
@@ -1102,6 +1104,8 @@ namespace Tizen.NUI
             /// The state if it owns memory
             /// </summary>
             /// <since_tizen> 5 </since_tizen>
+            //ToDo : raise ACR as [Obsolete("This has been deprecated in API9 and will be removed in API11. Please use SwigCMemOwn which is declared in parent class")]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "<Pending>")]
             protected bool swigCMemOwn;
             private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 

--- a/src/Tizen.NUI/src/public/UIComponents/ScrollViewEvent.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/ScrollViewEvent.cs
@@ -114,6 +114,7 @@ namespace Tizen.NUI
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
             /// It will be removed in API9
+            // ToDo : will proceed ACR as private bool swigCMemOwn;
             [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
             [Obsolete("Deprecated in API6; Will be removed in API9. Please use Tizen.NUI.Components")]
             [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix CS0108

https://docs.microsoft.com/ko-kr/dotnet/csharp/language-reference/compiler-messages/cs0108

'member1' hides inherited member 'member2'. Use the new keyword if hiding was intended.
A variable was declared with the same name as a variable in a base class. However, the new keyword was not used. This warning informs you that you should use new; the variable is declared as if new had been used in the declaration.

### API Changes ###
https://code.sec.samsung.net/jira/browse/TCSACR-394
