### PR TITLE
[Bluetooth][Non-ACR] Fix unhandled exception in GetBondedDevices()

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
@@ -63,7 +63,7 @@ namespace Tizen.Network.Bluetooth
         /// <summary>
         /// The name of the device.
         /// </summary>
-        [MarshalAsAttribute(UnmanagedType.LPStr)]
+        [MarshalAsAttribute(UnmanagedType.LPTStr)]
         internal string Name;
 
         /// <summary>


### PR DESCRIPTION
I/DOTNET_LAUNCHER (P 2613, T 2617): Unhandled exception.
I/DOTNET_LAUNCHER (P 2613, T 2617): System.Runtime.InteropServices.COMException (0x8007007A):
The data area passed to a system call is too small.
I/DOTNET_LAUNCHER (P 2613, T 2617):  (0x8007007A)
I/DOTNET_LAUNCHER (P 2613, T 2617):    at System.StubHelpers.ValueClassMarshaler.ConvertToNative(IntPtr dst, IntPtr src,
IntPtr pMT, CleanupWorkListElement& pCleanupWorkList)
I/DOTNET_LAUNCHER (P 2613, T 2617):    at Tizen.Network.Bluetooth.BluetoothAdapterImpl.GetBondedDevices()
I/DOTNET_LAUNCHER (P 2613, T 2617):    at Tizen.Network.Bluetooth.BluetoothAdapter.GetBondedDevices()
I/DOTNET_LAUNCHER (P 2613, T 2617):    at Tizen.Network.Bluetooth.Tests.BluetoothAdapterTests.GetBondedDevices_RETURN_LIST_OF_DEVICES()
in /var/lib/jenkins/jobs/CsharpTCT/TCT_6.0/api/tct-suite-vs/Tizen.Bluetooth.Manual.Tests/testcase/TSBluetoothAdapter.cs:line 435
I/DOTNET_LAUNCHER (P 2613, T 2617): Fatal error.
I/DOTNET_LAUNCHER (P 2613, T 2617): Internal CLR error. (0x80131506)
I/DOTNET_LAUNCHER (P 2613, T 2617): DLOG_ERROR_NOMSG
I/DOTNET_LAUNCHER (P 2613, T 2617):    at Interop+Bluetooth.GetBondedDevices(BondedDeviceCallback, IntPtr)
I/DOTNET_LAUNCHER (P 2613, T 2617):    at Tizen.Network.Bluetooth.BluetoothAdapterImpl.GetBondedDevices()
I/DOTNET_LAUNCHER (P 2613, T 2617):    at Tizen.Network.Bluetooth.BluetoothAdapter.GetBondedDevices()

Change-Id: I04a0a89d75dc973a752950c9274b80d9988a11ed
Signed-off-by: Anupam Roy <anupam.r@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
