### PR TITLE
[NUI] Add a VideoHoleEnabled property into WebView.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
@@ -46,7 +46,10 @@ namespace Tizen.NUI
             public static extern int ContentSizeGet();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_TITLE_get")]
-            public static extern int WebView_Property_TITLE_get();
+            public static extern int TitleGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_Property_VIDEO_HOLE_ENABLED_get")]
+            public static extern int VideoHoleEnabledGet();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetFavicon")]
             public static extern global::System.IntPtr WebView_GetFavicon(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/WebView.cs
+++ b/src/Tizen.NUI/src/internal/WebView.cs
@@ -167,7 +167,8 @@ namespace Tizen.NUI
             internal static readonly int ScrollPosition = Interop.WebView.ScrollPositionGet();
             internal static readonly int ScrollSize = Interop.WebView.ScrollSizeGet();
             internal static readonly int ContentSize = Interop.WebView.ContentSizeGet();
-            internal static readonly int Title = Interop.WebView.WebView_Property_TITLE_get();
+            internal static readonly int Title = Interop.WebView.TitleGet();
+            internal static readonly int VideoHoleEnabled = Interop.WebView.VideoHoleEnabledGet();
         }
 
         private static readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(WebView), string.Empty, propertyChanged: (bindable, oldValue, newValue) =>
@@ -242,8 +243,24 @@ namespace Tizen.NUI
             return title;
         });
 
+        private static readonly BindableProperty VideoHoleEnabledProperty = BindableProperty.Create(nameof(VideoHoleEnabled), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var webview = (WebView)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty(webview.SwigCPtr, WebView.Property.VideoHoleEnabled, new Tizen.NUI.PropertyValue((bool)newValue));
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var webview = (WebView)bindable;
+            bool temp;
+            Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.VideoHoleEnabled).Get(out temp);
+            return temp;
+        });
+
         /// <summary>
-        /// Creates an uninitialized WebView.
+        /// Creates a WebView.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public WebView() : this(Interop.WebView.WebView_New(), true)
@@ -252,9 +269,9 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Creates an uninitialized WebView.
-        /// <param name="locale">The locale of Web</param>
-        /// <param name="timezoneId">The timezoneId of Web</param>
+        /// Creates a WebView with local language and time zone.
+        /// <param name="locale">The locale language of Web</param>
+        /// <param name="timezoneId">The time zone Id of Web</param>
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public WebView(string locale, string timezoneId) : this(Interop.WebView.WebView_New_2(locale, timezoneId), true)
@@ -263,11 +280,11 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Creates an uninitialized WebView.
-        /// <param name="args">args array</param>
+        /// Creates a WebView with an args list.
+        /// <param name="args">args array. The first value of array must be program's name.</param>
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public WebView(string[] args) : this(Interop.WebView.WebView_New_3(args.Length, args), true)
+        public WebView(string[] args) : this(Interop.WebView.WebView_New_3(args?.Length ?? 0, args), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -487,6 +504,23 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Whether video hole is enabled or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool VideoHoleEnabled
+        {
+            get
+            {
+                return (bool)GetValue(VideoHoleEnabledProperty);
+            }
+            set
+            {
+                SetValue(VideoHoleEnabledProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// Event for the PageLoadStarted signal which can be used to subscribe or unsubscribe the event handler.<br />
         /// This signal is emitted when page loading has started.<br />
         /// </summary>
@@ -611,6 +645,8 @@ namespace Tizen.NUI
             get
             {
                 global::System.IntPtr imageView = Interop.WebView.WebView_GetFavicon(swigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                    return null;
                 return new ImageView(imageView, false);
             }
         }


### PR DESCRIPTION
Video hole is used for playing videos with high quality in WebView.
This patch is to add a VideoHoleEnabled property.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
