### PR TITLE
[NUI] Fix the crash issue when IndicatorSize is null(Pagination).

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -103,6 +103,7 @@ namespace Tizen.NUI.Components
                 }
                 paginationStyle.IndicatorSize = value;
                 UpdateVisual();
+                UpdateContainer();
             }
         }
 
@@ -470,6 +471,10 @@ namespace Tizen.NUI.Components
             if (paginationStyle == null)
             {
                 return;
+            }
+            if (paginationStyle.IndicatorSize == null)
+            {
+                paginationStyle.IndicatorSize = new Size(0, 0);
             }
             ImageVisual indicator = new ImageVisual
             {


### PR DESCRIPTION
### Description of Change ###
If IndicationSize is null,  CreateIndicator() will crash.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
