### PR TITLE
[NUI] Override Dispose() in Navigator

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -37,7 +37,10 @@ namespace Tizen.NUI.Components
         //This will be replaced with view transition class instance.
         private Animation _newAnimation = null;
 
+        //TODO: Needs to consider how to remove disposed window from dictionary.
+        //Two dictionaries are required to remove disposed navigator from dictionary.
         private static Dictionary<Window, Navigator> windowNavigator = new Dictionary<Window, Navigator>();
+        private static Dictionary<Navigator, Window> navigatorWindow = new Dictionary<Navigator, Window>();
 
         /// <summary>
         /// Creates a new instance of a Navigator.
@@ -310,6 +313,38 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Disposes Navigator and all children on it.
+        /// </summary>
+        /// <param name="type">Dispose type.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                foreach (Page page in NavigationPages)
+                {
+                    Utility.Dispose(page);
+                }
+                NavigationPages.Clear();
+
+                Window window;
+
+                if (navigatorWindow.TryGetValue(this, out window) == true)
+                {
+                    navigatorWindow.Remove(this);
+                    windowNavigator.Remove(window);
+                }
+            }
+
+            base.Dispose(type);
+        }
+
+        /// <summary>
         /// Returns the default navigator of the given window.
         /// </summary>
         /// <returns>The default navigator of the given window.</returns>
@@ -332,6 +367,7 @@ namespace Tizen.NUI.Components
             defaultNavigator.HeightResizePolicy = ResizePolicyType.FillToParent;
             window.Add(defaultNavigator);
             windowNavigator.Add(window, defaultNavigator);
+            navigatorWindow.Add(defaultNavigator, window);
 
             return defaultNavigator;
         }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/NavigatorSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/NavigatorSample.cs
@@ -81,20 +81,12 @@ namespace Tizen.NUI.Samples
             {
                 NUIApplication.GetDefaultWindow().Remove(navigator);
 
-                firstButton.Dispose();
-                firstButton = null;
-
-                secondButton.Dispose();
-                secondButton = null;
-
-                firstPage.Dispose();
-                firstPage = null;
-
-                secondPage.Dispose();
-                secondPage = null;
-
                 navigator.Dispose();
                 navigator = null;
+                firstButton = null;
+                firstPage = null;
+                secondButton = null;
+                secondPage = null;
             }
         }
     }


### PR DESCRIPTION
Pages pushed into Navigator are disposed if Navigator is disposed.

To override Dispose() in Navigator, two dictionaries are required to
remove disposed navigator from dictionary.

TODO: Needs to consider how to remove disposed window from dictionary.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
