### PR TITLE
[NUI] Remove CA2000 false alarm in Navigator

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
@@ -377,6 +378,9 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <param name="content">The content of Dialog.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [SuppressMessage("Microsoft.Reliability",
+                         "CA2000:DisposeObjectsBeforeLosingScope",
+                         Justification = "The pushed views are added to NavigationPages and are disposed in Navigator.Dispose().")]
         public static void ShowDialog(View content = null)
         {
             var window = NUIApplication.GetDefaultWindow();
@@ -397,6 +401,9 @@ namespace Tizen.NUI.Components
         /// <param name="content">The content of AlertDialog.</param>
         /// <param name="actionContent">The action content of AlertDialog.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [SuppressMessage("Microsoft.Reliability",
+                         "CA2000:DisposeObjectsBeforeLosingScope",
+                         Justification = "The pushed views are added to NavigationPages and are disposed in Navigator.Dispose().")]
         public static void ShowAlertDialog(View titleContent, View content, View actionContent)
         {
             var window = NUIApplication.GetDefaultWindow();
@@ -420,6 +427,9 @@ namespace Tizen.NUI.Components
         /// <param name="negativeButtonText">The negative button text in the action content of AlertDialog.</param>
         /// <param name="negativeButtonClickedHandler">The clicked callback of the negative button in the action content of AlertDialog.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [SuppressMessage("Microsoft.Reliability",
+                         "CA2000:DisposeObjectsBeforeLosingScope",
+                         Justification = "The pushed views are added to NavigationPages and are disposed in Navigator.Dispose().")]
         public static void ShowAlertDialog(string title = null, string message = null, string positiveButtonText = null, EventHandler<ClickedEventArgs> positiveButtonClickedHandler = null, string negativeButtonText = null, EventHandler<ClickedEventArgs> negativeButtonClickedHandler = null)
         {
             var window = NUIApplication.GetDefaultWindow();


### PR DESCRIPTION
Since the pushed views are added to NavigationPages and are disposed in
Navigator.Dispose(), the CA2000 in Navigator is false alarm.

To remove the CA2000 false alarm, SuppressMessage for CA2000 is added.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
