### PR TITLE
[NUI] Fix Dispose memory leak issue

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Disposable.cs
+++ b/src/Tizen.NUI/src/internal/Common/Disposable.cs
@@ -34,8 +34,6 @@ namespace Tizen.NUI
         private bool swigCMemOwn { get; set; }
         private bool isDisposeQueued = false;
 
-        private bool disposedThis = false;
-
         /// <summary>
         /// Create an instance of Disposable.
         /// </summary>
@@ -83,7 +81,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void Dispose(bool disposing)
         {
-            if (disposedThis)
+            if (disposed)
             {
                 return;
             }
@@ -120,8 +118,6 @@ namespace Tizen.NUI
 
             // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
             // TODO: set large fields to null.
-
-            disposedThis = true;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -48,8 +48,6 @@ namespace Tizen.NUI
         //A Flag to check who called Dispose(). (By User or DisposeQueue)
         private bool isDisposeQueued = false;
 
-        private bool disposedThis = false;
-
         /// <summary>
         /// Create an instance of BaseHandle.
         /// </summary>
@@ -307,7 +305,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void Dispose(bool disposing)
         {
-            if (disposedThis)
+            if (disposed)
             {
                 return;
             }
@@ -344,8 +342,6 @@ namespace Tizen.NUI
 
             // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
             // TODO: set large fields to null.
-
-            disposedThis = true;
         }
 
 

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -95,7 +95,6 @@ namespace Tizen.NUI
         private bool swigCMemOwn;
         private bool disposed;
         private bool isDisposeQueued = false;
-        private bool disposedThis = false;
 
         private MeasureSpecification parentMeasureSpecificationWidth;
         private MeasureSpecification parentMeasureSpecificationHeight;
@@ -304,7 +303,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(bool disposing)
         {
-            if (disposedThis)
+            if (disposed)
             {
                 return;
             }
@@ -341,7 +340,6 @@ namespace Tizen.NUI
 
             // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
             // TODO: set large fields to null.
-            disposedThis = true;
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
- 'disposedThis' blocks the release of memory.
- modified by this patch.
   -> https://github.com/Samsung/TizenFX/pull/2381

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
