### PR TITLE
[NUI] Delegate Button.OnAccessibilityActivated() to OnKey()

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -484,33 +484,19 @@ namespace Tizen.NUI.Components
 
         internal override bool OnAccessibilityActivated()
         {
-            if (!IsEnabled)
+            using (var key = new Key())
             {
-                return false;
+                key.State = Key.StateType.Down;
+                key.KeyPressedName = "Return";
+
+                // Touch Down
+                OnKey(key);
+
+                // Touch Up
+                key.State = Key.StateType.Up;
+                OnKey(key);
             }
 
-            // Touch Down
-            isPressed = true;
-            UpdateState();
-
-            // Touch Up
-            bool clicked = isPressed && IsEnabled;
-            isPressed = false;
-
-            if (IsSelectable)
-            {
-                IsSelected = !IsSelected;
-            }
-            else
-            {
-                UpdateState();
-            }
-
-            if (clicked)
-            {
-                ClickedEventArgs eventArgs = new ClickedEventArgs();
-                OnClickedInternal(eventArgs);
-            }
             return true;
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This commit fixes a bug where it was possible to select multiple radio
buttons from one RadioButtonGroup in accessibility (screen reader) mode.

OnAccessibilityActivated() contained code copied from OnKey(). However,
some classes derived from Button override OnKey(), e.g. SelectButton
makes sure that other buttons in the group are unselected if necessary.
Rather than overriding OnAccessibilityActivated() in derived classes, it
is better to invoke OnKey() instead, in order to reduce code
duplication.

Note: this change matches the corresponding logic in DALi Toolkit, where
OnAccessibilityActivated() is implemented in terms of OnKeyboardEnter().


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None
 - Added: None
 - Changed: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
