### PR TITLE
[NUI] Add internal and hidden APIs which are currently used

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
@@ -76,6 +76,63 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageView_IMAGE_VISUAL_ACTION_STOP_get")]
             public static extern int ImageVisualActionStopGet();
+
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.New(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0")]
+            public static extern global::System.IntPtr ImageView_New__SWIG_0();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.New(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_2")]
+            public static extern global::System.IntPtr ImageView_New__SWIG_2(string jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.New(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_3")]
+            public static extern global::System.IntPtr ImageView_New__SWIG_3(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.Upcast(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SWIGUpcast")]
+            public static extern global::System.IntPtr ImageView_SWIGUpcast(global::System.IntPtr jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.SetImage(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_1")]
+            public static extern void ImageView_SetImage__SWIG_1(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.SetImage(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_SetImage__SWIG_2")]
+            public static extern void ImageView_SetImage__SWIG_2(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.DeleteImageView(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageView")]
+            public static extern void delete_ImageView(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.ImageGet(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_IMAGE_get")]
+            public static extern int ImageView_Property_IMAGE_get();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.PreMultipliedAlphaGet(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PRE_MULTIPLIED_ALPHA_get")]
+            public static extern int ImageView_Property_PRE_MULTIPLIED_ALPHA_get();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.PixelAreaGet(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PIXEL_AREA_get")]
+            public static extern int ImageView_Property_PIXEL_AREA_get();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.ImageVisualActionReloadGet(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageView_IMAGE_VISUAL_ACTION_RELOAD_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_RELOAD_get();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.ImageVisualActionPlayGet(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageView_IMAGE_VISUAL_ACTION_PLAY_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_PLAY_get();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.ImageVisualActionPauseGet(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageView_IMAGE_VISUAL_ACTION_PAUSE_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_PAUSE_get();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageView.ImageVisualActionStopGet(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageView_IMAGE_VISUAL_ACTION_STOP_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_STOP_get();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
@@ -58,6 +58,11 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ResourceReadySignal")]
             public static extern global::System.IntPtr ResourceReadySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use View.GetVisualResourceStatus(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetVisualResourceStatus")]
+            public static extern int View_GetVisualResourceStatus(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
@@ -122,6 +122,35 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
+
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetView.PauseWidget(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_PauseWidget")]
+            public static extern bool WidgetView_PauseWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetView.ResumeWidget(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_ResumeWidget")]
+            public static extern bool WidgetView_ResumeWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetView.TerminateWidget(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_TerminateWidget")]
+            public static extern bool WidgetView_TerminateWidget(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetView.DeleteWidgetView(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WidgetView")]
+            public static extern void delete_WidgetView(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetView.Upcast(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_SWIGUpcast")]
+            public static extern global::System.IntPtr WidgetView_SWIGUpcast(global::System.IntPtr jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetView.WidgetAddedSignal(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_WidgetAddedSignal")]
+            public static extern global::System.IntPtr WidgetView_WidgetAddedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetView.WidgetDeletedSignal(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_WidgetDeletedSignal")]
+            public static extern global::System.IntPtr WidgetView_WidgetDeletedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetViewManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetViewManager.cs
@@ -32,6 +32,15 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetViewManager_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
+
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetViewManager.New(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetViewManager_New")]
+            public static extern global::System.IntPtr WidgetViewManager_New(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetViewManager.AddWidget(...) instead!")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetViewManager_AddWidget")]
+            public static extern global::System.IntPtr WidgetViewManager_AddWidget(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, int jarg4, int jarg5, float jarg6);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -15,6 +15,9 @@
  *
  */
 
+using System;
+using System.ComponentModel;
+
 namespace Tizen.NUI
 {
 
@@ -216,6 +219,13 @@ namespace Tizen.NUI
             {
                 SWIGRegisterStringCallbackNDalic(stringDelegate);
             }
+
+            [Obsolete("Please do not use! Deprecated in API9, will be removed in API11! Please delete this if currently used!")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public static void RegistCallback()
+            {
+                //do nothing!
+            }
         }
         static protected SWIGStringHelper swigStringHelper = new SWIGStringHelper();
         static NDalicPINVOKE()
@@ -266,5 +276,10 @@ namespace Tizen.NUI
 
         [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignal")]
         public static extern global::System.IntPtr ApplicationLowMemorySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+
+        [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use NDalicPINVOKE.DeleteBaseHandle(...) instead!")]
+        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle")]
+        public static extern void delete_BaseHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
     }
 }

--- a/src/Tizen.NUI/src/internal/NDalic.cs
+++ b/src/Tizen.NUI/src/internal/NDalic.cs
@@ -15,6 +15,7 @@
  *
  */
 
+using System;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
@@ -640,5 +641,13 @@ namespace Tizen.NUI
         internal static readonly int TooltipTailVisibility = Interop.NDalicToolTip.TooltipTailVisibilityGet();
         internal static readonly int TooltipTailAboveVisual = Interop.NDalicToolTip.TooltipTailAboveVisualGet();
         internal static readonly int TooltipTailBelowVisual = Interop.NDalicToolTip.TooltipTailBelowVisualGet();
+
+
+        [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageVisualUrl instead!")]
+        internal static readonly int IMAGE_VISUAL_URL = Interop.NDalicImageVisual.ImageVisualUrlGet();
+        [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageVisualAlphaMaskUrl instead!")]
+        internal static readonly int IMAGE_VISUAL_ALPHA_MASK_URL = Interop.NDalicImageVisual.ImageVisualAlphaMaskUrlGet();
+        [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ImageVisualAuxiliaryImageUrl instead!")]
+        internal static readonly int IMAGE_VISUAL_AUXILIARY_IMAGE_URL = Interop.NDalicImageVisual.ImageVisualAuxiliaryImageUrlGet();
     }
 }

--- a/src/Tizen.NUI/src/public/Renderer.cs
+++ b/src/Tizen.NUI/src/public/Renderer.cs
@@ -612,6 +612,18 @@ namespace Tizen.NUI
             /// This will be changed internal API after ACR done. Before ACR, need to be hidden as inhouse API.
             [EditorBrowsable(EditorBrowsableState.Never)]
             public static readonly int ForegroundEffect = Interop.Renderer.RangesForegroundEffectGet();
+
+
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ForegroundEffect instead!")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "<Pending>")]
+            public static readonly int FOREGROUND_EFFECT = Interop.Renderer.RangesForegroundEffectGet();
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use BackgroundEffect instead!")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "<Pending>")]
+            public static readonly int BACKGROUND_EFFECT = Interop.Renderer.RangesBackgroundEffectGet();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/WidgetView.cs
@@ -814,6 +814,16 @@ namespace Tizen.NUI
             internal static readonly int PermanentDelete = Interop.WidgetView.PermanentDeleteGet();
             internal static readonly int RetryText = Interop.WidgetView.RetryTextGet();
             internal static readonly int EFFECT = Interop.WidgetView.EffectGet();
+
+
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use WidgetId instead!")]
+            internal static readonly int WIDGET_ID = Interop.WidgetView.WidgetIdGet();
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use ContentInfo instead!")]
+            internal static readonly int CONTENT_INFO = Interop.WidgetView.ContentInfoGet();
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use UpdatePeriod instead!")]
+            internal static readonly int UPDATE_PERIOD = Interop.WidgetView.UpdatePeriodGet();
+            [Obsolete("Please do not use this! Deprecated in API9, will be removed in API11! Please use LoadingText instead!")]
+            internal static readonly int LOADING_TEXT = Interop.WidgetView.LoadingTextGet();
         }
     }
 


### PR DESCRIPTION
### Description of Change ###
[NUI] Add internal and hidden APIs which are currently used
- Add internal and hidden APIs which are currently used. otherwise removing them causes build errors.
- Let users to use proper APIs by deleting these deprecated APIs
- User can be informed that these are deprecated and should not be used by warning messeges during build time.

### API Changes ###
none