### PR TITLE
[NUI] Fix CA1721 warnings (#2541)

### DIFF
--- a/src/Tizen.NUI/src/internal/Camera.cs
+++ b/src/Tizen.NUI/src/internal/Camera.cs
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-
+using System;
 using System.ComponentModel;
 using Tizen.NUI.BaseComponents;
 
@@ -116,12 +116,14 @@ namespace Tizen.NUI
             return ret;
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use FieldOfView property instead!")]
         public void SetFieldOfView(float fieldOfView)
         {
             Interop.CameraActor.SetFieldOfView(SwigCPtr, fieldOfView);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use FieldOfView property instead!")]
         public float GetFieldOfView()
         {
             float ret = Interop.CameraActor.GetFieldOfView(SwigCPtr);
@@ -129,12 +131,14 @@ namespace Tizen.NUI
             return ret;
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use AspectRatio property instead!")]
         public void SetAspectRatio(float aspectRatio)
         {
             Interop.CameraActor.SetAspectRatio(SwigCPtr, aspectRatio);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use AspectRatio property instead!")]
         public float GetAspectRatio()
         {
             float ret = Interop.CameraActor.GetAspectRatio(SwigCPtr);
@@ -168,12 +172,14 @@ namespace Tizen.NUI
             return ret;
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use TargetPosition property instead!")]
         public void SetTargetPosition(Vector3 targetPosition)
         {
             Interop.CameraActor.SetTargetPosition(SwigCPtr, Vector3.getCPtr(targetPosition));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use TargetPosition property instead!")]
         public Vector3 GetTargetPosition()
         {
             Vector3 ret = new Vector3(Interop.CameraActor.GetTargetPosition(SwigCPtr), true);
@@ -181,12 +187,14 @@ namespace Tizen.NUI
             return ret;
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use InvertYAxis property instead!")]
         public void SetInvertYAxis(bool invertYAxis)
         {
             Interop.CameraActor.SetInvertYAxis(SwigCPtr, invertYAxis);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use InvertYAxis property instead!")]
         public bool GetInvertYAxis()
         {
             bool ret = Interop.CameraActor.GetInvertYAxis(SwigCPtr);
@@ -212,6 +220,8 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        // The type of GetType() and SetType() is different from Type property.
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public string Type
         {
             get
@@ -229,6 +239,9 @@ namespace Tizen.NUI
                 setValue.Dispose();
             }
         }
+
+        // The type of GetProjectionMode() and SetProjectionMode() is different from Projection Property.
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public string ProjectionMode
         {
             get

--- a/src/Tizen.NUI/src/internal/ItemView.cs
+++ b/src/Tizen.NUI/src/internal/ItemView.cs
@@ -195,15 +195,6 @@ namespace Tizen.NUI
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public new uint GetChildCount()
-        {
-            uint ret = Interop.ActorInternal.GetChildCount(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public new View GetChildAt(uint index)
         {
             View ret = new View(Interop.ActorInternal.GetChildAt(SwigCPtr, index), true);
@@ -252,57 +243,6 @@ namespace Tizen.NUI
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetMinimumSwipeSpeed(float speed)
-        {
-            Interop.ItemView.SetMinimumSwipeSpeed(SwigCPtr, speed);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public float GetMinimumSwipeSpeed()
-        {
-            float ret = Interop.ItemView.GetMinimumSwipeSpeed(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetMinimumSwipeDistance(float distance)
-        {
-            Interop.ItemView.SetMinimumSwipeDistance(SwigCPtr, distance);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public float GetMinimumSwipeDistance()
-        {
-            float ret = Interop.ItemView.GetMinimumSwipeDistance(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetWheelScrollDistanceStep(float step)
-        {
-            Interop.ItemView.SetWheelScrollDistanceStep(SwigCPtr, step);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public float GetWheelScrollDistanceStep()
-        {
-            float ret = Interop.ItemView.GetWheelScrollDistanceStep(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetAnchoring(bool enabled)
         {
             Interop.ItemView.SetAnchoring(SwigCPtr, enabled);
@@ -341,23 +281,6 @@ namespace Tizen.NUI
         {
             Interop.ItemView.ScrollToItem(SwigCPtr, itemId, durationSeconds);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetRefreshInterval(float intervalLayoutPositions)
-        {
-            Interop.ItemView.SetRefreshInterval(SwigCPtr, intervalLayoutPositions);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public float GetRefreshInterval()
-        {
-            float ret = Interop.ItemView.GetRefreshInterval(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/internal/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/RenderTask.cs
@@ -297,12 +297,14 @@ namespace Tizen.NUI
             return ret;
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ClearColor property instead!")]
         public void SetClearColor(Vector4 color)
         {
             Interop.RenderTask.SetClearColor(SwigCPtr, Vector4.getCPtr(color));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ClearColor property instead!")]
         public Vector4 GetClearColor()
         {
             Vector4 ret = new Vector4(Interop.RenderTask.GetClearColor(SwigCPtr), true);

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -314,6 +314,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <returns>The view's natural size</returns>
         /// <since_tizen> 3 </since_tizen>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public new virtual Size2D GetNaturalSize()
         {
             return (Size2D)GetValue(Size2DProperty);
@@ -338,6 +339,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">Width to use</param>
         /// <returns>The height based on the width</returns>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use HeightForWidth property instead!")]
         public new virtual float GetHeightForWidth(float width)
         {
             return viewWrapperImpl.GetHeightForWidthBase(width);
@@ -350,6 +352,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="height">Height to use</param>
         /// <returns>The width based on the width</returns>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use WidthForHeight property instead!")]
         public new virtual float GetWidthForHeight(float height)
         {
             return viewWrapperImpl.GetWidthForHeightBase(height);

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1083,10 +1083,8 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Get attribues, it is abstract function and must be override.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new ImageViewStyle();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -395,6 +395,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="padding">Width and height.</param>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use CellPadding property instead!")]
         public void SetCellPadding(Size2D padding)
         {
             Interop.TableView.SetCellPadding(SwigCPtr, Size2D.getCPtr(padding));
@@ -406,6 +407,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <returns>The current padding as width and height.</returns>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use CellPadding property instead!")]
         public Vector2 GetCellPadding()
         {
             Vector2 ret = new Vector2(Interop.TableView.GetCellPadding(SwigCPtr), true);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -62,10 +62,8 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Get attribues, it is abstract function and must be override.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new TextFieldStyle();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -996,10 +996,8 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Get attribues, it is abstract function and must be override.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override ViewStyle GetViewStyle()
+        protected override ViewStyle CreateViewStyle()
         {
             return new TextLabelStyle();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -160,7 +160,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (null == viewStyle)
                 {
-                    ApplyStyle(GetViewStyle());
+                    ApplyStyle(CreateViewStyle());
                 }
 
                 return viewStyle;
@@ -1457,7 +1457,7 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return GetChildCount();
+                return Convert.ToUInt32(Children.Count);
             }
         }
 
@@ -2419,18 +2419,6 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (bool)GetValue(ThemeChangeSensitiveProperty);
             set => SetValue(ThemeChangeSensitiveProperty, value);
-        }
-
-        /// <summary>
-        /// Get Style, it is abstract function and must be override.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        // TODO: It should be deprecated. please use CreateViewStyle instead.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual ViewStyle GetViewStyle()
-        {
-            return CreateViewStyle();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -221,6 +221,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <seealso cref="Container.GetChildCount" />
         /// <since_tizen> 4 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
         public override uint GetChildCount()
         {
             return Convert.ToUInt32(Children.Count);
@@ -261,6 +262,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="styleName">A string matching a style described in a stylesheet.</param>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use StyleName property instead!")]
         public void SetStyleName(string styleName)
         {
             Interop.View.SetStyleName(SwigCPtr, styleName);
@@ -272,6 +274,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <returns>A string matching a style, or an empty string.</returns>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use StyleName property instead!")]
         public string GetStyleName()
         {
             string ret = Interop.View.GetStyleName(SwigCPtr);
@@ -465,6 +468,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width to use.</param>
         /// <returns>The height based on the width.</returns>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use HeightForWidth property instead!")]
         public float GetHeightForWidth(float width)
         {
             float ret = Interop.Actor.GetHeightForWidth(SwigCPtr, width);
@@ -481,6 +485,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="height">The height to use.</param>
         /// <returns>The width based on the height.</returns>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use WidthForHeight property instead!")]
         public float GetWidthForHeight(float height)
         {
             float ret = Interop.Actor.GetWidthForHeight(SwigCPtr, height);
@@ -508,6 +513,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="padding">Padding for the view.</param>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use Padding property instead!")]
         public void SetPadding(PaddingType padding)
         {
             Interop.Actor.SetPadding(SwigCPtr, PaddingType.getCPtr(padding));
@@ -520,6 +526,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="paddingOut">the value of padding for the view</param>
         /// <since_tizen> 3 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use Padding property instead!")]
         public void GetPadding(PaddingType paddingOut)
         {
             Interop.Actor.GetPadding(SwigCPtr, PaddingType.getCPtr(paddingOut));

--- a/src/Tizen.NUI/src/public/Container.cs
+++ b/src/Tizen.NUI/src/public/Container.cs
@@ -57,6 +57,7 @@ namespace Tizen.NUI
         /// <pre>The child container has been initialized.</pre>
         /// <returns>The parent container.</returns>
         /// <since_tizen> 4 </since_tizen>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public new Container Parent
         {
             get
@@ -76,7 +77,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return GetChildCount();
+                return Convert.ToUInt32(Children.Count);
             }
         }
 
@@ -113,6 +114,7 @@ namespace Tizen.NUI
         /// <pre>The child container has been initialized.</pre>
         /// <returns>The parent container.</returns>
         /// <since_tizen> 4 </since_tizen>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public abstract Container GetParent();
 
         /// <summary>
@@ -121,6 +123,7 @@ namespace Tizen.NUI
         /// <pre>The container has been initialized.</pre>
         /// <returns>The number of children.</returns>
         /// <since_tizen> 4 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
         public abstract UInt32 GetChildCount();
 
         internal abstract View FindCurrentChildById(uint id);

--- a/src/Tizen.NUI/src/public/CustomView/Spin.cs
+++ b/src/Tizen.NUI/src/public/CustomView/Spin.cs
@@ -66,6 +66,8 @@ namespace Tizen.NUI
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         [ScriptableProperty()]
+        // GetValue() is in BindableObject. It's different from this Value.
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public int Value
         {
             get

--- a/src/Tizen.NUI/src/public/Layer.cs
+++ b/src/Tizen.NUI/src/public/Layer.cs
@@ -355,6 +355,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <returns>The child count of the layer.</returns>
         /// <since_tizen> 4 </since_tizen>
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
         public override uint GetChildCount()
         {
             return Convert.ToUInt32(Children.Count);

--- a/src/Tizen.NUI/src/public/Window.cs
+++ b/src/Tizen.NUI/src/public/Window.cs
@@ -1060,6 +1060,7 @@ namespace Tizen.NUI
         /// <since_tizen> 6 </since_tizen>
         /// <feature> http://tizen.org/feature/opengles.surfaceless_context </feature>
         /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public Window GetParent()
         {
             if (IsSupportedMultiWindow() == false)

--- a/src/Tizen.NUI/src/public/XamlBinding/Interactivity/DataTrigger.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Interactivity/DataTrigger.cs
@@ -44,6 +44,7 @@ namespace Tizen.NUI.Binding
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use GetValue() instead!")]
         public object Value
         {
             get { return ((BindingCondition)Condition).Value; }

--- a/src/Tizen.NUI/src/public/XamlBinding/Trigger.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Trigger.cs
@@ -51,6 +51,7 @@ namespace Tizen.NUI.Binding
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
+        // [Obsolete("Deprecated in API9, will be removed in API11. Please use GetValue() instead!")]
         public object Value
         {
             get { return ((XamlPropertyCondition)Condition).Value; }


### PR DESCRIPTION
Property names should not match get methods
https://docs.microsoft.com/ko-kr/dotnet/fundamentals/code-analysis/quality-rules/ca1721

Co-authored-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
