### PR TITLE
[NUI] Add TouchArea property.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -204,6 +204,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_BLEND_EQUATION_get")]
             public static extern int BlendEquationGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_TOUCH_AREA_get")]
+            public static extern int TouchAreaGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Actor_Property")]
             public static extern global::System.IntPtr NewActorProperty();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -218,6 +218,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int AccessibilityHighlightable = Interop.ViewProperty.AccessibilityHighlightableGet();
             internal static readonly int AccessibilityAttributes = Interop.ViewProperty.AccessibilityAttributesGet();
             internal static readonly int AccessibilityAnimated = Interop.ViewProperty.AccessibilityAnimatedGet();
+            internal static readonly int TouchArea = Interop.ActorProperty.TouchAreaGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -1364,5 +1364,25 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// TouchArea can reset the view's touchable area.<br/>
+        /// If you set the TouchArea on an view, when you touch the view, the touch area is used rather than the size of the view.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Size2D TouchArea
+        {
+            get
+            {
+                Size2D value = new Size2D(0, 0);
+                GetProperty(View.Property.TouchArea).Get(value);
+                return value;
+            }
+            set
+            {
+                SetProperty(View.Property.TouchArea, new Tizen.NUI.PropertyValue(value));
+                NotifyPropertyChanged();
+            }
+        }
+
     }
 }


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->

    
    Default touchable area is view's size.
    TouchArea can reset the view's touchable area.
    
    This is usefull when the view is small, but it should have a larger touch area.
    
    for example
    
          View view = new View();
          view.Size = new Size(10, 10);
          view.TouchEvent += OnTouchEvent;
          view.TouchArea = new Size2D(200, 200);
    
    The view is small, If you want to set the touch area to a larger area,
    you can use the TouchArea property.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
