### PR TITLE
[NUI] Add ImageList property

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Loading.cs
+++ b/src/Tizen.NUI.Components/Controls/Loading.cs
@@ -29,23 +29,39 @@ namespace Tizen.NUI.Components
     /// <since_tizen> 6 </since_tizen>
     public class Loading : Control
     {
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        /// <summary>The ImageArray bindable property.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ImageArrayProperty = BindableProperty.Create(nameof(ImageArray), typeof(string[]), typeof(Loading), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Loading)bindable;
             if (newValue != null)
             {
-                instance.loadingStyle.Images = (string[])newValue;
+                instance.loadingStyle.ImageList = new List<string>((string[])newValue);
                 instance.imageVisual.URLS = new List<string>((string[])newValue);
             }
         },
         defaultValueCreator: (bindable) =>
         {
             var instance = (Loading)bindable;
-            return instance.loadingStyle.Images;
+            return instance.loadingStyle.ImageList.ToArray();
         });
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        /// <summary>The ImageList bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ImageListProperty = BindableProperty.Create(nameof(ImageList), typeof(List<string>), typeof(Loading), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Loading)bindable;
+            if (newValue != null)
+            {
+                instance.loadingStyle.ImageList = (List<string>)newValue;
+                instance.imageVisual.URLS = (List<string>)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (Loading)bindable;
+            return instance.loadingStyle.ImageList;
+        });
+        /// <summary>The Size bindable property.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(Loading), new Size(0, 0), propertyChanged: (bindable, oldValue, newValue) =>
          {
@@ -62,7 +78,7 @@ namespace Tizen.NUI.Components
             var instance = (View)bindable;
             return instance.Size;
         });
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        /// <summary>The FrameRate bindable property.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FrameRateProperty = BindableProperty.Create(nameof(FrameRate), typeof(int), typeof(Loading), (int)(1000 / 16.6f), propertyChanged: (bindable, oldValue, newValue) =>
           {
@@ -156,6 +172,22 @@ namespace Tizen.NUI.Components
             set
             {
                 SetValue(ImageArrayProperty, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets loading image resource array.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<string> ImageList
+        {
+            get
+            {
+                return (List<string>)GetValue(ImageListProperty);
+            }
+            internal set
+            {
+                SetValue(ImageListProperty, value);
             }
         }
 

--- a/src/Tizen.NUI.Components/Style/LoadingStyle.cs
+++ b/src/Tizen.NUI.Components/Style/LoadingStyle.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+using System.Collections.Generic;
 using System.ComponentModel;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
@@ -52,15 +53,34 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ImagesProperty = BindableProperty.Create(nameof(Images), typeof(string[]), typeof(LoadingStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
-            ((LoadingStyle)bindable).images = (string[])((string[])newValue)?.Clone();
+            ((LoadingStyle)bindable).images = new List<string>((string[])newValue);
         },
         defaultValueCreator: (bindable) =>
         {
+            if(((LoadingStyle)bindable).images == null)
+            {
+                ((LoadingStyle)bindable).images = new List<string>();
+            }
+            return ((LoadingStyle)bindable).images.ToArray();
+        });
+
+        /// <summary>The Images bindable property.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ImageListProperty = BindableProperty.Create(nameof(ImageList), typeof(List<string>), typeof(LoadingStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((LoadingStyle)bindable).images = (List<string>)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            if (((LoadingStyle)bindable).images == null)
+            {
+                ((LoadingStyle)bindable).images = new List<string>();
+            }
             return ((LoadingStyle)bindable).images;
         });
 
         private Selector<int?> frameRate;
-        private string[] images;
+        private List<string> images;
 
         static LoadingStyle() { }
 
@@ -87,6 +107,16 @@ namespace Tizen.NUI.Components
         {
             get => (string[])GetValue(ImagesProperty);
             set => SetValue(ImagesProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets loading image resources.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<string> ImageList
+        {
+            get => (List<string>)GetValue(ImageListProperty);
+            internal set => SetValue(ImageListProperty, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Remove Images build warning.
CA1819: Properties should not return arrays
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1819

I will deprecate ACR to master branch.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
