### PR TITLE
[Build] Update nuspec for Tizen.NET.Internals

### DIFF
--- a/pkg/Tizen.NET.Internals/Tizen.NET.Internals.nuspec
+++ b/pkg/Tizen.NET.Internals/Tizen.NET.Internals.nuspec
@@ -16,7 +16,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Artifacts\bin\internal\ref\*.dll"  target="ref\netstandard2.0" />
-    <file src="Artifacts\bin\internal\*.xml"  target="ref\netstandard2.0" />
+    <file src="Artifacts\bin\internal\*.dll"  target="lib\netstandard2.0" />
+    <file src="Artifacts\bin\internal\*.xml"  target="lib\netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
## Description of Change

There are two issues with `Tizen.NET.Internals.nuspec` file. It copies incorrect assemblies (1) into wrong target folders (2).

(1) *Implementation Assemblies* should be used instead of *Reference Assemblies*, as the assemblies included in nupkg are going to be used in runtime as well, not only for compilation.
(2) *lib/{tfm}* folder should be used for target instead of *ref/{tfm}*, so the assemblies would be copied and included in the output TPK.

- When building `Tizen.NET.API9` package, assemblies should go into `ref/netstandard2.0/` folder inside the `.nupkg`.
- When building `Tizen.NET.Internals` package, assemblies should go into `lib/netstandard2.0/` folder inside the `.nupkg`.

### API Changes ###
No

### Tested with
```
$ dotnet --version
5.0.200
```