### PR TITLE
[NUI] Fix build warning CA1712

### DIFF
--- a/src/Tizen.NUI/src/public/DirectionBias.cs
+++ b/src/Tizen.NUI/src/public/DirectionBias.cs
@@ -21,6 +21,7 @@ namespace Tizen.NUI
     /// The Direction Bias type.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1712: Do not prefix enum values with type name")]
     public enum DirectionBias
     {
         /// <summary>


### PR DESCRIPTION
CA1712: Do not prefix enum values with type name

The name can not be changed becuase this enum is publicly open.
Suppress warning messages.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
