### PR TITLE
[NUI] Call show winodw on ApplicationInit

### DIFF
--- a/src/Tizen.NUI/src/internal/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application.cs
@@ -618,6 +618,12 @@ namespace Tizen.NUI
             // Initialize DisposeQueue Singleton class. This is also required to create DisposeQueue on main thread.
             DisposeQueue.Instance.Initialize();
 
+            // Notify that the window is displayed to the app core.
+            if (NUIApplication.IsPreLoad)
+            {
+                Window.Instance.Show();
+            }
+
             if (_applicationInitEventHandler != null)
             {
                 NUIApplicationInitEventArgs e = new NUIApplicationInitEventArgs();

--- a/src/Tizen.NUI/src/public/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/NUIApplication.cs
@@ -42,6 +42,7 @@ namespace Tizen.NUI
         private Position2D _windowPosition2D = null;
         private TransitionOptions transitionOptions;
 
+        private static bool isPreLoad = false;
 
         /// <summary>
         /// The default constructor.
@@ -386,6 +387,7 @@ namespace Tizen.NUI
         {
             Interop.Application.PreInitialize();
             ThemeManager.EnsureDefaultTheme();
+            isPreLoad = true;
         }
 
         /// <summary>
@@ -410,6 +412,17 @@ namespace Tizen.NUI
             set
             {
                 transitionOptions = value;
+            }
+        }
+
+        /// <summary>
+        /// Check if it is loaded as dotnet-loader-nui.
+        /// </summary>
+        static internal bool IsPreLoad
+        {
+            get
+            {
+                return isPreLoad;
             }
         }
     }


### PR DESCRIPTION
- When preload application, the show is called before the appcore is created.
- Call the window show at OnInit and notify the app core

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
