### PR TITLE
[NUI] remove unused measure specification size properties of View class

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -42,8 +42,6 @@ namespace Tizen.NUI.BaseComponents
         private int oldWidthPolicy = LayoutParamPolicies.MatchParent; // // Store Layout width to compare against later
         private int oldHeightPolicy = LayoutParamPolicies.MatchParent; // Store Layout height to compare against later
         private float weight = 0.0f; // Weighting of child View in a Layout
-        private MeasureSpecification measureSpecificationWidth; // Layout width and internal Mode
-        private MeasureSpecification measureSpecificationHeight; // Layout height and internal Mode
         private bool backgroundImageSynchronosLoading = false;
         private Dictionary<string, Transition> transDictionary = new Dictionary<string, Transition>();
         private string[] transitionNames;
@@ -833,10 +831,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 sizeSetExplicitly = value;  // Store size set by API, will be used in place of NaturalSize if not set.
                 SetValue(Size2DProperty, value);
-                // Set Specification so when layouts measure this View it matches the value set here.
-                // All Views are currently Layouts.
-                MeasureSpecificationWidth = new MeasureSpecification(new LayoutLength(value.Width), MeasureSpecification.ModeType.Exactly);
-                MeasureSpecificationHeight = new MeasureSpecification(new LayoutLength(value.Height), MeasureSpecification.ModeType.Exactly);
+
                 widthPolicy = value.Width;
                 heightPolicy = value.Height;
                 
@@ -2010,8 +2005,6 @@ namespace Tizen.NUI.BaseComponents
                 {
                     if (widthPolicy >= 0)
                     {
-                        measureSpecificationWidth = new MeasureSpecification(new LayoutLength(value), MeasureSpecification.ModeType.Exactly);
-
                         if (heightPolicy >= 0) // Policy an exact value
                         {
                             // Create Size2D only both _widthPolicy and _heightPolicy are set.
@@ -2041,8 +2034,6 @@ namespace Tizen.NUI.BaseComponents
                 {
                     if (heightPolicy >= 0)
                     {
-                        measureSpecificationHeight = new MeasureSpecification(new LayoutLength(value), MeasureSpecification.ModeType.Exactly);
-
                         if (widthPolicy >= 0) // Policy an exact value
                         {
                             // Create Size2D only both _widthPolicy and _heightPolicy are set.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -106,38 +106,6 @@ namespace Tizen.NUI.BaseComponents
             this.layout?.RequestLayout();
         }
 
-        /// <summary>
-        /// Stores the calculated width value and its ModeType. Width component.
-        /// </summary>
-        internal MeasureSpecification MeasureSpecificationWidth
-        {
-            set
-            {
-                measureSpecificationWidth = value;
-                layout?.RequestLayout();
-            }
-            get
-            {
-                return measureSpecificationWidth;
-            }
-        }
-
-        /// <summary>
-        /// Stores the calculated width value and its ModeType. Height component.
-        /// </summary>
-        internal MeasureSpecification MeasureSpecificationHeight
-        {
-            set
-            {
-                measureSpecificationHeight = value;
-                layout?.RequestLayout();
-            }
-            get
-            {
-                return measureSpecificationHeight;
-            }
-        }
-
         internal void AttachTransitionsToChildren(LayoutTransition transition)
         {
             // Iterate children, adding the transition unless a transition


### PR DESCRIPTION
No logical changes.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
