### PR TITLE
[Application.UI] UnmanagedCallersOnly to callbacks

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.Glib.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Glib.cs
@@ -19,13 +19,10 @@ using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
-    internal static partial class Glib
+    internal static unsafe partial class Glib
     {
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate bool GSourceFunc(IntPtr userData);
-
         [DllImport(Libraries.Glib, EntryPoint = "g_idle_add", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern uint IdleAdd(GSourceFunc d, IntPtr data);
+        internal static extern uint IdleAdd(delegate* unmanaged<IntPtr, byte> d, IntPtr data);
 
         [DllImport(Libraries.Glib, EntryPoint = "g_source_remove", CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool RemoveSource(uint source);

--- a/src/Tizen.Applications.Common/Tizen.Applications.Common.csproj
+++ b/src/Tizen.Applications.Common/Tizen.Applications.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tizen.Applications.Common/Tizen.Applications.CoreBackend/DefaultCoreBackend.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.CoreBackend/DefaultCoreBackend.cs
@@ -76,7 +76,7 @@ namespace Tizen.Applications.CoreBackend
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected IDictionary<EventType, object> Handlers = new Dictionary<EventType, object>();
+        protected static IDictionary<EventType, object> Handlers = new Dictionary<EventType, object>();
 
         /// <summary>
         /// Constructor of DefaultCoreBackend class.

--- a/src/Tizen.Applications.UI/Interop/Interop.Application.cs
+++ b/src/Tizen.Applications.UI/Interop/Interop.Application.cs
@@ -23,7 +23,7 @@ using Tizen.Internals.Errors;
 
 internal static partial class Interop
 {
-    internal static partial class Application
+    internal static unsafe partial class Application
     {
         internal delegate void AppEventCallback(IntPtr handle, IntPtr data);
 
@@ -58,11 +58,11 @@ internal static partial class Interop
         [StructLayout(LayoutKind.Sequential)]
         internal struct UIAppLifecycleCallbacks
         {
-            public AppCreateCallback OnCreate;
-            public AppTerminateCallback OnTerminate;
-            public AppPauseCallback OnPause;
-            public AppResumeCallback OnResume;
-            public AppControlCallback OnAppControl;
+            public delegate* unmanaged<IntPtr, byte> OnCreate;
+            public delegate* unmanaged<IntPtr, void> OnTerminate;
+            public delegate* unmanaged<IntPtr, void> OnPause;
+            public delegate* unmanaged<IntPtr, void> OnResume;
+            public delegate* unmanaged<IntPtr, IntPtr, void> OnAppControl;
         }
     }
 }

--- a/src/Tizen.Applications.UI/Tizen.Applications.UI.csproj
+++ b/src/Tizen.Applications.UI/Tizen.Applications.UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###
Mark `OnCreateNative()`, `OnTerminateNative()`, `OnPauseNative()`, `OnResumeNative()`, `OnAppControlNative()` and `TizenSynchronizationContext+GSourceManager.Handler` callbacks with [`UnmanagedCallersOnly` attribute](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.unmanagedcallersonlyattribute?view=net-5.0) to prevent of `IL_STUB_ReversePInvoke()` generating and jitting.

### API Changes ###
**Depends on netcoreapp5.0**
`UnmanagedCallersOnly` attribute applies only to .net 5.0.

**Upd**: seems it is not need changes in capi-appfw-appication. <details><summary>Old message</summary>
**Need change in capi-appfw-application**
Type of `__on_create()` should be changed to `unsigned char`, because `bool` is not blittable type and conflicts with `UnmanagedCallersOnly` attribute.
```diff
diff --git a/src/app_main_legacy.c b/src/app_main_legacy.c
index 32cb232..7d63542 100755
--- a/src/app_main_legacy.c
+++ b/src/app_main_legacy.c                                                                   
@@ -36,14 +36,14 @@ typedef struct {                                                          
        void *data;                                                                           
 } app_context_s;                                                                             
 
-static bool __on_create(void *data)
+static unsigned char __on_create(void *data)
 {
        app_context_s *context = data;
 
        if (context->callback->create)
                return context->callback->create(context->data);
 
-       return false;
+       return 0;
 }
 
 static void __on_terminate(void *data)
```
</details>

cc @alpencolt