### PR TITLE
[NUI] remove internal child properly when child view of FlexLayout is removed

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/Interop/Interop.FlexLayout.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/Interop/Interop.FlexLayout.cs
@@ -21,7 +21,7 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr AddChildWithMargin(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, Tizen.NUI.FlexLayout.ChildMeasureCallback jarg4, int jarg5);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexLayout_RemoveChild")]
-            public static extern global::System.IntPtr RemoveChild(global::System.Runtime.InteropServices.HandleRef jarg1, LayoutItem jarg2);
+            public static extern global::System.IntPtr RemoveChild(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexLayout_CalculateLayout")]
             public static extern global::System.IntPtr CalculateLayout(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, bool jarg4);

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -703,12 +703,17 @@ namespace Tizen.NUI
         /// Callback when child is removed from container.<br />
         /// </summary>
         /// <param name="child">The Layout child.</param>
+        /// <exception cref="ArgumentNullException"> Thrown when child is null. </exception>
         /// <since_tizen> 6 </since_tizen>
         protected override void OnChildRemove(LayoutItem child)
         {
+            if (null == child)
+            {
+                throw new ArgumentNullException(nameof(child));
+            }
             // When child View is removed from it's parent View (that is a Layout) then remove it from the layout too.
             // FlexLayout refers to the child as a View not LayoutItem.
-            Interop.FlexLayout.RemoveChild(swigCPtr, child);
+            Interop.FlexLayout.RemoveChild(swigCPtr, child.Owner.SwigCPtr);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -141,7 +141,7 @@ namespace Tizen.NUI
                 // If child removed then set all siblings not being added to a ChangeOnRemove transition.
                 SetConditionsForAnimationOnLayoutGroup(TransitionCondition.ChangeOnRemove);
             }
-
+            OnChildRemove(layoutItem);
             RequestLayout();
         }
 


### PR DESCRIPTION
In `FlexLayout`, when we add new view, the existing view shrink.
but when removed they are in shrinked state. they should change back.

To fix this issue, this patch remove internal child(child of yoga
layout) when child view of `FlexLayout` is removed.

For now, `OnChildRemove` API will work correctly.

Thanks Aman Jeph for the report.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
