### PR TITLE
[NUI] Fix CA1819 : Properties should not return arrays

### DIFF
--- a/src/Tizen.NUI/src/internal/FrameBroker/DefaultFrameBroker.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/DefaultFrameBroker.cs
@@ -109,17 +109,13 @@ namespace Tizen.NUI
                 providerImage.Show();
                 int propertyCount = transition.AnimationDataList.Count;
                 animation = new Animation(transition.DurationMilliSeconds+80);
-                animation.Properties = new string[propertyCount];
-                animation.DestValue = new string[propertyCount];
-                animation.StartTime = new int[propertyCount];
-                animation.EndTime = new int[propertyCount];
 
                 for (int i = 0; i < propertyCount; i++)
                 {
-                    animation.Properties[i] = transition.AnimationDataList[i].Property;
-                    animation.DestValue[i] = transition.AnimationDataList[i].DestinationValue;
-                    animation.StartTime[i] = 80+transition.AnimationDataList[i].StartTime;
-                    animation.EndTime[i] = 80+transition.AnimationDataList[i].EndTime;
+                    animation.PropertiesList.Add(transition.AnimationDataList[i].Property);
+                    animation.DestValueList.Add(transition.AnimationDataList[i].DestinationValue);
+                    animation.StartTimeList.Add(80 +transition.AnimationDataList[i].StartTime);
+                    animation.EndTimeList.Add(80 +transition.AnimationDataList[i].EndTime);
                 }
                 animation.PlayAnimateTo(providerImage);
                 animation.Finished += Ani_Finished;

--- a/src/Tizen.NUI/src/internal/FrameBroker/DefaultFrameBroker.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/DefaultFrameBroker.cs
@@ -112,7 +112,7 @@ namespace Tizen.NUI
 
                 for (int i = 0; i < propertyCount; i++)
                 {
-                    animation.PropertiesList.Add(transition.AnimationDataList[i].Property);
+                    animation.PropertyList.Add(transition.AnimationDataList[i].Property);
                     animation.DestValueList.Add(transition.AnimationDataList[i].DestinationValue);
                     animation.StartTimeList.Add(80 +transition.AnimationDataList[i].StartTime);
                     animation.EndTimeList.Add(80 +transition.AnimationDataList[i].EndTime);

--- a/src/Tizen.NUI/src/public/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation.cs
@@ -56,7 +56,7 @@ namespace Tizen.NUI
         private int[] _startTime = null;
         private int[] _endTime = null;
 
-        private List<string> _propertiesList = null;
+        private List<string> _propertyList = null;
         private List<string> _destValueList = null;
         private List<int> _startTimeList = null;
         private List<int> _endTimeList = null;
@@ -516,12 +516,12 @@ namespace Tizen.NUI
         {
             get
             {
-                if (null == _propertiesList)
+                if (null == _propertyList)
                 {
-                    _propertiesList = new List<string>();
+                    _propertyList = new List<string>();
                 }
 
-                return _propertiesList;
+                return _propertyList;
             }
         }
 
@@ -760,19 +760,19 @@ namespace Tizen.NUI
 
             Clear();
 
-            if (null != _propertiesList && null != _destValueList && null != _startTimeList && null != _endTimeList)
+            if (null != _propertyList && null != _destValueList && null != _startTimeList && null != _endTimeList)
             {
-                if (_propertiesList.Count == _destValueList.Count
+                if (_propertyList.Count == _destValueList.Count
                     &&
                     _startTimeList.Count == _endTimeList.Count
                     &&
-                    _propertiesList.Count == _startTimeList.Count)
+                    _propertyList.Count == _startTimeList.Count)
                 {
-                    int count = _propertiesList.Count;
+                    int count = _propertyList.Count;
                     for (int index = 0; index < count; index++)
                     {
                         var elementType = target.GetType();
-                        PropertyInfo propertyInfo = elementType.GetProperties().FirstOrDefault(fi => fi.Name == _propertiesList[index]);
+                        PropertyInfo propertyInfo = elementType.GetProperties().FirstOrDefault(fi => fi.Name == _propertyList[index]);
 
                         if (propertyInfo != null)
                         {
@@ -780,7 +780,7 @@ namespace Tizen.NUI
 
                             if (destinationValue != null)
                             {
-                                AnimateTo(target, _propertiesList[index], destinationValue, _startTimeList[index], _endTimeList[index]);
+                                AnimateTo(target, _propertyList[index], destinationValue, _startTimeList[index], _endTimeList[index]);
                             }
                         }
                     }

--- a/src/Tizen.NUI/src/public/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation.cs
@@ -56,10 +56,10 @@ namespace Tizen.NUI
         private int[] _startTime = null;
         private int[] _endTime = null;
 
-        private List<string> _propertyList = null;
-        private List<string> _destValueList = null;
-        private List<int> _startTimeList = null;
-        private List<int> _endTimeList = null;
+        private List<string> propertyList = null;
+        private List<string> destValueList = null;
+        private List<int> startTimeList = null;
+        private List<int> endTimeList = null;
 
         /// <summary>
         /// Creates an initialized animation.<br />
@@ -442,7 +442,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the properties of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API9, Will be removed in API11, Please use PropertyList instead")]
+        //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use PropertyList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public string[] Properties
         {
@@ -459,7 +459,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the destination value for each property of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API9, Will be removed in API11, Please use DestValueList instead")]
+        //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use DestValueList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public string[] DestValue
         {
@@ -476,7 +476,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the start time for each property of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API9, Will be removed in API11, Please use StartTimeList instead")]
+        //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use StartTimeList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public int[] StartTime
         {
@@ -493,7 +493,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the end time for each property of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API9, Will be removed in API11, Please use EndTimeList instead")]
+        //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use EndTimeList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public int[] EndTime
         {
@@ -510,72 +510,68 @@ namespace Tizen.NUI
         /// <summary>
         /// Get the list of the properties of the animation.
         /// </summary>
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public List<string> PropertyList
+        public IList<string> PropertyList
         {
             get
             {
-                if (null == _propertyList)
+                if (null == propertyList)
                 {
-                    _propertyList = new List<string>();
+                    propertyList = new List<string>();
                 }
 
-                return _propertyList;
+                return propertyList;
             }
         }
 
         /// <summary>
         /// Get the list of the destination value for each property of the animation.
         /// </summary>
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public List<string> DestValueList
+        public IList<string> DestValueList
         {
             get
             {
-                if (null == _destValueList)
+                if (null == destValueList)
                 {
-                    _destValueList = new List<string>();
+                    destValueList = new List<string>();
                 }
 
-                return _destValueList;
+                return destValueList;
             }
         }
 
         /// <summary>
         /// Get the list of the start time for each property of the animation.
         /// </summary>
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public List<int> StartTimeList
+        public IList<int> StartTimeList
         {
             get
             {
-                if (null == _startTimeList)
+                if (null == startTimeList)
                 {
-                    _startTimeList = new List<int>();
+                    startTimeList = new List<int>();
                 }
 
-                return _startTimeList;
+                return startTimeList;
             }
         }
 
         /// <summary>
         /// Get the list of end time for each property of the animation.
         /// </summary>
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public List<int> EndTimeList
+        public IList<int> EndTimeList
         {
             get
             {
-                if (null == _endTimeList)
+                if (null == endTimeList)
                 {
-                    _endTimeList = new List<int>();
+                    endTimeList = new List<int>();
                 }
 
-                return _endTimeList;
+                return endTimeList;
             }
         }
 
@@ -760,27 +756,27 @@ namespace Tizen.NUI
 
             Clear();
 
-            if (null != _propertyList && null != _destValueList && null != _startTimeList && null != _endTimeList)
+            if (null != propertyList && null != destValueList && null != startTimeList && null != endTimeList)
             {
-                if (_propertyList.Count == _destValueList.Count
+                if (propertyList.Count == destValueList.Count
                     &&
-                    _startTimeList.Count == _endTimeList.Count
+                    startTimeList.Count == endTimeList.Count
                     &&
-                    _propertyList.Count == _startTimeList.Count)
+                    propertyList.Count == startTimeList.Count)
                 {
-                    int count = _propertyList.Count;
+                    int count = propertyList.Count;
                     for (int index = 0; index < count; index++)
                     {
                         var elementType = target.GetType();
-                        PropertyInfo propertyInfo = elementType.GetProperties().FirstOrDefault(fi => fi.Name == _propertyList[index]);
+                        PropertyInfo propertyInfo = elementType.GetProperties().FirstOrDefault(fi => fi.Name == propertyList[index]);
 
                         if (propertyInfo != null)
                         {
-                            object destinationValue = ConvertTo(_destValueList[index], propertyInfo.PropertyType);
+                            object destinationValue = ConvertTo(destValueList[index], propertyInfo.PropertyType);
 
                             if (destinationValue != null)
                             {
-                                AnimateTo(target, _propertyList[index], destinationValue, _startTimeList[index], _endTimeList[index]);
+                                AnimateTo(target, propertyList[index], destinationValue, startTimeList[index], endTimeList[index]);
                             }
                         }
                     }

--- a/src/Tizen.NUI/src/public/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation.cs
@@ -31,6 +31,7 @@ namespace Tizen.NUI
     using Tizen.NUI.Binding;
     using System.Globalization;
     using Tizen.NUI.Xaml.Internals;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Animation can be used to animate the properties of any number of objects, typically view.<br />
@@ -54,6 +55,11 @@ namespace Tizen.NUI
         private string[] _destValue = null;
         private int[] _startTime = null;
         private int[] _endTime = null;
+
+        private List<string> _propertiesList = null;
+        private List<string> _destValueList = null;
+        private List<int> _startTimeList = null;
+        private List<int> _endTimeList = null;
 
         /// <summary>
         /// Creates an initialized animation.<br />
@@ -436,6 +442,8 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the properties of the animation.
         /// </summary>
+        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public string[] Properties
         {
             get
@@ -451,6 +459,8 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the destination value for each property of the animation.
         /// </summary>
+        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public string[] DestValue
         {
             get
@@ -466,6 +476,8 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the start time for each property of the animation.
         /// </summary>
+        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public int[] StartTime
         {
             get
@@ -481,6 +493,8 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the end time for each property of the animation.
         /// </summary>
+        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public int[] EndTime
         {
             get
@@ -490,6 +504,78 @@ namespace Tizen.NUI
             set
             {
                 _endTime = value;
+            }
+        }
+
+        /// <summary>
+        /// Get the list of the properties of the animation.
+        /// </summary>
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<string> PropertiesList
+        {
+            get
+            {
+                if (null == _propertiesList)
+                {
+                    _propertiesList = new List<string>();
+                }
+
+                return _propertiesList;
+            }
+        }
+
+        /// <summary>
+        /// Get the list of the destination value for each property of the animation.
+        /// </summary>
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<string> DestValueList
+        {
+            get
+            {
+                if (null == _destValueList)
+                {
+                    _destValueList = new List<string>();
+                }
+
+                return _destValueList;
+            }
+        }
+
+        /// <summary>
+        /// Get the list of the start time for each property of the animation.
+        /// </summary>
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<int> StartTimeList
+        {
+            get
+            {
+                if (null == _startTimeList)
+                {
+                    _startTimeList = new List<int>();
+                }
+
+                return _startTimeList;
+            }
+        }
+
+        /// <summary>
+        /// Get the list of end time for each property of the animation.
+        /// </summary>
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<int> EndTimeList
+        {
+            get
+            {
+                if (null == _endTimeList)
+                {
+                    _endTimeList = new List<int>();
+                }
+
+                return _endTimeList;
             }
         }
 
@@ -673,26 +759,57 @@ namespace Tizen.NUI
             }
 
             Clear();
-            if (_properties.Length == _destValue.Length && _startTime.Length == _endTime.Length && _properties.Length == _startTime.Length)
-            {
-                int length = _properties.Length;
-                for (int index = 0; index < length; index++)
-                {
-                    //object destinationValue = _destValue[index];
-                    var elementType = target.GetType();
-                    PropertyInfo propertyInfo = elementType.GetProperties().FirstOrDefault(fi => fi.Name == _properties[index]);
-                    //var propertyInfo = elementType.GetRuntimeProperties().FirstOrDefault(p => p.Name == localName);
-                    if (propertyInfo != null)
-                    {
-                        object destinationValue = ConvertTo(_destValue[index], propertyInfo.PropertyType);
 
-                        if (destinationValue != null)
+            if (null != _propertiesList && null != _destValueList && null != _startTimeList && null != _endTimeList)
+            {
+                if (_propertiesList.Count == _destValueList.Count
+                    &&
+                    _startTimeList.Count == _endTimeList.Count
+                    &&
+                    _propertiesList.Count == _startTimeList.Count)
+                {
+                    int count = _propertiesList.Count;
+                    for (int index = 0; index < count; index++)
+                    {
+                        var elementType = target.GetType();
+                        PropertyInfo propertyInfo = elementType.GetProperties().FirstOrDefault(fi => fi.Name == _propertiesList[index]);
+
+                        if (propertyInfo != null)
                         {
-                            AnimateTo(target, _properties[index], destinationValue, _startTime[index], _endTime[index]);
+                            object destinationValue = ConvertTo(_destValueList[index], propertyInfo.PropertyType);
+
+                            if (destinationValue != null)
+                            {
+                                AnimateTo(target, _propertiesList[index], destinationValue, _startTimeList[index], _endTimeList[index]);
+                            }
                         }
                     }
+                    Play();
                 }
-                Play();
+            }
+            else
+            {
+                if (_properties.Length == _destValue.Length && _startTime.Length == _endTime.Length && _properties.Length == _startTime.Length)
+                {
+                    int length = _properties.Length;
+                    for (int index = 0; index < length; index++)
+                    {
+                        //object destinationValue = _destValue[index];
+                        var elementType = target.GetType();
+                        PropertyInfo propertyInfo = elementType.GetProperties().FirstOrDefault(fi => fi.Name == _properties[index]);
+                        //var propertyInfo = elementType.GetRuntimeProperties().FirstOrDefault(p => p.Name == localName);
+                        if (propertyInfo != null)
+                        {
+                            object destinationValue = ConvertTo(_destValue[index], propertyInfo.PropertyType);
+
+                            if (destinationValue != null)
+                            {
+                                AnimateTo(target, _properties[index], destinationValue, _startTime[index], _endTime[index]);
+                            }
+                        }
+                    }
+                    Play();
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation.cs
@@ -442,7 +442,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the properties of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [Obsolete("Deprecated in API9, Will be removed in API11, Please use PropertyList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public string[] Properties
         {
@@ -459,7 +459,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the destination value for each property of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [Obsolete("Deprecated in API9, Will be removed in API11, Please use DestValueList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public string[] DestValue
         {
@@ -476,7 +476,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the start time for each property of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [Obsolete("Deprecated in API9, Will be removed in API11, Please use StartTimeList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public int[] StartTime
         {
@@ -493,7 +493,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the end time for each property of the animation.
         /// </summary>
-        [Obsolete("Deprecated in API6, Will be removed in API9, Please use as keyword instead!")]
+        [Obsolete("Deprecated in API9, Will be removed in API11, Please use EndTimeList instead")]
         [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
         public int[] EndTime
         {
@@ -512,7 +512,7 @@ namespace Tizen.NUI
         /// </summary>
         /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public List<string> PropertiesList
+        public List<string> PropertyList
         {
             get
             {

--- a/src/Tizen.NUI/src/public/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation.cs
@@ -443,7 +443,7 @@ namespace Tizen.NUI
         /// Gets or sets the properties of the animation.
         /// </summary>
         //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use PropertyList instead")]
-        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "This API will be deprecated, so suppressing the warning for now")]
         public string[] Properties
         {
             get
@@ -460,7 +460,7 @@ namespace Tizen.NUI
         /// Gets or sets the destination value for each property of the animation.
         /// </summary>
         //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use DestValueList instead")]
-        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "This API will be deprecated, so suppressing the warning for now")]
         public string[] DestValue
         {
             get
@@ -477,7 +477,7 @@ namespace Tizen.NUI
         /// Gets or sets the start time for each property of the animation.
         /// </summary>
         //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use StartTimeList instead")]
-        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "This API will be deprecated, so suppressing the warning for now")]
         public int[] StartTime
         {
             get
@@ -494,7 +494,7 @@ namespace Tizen.NUI
         /// Gets or sets the end time for each property of the animation.
         /// </summary>
         //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, Will be removed in API11, Please use EndTimeList instead")]
-        [SuppressMessage("Microsoft.Naming", "CA1819:This API will be deprecated, so suppressing the warning for now")]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "This API will be deprecated, so suppressing the warning for now")]
         public int[] EndTime
         {
             get

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2475,9 +2475,8 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Used to restore the transition.
         /// </summary>
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public List<Transition> StoryBoard
+        public IList<Transition> TransitionList
         {
             get;
         } = new List<Transition>();

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -46,7 +46,6 @@ namespace Tizen.NUI.BaseComponents
         private MeasureSpecification measureSpecificationHeight; // Layout height and internal Mode
         private bool backgroundImageSynchronosLoading = false;
         private Dictionary<string, Transition> transDictionary = new Dictionary<string, Transition>();
-        private string[] transitionNames;
         private bool controlStatePropagation = false;
         private ViewStyle viewStyle;
         private bool themeChangeSensitive = false;
@@ -2473,12 +2472,14 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// Used to restore the transition.
+        /// </summary>
         /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public StoryBoard StoryBoard
+        public List<Transition> StoryBoard
         {
             get;
-            set;
-        }
+        } = new List<Transition>();
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2307,21 +2307,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public string[] TransitionNames
-        {
-            get
-            {
-                return transitionNames;
-            }
-            set
-            {
-                transitionNames = value;
-                LoadTransitions();
-            }
-        }
-
         /// <summary>
         /// Enable/Disable ControlState propagation for children.
         /// It is false by default.
@@ -2486,6 +2471,14 @@ namespace Tizen.NUI.BaseComponents
                     }
                 }
             }
+        }
+
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public StoryBoard StoryBoard
+        {
+            get;
+            set;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1323,28 +1323,6 @@ namespace Tizen.NUI.BaseComponents
             return view;
         }
 
-        private void LoadTransitions()
-        {
-            foreach (string str in transitionNames)
-            {
-                string resourceName = str + ".xaml";
-                Transition trans = null;
-
-                string resource = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
-
-                string likelyResourcePath = resource + "animation/" + resourceName;
-
-                if (File.Exists(likelyResourcePath))
-                {
-                    trans = Xaml.Extensions.LoadObject<Transition>(likelyResourcePath);
-                }
-                if (trans != null)
-                {
-                    transDictionary.Add(trans.Name, trans);
-                }
-            }
-        }
-
         private void OnScaleChanged(float x, float y, float z)
         {
             Scale = new Vector3(x, y, z);

--- a/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
@@ -11,6 +11,7 @@ using static Tizen.NUI.Animation;
 
 namespace Tizen.NUI
 {
+    /// <since_tizen> 5 </since_tizen>
     /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class AnimationBehavior

--- a/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -10,6 +11,18 @@ using static Tizen.NUI.Animation;
 
 namespace Tizen.NUI
 {
+    /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class StoryBoard
+    {
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Add(object obj)
+        {
+            int temp = 0;
+        }
+    }
+
     /// <since_tizen> 5 </since_tizen>
     /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -101,6 +114,46 @@ namespace Tizen.NUI
     }
 
     /// <since_tizen> 5 </since_tizen>
+    /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BehaviorContainer : IEnumerable
+    {
+        private Dictionary<string, AnimationBehavior> behaviors = new Dictionary<string, AnimationBehavior>();
+
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Add(object obj)
+        {
+            var behavior = obj as AnimationBehavior;
+
+            if (null != behavior)
+            {
+                behaviors.Add(behavior.Key, behavior);
+            }
+        }
+
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AnimationBehavior GetAnimationBehavior(string key)
+        {
+            AnimationBehavior behavior = null;
+            behaviors.TryGetValue(key, out behavior);
+
+            return behavior;
+        }
+
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IEnumerator GetEnumerator()
+        {
+            return ((IEnumerable)behaviors).GetEnumerator();
+        }
+    }
+
+    /// <since_tizen> 5 </since_tizen>
     /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Transition : Animation
@@ -146,8 +199,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AnimateTo(View instance, string behaviorKey)
         {
-            AnimationBehavior behavior = null;
-            behaviors.TryGetValue(behaviorKey, out behavior);
+            AnimationBehavior behavior = Behaviors?.GetAnimationBehavior(behaviorKey);
 
             if (null != instance && null != behavior)
             {
@@ -182,8 +234,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AnimateBy(View instance, string behaviorKey)
         {
-            AnimationBehavior behavior = null;
-            behaviors.TryGetValue(behaviorKey, out behavior);
+            AnimationBehavior behavior = Behaviors?.GetAnimationBehavior(behaviorKey);
 
             if (null != instance && null != behavior)
             {
@@ -212,5 +263,13 @@ namespace Tizen.NUI
                 throw new XamlParseException(string.Format("Behaviors don't have key {0}", behaviorKey), new XmlLineInfo());
             }
         }
+
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public BehaviorContainer Behaviors
+        {
+            get;
+        } = new BehaviorContainer();
     }
 }

--- a/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
@@ -12,13 +12,11 @@ using static Tizen.NUI.Animation;
 namespace Tizen.NUI
 {
     /// <since_tizen> 5 </since_tizen>
-    /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class AnimationBehavior
     {
         private string _key = null;
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string Key
         {
@@ -35,7 +33,6 @@ namespace Tizen.NUI
         private string _property = null;
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string Property
         {
@@ -52,7 +49,6 @@ namespace Tizen.NUI
         private string _destValue = null;
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string DestValue
         {
@@ -69,7 +65,6 @@ namespace Tizen.NUI
         private int _startTime = -1;
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int StartTime
         {
@@ -86,7 +81,6 @@ namespace Tizen.NUI
         private int _endTime = -1;
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int EndTime
         {
@@ -105,7 +99,6 @@ namespace Tizen.NUI
     /// <summary>
     /// It is the container to contain the behaviors of Transition.
     /// </summary>
-    /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class BehaviorContainer : List<AnimationBehavior>
     {
@@ -114,7 +107,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The method for user to add behavior.
         /// </summary>
-        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Add(object obj)
         {
@@ -129,7 +121,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The method for user to get the behavior by the key.
         /// </summary>
-        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AnimationBehavior GetAnimationBehavior(string key)
         {
@@ -141,14 +132,12 @@ namespace Tizen.NUI
     }
 
     /// <since_tizen> 5 </since_tizen>
-    /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Transition : Animation
     {
         private string name;
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string Name
         {
@@ -163,7 +152,6 @@ namespace Tizen.NUI
         }
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AnimateTo(View instance, string behaviorKey)
         {
@@ -198,7 +186,6 @@ namespace Tizen.NUI
         }
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AnimateBy(View instance, string behaviorKey)
         {
@@ -233,7 +220,6 @@ namespace Tizen.NUI
         }
 
         /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public BehaviorContainer Behaviors
         {

--- a/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Transition.cs
@@ -13,19 +13,6 @@ namespace Tizen.NUI
 {
     /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class StoryBoard
-    {
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Add(object obj)
-        {
-            int temp = 0;
-        }
-    }
-
-    /// <since_tizen> 5 </since_tizen>
-    /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-    [EditorBrowsable(EditorBrowsableState.Never)]
     public class AnimationBehavior
     {
         private string _key = null;
@@ -113,14 +100,19 @@ namespace Tizen.NUI
         }
     }
 
-    /// <since_tizen> 5 </since_tizen>
+
+    /// <summary>
+    /// It is the container to contain the behaviors of Transition.
+    /// </summary>
     /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class BehaviorContainer : IEnumerable
+    public class BehaviorContainer : List<AnimationBehavior>
     {
         private Dictionary<string, AnimationBehavior> behaviors = new Dictionary<string, AnimationBehavior>();
 
-        /// <since_tizen> 5 </since_tizen>
+        /// <summary>
+        /// The method for user to add behavior.
+        /// </summary>
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Add(object obj)
@@ -133,7 +125,9 @@ namespace Tizen.NUI
             }
         }
 
-        /// <since_tizen> 5 </since_tizen>
+        /// <summary>
+        /// The method for user to get the behavior by the key.
+        /// </summary>
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AnimationBehavior GetAnimationBehavior(string key)
@@ -142,14 +136,6 @@ namespace Tizen.NUI
             behaviors.TryGetValue(key, out behavior);
 
             return behavior;
-        }
-
-        /// <since_tizen> 5 </since_tizen>
-        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public IEnumerator GetEnumerator()
-        {
-            return ((IEnumerable)behaviors).GetEnumerator();
         }
     }
 
@@ -172,25 +158,6 @@ namespace Tizen.NUI
             set
             {
                 name = value;
-            }
-        }
-
-        private Dictionary<string, AnimationBehavior> behaviors = new Dictionary<string, AnimationBehavior>();
-
-        /// <summary>
-        /// Hidden-API (Inhouse-API).
-        /// Convert previous "public AnimationBehavior[] Behaviors" property to method.
-        /// </summary>
-        /// <param name="Behaviors">Array of AnimationBehavior type</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetBehaviors(AnimationBehavior[] Behaviors)
-        {
-            if (null != Behaviors)
-            {
-                foreach (AnimationBehavior behavior in Behaviors)
-                {
-                    behaviors.Add(behavior.Key, behavior);
-                }
             }
         }
 


### PR DESCRIPTION
### Description of Change ###

Fix CA1819.
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1819

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: https://code.sec.samsung.net/jira/browse/TCSACR-395

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
