### PR TITLE
[NUI] Remove RegisterCallback function

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -216,10 +216,6 @@ namespace Tizen.NUI
             {
                 SWIGRegisterStringCallbackNDalic(stringDelegate);
             }
-            public static void RegistCallback()
-            {
-                SWIGRegisterStringCallbackNDalic(stringDelegate);
-            }
         }
         static protected SWIGStringHelper swigStringHelper = new SWIGStringHelper();
         static NDalicPINVOKE()

--- a/src/Tizen.NUI/src/internal/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/NUICoreBackend.cs
@@ -143,7 +143,6 @@ namespace Tizen.NUI
         public void Run(string[] args)
         {
             TizenSynchronizationContext.Initialize();
-            NDalicPINVOKE.SWIGStringHelper.RegistCallback();
 
             args[0] = Tizen.Applications.Application.Current.ApplicationInfo.ExecutablePath;
             if (string.IsNullOrEmpty(args[0]))


### PR DESCRIPTION
stringDelegate registration is aledy called from the constructor.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
