### PR TITLE
[NUI] Remove since_tizen tag for internal APIs

### DIFF
--- a/src/Tizen.NUI.Components/Utils/Selector.cs
+++ b/src/Tizen.NUI.Components/Utils/Selector.cs
@@ -77,13 +77,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// Bool selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class BoolSelector : Selector<bool?>
     {
         /// <summary>
         /// Bool selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new BoolSelector Clone()
@@ -166,13 +164,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// Size2D selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class Size2DSelector : Selector<Size2D>
     {
         /// <summary>
         /// Size2D selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new Size2DSelector Clone()
@@ -183,13 +179,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// Position2D selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class Position2DSelector : Selector<Position2D>
     {
         /// <summary>
         /// Position2D selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new Position2DSelector Clone()
@@ -201,13 +195,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// Position selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class PositionSelector : Selector<Position>
     {
         /// <summary>
         /// Position selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new PositionSelector Clone()
@@ -239,13 +231,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// Vector3 selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class Vector3Selector : Selector<Vector3>
     {
         /// <summary>
         /// Vector3 selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new Vector3Selector Clone()
@@ -277,13 +267,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// Horizontal alignment selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class HorizontalAlignmentSelector : Selector<HorizontalAlignment?>
     {
         /// <summary>
         /// Horizontal alignment selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new HorizontalAlignmentSelector Clone()
@@ -294,13 +282,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// Vertical alignment selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class VerticalAlignmentSelector : Selector<VerticalAlignment?>
     {
         /// <summary>
         /// Vertical alignment selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new VerticalAlignmentSelector Clone()
@@ -312,13 +298,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// AutoScrollStopMode selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class AutoScrollStopModeSelector : Selector<AutoScrollStopMode?>
     {
         /// <summary>
         /// AutoScrollStopMode selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new AutoScrollStopModeSelector Clone()
@@ -330,13 +314,11 @@ namespace Tizen.NUI.Components
     /// <summary>
     /// ResizePolicyType selector.
     /// </summary>
-    /// <since_tizen> 6 </since_tizen>
     internal class ResizePolicyTypeSelector : Selector<ResizePolicyType?>
     {
         /// <summary>
         /// ResizePolicyType selector clone function.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public new ResizePolicyTypeSelector Clone()

--- a/src/Tizen.NUI/src/internal/ActivatedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/ActivatedSignalType.cs
@@ -30,7 +30,6 @@ namespace Tizen.NUI
         /// <summary>
         /// Dispose
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.ActivatedSignalType.DeleteActivatedSignalType(swigCPtr);
@@ -40,7 +39,6 @@ namespace Tizen.NUI
         /// Queries whether there are any connected slots.
         /// </summary>
         /// <returns>True if there are any slots connected to the signal</returns>
-        /// <since_tizen> 3 </since_tizen>
         public bool Empty()
         {
             bool ret = Interop.ActivatedSignalType.Empty(SwigCPtr);
@@ -52,7 +50,6 @@ namespace Tizen.NUI
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
-        /// <since_tizen> 3 </since_tizen>
         public uint GetConnectionCount()
         {
             uint ret = Interop.ActivatedSignalType.GetConnectionCount(SwigCPtr);
@@ -64,7 +61,6 @@ namespace Tizen.NUI
         /// Connects a function.
         /// </summary>
         /// <param name="func">The function to connect</param>
-        /// <since_tizen> 3 </since_tizen>
         public void Connect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
@@ -78,7 +74,6 @@ namespace Tizen.NUI
         /// Disconnects a function.
         /// </summary>
         /// <param name="func">The function to disconnect</param>
-        /// <since_tizen> 3 </since_tizen>
         public void Disconnect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
@@ -92,7 +87,6 @@ namespace Tizen.NUI
         /// Emits the signal.
         /// </summary>
         /// <param name="arg">The first value to pass to callbacks</param>
-        /// <since_tizen> 5 </since_tizen>
         public void Emit(InputMethodContext arg)
         {
             Interop.ActivatedSignalType.Emit(SwigCPtr, InputMethodContext.getCPtr(arg));
@@ -102,7 +96,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The contructor.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
         public ActivatedSignalType() : this(Interop.ActivatedSignalType.NewActivatedSignalType(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Alignment.cs
+++ b/src/Tizen.NUI/src/internal/Alignment.cs
@@ -37,7 +37,6 @@ namespace Tizen.NUI
             Interop.Alignment.DeleteAlignment(swigCPtr);
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public new class Padding : Disposable
         {
 
@@ -50,25 +49,21 @@ namespace Tizen.NUI
                 return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
             }
 
-            /// <since_tizen> 3 </since_tizen>
             protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
             {
                 Interop.Alignment.DeleteAlignmentPadding(swigCPtr);
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public Padding() : this(Interop.Alignment.NewAlignmentPadding(), true)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public Padding(float l, float r, float t, float b) : this(Interop.Alignment.NewAlignmentPadding(l, r, t, b), true)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public float left
             {
                 set
@@ -84,7 +79,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public float right
             {
                 set
@@ -100,7 +94,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public float top
             {
                 set
@@ -116,7 +109,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public float bottom
             {
                 set
@@ -206,7 +198,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public enum Type
         {
             HorizontalLeft = 1,
@@ -217,7 +208,6 @@ namespace Tizen.NUI
             VerticalBottom = 32
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public enum Scaling
         {
             ScaleNone,

--- a/src/Tizen.NUI/src/internal/Any.cs
+++ b/src/Tizen.NUI/src/internal/Any.cs
@@ -72,7 +72,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class AnyContainerBase : Disposable
         {
 
@@ -85,19 +84,16 @@ namespace Tizen.NUI
                 return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
             }
 
-            /// <since_tizen> 3 </since_tizen>
             protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
             {
                 Interop.Any.DeleteAnyAnyContainerBase(swigCPtr);
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public AnyContainerBase(SWIGTYPE_p_std__type_info type, SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase cloneFunc, SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void deleteFunc) : this(Interop.Any.NewAnyAnyContainerBase(SWIGTYPE_p_std__type_info.getCPtr(type), SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase.getCPtr(cloneFunc), SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void.getCPtr(deleteFunc)), true)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public new SWIGTYPE_p_std__type_info GetType()
             {
                 SWIGTYPE_p_std__type_info ret = new SWIGTYPE_p_std__type_info(Interop.Any.AnyContainerBaseGetType(SwigCPtr));
@@ -105,7 +101,6 @@ namespace Tizen.NUI
                 return ret;
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public SWIGTYPE_p_std__type_info mType
             {
                 get
@@ -116,7 +111,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public SWIGTYPE_p_f_r_q_const__Dali__Any__AnyContainerBase__p_Dali__Any__AnyContainerBase mCloneFunc
             {
                 set
@@ -133,7 +127,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public SWIGTYPE_p_f_p_q_const__Dali__Any__AnyContainerBase__void mDeleteFunc
             {
                 set

--- a/src/Tizen.NUI/src/internal/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application.cs
@@ -531,7 +531,6 @@ namespace Tizen.NUI
             Interop.Application.DeleteApplication(swigCPtr);
         }
 
-        /// <since_tizen> 4 </since_tizen>
         public enum BatteryStatus
         {
             Normal,
@@ -539,7 +538,6 @@ namespace Tizen.NUI
             PowerOff
         };
 
-        /// <since_tizen> 4 </since_tizen>
         public enum MemoryStatus
         {
             Normal,
@@ -1414,7 +1412,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public enum WindowMode
         {
             Opaque = 0,

--- a/src/Tizen.NUI/src/internal/Builder.cs
+++ b/src/Tizen.NUI/src/internal/Builder.cs
@@ -34,7 +34,6 @@ namespace Tizen.NUI
             Interop.Builder.DeleteBuilder(swigCPtr);
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class QuitEventArgs : EventArgs
         {
         }
@@ -258,7 +257,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public enum UIFormat
         {
             JSON

--- a/src/Tizen.NUI/src/internal/ConnectionTrackerInterface.cs
+++ b/src/Tizen.NUI/src/internal/ConnectionTrackerInterface.cs
@@ -35,7 +35,6 @@ namespace Tizen.NUI
         /// <summary>
         /// Dispose
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.ConnectionTracker.DeleteConnectionTrackerInterface(swigCPtr);
@@ -46,7 +45,6 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="slotObserver">The slot observer i.e. a signal. Ownership is not passed</param>
         /// <param name="callback">The call back. Ownership is not passed</param>
-        /// <since_tizen> 4 </since_tizen>
         public virtual void SignalConnected(SlotObserver slotObserver, SWIGTYPE_p_CallbackBase callback)
         {
             Interop.ConnectionTracker.ConnectionTrackerInterfaceSignalConnected(SwigCPtr, SlotObserver.getCPtr(slotObserver), SWIGTYPE_p_CallbackBase.getCPtr(callback));

--- a/src/Tizen.NUI/src/internal/EventThreadCallback.cs
+++ b/src/Tizen.NUI/src/internal/EventThreadCallback.cs
@@ -20,7 +20,6 @@ namespace Tizen.NUI
 {
     internal class EventThreadCallback : Disposable
     {
-        /// <since_tizen> 3 </since_tizen>
         public delegate void CallbackDelegate();
 
         internal EventThreadCallback(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)

--- a/src/Tizen.NUI/src/internal/KeyboardEventSignalType.cs
+++ b/src/Tizen.NUI/src/internal/KeyboardEventSignalType.cs
@@ -37,7 +37,6 @@ namespace Tizen.NUI
         /// Queries whether there are any connected slots.
         /// </summary>
         /// <returns>True if there are any slots connected to the signal</returns>
-        /// <since_tizen> 3 </since_tizen>
         public bool Empty()
         {
             bool ret = Interop.KeyboardEventSignalType.Empty(SwigCPtr);
@@ -49,7 +48,6 @@ namespace Tizen.NUI
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
-        /// <since_tizen> 3 </since_tizen>
         public uint GetConnectionCount()
         {
             uint ret = Interop.KeyboardEventSignalType.GetConnectionCount(SwigCPtr);
@@ -61,7 +59,6 @@ namespace Tizen.NUI
         /// Connects a function.
         /// </summary>
         /// <param name="func">The function to connect</param>
-        /// <since_tizen> 3 </since_tizen>
         public void Connect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
@@ -75,7 +72,6 @@ namespace Tizen.NUI
         /// Disconnects a function.
         /// </summary>
         /// <param name="func">The function to disconnect</param>
-        /// <since_tizen> 3 </since_tizen>
         public void Disconnect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
@@ -91,7 +87,6 @@ namespace Tizen.NUI
         /// <param name="arg1">The first value to pass to callbacks</param>
         /// <param name="arg2">The second value to pass to callbacks</param>
         /// <returns>The value returned by the last callback, or a default constructed value if no callbacks are connected</returns>
-        /// <since_tizen> 5 </since_tizen>
         public InputMethodContext.CallbackData Emit(InputMethodContext arg1, InputMethodContext.EventData arg2)
         {
             InputMethodContext.CallbackData ret = new InputMethodContext.CallbackData(Interop.KeyboardEventSignalType.Emit(SwigCPtr, InputMethodContext.getCPtr(arg1), InputMethodContext.EventData.getCPtr(arg2)), true);
@@ -102,7 +97,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The contructor.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
         public KeyboardEventSignalType() : this(Interop.KeyboardEventSignalType.NewKeyboardEventSignalType(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/KeyboardResizedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/KeyboardResizedSignalType.cs
@@ -37,7 +37,6 @@ namespace Tizen.NUI
         /// Queries whether there are any connected slots.
         /// </summary>
         /// <returns>True if there are any slots connected to the signal</returns>
-        /// <since_tizen> 4 </since_tizen>
         public bool Empty()
         {
             bool ret = Interop.KeyboardResizedSignalType.Empty(SwigCPtr);
@@ -49,7 +48,6 @@ namespace Tizen.NUI
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
-        /// <since_tizen> 4 </since_tizen>
         public uint GetConnectionCount()
         {
             uint ret = Interop.KeyboardResizedSignalType.GetConnectionCount(SwigCPtr);
@@ -61,7 +59,6 @@ namespace Tizen.NUI
         /// Connects a function.
         /// </summary>
         /// <param name="func">The function to connect</param>
-        /// <since_tizen> 4 </since_tizen>
         public void Connect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
@@ -75,7 +72,6 @@ namespace Tizen.NUI
         /// Disconnects a function.
         /// </summary>
         /// <param name="func">The function to disconnect</param>
-        /// <since_tizen> 4 </since_tizen>
         public void Disconnect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
@@ -89,7 +85,6 @@ namespace Tizen.NUI
         /// Connects a member function.
         /// </summary>
         /// <param name="arg">The member function to connect</param>
-        /// <since_tizen> 4 </since_tizen>
         public void Emit(int arg)
         {
             Interop.KeyboardResizedSignalType.Emit(SwigCPtr, arg);
@@ -99,7 +94,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The contructor.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         public KeyboardResizedSignalType() : this(Interop.KeyboardResizedSignalType.NewKeyboardResizedSignalType(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/LanguageChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/LanguageChangedSignalType.cs
@@ -37,7 +37,6 @@ namespace Tizen.NUI
         /// Queries whether there are any connected slots.
         /// </summary>
         /// <returns>True if there are any slots connected to the signal</returns>
-        /// <since_tizen> 4 </since_tizen>
         public bool Empty()
         {
             bool ret = Interop.LanguageChangedSignalType.Empty(SwigCPtr);
@@ -49,7 +48,6 @@ namespace Tizen.NUI
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
-        /// <since_tizen> 4 </since_tizen>
         public uint GetConnectionCount()
         {
             uint ret = Interop.LanguageChangedSignalType.GetConnectionCount(SwigCPtr);
@@ -61,7 +59,6 @@ namespace Tizen.NUI
         /// Connects a member function.
         /// </summary>
         /// <param name="func">The member function to connect</param>
-        /// <since_tizen> 4 </since_tizen>
         public void Connect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
@@ -75,7 +72,6 @@ namespace Tizen.NUI
         /// Disconnects a function.
         /// </summary>
         /// <param name="func">The function to disconnect</param>
-        /// <since_tizen> 4 </since_tizen>
         public void Disconnect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
@@ -88,7 +84,6 @@ namespace Tizen.NUI
         /// <summary>
         /// Emits the signal.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         public void Emit(int arg)
         {
             Interop.LanguageChangedSignalType.Emit(SwigCPtr, arg);
@@ -98,7 +93,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The contructor.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         public LanguageChangedSignalType() : this(Interop.LanguageChangedSignalType.NewLanguageChangedSignalType(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Model3dView.cs
+++ b/src/Tizen.NUI/src/internal/Model3dView.cs
@@ -77,7 +77,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public enum IluminationTypeEnum
         {
             DIFFUSE,

--- a/src/Tizen.NUI/src/internal/NUIWindowInfo.cs
+++ b/src/Tizen.NUI/src/internal/NUIWindowInfo.cs
@@ -18,7 +18,6 @@ namespace Tizen.NUI
         /// Initializes the NUI Window class.
         /// </summary>
         /// <param name="win">The window object of component.</param>
-        /// <since_tizen> 6 </since_tizen>
         internal NUIWindowInfo(Window win)
         {
             _win = win;
@@ -64,7 +63,6 @@ namespace Tizen.NUI
         /// Dispose the window resources
         /// </summary>
         /// <returns></returns>
-        /// <since_tizen> 6 </since_tizen>
         public void Dispose()
         {
             Dispose(true);

--- a/src/Tizen.NUI/src/internal/ObjectRegistry.cs
+++ b/src/Tizen.NUI/src/internal/ObjectRegistry.cs
@@ -36,12 +36,10 @@ namespace Tizen.NUI
             Interop.ObjectRegistry.DeleteObjectRegistry(swigCPtr);
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class ObjectCreatedEventArgs : EventArgs
         {
             private BaseHandle _baseHandle;
 
-            /// <since_tizen> 3 </since_tizen>
             public BaseHandle BaseHandle
             {
                 get
@@ -55,12 +53,10 @@ namespace Tizen.NUI
             }
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class ObjectDestroyedEventArgs : EventArgs
         {
             private RefObject _refObject;
 
-            /// <since_tizen> 3 </since_tizen>
             public RefObject RefObject
             {
                 get

--- a/src/Tizen.NUI/src/internal/PageTurnView.cs
+++ b/src/Tizen.NUI/src/internal/PageTurnView.cs
@@ -37,12 +37,10 @@ namespace Tizen.NUI
             Interop.PageTurnView.DeletePageTurnView(swigCPtr);
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class PagePanStartedEventArgs : EventArgs
         {
             private PageTurnView _pageTurnView;
 
-            /// <since_tizen> 3 </since_tizen>
             public PageTurnView PageTurnView
             {
                 get
@@ -56,12 +54,10 @@ namespace Tizen.NUI
             }
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class PagePanFinishedEventArgs : EventArgs
         {
             private PageTurnView _pageTurnView;
 
-            /// <since_tizen> 3 </since_tizen>
             public PageTurnView PageTurnView
             {
                 get
@@ -75,14 +71,12 @@ namespace Tizen.NUI
             }
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class PageTurnStartedEventArgs : EventArgs
         {
             private PageTurnView _pageTurnView;
             private uint _pageIndex;
             private bool _isTurningForward;
 
-            /// <since_tizen> 3 </since_tizen>
             public PageTurnView PageTurnView
             {
                 get
@@ -95,7 +89,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public uint PageIndex
             {
                 get
@@ -108,7 +101,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public bool IsTurningForward
             {
                 get
@@ -123,14 +115,12 @@ namespace Tizen.NUI
 
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public class PageTurnFinishedEventArgs : EventArgs
         {
             private PageTurnView _pageTurnView;
             private uint _pageIndex;
             private bool _isTurningForward;
 
-            /// <since_tizen> 3 </since_tizen>
             public PageTurnView PageTurnView
             {
                 get
@@ -143,7 +133,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public uint PageIndex
             {
                 get
@@ -156,7 +145,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public bool IsTurningForward
             {
                 get

--- a/src/Tizen.NUI/src/internal/PropertyRangeManager.cs
+++ b/src/Tizen.NUI/src/internal/PropertyRangeManager.cs
@@ -112,11 +112,9 @@ namespace Tizen.NUI
 
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public struct PropertyRange
         {
 
-            /// <since_tizen> 3 </since_tizen>
             public int GetNextFreePropertyIndex(ScriptableProperty.ScriptableType type)
             {
                 if (type == ScriptableProperty.ScriptableType.Default)
@@ -131,14 +129,10 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public int startEventIndex;        // start of the property range
-            /// <since_tizen> 3 </since_tizen>
             public int lastUsedEventIndex;     // last used of the property index
 
-            /// <since_tizen> 3 </since_tizen>
             public int startAnimationIndex;    // start of the property range
-            /// <since_tizen> 3 </since_tizen>
             public int lastUsedAnimationIndex; // last used of the property index
         };
     }

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_CallbackBase.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_CallbackBase.cs
@@ -25,7 +25,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The Constructor.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         protected SWIGTYPE_p_CallbackBase()
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CallbackBase.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__CallbackBase.cs
@@ -25,7 +25,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The Constructor.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         protected SWIGTYPE_p_Dali__CallbackBase()
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);

--- a/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__FunctorDelegate.cs
+++ b/src/Tizen.NUI/src/internal/SWIGTYPE_p_Dali__FunctorDelegate.cs
@@ -25,7 +25,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The Constructor.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         protected SWIGTYPE_p_Dali__FunctorDelegate()
         {
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);

--- a/src/Tizen.NUI/src/internal/SignalObserver.cs
+++ b/src/Tizen.NUI/src/internal/SignalObserver.cs
@@ -38,7 +38,6 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="slotObserver">The signal that has disconnected</param>
         /// <param name="callback">The callback attached to the signal disconnected</param>
-        /// <since_tizen> 4 </since_tizen>
         public virtual void SignalDisconnected(SlotObserver slotObserver, SWIGTYPE_p_Dali__CallbackBase callback)
         {
             Interop.SignalObserver.SignalDisconnected(SwigCPtr, SlotObserver.getCPtr(slotObserver), SWIGTYPE_p_Dali__CallbackBase.getCPtr(callback));

--- a/src/Tizen.NUI/src/internal/SlotObserver.cs
+++ b/src/Tizen.NUI/src/internal/SlotObserver.cs
@@ -41,7 +41,6 @@ namespace Tizen.NUI
         /// This method is called when the slot is disconnecting.
         /// </summary>
         /// <param name="callback">The callback attached to the signal disconnected.</param>
-        /// <since_tizen> 4 </since_tizen>
         public virtual void SlotDisconnected(SWIGTYPE_p_Dali__CallbackBase callback)
         {
             SlotObserver_SlotDisconnected(SwigCPtr, SWIGTYPE_p_Dali__CallbackBase.getCPtr(callback));

--- a/src/Tizen.NUI/src/internal/StatusSignalType.cs
+++ b/src/Tizen.NUI/src/internal/StatusSignalType.cs
@@ -37,7 +37,6 @@ namespace Tizen.NUI
         /// Queries whether there are any connected slots.
         /// </summary>
         /// <returns>True if there are any slots connected to the signal</returns>
-        /// <since_tizen> 3 </since_tizen>
         public bool Empty()
         {
             bool ret = Interop.StatusSignalType.Empty(SwigCPtr);
@@ -49,7 +48,6 @@ namespace Tizen.NUI
         /// Queries the number of slots.
         /// </summary>
         /// <returns>The number of slots connected to this signal</returns>
-        /// <since_tizen> 3 </since_tizen>
         public uint GetConnectionCount()
         {
             uint ret = Interop.StatusSignalType.GetConnectionCount(SwigCPtr);
@@ -61,7 +59,6 @@ namespace Tizen.NUI
         /// Connects a function.
         /// </summary>
         /// <param name="func">The function to connect</param>
-        /// <since_tizen> 3 </since_tizen>
         public void Connect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
@@ -75,7 +72,6 @@ namespace Tizen.NUI
         /// Disconnects a function.
         /// </summary>
         /// <param name="func">The function to disconnect</param>
-        /// <since_tizen> 3 </since_tizen>
         public void Disconnect(System.Delegate func)
         {
             System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
@@ -89,7 +85,6 @@ namespace Tizen.NUI
         /// Connects a member function.
         /// </summary>
         /// <param name="arg">The member function to connect</param>
-        /// <since_tizen> 3 </since_tizen>
         public void Emit(bool arg)
         {
             Interop.StatusSignalType.Emit(SwigCPtr, arg);
@@ -99,7 +94,6 @@ namespace Tizen.NUI
         /// <summary>
         /// The constructor.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
         public StatusSignalType() : this(Interop.StatusSignalType.NewStatusSignalType(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/TouchPoint.cs
+++ b/src/Tizen.NUI/src/internal/TouchPoint.cs
@@ -124,7 +124,6 @@ namespace Tizen.NUI
             }
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public enum StateType
         {
             Started,

--- a/src/Tizen.NUI/src/internal/TouchPointContainer.cs
+++ b/src/Tizen.NUI/src/internal/TouchPointContainer.cs
@@ -151,7 +151,6 @@ namespace Tizen.NUI
         /// whenever the collection is modified. This has been done for changes in the size of the
         /// collection, but not when one of the elements of the collection is modified as it is a bit
         /// tricky to detect unmanaged code that modifies the collection under our feet.
-        /// <since_tizen> 3 </since_tizen>
         public sealed class TouchPointContainerEnumerator : global::System.Collections.IEnumerator
           , global::System.Collections.Generic.IEnumerator<TouchPoint>
         {
@@ -160,7 +159,6 @@ namespace Tizen.NUI
             private object currentObject;
             private int currentSize;
 
-            /// <since_tizen> 3 </since_tizen>
             public TouchPointContainerEnumerator(TouchPointContainer collection)
             {
                 collectionRef = collection;
@@ -170,7 +168,6 @@ namespace Tizen.NUI
             }
 
             // Type-safe iterator Current
-            /// <since_tizen> 3 </since_tizen>
             public TouchPoint Current
             {
                 get
@@ -194,7 +191,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public bool MoveNext()
             {
                 int size = collectionRef.Count;
@@ -211,7 +207,6 @@ namespace Tizen.NUI
                 return moveOkay;
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public void Reset()
             {
                 currentIndex = -1;
@@ -222,7 +217,6 @@ namespace Tizen.NUI
                 }
             }
 
-            /// <since_tizen> 3 </since_tizen>
             public void Dispose()
             {
                 currentIndex = -1;

--- a/src/Tizen.NUI/src/internal/Uint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Uint16Pair.cs
@@ -30,7 +30,6 @@ namespace Tizen.NUI
     /// One of these can be passed in a single 32 bit integer register on
     /// common architectures.<br />
     /// </summary>
-    /// <since_tizen> 3 </since_tizen>
     internal class Uint16Pair : Disposable
     {
 
@@ -54,7 +53,6 @@ namespace Tizen.NUI
         /// <param name="arg1">A reference for comparison.</param>
         /// <param name="arg2">A reference for comparison</param>
         /// <return>True if arg1 less than arg2</return>
-        /// <since_tizen> 3 </since_tizen>
         public static bool operator <(Uint16Pair arg1, Uint16Pair arg2)
         {
             return arg1.LessThan(arg2);
@@ -66,7 +64,6 @@ namespace Tizen.NUI
         /// <param name="arg1">A reference for comparison.</param>
         /// <param name="arg2">A reference for comparison</param>
         /// <return>True if arg1 > arg2</return>
-        /// <since_tizen> 3 </since_tizen>
         public static bool operator >(Uint16Pair arg1, Uint16Pair arg2)
         {
             return arg1.GreaterThan(arg2);
@@ -75,7 +72,6 @@ namespace Tizen.NUI
         /// <summary>
         /// Default constructor for the(0, 0) tuple.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
         public Uint16Pair() : this(Interop.Uint16Pair.NewUint16Pair(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -86,7 +82,6 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="width">The width or X dimension of the tuple. Make sure it is less than 65536.</param>
         /// <param name="height">The height or Y dimension of the tuple.Make sure it is less than 65536.</param>
-        /// <since_tizen> 3 </since_tizen>
         public Uint16Pair(uint width, uint height) : this(Interop.Uint16Pair.NewUint16Pair(width, height), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -96,7 +91,6 @@ namespace Tizen.NUI
         /// Constructor taking separate x and y (width and height) parameters.
         /// </summary>
         /// <param name="rhs">A reference to assign.</param>
-        /// <since_tizen> 3 </since_tizen>
         public Uint16Pair(Uint16Pair rhs) : this(Interop.Uint16Pair.NewUint16Pair(Uint16Pair.getCPtr(rhs)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -106,7 +100,6 @@ namespace Tizen.NUI
         /// Sets the width.
         /// </summary>
         /// <param name="width">The x dimension to be stored in this 2-tuple.</param>
-        /// <since_tizen> 3 </since_tizen>
         public void SetWidth(ushort width)
         {
             Interop.Uint16Pair.SetWidth(SwigCPtr, width);
@@ -119,7 +112,6 @@ namespace Tizen.NUI
         /// <return>
         /// The x dimension stored in this 2-tuple.
         /// </return>
-        /// <since_tizen> 3 </since_tizen>
         public ushort GetWidth()
         {
             ushort ret = Interop.Uint16Pair.GetWidth(SwigCPtr);
@@ -131,7 +123,6 @@ namespace Tizen.NUI
         /// Sets the height.
         /// </summary>
         /// <param name="height">The y dimension to be stored in this 2-tuple.</param>
-        /// <since_tizen> 3 </since_tizen>
         public void SetHeight(ushort height)
         {
             Interop.Uint16Pair.SetHeight(SwigCPtr, height);
@@ -144,7 +135,6 @@ namespace Tizen.NUI
         /// <return>
         /// The y dimension stored in this 2-tuple.
         /// </return>
-        /// <since_tizen> 3 </since_tizen>
         public ushort GetHeight()
         {
             ushort ret = Interop.Uint16Pair.GetHeight(SwigCPtr);
@@ -156,7 +146,6 @@ namespace Tizen.NUI
         /// Sets the x dimension.
         /// </summary>
         /// <param name="x">The x dimension to be stored in this 2-tuple.</param>
-        /// <since_tizen> 3 </since_tizen>
         public void SetX(ushort x)
         {
             Interop.Uint16Pair.SetX(SwigCPtr, x);
@@ -169,7 +158,6 @@ namespace Tizen.NUI
         /// <return>
         /// The x dimension stored in this 2-tuple.
         /// </return>
-        /// <since_tizen> 3 </since_tizen>
         public ushort GetX()
         {
             ushort ret = Interop.Uint16Pair.GetX(SwigCPtr);
@@ -181,7 +169,6 @@ namespace Tizen.NUI
         /// Sets the y dimension.
         /// </summary>
         /// <param name="y">The y dimension to be stored in this 2-tuple.</param>
-        /// <since_tizen> 3 </since_tizen>
         public void SetY(ushort y)
         {
             Interop.Uint16Pair.SetY(SwigCPtr, y);
@@ -194,7 +181,6 @@ namespace Tizen.NUI
         /// <return>
         /// The y dimension stored in this 2-tuple.
         /// </return>
-        /// <since_tizen> 3 </since_tizen>
         public ushort GetY()
         {
             ushort ret = Interop.Uint16Pair.GetY(SwigCPtr);
@@ -207,7 +193,6 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="rhs">A reference to assign.</param>
         /// <return>The created object.</return>
-        /// <since_tizen> 3 </since_tizen>
         public Uint16Pair Assign(Uint16Pair rhs)
         {
             Uint16Pair ret = new Uint16Pair(Interop.Uint16Pair.Assign(SwigCPtr, Uint16Pair.getCPtr(rhs)), false);

--- a/src/Tizen.NUI/src/internal/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/ViewImpl.cs
@@ -172,7 +172,6 @@ namespace Tizen.NUI
         /// [Obsolete("Please do not use! this will be deprecated")]
         /// </summary>
         /// Please do not use! this will be deprecated!
-        /// <since_tizen> 5 </since_tizen>
         [Obsolete("Please do not use! this will be deprecated.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AccessibilityActivate()
@@ -185,7 +184,6 @@ namespace Tizen.NUI
         /// [Obsolete("Please do not use! this will be deprecated")]
         /// </summary>
         /// Please do not use! this will be deprecated!
-        /// <since_tizen> 5 </since_tizen>
         [Obsolete("Please do not use! this will be deprecated.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void KeyboardEnter()
@@ -219,7 +217,6 @@ namespace Tizen.NUI
         /// [Obsolete("Please do not use! this will be deprecated")]
         /// </summary>
         /// Please do not use! this will be deprecated!
-        /// <since_tizen> 5 </since_tizen>
         [Obsolete("Please do not use! this will be deprecated.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EmitKeyEventSignal(Key arg0)
@@ -732,79 +729,42 @@ namespace Tizen.NUI
             SignalDisconnected((slotObserver == global::System.IntPtr.Zero) ? null : new SlotObserver(slotObserver, false), (callback == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_Dali__CallbackBase(callback));
         }
 
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_0(int depth);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_1();
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_2(global::System.IntPtr child);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_3(global::System.IntPtr child);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_4(int index, global::System.IntPtr propertyValue);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_5(global::System.IntPtr targetSize);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_6(global::System.IntPtr animation, global::System.IntPtr targetSize);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_9(global::System.IntPtr arg0);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_11(global::System.IntPtr size, global::System.IntPtr container);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_12(int policy, int dimension);
-        /// <since_tizen> 3 </since_tizen>
         public delegate global::System.IntPtr SwigDelegateViewImpl_13();
-        /// <since_tizen> 3 </since_tizen>
         public delegate float SwigDelegateViewImpl_14(global::System.IntPtr child, int dimension);
-        /// <since_tizen> 3 </since_tizen>
         public delegate float SwigDelegateViewImpl_15(float width);
-        /// <since_tizen> 3 </since_tizen>
         public delegate float SwigDelegateViewImpl_16(float height);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_17(int dimension);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_18();
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_19(int dimension);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_20(float size, int dimension);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_21();
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_22(global::System.IntPtr child);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_23(global::System.IntPtr child);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_24(global::System.IntPtr styleManager, int change);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_25();
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_26(global::System.IntPtr gesture);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_28(bool isIncrease);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_29();
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_30();
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_31();
-        /// <since_tizen> 3 </since_tizen>
         public delegate global::System.IntPtr SwigDelegateViewImpl_32(global::System.IntPtr currentFocusedActor, int direction, bool loopEnabled);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_33(global::System.IntPtr commitedFocusableActor);
-        /// <since_tizen> 3 </since_tizen>
         public delegate bool SwigDelegateViewImpl_34();
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_35(global::System.IntPtr pinch);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_36(global::System.IntPtr pan);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_37(global::System.IntPtr tap);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_38(global::System.IntPtr longPress);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_39(global::System.IntPtr slotObserver, global::System.IntPtr callback);
-        /// <since_tizen> 3 </since_tizen>
         public delegate void SwigDelegateViewImpl_40(global::System.IntPtr slotObserver, global::System.IntPtr callback);
 
         private SwigDelegateViewImpl_0 swigDelegate0;

--- a/src/Tizen.NUI/src/internal/WatchApplication.cs
+++ b/src/Tizen.NUI/src/internal/WatchApplication.cs
@@ -113,13 +113,11 @@ namespace Tizen.NUI
         /// <summary>
         /// Event arguments that passed via time tick event signal.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         public class TimeTickEventArgs : EventArgs
         {
             /// <summary>
             /// Application.
             /// </summary>
-            /// <since_tizen> 4 </since_tizen>
             public Application Application
             {
                 get;
@@ -129,7 +127,6 @@ namespace Tizen.NUI
             /// <summary>
             /// WatchTime.
             /// </summary>
-            /// <since_tizen> 4 </since_tizen>
             public WatchTime WatchTime
             {
                 get;
@@ -189,13 +186,11 @@ namespace Tizen.NUI
         /// <summary>
         /// Event arguments that passed via ambient tick event signal.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         public class AmbientTickEventArgs : EventArgs
         {
             /// <summary>
             /// Application.
             /// </summary>
-            /// <since_tizen> 4 </since_tizen>
             public Application Application
             {
                 get;
@@ -205,7 +200,6 @@ namespace Tizen.NUI
             /// <summary>
             /// WatchTime.
             /// </summary>
-            /// <since_tizen> 4 </since_tizen>
             public WatchTime WatchTime
             {
                 get;
@@ -264,13 +258,11 @@ namespace Tizen.NUI
         /// <summary>
         /// Event arguments that passed via ambient tick event signal.
         /// </summary>
-        /// <since_tizen> 4 </since_tizen>
         public class AmbientChangedEventArgs : EventArgs
         {
             /// <summary>
             /// Application.
             /// </summary>
-            /// <since_tizen> 4 </since_tizen>
             public Application Application
             {
                 get;
@@ -280,7 +272,6 @@ namespace Tizen.NUI
             /// <summary>
             /// Changed.
             /// </summary>
-            /// <since_tizen> 4 </since_tizen>
             public bool Changed
             {
                 get;

--- a/src/Tizen.NUI/src/public/Property.cs
+++ b/src/Tizen.NUI/src/public/Property.cs
@@ -25,7 +25,6 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="arg0">A valid handle to the target object.</param>
         /// <param name="propertyIndex">The index of a property.</param>
-        /// <since_tizen> 3 </since_tizen>
         public Property(Animatable arg0, int propertyIndex) : this(Interop.Property.NewProperty(Animatable.getCPtr(arg0), propertyIndex), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -37,7 +36,6 @@ namespace Tizen.NUI
         /// <param name="arg0">A valid handle to the target object.</param>
         /// <param name="propertyIndex">The index of a property.</param>
         /// <param name="componentIndex">Index to a sub component of a property, for use with Vector2, Vector3 and Vector4. -1 for the main property (default is -1).</param>
-        /// <since_tizen> 3 </since_tizen>
         public Property(Animatable arg0, int propertyIndex, int componentIndex) : this(Interop.Property.NewProperty(Animatable.getCPtr(arg0), propertyIndex, componentIndex), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -49,7 +47,6 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="arg0">A valid handle to the target object.</param>
         /// <param name="propertyName">The property name.</param>
-        /// <since_tizen> 3 </since_tizen>
         public Property(Animatable arg0, string propertyName) : this(Interop.Property.NewProperty(Animatable.getCPtr(arg0), propertyName), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -62,7 +59,6 @@ namespace Tizen.NUI
         /// <param name="arg0">A valid handle to the target object.</param>
         /// <param name="propertyName">The property name.</param>
         /// <param name="componentIndex">Index to a sub component of a property, for use with Vector2, Vector3 and Vector4. -1 for main property (default is -1).</param>
-        /// <since_tizen> 3 </since_tizen>
         public Property(Animatable arg0, string propertyName, int componentIndex) : this(Interop.Property.NewProperty(Animatable.getCPtr(arg0), propertyName, componentIndex), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -75,7 +71,6 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the index of the property.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
         public int propertyIndex
         {
             set
@@ -94,7 +89,6 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the component index of the property.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>
         public int componentIndex
         {
             set


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
