### PR TITLE
[NUI] use Size2DProperty for GetNaturalSize() instead of local field

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -316,7 +316,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public new virtual Size2D GetNaturalSize()
         {
-            return sizeSetExplicitly;  // Returns the size set explicitly on View unless Overridden.
+            return (Size2D)GetValue(Size2DProperty);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -29,7 +29,6 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class View : Container, IResourcesProvider
     {
-        internal Size2D sizeSetExplicitly = new Size2D(); // Store size set by API, will be used in place of NaturalSize if not set.
         internal BackgroundExtraData backgroundExtraData;
 
         private bool layoutSet = false;
@@ -827,7 +826,6 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                sizeSetExplicitly = value;  // Store size set by API, will be used in place of NaturalSize if not set.
                 SetValue(Size2DProperty, value);
 
                 widthPolicy = value.Width;


### PR DESCRIPTION
Since we can take the size value using `Size2DProperty`, we don't need to
save Size2D value in local value.
It will save a bit of memory.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
