### PR TITLE
[NUI] make GridLayout.ColumnSpan/RowSpan work properly in xaml

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -637,6 +637,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetValue(RowSpanProperty, value);
+                SetValue(GridLayout.RowSpanProperty, (int)value);
                 NotifyPropertyChanged();
             }
         }
@@ -654,6 +655,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetValue(ColumnSpanProperty, value);
+                SetValue(GridLayout.ColumnSpanProperty, (int)value);
                 NotifyPropertyChanged();
             }
         }


### PR DESCRIPTION
Since xaml parser find property setter by property name, the parser will find
`View.ColumnSpan` even if you use "GridLayout.ColumnSpan" in xaml.
GridLayout.ColumnSpan/RowSpan didn't work for the above reason.

To fix this, SetValue of `GridLayout.ColumnSpan/RowSpan` is added in
`View.ColumnSpan/RowSpan`.

Here is xaml code for the test.
```xaml
<View x:Class="Demo.XamlPage"
      xmlns="http://tizen.org/Tizen.NUI/2018/XAML"
      xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
      xmlns:c="clr-namespace:Tizen.NUI.Components;assembly=Tizen.NUI.Components"
      >
    <View.Layout>
        <GridLayout Columns="2"/>
    </View.Layout>

    <c:Button x:Name="left" Text="left" GridLayout.ColumnSpan="2" GridLayout.HorizontalStretch="ExpandAndFill" BackgroundColor="1,0.96,0.85,1"/>
    <c:Button x:Name="left2" Text="left22" GridLayout.HorizontalStretch="ExpandAndFill" BackgroundColor="0,0.96,0.85,1"/>
    <c:Button x:Name="left3" Text="left33" GridLayout.HorizontalStretch="ExpandAndFill" BackgroundColor="0,0.96,1,1"/>

</View>
```

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
