### PR TITLE
[NUI] Add a VideoHoleEnabled property into WebView.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
@@ -60,6 +60,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TITLE_get")]
             public static extern int TitleGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_VIDEO_HOLE_ENABLED_get")]
+            public static extern int VideoHoleEnabledGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetFavicon")]
             public static extern global::System.IntPtr GetFavicon(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/internal/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebView.cs
@@ -169,6 +169,7 @@ namespace Tizen.NUI
             internal static readonly int ScrollSize = Interop.WebView.ScrollSizeGet();
             internal static readonly int ContentSize = Interop.WebView.ContentSizeGet();
             internal static readonly int Title = Interop.WebView.TitleGet();
+            internal static readonly int VideoHoleEnabled = Interop.WebView.VideoHoleEnabledGet();
         }
 
         private static readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(WebView), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -241,6 +242,22 @@ namespace Tizen.NUI
             string title;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.Title).Get(out title);
             return title;
+        });
+
+        private static readonly BindableProperty VideoHoleEnabledProperty = BindableProperty.Create(nameof(VideoHoleEnabled), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var webview = (WebView)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty(webview.SwigCPtr, WebView.Property.VideoHoleEnabled, new Tizen.NUI.PropertyValue((bool)newValue));
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var webview = (WebView)bindable;
+            bool temp;
+            Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.VideoHoleEnabled).Get(out temp);
+            return temp;
         });
 
         /// <summary>
@@ -484,6 +501,23 @@ namespace Tizen.NUI
             {
                 Vector2 sv = (Vector2)GetValue(ContentSizeProperty);
                 return new Size(sv.Width, sv.Height);
+            }
+        }
+
+        /// <summary>
+        /// Whether video hole is enabled or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool VideoHoleEnabled
+        {
+            get
+            {
+                return (bool)GetValue(VideoHoleEnabledProperty);
+            }
+            set
+            {
+                SetValue(VideoHoleEnabledProperty, value);
+                NotifyPropertyChanged();
             }
         }
 


### PR DESCRIPTION
Video hole is used for playing videos with high quality in WebView.
This patch is to add a VideoHoleEnabled property.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
