### PR TITLE
[NUI] change size specification in changed callback of bindable property

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -830,10 +830,6 @@ namespace Tizen.NUI.BaseComponents
                 sizeSetExplicitly = value;  // Store size set by API, will be used in place of NaturalSize if not set.
                 SetValue(Size2DProperty, value);
 
-                widthPolicy = value.Width;
-                heightPolicy = value.Height;
-                
-                layout?.RequestLayout();
                 NotifyPropertyChanged();
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -611,6 +611,10 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SIZE, new Tizen.NUI.PropertyValue(new Size((Size2D)newValue)));
+                view.widthPolicy = ((Size2D)newValue).Width;
+                view.heightPolicy = ((Size2D)newValue).Height;
+
+                view.layout?.RequestLayout();
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>


### PR DESCRIPTION
If we change size2D by using Size2DProperty, size specification is not
changed. this patch will fix that issue.

Here is sample code:
```cs
View view = new View();
view.Size2D = new Size2D(100, 50);
Tizen.Log.Error("NUI", $"WidthSpecification : {view.WidthSpecification}, HeightSpecification : {view.HeightSpecification}");

View view2 = new View();
view2.SetValue(View.Size2DProperty, new Size2D(100, 50));
Tizen.Log.Error("NUI", $"WidthSpecification : {view2.WidthSpecification}, HeightSpecification : {view2.HeightSpecification}");
```

Before:
```
WidthSpecification : 100, HeightSpecification : 50
WidthSpecification : -2, HeightSpecification : -2
```

After:
```
WidthSpecification : 100, HeightSpecification : 50
WidthSpecification : 100, HeightSpecification : 50
```

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
