### PR TITLE
[NUI] Removed old dependency in Tizen.NUI.csproj

### DIFF
--- a/src/Tizen.NUI/Tizen.NUI.csproj
+++ b/src/Tizen.NUI/Tizen.NUI.csproj
@@ -17,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\internals\src\Tizen.Applications.ThemeManager\Tizen.Applications.ThemeManager.csproj" />
     <ProjectReference Include="..\Tizen.Applications.Common\Tizen.Applications.Common.csproj" />
     <ProjectReference Include="..\Tizen.Applications.ComponentBased\Tizen.Applications.ComponentBased.csproj" />
     <ProjectReference Include="..\Tizen.System.Information\Tizen.System.Information.csproj" />


### PR DESCRIPTION
* This enables building Tizen.NUI as a reference in Visual Studio
project.

### Description of Change ###
Removed ProjectReference of Tizen.Applications.ThemeManager from Tizen.NUI.csproj


### API Changes ###
none

