### PR TITLE
[NUI] Add API for delete widgetView

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetViewManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetViewManager.cs
@@ -30,6 +30,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetViewManager_AddWidget")]
             public static extern global::System.IntPtr AddWidget(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, int jarg4, int jarg5, float jarg6);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetViewManager_RemoveWidget")]
+            public static extern bool RemoveWidget(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetViewManager_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
 

--- a/src/Tizen.NUI/src/public/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/NUIApplication.cs
@@ -41,6 +41,8 @@ namespace Tizen.NUI
         private Size2D _windowSize2D = null;
         private Position2D _windowPosition2D = null;
         private TransitionOptions transitionOptions;
+        private string appId = null;
+        internal static NUIApplication me;
 
         private static bool isPreLoad = false;
 
@@ -51,6 +53,7 @@ namespace Tizen.NUI
         public NUIApplication() : base(new NUICoreBackend())
         {
             Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
+            me = this;
         }
 
         /// <summary>
@@ -66,6 +69,7 @@ namespace Tizen.NUI
             Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
             _windowSize2D = windowSize;
             _windowPosition2D = windowPosition;
+            me = this;
         }
 
         /// <summary>
@@ -76,6 +80,7 @@ namespace Tizen.NUI
         public NUIApplication(string styleSheet) : base(new NUICoreBackend(styleSheet))
         {
             Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
+            me = this;
         }
 
         /// <summary>
@@ -92,6 +97,7 @@ namespace Tizen.NUI
             Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
             _windowSize2D = windowSize;
             _windowPosition2D = windowPosition;
+            me = this;
         }
 
         /// <summary>
@@ -103,6 +109,7 @@ namespace Tizen.NUI
         public NUIApplication(string styleSheet, WindowMode windowMode) : base(new NUICoreBackend(styleSheet, windowMode))
         {
             Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
+            me = this;
         }
 
         /// <summary>
@@ -120,6 +127,7 @@ namespace Tizen.NUI
             Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
             _windowSize2D = windowSize;
             _windowPosition2D = windowPosition;
+            me = this;
         }
 
         /// <summary>
@@ -142,6 +150,7 @@ namespace Tizen.NUI
             if (windowSize != null) { _windowSize2D = windowSize; }
             if (windowPosition != null) { _windowPosition2D = windowPosition; }
             Registry.Instance.SavedApplicationThread = Thread.CurrentThread;
+            me = this;
         }
 
         /// <summary>
@@ -201,6 +210,19 @@ namespace Tizen.NUI
             get
             {
                 return GetDefaultWindow();
+            }
+        }
+
+        /// <summary>
+        /// Gets the Application Id.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string AppId
+        {
+            get
+            {
+                return appId;
             }
         }
 
@@ -377,6 +399,7 @@ namespace Tizen.NUI
         protected override void OnCreate()
         {
             base.OnCreate();
+            appId = Tizen.Applications.Application.Current.ApplicationInfo.ApplicationId;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/WidgetViewManager.cs
+++ b/src/Tizen.NUI/src/public/WidgetViewManager.cs
@@ -25,6 +25,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class WidgetViewManager : BaseHandle
     {
+        private static WidgetViewManager instance;
 
         /// <summary>
         /// Creates a new widgetView manager object.
@@ -34,8 +35,35 @@ namespace Tizen.NUI
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
+
+        /// <summary>
+        /// Creates a new widgetView manager object.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        internal WidgetViewManager() : this(Interop.WidgetViewManager.New(Application.getCPtr(NUIApplication.me?.ApplicationHandle), NUIApplication.me?.AppId), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
         internal WidgetViewManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.WidgetViewManager.Upcast(cPtr), cMemoryOwn)
         {
+        }
+
+        /// <summary>
+        /// Gets the singleton of the WidgetViewManager object.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static WidgetViewManager Instance
+        {
+            get
+            {
+                if(!instance)
+                {
+                    instance  = new WidgetViewManager();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                }
+                return instance;
+            }
         }
 
         /// <summary>
@@ -51,6 +79,19 @@ namespace Tizen.NUI
         public WidgetView AddWidget(string widgetId, string contentInfo, int width, int height, float updatePeriod)
         {
             WidgetView ret = new WidgetView(Interop.WidgetViewManager.AddWidget(SwigCPtr, widgetId, contentInfo, width, height, updatePeriod), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Remove a widget view object.
+        /// </summary>
+        /// <param name="widgetView">widgetView to remove</param>
+        /// <returns> True on success, false otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool RemoveWidget(WidgetView widgetView)
+        {
+            bool ret = Interop.WidgetViewManager.RemoveWidget(SwigCPtr, WidgetView.getCPtr(widgetView));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
WidgetViewManager provide API for delete widgetView instead TerminateWidget().
TerminateWidget() will be deprecated.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
