### PR TITLE
[NUI] Change Tizen.NUI.Components sequence

### DIFF
--- a/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj
+++ b/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TizenPreloadFile Include="Tizen.NUI.Components.preload" Sequence="30" />
+    <TizenPreloadFile Include="Tizen.NUI.Components.preload" Sequence="31" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Tizen.NUI.preload -> 30
Tizen.NUI.Components.preload ->31

The Tizen.NUI.Componentes is preloaded after the NUI is preloaded.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
