### PR TITLE
[NUI] Suppress CA1716, CA1052, CA1034 for deprecated APIs

### DIFF
--- a/src/Tizen.NUI/src/internal/ItemView.cs
+++ b/src/Tizen.NUI/src/internal/ItemView.cs
@@ -63,11 +63,11 @@ namespace Tizen.NUI
         /// <summary>
         /// Property for ItemView. This is internal use only, so not recommended to use. Need to use ItemView's properties.
         /// </summary>
-        [SuppressMessage("Microsoft.Design", "CA1052:StaticHolderTypesShouldBeStaticOrNotInheritable")]
         [Obsolete("Deprecated in API6; Will be removed in API9.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
+#pragma warning disable CA1034, CA1052, CA1716 // Identifiers should not match keywords
         public new class Property
+#pragma warning restore CA1034, CA1052, CA1716 // Identifiers should not match keywords
         {
             /// <summary>
             /// LAYOUT. This is internal use only, so not recommended to use. Need to use ItemView's properties.

--- a/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
@@ -747,10 +747,11 @@ namespace Tizen.NUI.BaseComponents
         /// Enumeration for the instance of properties belonging to the Scrollable class.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [SuppressMessage("Microsoft.Design", "CA1052:StaticHolderTypesShouldBeStaticOrNotInheritable")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Deprecated in API6; Will be removed in API9.")]
+#pragma warning disable CA1716, CA1052, CA1034 // Identifiers should not match keywords
         public new class Property
+#pragma warning restore CA1716, CA1052, CA1034 // Identifiers should not match keywords
         {
             /// <summary>
             /// The color of the overshoot effect.

--- a/src/Tizen.NUI/src/public/Renderer.cs
+++ b/src/Tizen.NUI/src/public/Renderer.cs
@@ -618,11 +618,11 @@ namespace Tizen.NUI
         /// Enumeration for instances of properties belonging to the Renderer class.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [SuppressMessage("Microsoft.Design", "CA1052:StaticHolderTypesShouldBeStaticOrNotInheritable")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Deprecated in API6; Will be removed in API9.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
+#pragma warning disable CA1716, CA1052, CA1034 // Identifiers should not match keywords
         public class Property
+#pragma warning restore CA1716, CA1052, CA1034 // Identifiers should not match keywords
         {
             /// <summary>
             /// This should be internal, please do not use.

--- a/src/Tizen.NUI/src/public/Shader.cs
+++ b/src/Tizen.NUI/src/public/Shader.cs
@@ -120,11 +120,11 @@ namespace Tizen.NUI
         /// Enumeration for instances of properties belonging to the Shader class.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [SuppressMessage("Microsoft.Design", "CA1052:StaticHolderTypesShouldBeStaticOrNotInheritable")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Deprecated in API6; Will be removed in API9.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
+#pragma warning disable CA1716, CA1052, CA1034 // Identifiers should not match keywords
         public class Property
+#pragma warning restore CA1716, CA1052, CA1034 // Identifiers should not match keywords
         {
             /// <summary>
             /// The default value is empty.

--- a/src/Tizen.NUI/src/public/UIComponents/ScrollView.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/ScrollView.cs
@@ -1247,11 +1247,11 @@ namespace Tizen.NUI
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         /// This will be deprecated
-        [SuppressMessage("Microsoft.Design", "CA1052:StaticHolderTypesShouldBeStaticOrNotInheritable")]
         [Obsolete("Deprecated in API6; Will be removed in API9. Please use Tizen.NUI.Components")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
+#pragma warning disable CA1716, CA1052, CA1034 // Identifiers should not match keywords
         public new class Property
+#pragma warning restore CA1716, CA1052, CA1034 // Identifiers should not match keywords
         {
             /// <summary>
             /// This should be internal, please do not use.

--- a/src/Tizen.NUI/src/public/UIComponents/ToggleButton.cs
+++ b/src/Tizen.NUI/src/public/UIComponents/ToggleButton.cs
@@ -175,11 +175,11 @@ namespace Tizen.NUI
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         /// This will be deprecated
-        [SuppressMessage("Microsoft.Design", "CA1052:StaticHolderTypesShouldBeStaticOrNotInheritable")]
         [Obsolete("Deprecated in API6; Will be removed in API9. Please use Tizen.NUI.Components")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
+#pragma warning disable CA1716, CA1052, CA1034 // Identifiers should not match keywords
         public new class Property
+#pragma warning restore CA1716, CA1052, CA1034 // Identifiers should not match keywords
         {
             /// <summary>
             /// This should be internal, please do not use.


### PR DESCRIPTION
### Description of Change ###
[NUI] Suppress CA1716, CA1052, CA1034 for deprecated APIs
- Since the detected classes will be deprecated, CA1716 warning message is suppressed.
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1716
- This is conflict resolving patch for https://github.com/Samsung/TizenFX/pull/2374

### API Changes ###
none