### PR TITLE
[NUI] Fix ScrollBar Unparent bug

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1353,6 +1353,11 @@ namespace Tizen.NUI.Components
             }
         }
 
+        internal void BaseRemove(View view)
+        {
+            base.Remove(view);
+        }
+
         internal override bool OnAccessibilityPan(PanGesture gestures)
         {
             if (SnapToPage && scrollAnimation != null && scrollAnimation.State == Animation.States.Playing)

--- a/src/Tizen.NUI.Components/Controls/ScrollbarBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollbarBase.cs
@@ -59,6 +59,14 @@ namespace Tizen.NUI.Components
         #region Methods
 
         /// <summary>
+        /// Removes a view from its parent ScrollableBase. If a view has no parent, this method does nothing.
+        /// </summary>
+        public new void Unparent()
+        {
+            (GetParent() as ScrollableBase)?.BaseRemove(this);
+        }
+
+        /// <summary>
         /// Update content length and position at once.
         /// </summary>
         /// <param name="contentLength">The total length of the content.</param>


### PR DESCRIPTION
ScrollBar.Unparent() is not working.

ScrollBar.Unparent() -> ScrollableBase.Remove(view)
Remove() of ScrollableBase is overridden to be removed based on ContentContainer.

ScrollBar Add
https://github.com/Samsung/TizenFX/blob/5b0849a02bda32613c9476a2b360464ed4e8e2fd/src/Tizen.NUI.Components/Controls/ScrollableBase.cs#L382

ScrollBar Remove
https://github.com/Samsung/TizenFX/blob/5b0849a02bda32613c9476a2b360464ed4e8e2fd/src/Tizen.NUI.Components/Controls/ScrollableBase.cs#L720

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
