### PR TITLE
[NUI] Fix null exception in Loading and improve code

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Loading.cs
+++ b/src/Tizen.NUI.Components/Controls/Loading.cs
@@ -54,7 +54,7 @@ namespace Tizen.NUI.Components
             {
                 var newValueList = newValue as List<string>;
                 instance.loadingStyle.ImageList = newValueList;
-                instance.imageVisual.URLS = newValueList;
+                if (instance.imageVisual != null) instance.imageVisual.URLS = newValueList;
             }
         },
         defaultValueCreator: (bindable) =>

--- a/src/Tizen.NUI.Components/Style/LoadingStyle.cs
+++ b/src/Tizen.NUI.Components/Style/LoadingStyle.cs
@@ -53,16 +53,10 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ImagesProperty = BindableProperty.Create(nameof(Images), typeof(string[]), typeof(LoadingStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
-            ((LoadingStyle)bindable).images = new List<string>((string[])newValue);
+            ((LoadingStyle)bindable).images = newValue == null ? null : new List<string>((string[])newValue);
         },
-        defaultValueCreator: (bindable) =>
-        {
-            if (((LoadingStyle)bindable).images == null)
-            {
-                ((LoadingStyle)bindable).images = new List<string>();
-            }
-            return ((LoadingStyle)bindable).images?.ToArray();
-        });
+        defaultValueCreator: (bindable) => ((LoadingStyle)bindable).images?.ToArray()
+        );
 
         /// <summary>The Images bindable property.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -70,14 +64,8 @@ namespace Tizen.NUI.Components
         {
             ((LoadingStyle)bindable).images = newValue as List<string>;
         },
-        defaultValueCreator: (bindable) =>
-        {
-            if(((LoadingStyle)bindable).images == null)
-            {
-                ((LoadingStyle)bindable).images = new List<string>();
-            }
-            return ((LoadingStyle)bindable).images;
-        });
+        defaultValueCreator: (bindable) => ((LoadingStyle)bindable).images
+        );
 
         private Selector<int?> frameRate;
         private List<string> images;
@@ -105,7 +93,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public string[] Images
         {
-            get => (string[])GetValue(ImagesProperty);
+            get => (ImageList as List<string>)?.ToArray();
             set => SetValue(ImagesProperty, value);
         }
 
@@ -115,7 +103,14 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IList<string> ImageList
         {
-            get => GetValue(ImageListProperty) as List<string>;
+            get
+            {
+                if (images == null)
+                {
+                    images = new List<string>();
+                }
+                return GetValue(ImageListProperty) as List<string>;
+            }
             internal set => SetValue(ImageListProperty, value);
         }
 


### PR DESCRIPTION
This fixes null pointer exception in Loading when running following sample,

```C#
var loading1 = new Loading(new LoadingStyle
{
    Size = new Size(100, 100),
    Position = new Position(0, 100),
    Images  = imageArray
});
```

Plus, this patch removes redundant behaviors when applying a style to a Loading component.
All components copies a default style to the component properties when it is created.
When copying a style, all bindable properties defined in the style class that is not null value are copied to the component properties,
so it is important to keep null value for the property that is not set by user.
Hence this patch removes code that allocates empty list object in the getter of ImageList bindable property.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
