### PR TITLE
[Bluetooth][Non-ACR] Fix unhandled exception in GetBondedDevice()

### DIFF
--- a/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
+++ b/src/Tizen.Network.Bluetooth/Tizen.Network.Bluetooth/BluetoothStructs.cs
@@ -241,6 +241,8 @@ namespace Tizen.Network.Bluetooth
         internal static BluetoothDevice ConvertStructToDeviceClass(BluetoothDeviceStruct device)
         {
             const int DeviceNameLengthMax = 248;
+            const int UuidLengthMax = 50;
+
             BluetoothDevice resultDevice = new BluetoothDevice();
             Collection<string> uuidList = null;
 
@@ -250,8 +252,11 @@ namespace Tizen.Network.Bluetooth
                 Marshal.Copy (device.ServiceUuidList, extensionList, 0, device.ServiceCount);
                 uuidList = new Collection<string> ();
                 foreach (IntPtr extension in extensionList) {
-                    string uuid = Marshal.PtrToStringAnsi (extension);
-                    uuidList.Add (uuid);
+                    if (extension != IntPtr.Zero)
+                    {
+                        string uuid = Marshal.PtrToStringAnsi (extension, UuidLengthMax);
+                        uuidList.Add (uuid);
+                    }
                 }
             }
 


### PR DESCRIPTION
Device is not bonded : System.NullReferenceException: Object reference not set to an instance of an object.
    at System.SpanHelpers.IndexOf(Byte& searchSpace, Byte value, Int32 length)
    at System.String.Ctor(SByte* value)
    at System.Runtime.InteropServices.Marshal.PtrToStringAnsi(IntPtr ptr)
    at Tizen.Network.Bluetooth.BluetoothUtils.ConvertStructToDeviceClass(BluetoothDeviceStruct device)
    at Tizen.Network.Bluetooth.BluetoothAdapterImpl.GetBondedDevice(String address)
    at Tizen.Network.Bluetooth.BluetoothAdapter.GetBondedDevice(String address)

Signed-off-by: DoHyun Pyun <dh79.pyun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
