### PR TITLE
[Packagemanager] Fix registering internal event callback

### DIFF
--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -1290,13 +1290,6 @@ namespace Tizen.Applications
             {
                 lock (Handle)
                 {
-                    Log.Debug(LogTag, "Reset Package Event");
-                    err = Interop.PackageManager.PackageManagerUnsetEvent(Handle);
-                    if (err != Interop.PackageManager.ErrorCode.None)
-                    {
-                        throw PackageManagerErrorFactory.GetException(err, "Failed to unregister package manager event event.");
-                    }
-
                     err = Interop.PackageManager.PackageManagerSetEvent(Handle, s_packageManagerEventCallback, IntPtr.Zero);
                 }
             }


### PR DESCRIPTION
### Description of Change ###
Do not invoke Interop.PackageManager.PackageManagerSetEvent().
This will unset all internal callback information and this may make user cannot
listen the package event completely.


### API Changes ###
N/A