### PR TITLE
[NUI] Deprecate visible instance fields [CA1051]

### DIFF
--- a/src/Tizen.NUI/src/internal/Disposable.cs
+++ b/src/Tizen.NUI/src/internal/Disposable.cs
@@ -177,9 +177,12 @@ namespace Tizen.NUI
             }
         }
 
-        internal bool SwigCMemOwn
-        {
-            get => swigCMemOwn;
-        }
+        internal bool SwigCMemOwn => swigCMemOwn;
+
+        /// <summary>
+        /// A Flag to check if it is already disposed.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal bool Disposed => disposed;
     }
 }

--- a/src/Tizen.NUI/src/public/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/BaseHandle.cs
@@ -559,6 +559,18 @@ namespace Tizen.NUI
                 swigCPtr = value;
             }
         }
+
+        /// <summary>
+        /// swigCMemOwn
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal bool SwigCMemOwn => swigCMemOwn;
+
+        /// <summary>
+        /// A flag to check if it is already disposed.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal bool Disposed => disposed;
     }
 
 }

--- a/src/Tizen.NUI/src/public/CustomViewRegistry.cs
+++ b/src/Tizen.NUI/src/public/CustomViewRegistry.cs
@@ -4,6 +4,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 using Tizen.NUI.BaseComponents;
+using System.ComponentModel;
 
 namespace Tizen.NUI
 {
@@ -98,6 +99,12 @@ namespace Tizen.NUI
             Default,    // Read Writable, non-animatable property, event thread only
                         //  Animatable // Animatable property, Currently disabled, UK
         }
+
+        /// <summary>
+        /// ScriptableType. Read Writable, non-animatable property, event thread only.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ScriptableType Type => type;
     }
 
     /// <summary>

--- a/src/Tizen.NUI/src/public/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/InputMethodContext.cs
@@ -944,7 +944,7 @@ namespace Tizen.NUI
             /// The state if it owns memory
             /// </summary>
             /// <since_tizen> 5 </since_tizen>
-            //ToDo : raise ACR as [Obsolete("This has been deprecated in API9 and will be removed in API11. Please use swigCMemOwn which is declared in parent class")]
+            [Obsolete("Deprecated in API9, Will be removed in API11, Please use SwigCMemOwn which is declared in parent class")]
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "<Pending>")]
             protected bool swigCMemOwn;
             private global::System.Runtime.InteropServices.HandleRef swigCPtr;

--- a/src/Tizen.NUI/src/public/KeyValue.cs
+++ b/src/Tizen.NUI/src/public/KeyValue.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Tizen.NUI.Binding;
 
 namespace Tizen.NUI
@@ -30,16 +31,25 @@ namespace Tizen.NUI
         /// <summary>
         /// Int key.
         /// </summary>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use IntegerKey instead.")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public int? KeyInt = null;
 
         /// <summary>
         /// String key.
         /// </summary>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use StringKey instead.")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public string KeyString = null;
 
         /// <summary>
         /// True value.
         /// </summary>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use PropertyValue instead.")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public PropertyValue TrueValue = null;
 
         private string _key = null;
@@ -118,6 +128,55 @@ namespace Tizen.NUI
             {
                 _originalValue = value;
                 TrueValue = PropertyValue.CreateFromObject(value);
+            }
+        }
+
+        /// <summary>
+        /// Int key.
+        /// </summary>
+        /// When deleting the field, change it to prperty.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int? IntegerKey
+        {
+            get
+            {
+                return KeyInt;
+            }
+            set
+            {
+                KeyInt = value;
+            }
+        }
+
+        /// <summary>
+        /// String key.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string StringKey
+        {
+            get
+            {
+                return KeyString;
+            }
+            set
+            {
+                KeyString = value;
+            }
+        }
+
+        /// <summary>
+        /// Property value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PropertyValue PropertyValue
+        {
+            get
+            {
+                return TrueValue;
+            }
+            set
+            {
+                TrueValue = value;
             }
         }
 

--- a/src/Tizen.NUI/src/public/Layouting/LayoutTransition.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutTransition.cs
@@ -18,6 +18,7 @@
 using System.Collections.Generic;
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Tizen.NUI
 {
@@ -135,18 +136,82 @@ namespace Tizen.NUI
         /// Get, Set the time transition should execute for . Milliseconds.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use GetDuration, SetDuration instead!")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public int Duration;
+
         /// <summary>
         /// Get, Set the delay before the transition executes. Milliseconds.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use GetDelay, SetDelay instead!")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public int Delay;
+
         /// <summary>
         /// Get, Set the function to alter the transition path over time.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use GetAlphaFunction, SetAlphaFunction instead!")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public AlphaFunction AlphaFunction;
 
+        /// <summary>
+        /// Set the time transition should execute for . Milliseconds.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetDuration(int duration)
+        {
+            Duration = duration;
+        }
+
+        /// <summary>
+        /// Get the time transition should execute for . Milliseconds.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int GetDuration()
+        {
+            return Duration;
+        }
+
+        /// <summary>
+        /// Set the delay before the transition executes. Milliseconds.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetDelay(int delay)
+        {
+            Delay = delay;
+        }
+
+        /// <summary>
+        /// Get the delay before the transition executes. Milliseconds.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int GetDelay()
+        {
+            return Delay;
+        }
+
+        /// <summary>
+        /// Set the function to alter the transition path over time.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetAlphaFunction(AlphaFunction alphaFunction)
+        {
+            AlphaFunction = alphaFunction;
+        }
+
+        /// <summary>
+        /// Get the function to alter the transition path over time.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AlphaFunction GetAlphaFunction()
+        {
+            return AlphaFunction;
+        }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void Dispose(bool disposing)

--- a/src/Tizen.NUI/src/public/Layouting/MeasureSpecification.cs
+++ b/src/Tizen.NUI/src/public/Layouting/MeasureSpecification.cs
@@ -15,7 +15,9 @@
  *
  */
 
+using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
@@ -30,12 +32,18 @@ namespace Tizen.NUI
         /// MeasureSpecification Size value.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use GetSize,SetSize instead!")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public LayoutLength Size;
 
         /// <summary>
         /// MeasureSpecification Mode.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
+        /// When deleting the field, change it to prperty.
+        [Obsolete("Deprecated in API9, Will be removed in API11. Please use GetMode,SetMode instead!")]
+        [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public MeasureSpecification.ModeType Mode;
 
         /// <summary>
@@ -70,6 +78,42 @@ namespace Tizen.NUI
             /// The child must guarantee that it and all of it's descendants will fit within this size.
             /// </summary>
             AtMost
+        }
+
+        /// <summary>
+        /// Set MeasureSpecification Size value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSize(LayoutLength size)
+        {
+            Size = size;
+        }
+
+        /// <summary>
+        /// Get MeasureSpecification Size value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public LayoutLength GetSize()
+        {
+            return Size;
+        }
+
+        /// <summary>
+        /// Set MeasureSpecification Mode.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetMode(MeasureSpecification.ModeType mode)
+        {
+            Mode = mode;
+        }
+
+        /// <summary>
+        /// Get MeasureSpecification Mode.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public MeasureSpecification.ModeType GetMode()
+        {
+            return Mode;
         }
     }
 }


### PR DESCRIPTION
CA1051: Do not declare visible instance fields
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1051

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: https://code.sec.samsung.net/jira/browse/TCSACR-396

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
