### PR TITLE
[MachineLearning.Inference][Non-ACR] Fix the potential bug (#2547)

### DIFF
--- a/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
+++ b/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string Nnstreamer = "libcapi-nnstreamer.so.0";
+        public const string Nnstreamer = "libcapi-nnstreamer.so.1";
     }
 
     internal static partial class Pipeline

--- a/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/TensorsData.cs
+++ b/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/TensorsData.cs
@@ -34,7 +34,7 @@ namespace Tizen.MachineLearning.Inference
         /// Creates a TensorsData instance with handle which is given by TensorsInfo.
         /// </summary>
         /// <param name="handle">The handle of tensors data.</param>
-        /// <param name="info">The handle of tensors info. (Default: null)</param>
+        /// <param name="info">The handle of tensors info.</param>
         /// <param name="isFetch">The boolean value for fetching the data (Default: false)</param>
         /// <param name="hasOwnership">The boolean value for automatic disposal (Default: true)</param>
         /// <since_tizen> 6 </since_tizen>
@@ -45,7 +45,8 @@ namespace Tizen.MachineLearning.Inference
 
             /* Set internal object */
             _handle = handle;
-            _tensorsInfo = info;
+            /* Because developers can change the TensorsInfo object, it should be stored as a deep-copied instance. */
+            _tensorsInfo = info.Clone();
 
             /* Set count */
             int count = 0;
@@ -202,6 +203,8 @@ namespace Tizen.MachineLearning.Inference
             if (disposing)
             {
                 // release managed object
+                _tensorsInfo.Dispose();
+                _tensorsInfo = null;
             }
 
             // release unmanaged objects

--- a/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/TensorsInfo.cs
+++ b/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/TensorsInfo.cs
@@ -327,10 +327,6 @@ namespace Tizen.MachineLearning.Inference
 
             for (int i = 0; i < this.Count; ++i)
             {
-                // Name
-                if (string.Compare(this.GetTensorName(i), other.GetTensorName(i)) != 0)
-                    return false;
-
                 // Type
                 if (this.GetTensorType(i) != other.GetTensorType(i))
                     return false;
@@ -340,6 +336,23 @@ namespace Tizen.MachineLearning.Inference
                     return false;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Create a new TensorsInfo object cloned from the current tensors information.
+        /// </summary>
+        /// <returns>Hard-copied TensorsInfo object</returns>
+        /// <since_tizen> 9 </since_tizen>
+        internal TensorsInfo Clone()
+        {
+            TensorsInfo retInfo = null;
+            retInfo = new TensorsInfo();
+
+            foreach (TensorInfo t in _infoList) {
+                retInfo.AddTensorInfo(t.Name, t.Type, t.Dimension);
+            }
+
+            return retInfo;
         }
 
         /// <summary>


### PR DESCRIPTION
* [MachineLearning.Inference] Update the version number of the shared library

This patch updates the version number of the nnstreamer library.
* libcapi-nnstreamer.so.0 -> libcapi-nnstreamer.so.1

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

* [MachineLearning.Inference] Remove the name comparision in TensorsInfo.Equals()

Since the name of the TensorsInfo is not used when negociating the
pipeline, the name comparison in TensorsInfo.Equals() should be removed.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

* [MachineLearning.Inference] Add Clone() to TensorsInfo class for deep copy

It is not a common case but developers can modify the TensorsInfo after
creating the TensorsData. Because of this reason, TensorsData should
have a hard-copied instance of the TensorsInfo object. If not, it shows
the wrong information of TensorsData. This patch fixes this potential
bug.

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
