### PR TITLE
[NUI] Fix CA1721 warnings of Public APIs

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTask.cs
@@ -297,14 +297,14 @@ namespace Tizen.NUI
             return ret;
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ClearColor property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use ClearColor property instead!")]
         public void SetClearColor(Vector4 color)
         {
             Interop.RenderTask.SetClearColor(SwigCPtr, Vector4.getCPtr(color));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ClearColor property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use ClearColor property instead!")]
         public Vector4 GetClearColor()
         {
             Vector4 ret = new Vector4(Interop.RenderTask.GetClearColor(SwigCPtr), true);

--- a/src/Tizen.NUI/src/internal/Utility/Camera.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Camera.cs
@@ -116,14 +116,14 @@ namespace Tizen.NUI
             return ret;
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use FieldOfView property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use FieldOfView property instead!")]
         public void SetFieldOfView(float fieldOfView)
         {
             Interop.CameraActor.SetFieldOfView(SwigCPtr, fieldOfView);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use FieldOfView property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use FieldOfView property instead!")]
         public float GetFieldOfView()
         {
             float ret = Interop.CameraActor.GetFieldOfView(SwigCPtr);
@@ -131,14 +131,14 @@ namespace Tizen.NUI
             return ret;
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use AspectRatio property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use AspectRatio property instead!")]
         public void SetAspectRatio(float aspectRatio)
         {
             Interop.CameraActor.SetAspectRatio(SwigCPtr, aspectRatio);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use AspectRatio property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use AspectRatio property instead!")]
         public float GetAspectRatio()
         {
             float ret = Interop.CameraActor.GetAspectRatio(SwigCPtr);
@@ -172,14 +172,14 @@ namespace Tizen.NUI
             return ret;
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use TargetPosition property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use TargetPosition property instead!")]
         public void SetTargetPosition(Vector3 targetPosition)
         {
             Interop.CameraActor.SetTargetPosition(SwigCPtr, Vector3.getCPtr(targetPosition));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use TargetPosition property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use TargetPosition property instead!")]
         public Vector3 GetTargetPosition()
         {
             Vector3 ret = new Vector3(Interop.CameraActor.GetTargetPosition(SwigCPtr), true);
@@ -187,14 +187,14 @@ namespace Tizen.NUI
             return ret;
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use InvertYAxis property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use InvertYAxis property instead!")]
         public void SetInvertYAxis(bool invertYAxis)
         {
             Interop.CameraActor.SetInvertYAxis(SwigCPtr, invertYAxis);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use InvertYAxis property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use InvertYAxis property instead!")]
         public bool GetInvertYAxis()
         {
             bool ret = Interop.CameraActor.GetInvertYAxis(SwigCPtr);

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -339,7 +339,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">Width to use</param>
         /// <returns>The height based on the width</returns>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use HeightForWidth property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use HeightForWidth property instead!")]
         public new virtual float GetHeightForWidth(float width)
         {
             return viewWrapperImpl.GetHeightForWidthBase(width);
@@ -352,7 +352,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="height">Height to use</param>
         /// <returns>The width based on the width</returns>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use WidthForHeight property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use WidthForHeight property instead!")]
         public new virtual float GetWidthForHeight(float height)
         {
             return viewWrapperImpl.GetWidthForHeightBase(height);

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -395,7 +395,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="padding">Width and height.</param>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use CellPadding property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use CellPadding property instead!")]
         public void SetCellPadding(Size2D padding)
         {
             Interop.TableView.SetCellPadding(SwigCPtr, Size2D.getCPtr(padding));
@@ -407,7 +407,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <returns>The current padding as width and height.</returns>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use CellPadding property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use CellPadding property instead!")]
         public Vector2 GetCellPadding()
         {
             Vector2 ret = new Vector2(Interop.TableView.GetCellPadding(SwigCPtr), true);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -221,7 +221,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <seealso cref="Container.GetChildCount" />
         /// <since_tizen> 4 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
         public override uint GetChildCount()
         {
             return Convert.ToUInt32(Children.Count);
@@ -262,7 +262,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="styleName">A string matching a style described in a stylesheet.</param>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use StyleName property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use StyleName property instead!")]
         public void SetStyleName(string styleName)
         {
             Interop.View.SetStyleName(SwigCPtr, styleName);
@@ -274,7 +274,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <returns>A string matching a style, or an empty string.</returns>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use StyleName property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use StyleName property instead!")]
         public string GetStyleName()
         {
             string ret = Interop.View.GetStyleName(SwigCPtr);
@@ -468,7 +468,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width to use.</param>
         /// <returns>The height based on the width.</returns>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use HeightForWidth property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use HeightForWidth property instead!")]
         public float GetHeightForWidth(float width)
         {
             float ret = Interop.Actor.GetHeightForWidth(SwigCPtr, width);
@@ -485,7 +485,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="height">The height to use.</param>
         /// <returns>The width based on the height.</returns>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use WidthForHeight property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use WidthForHeight property instead!")]
         public float GetWidthForHeight(float height)
         {
             float ret = Interop.Actor.GetWidthForHeight(SwigCPtr, height);
@@ -526,7 +526,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="paddingOut">the value of padding for the view</param>
         /// <since_tizen> 3 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use Padding property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use Padding property instead!")]
         public void GetPadding(PaddingType paddingOut)
         {
             Interop.Actor.GetPadding(SwigCPtr, PaddingType.getCPtr(paddingOut));

--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -123,7 +123,7 @@ namespace Tizen.NUI
         /// <pre>The container has been initialized.</pre>
         /// <returns>The number of children.</returns>
         /// <since_tizen> 4 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
         public abstract UInt32 GetChildCount();
 
         internal abstract View FindCurrentChildById(uint id);

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -355,7 +355,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <returns>The child count of the layer.</returns>
         /// <since_tizen> 4 </since_tizen>
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use ChildCount property instead!")]
         public override uint GetChildCount()
         {
             return Convert.ToUInt32(Children.Count);

--- a/src/Tizen.NUI/src/public/XamlBinding/Interactivity/DataTrigger.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Interactivity/DataTrigger.cs
@@ -44,7 +44,7 @@ namespace Tizen.NUI.Binding
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use GetValue() instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use GetValue() instead!")]
         public object Value
         {
             get { return ((BindingCondition)Condition).Value; }

--- a/src/Tizen.NUI/src/public/XamlBinding/Trigger.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Trigger.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI.Binding
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        // [Obsolete("Deprecated in API9, will be removed in API11. Please use GetValue() instead!")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use GetValue() instead!")]
         public object Value
         {
             get { return ((XamlPropertyCondition)Condition).Value; }


### PR DESCRIPTION
CA1721: Property names should not match get methods
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1721

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
