### PR TITLE
[NUI] Fix CA1054

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -154,6 +154,19 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Creates an initialized VideoView.
+        /// If the string is empty, VideoView will not display anything.
+        /// </summary>
+        /// <param name="uri">The URI of the video resource to display.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VideoView(Uri uri) : this(Interop.VideoView.New((uri == null) ? String.Empty : uri.AbsoluteUri), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Creates an initialized VideoView.<br />
         /// If the string is empty, VideoView will not display anything.<br />
         /// </summary>
@@ -172,6 +185,20 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="swCodec">Video rendering by H/W codec if false.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public VideoView(string url, bool swCodec) : this(Interop.VideoView.New(url, swCodec), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Creates an initialized VideoView.
+        /// If the string is empty, VideoView will not display anything.
+        /// </summary>
+        /// <param name="uri">The URI of the video resource to display.</param>
+        /// <param name="swCodec">Video rendering by H/W codec if false.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VideoView(Uri uri, bool swCodec) : this(Interop.VideoView.New((uri == null) ? String.Empty : uri.AbsoluteUri, swCodec), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/ImageLoading.cs
+++ b/src/Tizen.NUI/src/public/ImageLoading.cs
@@ -49,6 +49,41 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(url, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode, orientationCorrection), true);
+            uSize.Dispose();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from local file.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <param name="fittingMode">The method used to fit the shape of the image before loading to the shape defined by the size parameter.</param>
+        /// <param name="samplingMode">The filtering method used when sampling pixels from the input image while fitting it to desired size.</param>
+        /// <param name="orientationCorrection">Reorient the image to respect any orientation metadata in its header.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case loading failed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when size is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer LoadImageFromFile(Uri uri, Size2D size, FittingModeType fittingMode, SamplingModeType samplingMode, bool orientationCorrection)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            PixelBuffer ret;
+            using (var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height))
+            {
+                ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode, orientationCorrection), true);
+            }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -73,7 +108,40 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(url, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode), true);
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from local file.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <param name="fittingMode">The method used to fit the shape of the image before loading to the shape defined by the size parameter.</param>
+        /// <param name="samplingMode">The filtering method used when sampling pixels from the input image while fitting it to desired size.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case loading failed.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when size is null. </exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer LoadImageFromFile(Uri uri, Size2D size, FittingModeType fittingMode, SamplingModeType samplingMode)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            uSize.Dispose();
             return ret;
         }
 
@@ -96,6 +164,37 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(url, Uint16Pair.getCPtr(uSize), (int)fittingMode), true);
+            uSize.Dispose();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from local file.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <param name="fittingMode">The method used to fit the shape of the image before loading to the shape defined by the size parameter.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case loading failed.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when size is null. </exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer LoadImageFromFile(Uri uri, Size2D size, FittingModeType fittingMode)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize), (int)fittingMode), true);
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -118,6 +217,36 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(url, Uint16Pair.getCPtr(uSize)), true);
+            uSize.Dispose();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from local file.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case loading failed.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when size is null. </exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer LoadImageFromFile(Uri uri, Size2D size)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize)), true);
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -133,6 +262,27 @@ namespace Tizen.NUI
         public static PixelBuffer LoadImageFromFile(string url)
         {
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(url), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from local file.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case loading failed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer LoadImageFromFile(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.LoadImageFromFile(uri.AbsoluteUri), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -159,6 +309,8 @@ namespace Tizen.NUI
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             var val = new Uint16Pair(Interop.ImageLoading.GetClosestImageSize(filename, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode, orientationCorrection), true);
             Size2D ret = new Size2D(val.GetWidth(), val.GetHeight());
+            val.Dispose();
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -184,6 +336,8 @@ namespace Tizen.NUI
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             var val = new Uint16Pair(Interop.ImageLoading.GetClosestImageSize(filename, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode), true);
             Size2D ret = new Size2D(val.GetWidth(), val.GetHeight());
+            val.Dispose();
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -208,6 +362,8 @@ namespace Tizen.NUI
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             var val = new Uint16Pair(Interop.ImageLoading.GetClosestImageSize(filename, Uint16Pair.getCPtr(uSize), (int)fittingMode), true);
             Size2D ret = new Size2D(val.GetWidth(), val.GetHeight());
+            val.Dispose();
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -231,6 +387,8 @@ namespace Tizen.NUI
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             var val = new Uint16Pair(Interop.ImageLoading.GetClosestImageSize(filename, Uint16Pair.getCPtr(uSize)), true);
             Size2D ret = new Size2D(val.GetWidth(), val.GetHeight());
+            val.Dispose();
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -247,6 +405,7 @@ namespace Tizen.NUI
         {
             var val = new Uint16Pair(Interop.ImageLoading.GetClosestImageSize(filename), true);
             Size2D ret = new Size2D(val.GetWidth(), val.GetHeight());
+            val.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -263,6 +422,7 @@ namespace Tizen.NUI
         {
             var val = new Uint16Pair(Interop.ImageLoading.GetOriginalImageSize(filename), true);
             Size2D ret = new Size2D(val.GetWidth(), val.GetHeight());
+            val.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -288,7 +448,41 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(url, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode, orientationCorrection), true);
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from a remote resource.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <param name="fittingMode">The method used to fit the shape of the image before loading to the shape defined by the size parameter.</param>
+        /// <param name="samplingMode">The filtering method used when sampling pixels from the input image while fitting it to desired size.</param>
+        /// <param name="orientationCorrection">Reorient the image to respect any orientation metadata in its header.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case downloading or decoding failed.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when size is null. </exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer DownloadImageSynchronously(Uri uri, Size2D size, FittingModeType fittingMode, SamplingModeType samplingMode, bool orientationCorrection)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode, orientationCorrection), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            uSize.Dispose();
             return ret;
         }
 
@@ -312,6 +506,38 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(url, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode), true);
+            uSize.Dispose();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from a remote resource.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <param name="fittingMode">The method used to fit the shape of the image before loading to the shape defined by the size parameter.</param>
+        /// <param name="samplingMode">The filtering method used when sampling pixels from the input image while fitting it to desired size.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case downloading or decoding failed.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when size is null. </exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer DownloadImageSynchronously(Uri uri, Size2D size, FittingModeType fittingMode, SamplingModeType samplingMode)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize), (int)fittingMode, (int)samplingMode), true);
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -335,6 +561,37 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(url, Uint16Pair.getCPtr(uSize), (int)fittingMode), true);
+            uSize.Dispose();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from a remote resource.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <param name="fittingMode">The method used to fit the shape of the image before loading to the shape defined by the size parameter.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case downloading or decoding failed.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when size is null. </exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer DownloadImageSynchronously(Uri uri, Size2D size, FittingModeType fittingMode)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize), (int)fittingMode), true);
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -357,6 +614,36 @@ namespace Tizen.NUI
             }
             var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(url, Uint16Pair.getCPtr(uSize)), true);
+            uSize.Dispose();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from a remote resource.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <param name="size">The width and height to fit the loaded image to, 0.0 means whole image.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case downloading or decoding failed.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when size is null. </exception>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer DownloadImageSynchronously(Uri uri, Size2D size)
+        {
+            if (null == size)
+            {
+                throw new ArgumentNullException(nameof(size));
+            }
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uSize = new Uint16Pair((uint)size.Width, (uint)size.Height);
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(uri.AbsoluteUri, Uint16Pair.getCPtr(uSize)), true);
+            uSize.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -372,6 +659,27 @@ namespace Tizen.NUI
         public static PixelBuffer DownloadImageSynchronously(string url)
         {
             PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(url), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Using Uri class to provide safe sevice and secure API.
+        /// Load an image synchronously from a remote resource.
+        /// </summary>
+        /// <param name="uri">The URI of the image file to load.</param>
+        /// <returns>Handle to the loaded PixelBuffer object or an empty handle in case downloading or decoding failed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PixelBuffer DownloadImageSynchronously(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            PixelBuffer ret = new PixelBuffer(Interop.ImageLoading.DownloadImageSynchronously(uri.AbsoluteUri), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/ViewProperty/ImageShadow.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/ImageShadow.cs
@@ -49,6 +49,27 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Hidden API (Inhouse API).
+        /// Constructor.
+        /// Using Uri class to provide safe sevice and secure API.
+        /// </summary>
+        /// <param name="uri">uri.</param>
+        /// <param name="border">border.</param>
+        /// <param name="offset">offset.</param>
+        /// <param name="extents">extents.</param>
+        /// <exception cref="ArgumentNullException">Thrown when uri is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ImageShadow(Uri uri, Rectangle border, Vector2 offset, Vector2 extents) : base(offset, extents)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+            Url = uri.AbsoluteUri;
+            Border = border == null ? null : new Rectangle(border);
+        }
+
+        /// <summary>
         /// Constructor
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix CA1054
- https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1054
- This rule splits the parameter name into tokens based on the camel casing convention and checks whether each token equals "uri", "Uri", "urn", "Urn", "url", or "Url". If there is a match, the rule assumes that the parameter represents a uniform resource identifier (URI). A string representation of a URI is prone to parsing and encoding errors, and can lead to security vulnerabilities. If a method takes a string representation of a URI, a corresponding overload should be provided that takes an instance of the Uri class, which provides these services in a safe and secure manner.

### API Changes ###
if ACR is needed, I will raise new ACR request soon.