### PR TITLE
Add some new APIs like Context, Settings, etc.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebBackForwardList.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebBackForwardList.cs
@@ -1,0 +1,31 @@
+﻿
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WebBackForwardListItem
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetUrl")]
+            public static extern string GetUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetTitle")]
+            public static extern string GetTitle(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardListItem_GetOriginalUrl")]
+            public static extern string GetOriginalUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+
+        internal static partial class WebBackForwardList
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemCount")]
+            public static extern int GetItemCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetCurrentItem")]
+            public static extern global::System.IntPtr GetCurrentItem(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebBackForwardList_GetItemAtIndex")]
+            public static extern global::System.IntPtr GetItemAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+        }
+    }
+}
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebContext.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebContext.cs
@@ -1,0 +1,40 @@
+﻿
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WebContext
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_GetCacheModel")]
+            public static extern int GetCacheModel(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetCacheModel")]
+            public static extern void SetCacheModel(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetProxyUri")]
+            public static extern void SetProxyUri(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetCertificateFilePath")]
+            public static extern void SetCertificateFilePath(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DisableCache")]
+            public static extern void DisableCache(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_SetDefaultProxyAuth")]
+            public static extern void SetDefaultProxyAuth(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteWebDatabase")]
+            public static extern void DeleteWebDatabase(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteWebStorage")]
+            public static extern void DeleteWebStorage(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_DeleteLocalFileSystem")]
+            public static extern void DeleteLocalFileSystem(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebContext_ClearCache")]
+            public static extern void ClearCache(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebCookieManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebCookieManager.cs
@@ -1,0 +1,22 @@
+﻿
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WebCookieManager
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_GetCookieAcceptPolicy")]
+            public static extern int GetCookieAcceptPolicy(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_SetCookieAcceptPolicy")]
+            public static extern void SetCookieAcceptPolicy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_SetPersistentStorage")]
+            public static extern void SetPersistentStorage(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCookieManager_ClearCookies")]
+            public static extern void ClearCookies(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebSettings.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebSettings.cs
@@ -1,0 +1,49 @@
+﻿
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WebSettings
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowMixedContents")]
+            public static extern void AllowMixedContents(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableSpatialNavigation")]
+            public static extern void EnableSpatialNavigation(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetDefaultFontSize")]
+            public static extern int GetDefaultFontSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultFontSize")]
+            public static extern void SetDefaultFontSize(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableWebSecurity")]
+            public static extern void EnableWebSecurity(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowFileAccessFromExternalUrl")]
+            public static extern void AllowFileAccessFromExternalUrl(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_IsJavaScriptEnabled")]
+            public static extern bool IsJavaScriptEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_EnableJavaScript")]
+            public static extern void EnableJavaScript(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowScriptsOpenWindows")]
+            public static extern void AllowScriptsOpenWindows(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AreImagesAutomaticallyLoaded")]
+            public static extern bool AreImagesAutomaticallyLoaded(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_AllowImagesLoadAutomatically")]
+            public static extern void AllowImagesLoadAutomatically(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_GetDefaultTextEncodingName")]
+            public static extern string GetDefaultTextEncodingName(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebSettings_SetDefaultTextEncodingName")]
+            public static extern void SetDefaultTextEncodingName(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+        }
+    }
+}
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
@@ -30,26 +30,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_URL_get")]
             public static extern int WebView_Property_URL_get();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_CACHE_MODEL_get")]
-            public static extern int WebView_Property_CACHE_MODEL_get();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_COOKIE_ACCEPT_POLICY_get")]
-            public static extern int WebView_Property_COOKIE_ACCEPT_POLICY_get();
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_USER_AGENT_get")]
             public static extern int WebView_Property_USER_AGENT_get();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_ENABLE_JAVASCRIPT_get")]
-            public static extern int WebView_Property_ENABLE_JAVASCRIPT_get();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_LOAD_IMAGES_AUTOMATICALLY_get")]
-            public static extern int WebView_Property_LOAD_IMAGES_AUTOMATICALLY_get();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_DEFAULT_TEXT_ENCODING_NAME_get")]
-            public static extern int WebView_Property_DEFAULT_TEXT_ENCODING_NAME_get();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_DEFAULT_FONT_SIZE_get")]
-            public static extern int WebView_Property_DEFAULT_FONT_SIZE_get();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_SCROLL_POSITION_get")]
             public static extern int ScrollPositionGet();
@@ -60,11 +42,23 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_CONTENT_SIZE_get")]
             public static extern int ContentSizeGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetBackForwardList")]
+            public static extern global::System.IntPtr GetWebBackForwardList(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetContext")]
+            public static extern global::System.IntPtr GetWebContext(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetCookieManager")]
+            public static extern global::System.IntPtr GetWebCookieManager(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetSettings")]
+            public static extern global::System.IntPtr GetWebSettings(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadUrl")]
             public static extern void WebView_LoadUrl(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadHTMLString")]
-            public static extern void WebView_LoadHTMLString(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_LoadHtmlString")]
+            public static extern void LoadHtmlString(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Reload")]
             public static extern void WebView_Reload(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -101,12 +95,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ClearHistory")]
             public static extern void WebView_ClearHistory(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ClearCache")]
-            public static extern void WebView_ClearCache(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_ClearCookies")]
-            public static extern void WebView_ClearCookies(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_SWIGUpcast")]
             public static extern global::System.IntPtr WebView_SWIGUpcast(global::System.IntPtr jarg1);

--- a/src/Tizen.NUI/src/internal/WebBackForwardList.cs
+++ b/src/Tizen.NUI/src/internal/WebBackForwardList.cs
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// WebBackForwardListItem is a class for back-forward list item of web view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebBackForwardListItem : Disposable
+    {
+        /// <summary>
+        /// Get uri.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Uri Url
+        {
+            get
+            {
+                return new Uri(Interop.WebBackForwardListItem.GetUrl(SwigCPtr));
+            }
+        }
+
+        /// <summary>
+        /// Get title.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Title
+        {
+            get
+            {
+                return Interop.WebBackForwardListItem.GetTitle(SwigCPtr);
+            }
+        }
+
+        /// <summary>
+        /// Get original url.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Uri OriginalUrl
+        {
+            get
+            {
+                return new Uri(Interop.WebBackForwardListItem.GetOriginalUrl(SwigCPtr));
+            }
+        }
+
+        internal WebBackForwardListItem(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebBackForwardListItem obj)
+        {
+            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
+        }
+
+        /// <summary>
+        /// Dispose for IDisposable pattern
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+            }
+
+            base.Dispose(type);
+        }
+    }
+
+    /// <summary>
+    /// WebBackForwardList is a class for back-forward list of web view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebBackForwardList : Disposable
+    {
+        /// <summary>
+        /// Get item count.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int ItemCount
+        {
+            get
+            {
+                return Interop.WebBackForwardList.GetItemCount(SwigCPtr);
+            }
+        }
+
+        /// <summary>
+        /// Get current item.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebBackForwardListItem GetCurrentItem()
+        {
+            System.IntPtr itemPtr = Interop.WebBackForwardList.GetCurrentItem(SwigCPtr);
+            return new WebBackForwardListItem(itemPtr, false);
+        }
+
+        /// <summary>
+        /// Get current item.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebBackForwardListItem GetItemAtIndex(int index)
+        {
+            System.IntPtr itemPtr = Interop.WebBackForwardList.GetItemAtIndex(SwigCPtr, index);
+            return new WebBackForwardListItem(itemPtr, false);
+        }
+
+        internal WebBackForwardList(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebBackForwardList obj)
+        {
+            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
+        }
+
+        /// <summary>
+        /// Dispose for IDisposable pattern
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+            }
+
+            base.Dispose(type);
+        }
+    }
+}
+

--- a/src/Tizen.NUI/src/internal/WebContext.cs
+++ b/src/Tizen.NUI/src/internal/WebContext.cs
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// WebContext is a class for context of web view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebContext : Disposable
+    {
+        /// <summary>
+        /// Cache model
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum CacheModelType
+        {
+            /// <summary>
+            /// The smallest cache capacity
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            DocumentViewer,
+
+            /// <summary>
+            /// The bigger cache capacity than DocumentBrowser
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            DocumentBrowser,
+
+            /// <summary>
+            /// The biggest cache capacity.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            PrimaryWebBrowser,
+        }
+
+        /// <summary>
+        /// Cache model
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CacheModelType CacheModel
+        {
+            get
+            {
+                return (CacheModelType)Interop.WebContext.GetCacheModel(SwigCPtr);
+            }
+            set
+            {
+                Interop.WebContext.SetCacheModel(SwigCPtr, (int)value);
+            }
+        }
+
+        /// <summary>
+        /// Set the proxy uri.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Uri ProxyUri
+        {
+            get
+            {
+                return new Uri(proxyUri);
+            }
+            set
+            {
+                if (value != null)
+                {
+                    proxyUri = value.AbsoluteUri;
+                    Interop.WebContext.SetProxyUri(SwigCPtr, proxyUri);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set the Certificate File Path.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string CertificateFilePath
+        {
+            get
+            {
+                return certificateFilePath;
+            }
+            set
+            {
+                certificateFilePath = value;
+                Interop.WebContext.SetCertificateFilePath(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Disable cache or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DisableCache
+        {
+            get
+            {
+                return disableCache;
+            }
+            set
+            {
+                disableCache = value;
+                Interop.WebContext.DisableCache(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Set Default Proxy Auth.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetDefaultProxyAuth(string username, string password)
+        {
+            Interop.WebContext.SetDefaultProxyAuth(SwigCPtr, username, password);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Delete Web Database.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void DeleteWebDatabase()
+        {
+            Interop.WebContext.DeleteWebDatabase(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Delete Web Storage.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void DeleteWebStorage()
+        {
+            Interop.WebContext.DeleteWebStorage(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Delete Local FileSystem.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void DeleteLocalFileSystem()
+        {
+            Interop.WebContext.DeleteLocalFileSystem(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Clear cache.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ClearCache()
+        {
+            Interop.WebContext.ClearCache(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal WebContext(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebContext obj)
+        {
+            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
+        }
+
+        /// <summary>
+        /// Dispose for IDisposable pattern
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+            }
+
+            base.Dispose(type);
+        }
+
+        // private
+        private string proxyUri;
+        private string certificateFilePath;
+        private bool disableCache;
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebCookieManager.cs
+++ b/src/Tizen.NUI/src/internal/WebCookieManager.cs
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// WebCookieManager is a class for cookie manager of web view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebCookieManager : Disposable
+    {
+        /// <summary>
+        /// Cookie Accept Policy
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum CookieAcceptPolicyType
+        {
+            /// <summary>
+            /// Always
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Always,
+
+            /// <summary>
+            /// Never
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Never,
+
+            /// <summary>
+            /// No third party.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            NoThirdParty,
+        }
+
+        /// <summary>
+        /// Cookie accept policy
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CookieAcceptPolicyType CookieAcceptPolicy
+        {
+            get
+            {
+                return (CookieAcceptPolicyType)Interop.WebCookieManager.GetCookieAcceptPolicy(SwigCPtr);
+            }
+            set
+            {
+                Interop.WebCookieManager.SetCookieAcceptPolicy(SwigCPtr, (int)value);
+            }
+        }
+
+        /// <summary>
+        /// Cookie persistent storage type.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum CookiePersistentStorageType
+        {
+            /// <summary>
+            /// @deprecated Cookies are stored in a text file.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Text,
+
+            /// <summary>
+            /// stored in a SQLite file
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            SqlLite,
+        }
+
+        /// <summary>
+        /// Set the proxy uri.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetPersistentStorage(string path, CookiePersistentStorageType storageType)
+        {
+            Interop.WebCookieManager.SetPersistentStorage(SwigCPtr, path, (int)storageType);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Set Default Proxy Auth.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ClearCookies()
+        {
+            Interop.WebCookieManager.ClearCookies(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal WebCookieManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebCookieManager obj)
+        {
+            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
+        }
+
+        /// <summary>
+        /// Dispose for IDisposable pattern
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+            }
+
+            base.Dispose(type);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebSettings.cs
+++ b/src/Tizen.NUI/src/internal/WebSettings.cs
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// WebSettings is a class for settings of web view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebSettings : Disposable
+    {
+        /// <summary>
+        /// Allow Mixed Contents
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowMixedContents
+        {
+            get
+            {
+                return allowMixedContents;
+            }
+            set
+            {
+                allowMixedContents = value;
+                Interop.WebSettings.AllowMixedContents(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Enable Spatial Navigation.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool EnableSpatialNavigation
+        {
+            get
+            {
+                return enableSpatialNavigation;
+            }
+            set
+            {
+                enableSpatialNavigation = value;
+                Interop.WebSettings.EnableSpatialNavigation(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Default Font Size.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int DefaultFontSize
+        {
+            get
+            {
+                return Interop.WebSettings.GetDefaultFontSize(SwigCPtr);
+            }
+            set
+            {
+                Interop.WebSettings.SetDefaultFontSize(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Enable web security.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool EnableWebSecurity
+        {
+            get
+            {
+                return enableWebSecurity;
+            }
+            set
+            {
+                enableWebSecurity = value;
+                Interop.WebSettings.EnableWebSecurity(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Allow File Access From External Url.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowFileAccessFromExternalUrl
+        {
+            get
+            {
+                return allowFileAccessFromExternalUrl;
+            }
+            set
+            {
+                allowFileAccessFromExternalUrl = value;
+                Interop.WebSettings.AllowFileAccessFromExternalUrl(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Enable JavaScript.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool EnableJavaScript
+        {
+            get
+            {
+                return Interop.WebSettings.IsJavaScriptEnabled(SwigCPtr);
+            }
+            set
+            {
+                Interop.WebSettings.EnableJavaScript(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Allow Scripts Open Windows.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowScriptsOpenWindows
+        {
+            get
+            {
+                return allowScriptsOpenWindows;
+            }
+            set
+            {
+                allowScriptsOpenWindows = value;
+                Interop.WebSettings.AllowScriptsOpenWindows(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Allow Images Load Automatically.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowImagesLoadAutomatically
+        {
+            get
+            {
+                return Interop.WebSettings.AreImagesAutomaticallyLoaded(SwigCPtr);
+            }
+            set
+            {
+                Interop.WebSettings.AllowImagesLoadAutomatically(SwigCPtr, value);
+            }
+        }
+
+        /// <summary>
+        /// Default Text Encoding Name.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string DefaultTextEncodingName
+        {
+            get
+            {
+                return Interop.WebSettings.GetDefaultTextEncodingName(SwigCPtr);
+            }
+            set
+            {
+                Interop.WebSettings.SetDefaultTextEncodingName(SwigCPtr, value);
+            }
+        }
+
+        internal WebSettings(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebSettings obj)
+        {
+            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
+        }
+
+        /// <summary>
+        /// Dispose for IDisposable pattern
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+            }
+
+            base.Dispose(type);
+        }
+
+        // private.
+        private bool allowMixedContents;
+        private bool enableSpatialNavigation;
+        private bool enableWebSecurity;
+        private bool allowFileAccessFromExternalUrl;
+        private bool allowScriptsOpenWindows;
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebView.cs
+++ b/src/Tizen.NUI/src/internal/WebView.cs
@@ -61,6 +61,11 @@ namespace Tizen.NUI
             pageLoadFinishedSignal = new WebViewPageLoadSignal(Interop.WebView.new_WebViewPageLoadSignal_PageLoadFinished(swigCPtr));
             pageLoadErrorSignal = new WebViewPageLoadErrorSignal(Interop.WebView.new_WebViewPageLoadErrorSignal_PageLoadError(swigCPtr));
             scrollEdgeReachedSignal = new WebViewScrollEdgeReachedSignal(Interop.WebView.NewWebViewScrollEdgeReachedSignalScrollEdgeReached(swigCPtr));
+
+            BackForwardList = new WebBackForwardList(Interop.WebView.GetWebBackForwardList(SwigCPtr), false);
+            Context = new WebContext(Interop.WebView.GetWebContext(SwigCPtr), false);
+            CookieManager = new WebCookieManager(Interop.WebView.GetWebCookieManager(SwigCPtr), false);
+            Settings = new WebSettings(Interop.WebView.GetWebSettings(SwigCPtr), false);
         }
 
         internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebView obj)
@@ -101,6 +106,11 @@ namespace Tizen.NUI
                 pageLoadStartedSignal.Dispose();
                 pageLoadFinishedSignal.Dispose();
                 pageLoadErrorSignal.Dispose();
+
+                BackForwardList.Dispose();
+                Context.Dispose();
+                CookieManager.Dispose();
+                Settings.Dispose();
             }
 
             base.Dispose(type);
@@ -121,10 +131,7 @@ namespace Tizen.NUI
             e.WebView = Registry.GetManagedBaseHandleFromNativePtr(data) as WebView;
             e.PageUrl = pageUrl;
 
-            if (pageLoadStartedEventHandler != null)
-            {
-                pageLoadStartedEventHandler(this, e);
-            }
+            pageLoadStartedEventHandler?.Invoke(this, e);
         }
 
         private void OnPageLoadFinished(IntPtr data, string pageUrl)
@@ -134,10 +141,7 @@ namespace Tizen.NUI
             e.WebView = Registry.GetManagedBaseHandleFromNativePtr(data) as WebView;
             e.PageUrl = pageUrl;
 
-            if (pageLoadFinishedEventHandler != null)
-            {
-                pageLoadFinishedEventHandler(this, e);
-            }
+            pageLoadFinishedEventHandler?.Invoke(this, e);
         }
 
         private void OnPageLoadError(IntPtr data, string pageUrl, int errorCode)
@@ -148,10 +152,7 @@ namespace Tizen.NUI
             e.PageUrl = pageUrl;
             e.ErrorCode = (WebViewPageLoadErrorEventArgs.LoadErrorCode)errorCode;
 
-            if (pageLoadErrorEventHandler != null)
-            {
-                pageLoadErrorEventHandler(this, e);
-            }
+            pageLoadErrorEventHandler?.Invoke(this, e);
         }
 
         private void OnScrollEdgeReached(IntPtr data, int edge)
@@ -163,13 +164,7 @@ namespace Tizen.NUI
         internal static new class Property
         {
             internal static readonly int URL = Interop.WebView.WebView_Property_URL_get();
-            internal static readonly int CACHE_MODEL = Interop.WebView.WebView_Property_CACHE_MODEL_get();
-            internal static readonly int COOKIE_ACCEPT_POLICY = Interop.WebView.WebView_Property_COOKIE_ACCEPT_POLICY_get();
             internal static readonly int USER_AGENT = Interop.WebView.WebView_Property_USER_AGENT_get();
-            internal static readonly int ENABLE_JAVASCRIPT = Interop.WebView.WebView_Property_ENABLE_JAVASCRIPT_get();
-            internal static readonly int LOAD_IMAGES_AUTOMATICALLY = Interop.WebView.WebView_Property_LOAD_IMAGES_AUTOMATICALLY_get();
-            internal static readonly int DEFAULT_TEXT_ENCODING_NAME = Interop.WebView.WebView_Property_DEFAULT_TEXT_ENCODING_NAME_get();
-            internal static readonly int DEFAULT_FONT_SIZE = Interop.WebView.WebView_Property_DEFAULT_FONT_SIZE_get();
             internal static readonly int ScrollPosition = Interop.WebView.ScrollPositionGet();
             internal static readonly int ScrollSize = Interop.WebView.ScrollSizeGet();
             internal static readonly int ContentSize = Interop.WebView.ContentSizeGet();
@@ -191,54 +186,6 @@ namespace Tizen.NUI
             return temp;
         });
 
-        private static readonly BindableProperty CacheModelProperty = BindableProperty.Create(nameof(CacheModel), typeof(CacheModel), typeof(WebView), CacheModel.DocumentViewer, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var webview = (WebView)bindable;
-            if (newValue != null)
-            {
-                Tizen.NUI.Object.SetProperty(webview.swigCPtr, WebView.Property.CACHE_MODEL, new Tizen.NUI.PropertyValue((int)newValue));
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var webview = (WebView)bindable;
-            string temp;
-            if (Tizen.NUI.Object.GetProperty(webview.swigCPtr, WebView.Property.CACHE_MODEL).Get(out temp) == false)
-            {
-                NUILog.Error("CacheModel get error!");
-            }
-            switch (temp)
-            {
-                case "DOCUMENT_VIEWER": return CacheModel.DocumentViewer;
-                case "DOCUMENT_BROWSER": return CacheModel.DocumentBrowser;
-                default: return CacheModel.PrimaryWebBrowser;
-            }
-        });
-
-        private static readonly BindableProperty CookieAcceptPolicyProperty = BindableProperty.Create(nameof(CookieAcceptPolicy), typeof(CookieAcceptPolicy), typeof(WebView), CookieAcceptPolicy.NoThirdParty, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var webview = (WebView)bindable;
-            if (newValue != null)
-            {
-                Tizen.NUI.Object.SetProperty(webview.swigCPtr, WebView.Property.COOKIE_ACCEPT_POLICY, new Tizen.NUI.PropertyValue((int)newValue));
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var webview = (WebView)bindable;
-            string temp;
-            if (Tizen.NUI.Object.GetProperty(webview.swigCPtr, WebView.Property.COOKIE_ACCEPT_POLICY).Get(out temp) == false)
-            {
-                NUILog.Error("CookieAcceptPolicy get error!");
-            }
-            switch (temp)
-            {
-                case "ALWAYS": return CookieAcceptPolicy.Always;
-                case "NEVER": return CookieAcceptPolicy.Never;
-                default: return CookieAcceptPolicy.NoThirdParty;
-            }
-        });
-
         private static readonly BindableProperty UserAgentProperty = BindableProperty.Create(nameof(UserAgent), typeof(string), typeof(WebView), string.Empty, propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
@@ -254,71 +201,6 @@ namespace Tizen.NUI
             Tizen.NUI.Object.GetProperty(webview.swigCPtr, WebView.Property.USER_AGENT).Get(out temp);
             return temp;
         });
-
-        private static readonly BindableProperty EnableJavaScriptProperty = BindableProperty.Create(nameof(EnableJavaScript), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var webview = (WebView)bindable;
-            if (newValue != null)
-            {
-                Tizen.NUI.Object.SetProperty(webview.swigCPtr, WebView.Property.ENABLE_JAVASCRIPT, new Tizen.NUI.PropertyValue((bool)newValue));
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var webview = (WebView)bindable;
-            bool temp;
-            Tizen.NUI.Object.GetProperty(webview.swigCPtr, WebView.Property.ENABLE_JAVASCRIPT).Get(out temp);
-            return temp;
-        });
-
-        private static readonly BindableProperty LoadImagesAutomaticallyProperty = BindableProperty.Create(nameof(LoadImagesAutomatically), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var webview = (WebView)bindable;
-            if (newValue != null)
-            {
-                Tizen.NUI.Object.SetProperty(webview.swigCPtr, WebView.Property.LOAD_IMAGES_AUTOMATICALLY, new Tizen.NUI.PropertyValue((bool)newValue));
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var webview = (WebView)bindable;
-            bool temp;
-            Tizen.NUI.Object.GetProperty(webview.swigCPtr, WebView.Property.LOAD_IMAGES_AUTOMATICALLY).Get(out temp);
-            return temp;
-        });
-
-        private static readonly BindableProperty DefaultTextEncodingNameProperty = BindableProperty.Create(nameof(DefaultTextEncodingName), typeof(string), typeof(WebView), string.Empty, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var webview = (WebView)bindable;
-            if (newValue != null)
-            {
-                Tizen.NUI.Object.SetProperty(webview.swigCPtr, WebView.Property.DEFAULT_TEXT_ENCODING_NAME, new Tizen.NUI.PropertyValue((string)newValue));
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var webview = (WebView)bindable;
-            string temp;
-            Tizen.NUI.Object.GetProperty(webview.swigCPtr, WebView.Property.DEFAULT_TEXT_ENCODING_NAME).Get(out temp);
-            return temp;
-        });
-
-        private static readonly BindableProperty DefaultFontSizeProperty = BindableProperty.Create(nameof(DefaultFontSize), typeof(int), typeof(WebView), 16, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var webview = (WebView)bindable;
-            if (newValue != null)
-            {
-                Tizen.NUI.Object.SetProperty(webview.swigCPtr, WebView.Property.DEFAULT_FONT_SIZE, new Tizen.NUI.PropertyValue((int)newValue));
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var webview = (WebView)bindable;
-            int temp;
-            Tizen.NUI.Object.GetProperty(webview.swigCPtr, WebView.Property.DEFAULT_FONT_SIZE).Get(out temp);
-            return temp;
-        });
-
 
         private static readonly BindableProperty ScrollPositionProperty = BindableProperty.Create(nameof(ScrollPosition), typeof(Vector2), typeof(WebView), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
@@ -359,7 +241,6 @@ namespace Tizen.NUI
         public WebView() : this(Interop.WebView.WebView_New(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
         }
 
         /// <summary>
@@ -384,6 +265,30 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// BackForwardList.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebBackForwardList BackForwardList { get; }
+
+        /// <summary>
+        /// Context.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebContext Context { get; }
+
+        /// <summary>
+        /// CookieManager.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebCookieManager CookieManager { get; }
+
+        /// <summary>
+        /// BackForwardList.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebSettings Settings { get; }
+
+        /// <summary>
         /// The url to load.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -401,36 +306,34 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// The cache model of the current WebView.
+        /// Deprecated. The cache model of the current WebView.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CacheModel CacheModel
         {
             get
             {
-                return (CacheModel)GetValue(CacheModelProperty);
+                return (CacheModel)Context.CacheModel;
             }
             set
             {
-                SetValue(CacheModelProperty, value);
-                NotifyPropertyChanged();
+                Context.CacheModel = (WebContext.CacheModelType)value;
             }
         }
 
         /// <summary>
-        /// The cookie acceptance policy.
+        /// Deprecated. The cookie acceptance policy.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public CookieAcceptPolicy CookieAcceptPolicy
         {
             get
             {
-                return (CookieAcceptPolicy)GetValue(CookieAcceptPolicyProperty);
+                return (CookieAcceptPolicy)CookieManager.CookieAcceptPolicy;
             }
             set
             {
-                SetValue(CookieAcceptPolicyProperty, value);
-                NotifyPropertyChanged();
+                CookieManager.CookieAcceptPolicy = (WebCookieManager.CookieAcceptPolicyType)value;
             }
         }
 
@@ -452,36 +355,34 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Whether JavaScript is enabled.
+        /// Deprecated. Whether JavaScript is enabled.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool EnableJavaScript
         {
             get
             {
-                return (bool)GetValue(EnableJavaScriptProperty);
+                return Settings.EnableJavaScript;
             }
             set
             {
-                SetValue(EnableJavaScriptProperty, value);
-                NotifyPropertyChanged();
+                Settings.EnableJavaScript = value;
             }
         }
 
         /// <summary>
-        /// Whether images can be loaded automatically.
+        /// Deprecated. Whether images can be loaded automatically.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool LoadImagesAutomatically
         {
             get
             {
-                return (bool)GetValue(LoadImagesAutomaticallyProperty);
+                return Settings.AllowImagesLoadAutomatically;
             }
             set
             {
-                SetValue(LoadImagesAutomaticallyProperty, value);
-                NotifyPropertyChanged();
+                Settings.AllowImagesLoadAutomatically = value;
             }
         }
 
@@ -494,12 +395,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return (string)GetValue(DefaultTextEncodingNameProperty);
+                return Settings.DefaultTextEncodingName;
             }
             set
             {
-                SetValue(DefaultTextEncodingNameProperty, value);
-                NotifyPropertyChanged();
+                Settings.DefaultTextEncodingName = value;
             }
         }
 
@@ -511,12 +411,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return (int)GetValue(DefaultFontSizeProperty);
+                return Settings.DefaultFontSize;
             }
             set
             {
-                SetValue(DefaultFontSizeProperty, value);
-                NotifyPropertyChanged();
+                Settings.DefaultFontSize = value;
             }
         }
 
@@ -685,13 +584,24 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Returns the URL of the Web
+        /// Deprecated. Loads a html by string.
         /// <param name="data">The data of Web</param>
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void LoadHTMLString(string data)
         {
-            Interop.WebView.WebView_LoadHTMLString(swigCPtr, data);
+            Interop.WebView.LoadHtmlString(SwigCPtr, data);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Loads a html by string.
+        /// <param name="data">The data of Web</param>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void LoadHtmlString(string data)
+        {
+            Interop.WebView.LoadHtmlString(SwigCPtr, data);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -844,23 +754,21 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Clears the cache of current WebView.
+        /// Deprecated. Clears the cache of current WebView.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ClearCache()
         {
-            Interop.WebView.WebView_ClearCache(swigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            Context.ClearCache();
         }
 
         /// <summary>
-        /// Clears all the cookies of current WebView.
+        /// Deprecated. Clears all the cookies of current WebView.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ClearCookies()
         {
-            Interop.WebView.WebView_ClearCookies(swigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            CookieManager.ClearCookies();
         }
     }
 }


### PR DESCRIPTION
Originally only WebView is used to add new APIs, it will become
bigger, and be hard to maintain.
This patch is to move some related APIs into a class like WebContext,
WebSettings, etc.
And it also adds some new APIs like WebBackForwardList, etc.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
