### PR TITLE
[NUI] Fix CA1716 build warning

### DIFF
--- a/src/Tizen.NUI/src/internal/DaliEnumConstants.cs
+++ b/src/Tizen.NUI/src/internal/DaliEnumConstants.cs
@@ -76,6 +76,7 @@ namespace Tizen.NUI
             /// The properties used for a Tooltip.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+	    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716: Identifiers should not match keywords")]
             public struct Property
             {
                 /// <summary>

--- a/src/Tizen.NUI/src/public/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/VisualConstants.cs
@@ -451,6 +451,7 @@ namespace Tizen.NUI
         /// This specifies visual properties.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716: Identifiers should not match keywords")]
         public struct Property
         {
             /// <summary>

--- a/src/Tizen.NUI/src/public/XamlBinding/Internals/IDynamicResourceHandler.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Internals/IDynamicResourceHandler.cs
@@ -9,6 +9,6 @@ namespace Tizen.NUI.Binding.Internals
     {
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        void SetDynamicResource(BindableProperty property, string key);
+        void SetDynamicResource(BindableProperty targetProperty, string key);
     }
 }


### PR DESCRIPTION
### Description of Change ###
CA1716: Identifiers should not match keywords
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1716

- Change one hidden API. no ACR
- Since two enums are public APIs, Added suppress messages for CA1716 build warning, not fix them.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
