### PR TITLE
[NUI] fix bug when setting desired size in ImageView

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1135,23 +1135,10 @@ namespace Tizen.NUI.BaseComponents
             {
                 if(_resourceUrl != null)
                 {
-                  Size2D imageSize = ImageLoading.GetOriginalImageSize(_resourceUrl);
-
-                  int adjustedDesiredWidth, adjustedDesiredHeight;
-                  float aspectOfDesiredSize = (float)_desired_height / (float)_desired_width;
-                  float aspectOfImageSize = (float)imageSize.Height / (float)imageSize.Width;
-                  if( aspectOfImageSize > aspectOfDesiredSize)
-                  {
-                      adjustedDesiredWidth = _desired_width;
-                      adjustedDesiredHeight = imageSize.Height * _desired_width / imageSize.Width;
-                  }
-                  else
-                  {
-                      adjustedDesiredWidth = imageSize.Width * _desired_height/ imageSize.Height;
-                      adjustedDesiredHeight = _desired_height;
-                  }
-                  temp.Insert(ImageVisualProperty.DesiredWidth, new PropertyValue(adjustedDesiredWidth));
-                  temp.Insert(ImageVisualProperty.DesiredHeight, new PropertyValue(adjustedDesiredHeight));
+                  Size2D desiredSize = new Size2D(_desired_width,_desired_height);
+                  Size2D imageSize = ImageLoading.GetClosestImageSize(_resourceUrl, desiredSize, FittingModeType.ScaleToFill);
+                  temp.Insert(ImageVisualProperty.DesiredWidth, new PropertyValue((int)imageSize.Width));
+                  temp.Insert(ImageVisualProperty.DesiredHeight, new PropertyValue((int)imageSize.Height));
                   temp.Insert(ImageVisualProperty.FittingMode, new PropertyValue((int) FittingModeType.ScaleToFill));
                 }
             }


### PR DESCRIPTION
before, ImageView calculate desired size using GetOriginalImageSize()
but this api does not consider rotate value
so i changed it

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
