### PR TITLE
[NUI] remove internal child properly when child view of FlexLayout is removed

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/Interop/Interop.FlexLayout.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/Interop/Interop.FlexLayout.cs
@@ -21,7 +21,7 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr FlexLayout_AddChildWithMargin( global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, Tizen.NUI.FlexLayout.ChildMeasureCallback jarg4, int jarg5);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexLayout_RemoveChild")]
-            public static extern global::System.IntPtr FlexLayout_RemoveChild( global::System.Runtime.InteropServices.HandleRef jarg1, LayoutItem jarg2);
+            public static extern global::System.IntPtr FlexLayout_RemoveChild( global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexLayout_CalculateLayout")]
             public static extern global::System.IntPtr FlexLayout_CalculateLayout( global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, bool jarg4);

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -626,7 +626,7 @@ namespace Tizen.NUI
         {
             // When child View is removed from it's parent View (that is a Layout) then remove it from the layout too.
             // FlexLayout refers to the child as a View not LayoutItem.
-            Interop.FlexLayout.FlexLayout_RemoveChild(swigCPtr, child);
+            Interop.FlexLayout.FlexLayout_RemoveChild(swigCPtr, child.Owner.SwigCPtr);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -119,7 +119,7 @@ namespace Tizen.NUI
                 // If child removed then set all siblings not being added to a ChangeOnRemove transition.
                 SetConditionsForAnimationOnLayoutGroup(TransitionCondition.ChangeOnRemove);
             }
-
+            OnChildRemove(layoutItem);
             RequestLayout();
         }
 


### PR DESCRIPTION
In `FlexLayout`, when we add new view, the existing view shrink.
but when removed they are in shrinked state. they should change back.

To fix this issue, this patch remove internal child(child of yoga
layout) when child view of `FlexLayout` is removed.

For now, `OnChildRemove` API will work correctly.

Thanks Aman Jeph for the report.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
