### PR TITLE
[NUI] Add Exit when key is either Back or Escape in a sample

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AccessibilityManagerSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AccessibilityManagerSample.cs
@@ -29,6 +29,7 @@ namespace Tizen.NUI.Samples
         {
             Window window = NUIApplication.GetDefaultWindow();
             window.BackgroundColor = Color.White;
+            window.KeyEvent += OnKeyEvent;
             windowSize = window.Size;
 
             // Create Table
@@ -100,6 +101,14 @@ namespace Tizen.NUI.Samples
             {
                 // Here, in the sample, if one finger double tap, the following log will shows in terminal.
                 Tizen.Log.Error(tag, "The current focused view is "+ args.View.Name +"\n");
+            }
+        }
+
+        public void OnKeyEvent(object sender, Window.KeyEventArgs e)
+        {
+            if (e.Key.State == Key.StateType.Down && (e.Key.KeyPressedName == "XF86Back" || e.Key.KeyPressedName == "Escape"))
+            {
+                Exit();
             }
         }
 


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- In AccessibilityManager sample, when the key pressed name is 'Back' or 'Escape',
 then the app is terminated.


### API Changes ###
- N/A