### PR TITLE
[NUI] Initialize feedback only when the Feedback property is true

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -16,7 +16,7 @@
  */
 
 using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.ComponentModel;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
@@ -44,9 +44,9 @@ namespace Tizen.NUI.Components
 
         private bool onThemeChangedEventOverrideChecker;
 
-        private Feedback feedback = new Feedback();
+        private Feedback feedback = null;
 
-        private TapGestureDetector tapGestureDetector = new TapGestureDetector();
+        private TapGestureDetector tapGestureDetector = null;
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -101,7 +101,38 @@ namespace Tizen.NUI.Components
         /// Enable/Disable a sound feedback when tap gesture detected.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Feedback { get; set; } = false;
+        public bool Feedback
+        {
+            get => feedback != null;
+            set
+            {
+                if (value == (feedback != null))
+                {
+                    return;
+                }
+
+                if (value)
+                {
+                    Debug.Assert(feedback == null && tapGestureDetector == null);
+
+                    tapGestureDetector = new TapGestureDetector();
+                    tapGestureDetector.Attach(this);
+                    tapGestureDetector.Detected += OnTapGestureDetected;
+                    feedback = new Feedback();
+                }
+                else
+                {
+                    Debug.Assert(feedback != null && tapGestureDetector != null);
+
+                    feedback.Stop();
+                    feedback = null;
+
+                    tapGestureDetector.Detected -= OnTapGestureDetected;
+                    tapGestureDetector.Detach(this);
+                    tapGestureDetector = null;
+                }
+            }
+        }
 
         /// Internal used.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -159,14 +190,7 @@ namespace Tizen.NUI.Components
 
             if (type == DisposeTypes.Explicit)
             {
-                tapGestureDetector.Detected -= OnTapGestureDetected;
-                tapGestureDetector.Detach(this);
-
-                if (feedback != null)
-                {
-                    feedback.Stop();
-                    feedback = null;
-                }
+                Feedback = false; // Release feedback resources.
             }
 
             base.Dispose(type);
@@ -294,9 +318,6 @@ namespace Tizen.NUI.Components
             LeaveRequired = true;
 
             StateFocusableOnTouchMode = false;
-
-            tapGestureDetector.Attach(this);
-            tapGestureDetector.Detected += OnTapGestureDetected;
 
             EnableControlState = true;
         }


### PR DESCRIPTION

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
