### PR TITLE
[NUI] Null check of Owner property of LayoutItem for Independent View.

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -242,7 +242,7 @@ namespace Tizen.NUI
         /// <since_tizen> 6 </since_tizen>
         public void Layout(LayoutLength left, LayoutLength top, LayoutLength right, LayoutLength bottom)
         {
-            Layout(left, top, right, bottom, Owner.ExcludeLayouting);
+            Layout(left, top, right, bottom, Owner?.ExcludeLayouting ?? false);
         }
 
         /// <summary>


### PR DESCRIPTION
 - Current implementation, we didn't check whether the Owner Property is null or not in the Layout method.
 - This patch add null check of it to avoid null exception

Signed-off-by: Seungho Baek <sbsh.baek@samsung.com>
