### PR TITLE
[NUI] Theme change do not overwrite user set properties. 

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -410,6 +410,16 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             SetAccessibilityConstructor(Role.PushButton);
+
+            AccessibilityHighlightable = true;
+            EnableControlStatePropagation = true;
+            LayoutDirectionChanged += OnLayoutDirectionChanged;
+
+            AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Trait, "Button");
+
+#if PROFILE_MOBILE
+            Feedback = true;
+#endif
         }
 
         /// <inheritdoc/>
@@ -431,24 +441,6 @@ namespace Tizen.NUI.Components
             {
                 isPressed = statePressed;
             }
-        }
-
-        /// <summary>
-        /// It is hijack by using protected, style copy problem when class inherited from Button.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        private void Initialize()
-        {
-            AccessibilityHighlightable = true;
-            EnableControlStatePropagation = true;
-            UpdateState();
-            LayoutDirectionChanged += OnLayoutDirectionChanged;
-
-            AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Trait, "Button");
-
-#if PROFILE_MOBILE
-                Feedback = true;
-#endif
         }
 
         private void UpdateUIContent()

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,12 +75,6 @@ namespace Tizen.NUI.Components
                 if (instance.isEnabled != newEnabled)
                 {
                     instance.isEnabled = newEnabled;
-
-                    if (instance.buttonStyle != null)
-                    {
-                        instance.buttonStyle.IsEnabled = newEnabled;
-                    }
-
                     instance.UpdateState();
                 }
             }
@@ -97,11 +91,6 @@ namespace Tizen.NUI.Components
                 if (instance.isSelected != newSelected)
                 {
                     instance.isSelected = newSelected;
-
-                    if (instance.buttonStyle != null)
-                    {
-                        instance.buttonStyle.IsSelected = newSelected;
-                    }
 
                     if (instance.isSelectable)
                     {
@@ -126,12 +115,6 @@ namespace Tizen.NUI.Components
                 if (instance.isSelectable != newSelectable)
                 {
                     instance.isSelectable = newSelectable;
-
-                    if (instance.buttonStyle != null)
-                    {
-                        instance.buttonStyle.IsSelectable = newSelectable;
-                    }
-
                     instance.UpdateState();
                 }
             }
@@ -173,7 +156,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public Button() : base()
         {
-            Initialize();
         }
 
         /// <summary>
@@ -183,7 +165,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Button(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -193,7 +174,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Button(ButtonStyle buttonStyle) : base(buttonStyle)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -352,25 +332,13 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Return a copied Style instance of Button
+        /// Return currently applied style.
         /// </summary>
         /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the Button.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// Modifying contents in style may cause unexpected behaviour.
         /// </remarks>
         /// <since_tizen> 8 </since_tizen>
-        public new ButtonStyle Style
-        {
-            get
-            {
-                var result = (ButtonStyle)ViewStyle.Clone();
-                result.CopyPropertiesFromView(this);
-                result.Text.CopyPropertiesFromView(TextLabel);
-                result.Icon.CopyPropertiesFromView(Icon);
-                result.Overlay.CopyPropertiesFromView(OverlayImage);
-                return result;
-            }
-        }
+        public ButtonStyle Style => (ButtonStyle)(ViewStyle as ButtonStyle)?.Clone();
 
         /// <summary>
         /// The text of Button.
@@ -683,8 +651,6 @@ namespace Tizen.NUI.Components
             set => SetValue(TextPaddingProperty, value);
         }
 
-        private ButtonStyle buttonStyle => ViewStyle as ButtonStyle;
-
         /// <summary>
         /// Called after a key event is received by the view that has had its focus set.
         /// </summary>
@@ -779,7 +745,7 @@ namespace Tizen.NUI.Components
 
             base.ApplyStyle(viewStyle);
 
-            if (null != buttonStyle)
+            if (viewStyle is ButtonStyle buttonStyle)
             {
                 Extension = buttonStyle.CreateExtension();
                 if (buttonStyle.Overlay != null)
@@ -799,6 +765,7 @@ namespace Tizen.NUI.Components
             }
 
             styleApplied = true;
+            UpdateState();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/CheckBox.cs
+++ b/src/Tizen.NUI.Components/Controls/CheckBox.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
+
             SetAccessibilityConstructor(Role.CheckBox);
         }
 
@@ -68,21 +69,6 @@ namespace Tizen.NUI.Components
             internal set
             {
                 base.ItemGroup = value;
-            }
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void ApplyStyle(ViewStyle viewStyle)
-        {
-            if (viewStyle is ButtonStyle buttonStyle)
-            {
-                if (buttonStyle.IsSelectable == null)
-                {
-                    buttonStyle.IsSelectable = true;
-                }
-
-                base.ApplyStyle(buttonStyle);
             }
         }
 

--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -46,10 +46,6 @@ namespace Tizen.NUI.Components
 
         private Feedback feedback = null;
 
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ControlStyle Style => (ControlStyle)ViewStyle.Clone();
-
         static Control()
         {
             ThemeManager.AddPackageTheme(DefaultThemeCreator.Instance);
@@ -83,7 +79,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Control(ControlStyle style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -93,15 +88,14 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Control(string styleName) : this(ThemeManager.GetStyle(styleName) as ControlStyle)
+        public Control(string styleName) : this(new ControlStyle() /* Apply empty style */)
         {
             if (ThemeManager.GetStyle(styleName) == null)
             {
                 throw new InvalidOperationException($"There is no style {styleName}");
             }
 
-            this.styleName = styleName;
-            ThemeChangeSensitive = true;
+            StyleName = styleName;
         }
 
         /// <summary>
@@ -207,12 +201,14 @@ namespace Tizen.NUI.Components
             base.Dispose(type);
         }
 
-        /// <summary>
-        /// OnInitialize
-        /// </summary>
+        /// <inheritdoc/>
         public override void OnInitialize()
         {
             base.OnInitialize();
+
+            LeaveRequired = true;
+            StateFocusableOnTouchMode = false;
+            EnableControlState = true;
         }
 
         /// <summary>
@@ -311,15 +307,6 @@ namespace Tizen.NUI.Components
 
             // If the OnThemeChangedEvent is not implemented, ApplyStyle()
             base.OnThemeChanged(sender, e);
-        }
-
-        private void Initialize()
-        {
-            LeaveRequired = true;
-
-            StateFocusableOnTouchMode = false;
-
-            EnableControlState = true;
         }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/FlexibleView.cs
@@ -657,11 +657,11 @@ namespace Tizen.NUI.Components
             }
             if (mScrollBar.Direction == ScrollBar.DirectionType.Vertical)
             {
-                mScrollBar.Style.Thumb.Size = new Size(thickness, length);
+                mScrollBar.ThumbSize = new Size(thickness, length);
             }
             else
             {
-                mScrollBar.Style.Thumb.Size = new Size(length, thickness);
+                mScrollBar.ThumbSize = new Size(length, thickness);
             }
             mScrollBar.MinValue = 0;
             mScrollBar.MaxValue = (int)(range - extent);

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,17 +35,15 @@ namespace Tizen.NUI.Components
         public static readonly BindableProperty ButtonHeightProperty = BindableProperty.Create(nameof(ButtonHeight), typeof(int), typeof(Popup), default(int), propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Popup)bindable;
-            if (newValue != null && instance?.popupStyle?.Buttons?.Size != null)
+            if (newValue != null)
             {
-                instance.popupStyle.Buttons.SizeHeight = (int)newValue;
                 instance.btGroup.Itemheight = (int)newValue;
                 instance.UpdateView();
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return (int)(instance.popupStyle?.Buttons?.Size?.Height ?? 0);
+            return (int)((Popup)bindable).btGroup.Itemheight;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -55,17 +53,12 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             if (newValue != null)
             {
-                if (instance.popupStyle?.Buttons?.Text != null)
-                {
-                    instance.popupStyle.Buttons.Text.PointSize = (float)newValue;
-                }
                 instance.btGroup.ItemPointSize = (float)newValue;
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.Text?.PointSize?.All ?? 0;
+            return ((Popup)bindable).btGroup.ItemPointSize;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -75,14 +68,12 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             if (newValue != null)
             {
-                instance.popupStyle.Buttons.Text.FontFamily = (string)newValue;
                 instance.btGroup.ItemFontFamily = (string)newValue;
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.Text?.FontFamily.All;
+            return ((Popup)bindable).btGroup.ItemFontFamily;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -92,17 +83,12 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             if (newValue != null)
             {
-                if (instance.popupStyle?.Buttons?.Text != null)
-                {
-                    instance.popupStyle.Buttons.Text.TextColor = (Color)newValue;
-                }
                 instance.btGroup.ItemTextColor = (Color)newValue;
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.Text?.TextColor?.All;
+            return ((Popup)bindable).btGroup.ItemTextColor;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -112,14 +98,12 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             if (newValue != null)
             {
-                instance.popupStyle.Buttons.Overlay.BackgroundColor = (Selector<Color>)newValue;
                 instance.btGroup.OverLayBackgroundColorSelector = (Selector<Color>)newValue;
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.Overlay?.BackgroundColor;
+            return ((Popup)bindable).btGroup.OverLayBackgroundColorSelector;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -129,14 +113,12 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             if (newValue != null)
             {
-                instance.popupStyle.Buttons.Text.HorizontalAlignment = (HorizontalAlignment)newValue;
                 instance.btGroup.ItemTextAlignment = (HorizontalAlignment)newValue;
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.Text?.HorizontalAlignment ?? HorizontalAlignment.Center;
+            return ((Popup)bindable).btGroup.ItemTextAlignment;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -146,19 +128,12 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             if (newValue != null)
             {
-                if (instance.popupStyle.Buttons.BackgroundImage == null)
-                {
-                    instance.popupStyle.Buttons.BackgroundImage = new Selector<string>();
-                }
-                instance.popupStyle.Buttons.BackgroundColor = new Selector<Color>();
-                instance.popupStyle.Buttons.BackgroundImage = (string)newValue;
                 instance.btGroup.ItemBackgroundImageUrl = (string)newValue;
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.BackgroundImage?.All;
+            return ((Popup)bindable).btGroup.ItemBackgroundImageUrl;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -168,18 +143,12 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             if (newValue != null)
             {
-                if (instance.popupStyle.Buttons.BackgroundImageBorder == null)
-                {
-                    instance.popupStyle.Buttons.BackgroundImageBorder = new Selector<Rectangle>();
-                }
-                instance.popupStyle.Buttons.BackgroundImageBorder = (Rectangle)newValue;
                 instance.btGroup.ItemBackgroundBorder = (Rectangle)newValue;
             }
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.BackgroundImageBorder?.All;
+            return ((Popup)bindable).btGroup.ItemBackgroundBorder;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -189,20 +158,18 @@ namespace Tizen.NUI.Components
             var instance = (Popup)bindable;
             ImageShadow shadow = (ImageShadow)newValue;
             instance.btGroup.ItemImageShadow = new ImageShadow(shadow);
-            instance.popupStyle.Buttons.ImageShadow = new ImageShadow(shadow);
         },
         defaultValueCreator: (bindable) =>
         {
-            var instance = (Popup)bindable;
-            return instance.popupStyle?.Buttons?.ImageShadow?.All;
+            return ((Popup)bindable).btGroup.ItemImageShadow;
         });
 
-
-        private PopupStyle popupStyle => ViewStyle as PopupStyle;
         private TextLabel titleText;
         private ButtonGroup btGroup = null;
         private Window window = null;
         private Layer container = new Layer();
+        private ButtonStyle buttonStyle = new ButtonStyle();
+
         static Popup() { }
 
         /// <summary>
@@ -212,7 +179,6 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public Popup() : base()
         {
-            Initialize();
         }
 
         /// <summary>
@@ -222,7 +188,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Popup(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -232,7 +197,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Popup(PopupStyle popupStyle) : base(popupStyle)
         {
-            Initialize();
         }
 
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -268,14 +232,11 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddButton(string buttonText)
         {
-            if (popupStyle.Buttons != null)
-            {
-                Button btn = new Button(popupStyle.Buttons);
-                btn.Text = buttonText;
-                btn.ClickEvent += ButtonClickEvent;
-                btGroup.AddItem(btn);
-                UpdateView();
-            }
+            Button btn = new Button(buttonStyle);
+            btn.Text = buttonText;
+            btn.ClickEvent += ButtonClickEvent;
+            btGroup.AddItem(btn);
+            UpdateView();
         }
 
         /// <summary>
@@ -293,11 +254,11 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddButton(string buttonText, ButtonStyle style)
         {
-            if (popupStyle.Buttons != null && style != null)
-            {
-                popupStyle.Buttons.CopyFrom(style);
-                AddButton(buttonText);
-            }
+            Button btn = new Button(style);
+            btn.Text = buttonText;
+            btn.ClickEvent += ButtonClickEvent;
+            btGroup.AddItem(btn);
+            UpdateView();
         }
 
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -331,21 +292,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public event EventHandler<ButtonClickEventArgs> PopupButtonClickEvent;
-
-        /// <summary>
-        /// Get style of popup.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new PopupStyle Style
-        {
-            get
-            {
-                var result = new PopupStyle(popupStyle);
-                result.CopyPropertiesFromView(this);
-                result.Title.CopyPropertiesFromView(titleText);
-                return result;
-            }
-        }
 
         /// <summary>
         /// Popup Title.
@@ -383,20 +329,8 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public string TitleText
         {
-            get
-            {
-                return popupStyle?.Title?.Text?.All;
-            }
-            set
-            {
-                if (value != null)
-                {
-                    if (popupStyle?.Title != null)
-                    {
-                        popupStyle.Title.Text = value;
-                    }
-                }
-            }
+            get => Title.Text;
+            set => Title.Text = value;
         }
 
         /// <summary>
@@ -406,17 +340,8 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public float TitlePointSize
         {
-            get
-            {
-                return popupStyle?.Title?.PointSize?.All ?? 0;
-            }
-            set
-            {
-                if (popupStyle?.Title != null)
-                {
-                    popupStyle.Title.PointSize = value;
-                }
-            }
+            get => Title.PointSize;
+            set => Title.PointSize = value;
         }
 
         /// <summary>
@@ -426,17 +351,8 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public Color TitleTextColor
         {
-            get
-            {
-                return popupStyle?.Title?.TextColor?.All;
-            }
-            set
-            {
-                if (popupStyle?.Title != null)
-                {
-                    popupStyle.Title.TextColor = value;
-                }
-            }
+            get => Title.TextColor;
+            set => Title.TextColor = value;
         }
 
         /// <summary>
@@ -446,14 +362,8 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public HorizontalAlignment TitleTextHorizontalAlignment
         {
-            get
-            {
-                return popupStyle?.Title?.HorizontalAlignment ?? HorizontalAlignment.Center;
-            }
-            set
-            {
-                popupStyle.Title.HorizontalAlignment = value;
-            }
+            get => Title.HorizontalAlignment;
+            set => Title.HorizontalAlignment = value;
         }
 
         /// <summary>
@@ -463,14 +373,8 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public Position TitleTextPosition
         {
-            get
-            {
-                return popupStyle?.Title?.Position ?? new Position(0, 0, 0);
-            }
-            set
-            {
-                popupStyle.Title.Position = value;
-            }
+            get => Title.Position;
+            set => Title.Position = value;
         }
 
         /// <summary>
@@ -480,17 +384,8 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public int TitleHeight
         {
-            get
-            {
-                return (int)(popupStyle?.Title?.Size?.Height ?? 0);
-            }
-            set
-            {
-                if (popupStyle?.Title?.Size != null)
-                {
-                    popupStyle.Title.SizeHeight = value;
-                }
-            }
+            get => (int)Title.SizeHeight;
+            set => Title.SizeHeight = (int)value;
         }
 
         /// <summary>
@@ -715,6 +610,8 @@ namespace Tizen.NUI.Components
                     btGroup.Dispose();
                     btGroup = null;
                 }
+
+                buttonStyle?.Dispose();
             }
 
             base.Dispose(type);
@@ -753,20 +650,22 @@ namespace Tizen.NUI.Components
 
             if (viewStyle is PopupStyle ppStyle)
             {
-                if (ppStyle.Buttons == null)
+                if (ppStyle.Buttons?.SizeHeight != null)
                 {
-                    ppStyle.Buttons = new ButtonStyle();
+                    ButtonHeight = (int)ppStyle.Buttons.SizeHeight;
                 }
 
-                if (ppStyle.Buttons.PositionUsesPivotPoint == null) ppStyle.Buttons.PositionUsesPivotPoint = true;
-                if (ppStyle.Buttons.ParentOrigin == null) ppStyle.Buttons.ParentOrigin = Tizen.NUI.ParentOrigin.BottomLeft;
-                if (ppStyle.Buttons.PivotPoint == null) ppStyle.Buttons.PivotPoint = Tizen.NUI.PivotPoint.BottomLeft;
+                buttonStyle = (ButtonStyle)ppStyle.Buttons?.Clone();
+                if (buttonStyle.PositionUsesPivotPoint == null) buttonStyle.PositionUsesPivotPoint = true;
+                if (buttonStyle.ParentOrigin == null) buttonStyle.ParentOrigin = Tizen.NUI.ParentOrigin.BottomLeft;
+                if (buttonStyle.PivotPoint == null) buttonStyle.PivotPoint = Tizen.NUI.PivotPoint.BottomLeft;
 
                 if (btGroup != null)
                 {
                     for (int i = 0; i < btGroup.Count; i++)
                     {
-                        GetButton(i)?.ApplyStyle(ppStyle.Buttons);
+                        var button = GetButton(i);
+                        button.ApplyStyle(buttonStyle);
                     }
                 }
 
@@ -793,8 +692,16 @@ namespace Tizen.NUI.Components
             UpdateView();
         }
 
-        private void Initialize()
+        /// <summary>
+        /// Initialize AT-SPI object.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnInitialize()
         {
+            base.OnInitialize();
+            SetAccessibilityConstructor(Role.Dialog);
+            AppendAccessibilityAttribute("sub-role", "Alert");
+
             container.Add(this);
             container.SetTouchConsumed(true);
             container.SetHoverConsumed(true);
@@ -817,17 +724,6 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Initialize AT-SPI object.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnInitialize()
-        {
-            base.OnInitialize();
-            SetAccessibilityConstructor(Role.Dialog);
-            AppendAccessibilityAttribute("sub-role", "Alert");
-        }
-
-        /// <summary>
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -840,8 +736,7 @@ namespace Tizen.NUI.Components
 
         private void UpdateView()
         {
-            if (popupStyle == null) return;
-            btGroup.UpdateButton(popupStyle.Buttons);
+            btGroup.UpdateButton(buttonStyle);
             UpdateContentView();
             UpdateTitle();
         }
@@ -867,7 +762,7 @@ namespace Tizen.NUI.Components
         {
             if (e.PropertyName.Equals("LayoutDirection"))
             {
-                btGroup.UpdateButton(popupStyle.Buttons);
+                btGroup.UpdateButton(buttonStyle);
             }
         }
 
@@ -889,9 +784,9 @@ namespace Tizen.NUI.Components
                 titleY = (int)Title.Position.Y;
             }
 
-            if (btGroup.Count != 0 && popupStyle?.Buttons?.Size != null)
+            if (btGroup.Count != 0)
             {
-                buttonH = (int)popupStyle.Buttons.Size.Height;
+                buttonH = ButtonHeight;
             }
             ContentView.Size = new Size(Size.Width - titleX * 2, Size.Height - titleY - titleH - buttonH);
             ContentView.Position = new Position(titleX, titleY + titleH);
@@ -900,7 +795,7 @@ namespace Tizen.NUI.Components
 
         private void UpdateTitle()
         {
-            if (titleText != null && string.IsNullOrEmpty(popupStyle.Title.Text.All) && popupStyle.Title.Size != null)
+            if (titleText != null && string.IsNullOrEmpty(Title.Text) && Title.Size != null)
             {
                 titleText.RaiseToTop();
             }

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace Tizen.NUI.Components
 {
@@ -130,7 +131,6 @@ namespace Tizen.NUI.Components
         private float minValue = 0;
         private float currentValue = 0;
         private float bufferValue = 0;
-        private ProgressStyle progressStyle => ViewStyle as ProgressStyle;
 
         static Progress() { }
         /// <summary>
@@ -139,7 +139,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public Progress() : base()
         {
-            Initialize();
         }
 
         /// <summary>
@@ -149,7 +148,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Progress(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -159,7 +157,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Progress(ProgressStyle progressStyle) : base(progressStyle)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -188,21 +185,13 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Get style of progress.
+        /// Return currently applied style.
         /// </summary>
+        /// <remarks>
+        /// Modifying contents in style may cause unexpected behaviour.
+        /// </remarks>
         /// <since_tizen> 8 </since_tizen>
-        public new ProgressStyle Style
-        {
-            get
-            {
-                var result = new ProgressStyle(progressStyle);
-                result.CopyPropertiesFromView(this);
-                result.Track.CopyPropertiesFromView(trackImage);
-                result.Progress.CopyPropertiesFromView(progressImage);
-                result.Buffer.CopyPropertiesFromView(bufferImage);
-                return result;
-            }
-        }
+        public ProgressStyle Style => (ProgressStyle)(ViewStyle as ProgressStyle)?.Clone();
 
         /// <summary>
         /// The property to get/set Track image object URL of the Progress.
@@ -210,17 +199,8 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public string TrackImageURL
         {
-            get
-            {
-                return progressStyle?.Track?.ResourceUrl?.All;
-            }
-            set
-            {
-                if (null != progressStyle?.Track)
-                {
-                    progressStyle.Track.ResourceUrl = value;
-                }
-            }
+            get => trackImage.ResourceUrl;
+            set => trackImage.ResourceUrl = value;
         }
 
         /// <summary>
@@ -229,17 +209,8 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public string ProgressImageURL
         {
-            get
-            {
-                return progressStyle?.Progress?.ResourceUrl?.All;
-            }
-            set
-            {
-                if (null != progressStyle?.Progress)
-                {
-                    progressStyle.Progress.ResourceUrl = value;
-                }
-            }
+            get => progressImage.ResourceUrl;
+            set => progressImage.ResourceUrl = value;
         }
 
         /// <summary>
@@ -248,18 +219,8 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public string BufferImageURL
         {
-            get
-            {
-                return progressStyle?.Buffer?.ResourceUrl?.All;
-            }
-            set
-            {
-                if (null != progressStyle?.Buffer)
-                {
-                    progressStyle.Buffer.ResourceUrl = value;
-                    RelayoutRequest();
-                }
-            }
+            get => bufferImage.ResourceUrl;
+            set => bufferImage.ResourceUrl = value;
         }
 
         /// <summary>
@@ -268,17 +229,8 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public Color TrackColor
         {
-            get
-            {
-                return progressStyle?.Track?.BackgroundColor?.All;
-            }
-            set
-            {
-                if (null != progressStyle?.Track)
-                {
-                    progressStyle.Track.BackgroundColor = value;
-                }
-            }
+            get => trackImage.BackgroundColor;
+            set => trackImage.BackgroundColor = value;
         }
 
         /// <summary>
@@ -287,17 +239,8 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public Color ProgressColor
         {
-            get
-            {
-                return progressStyle?.Progress?.BackgroundColor?.All;
-            }
-            set
-            {
-                if (null != progressStyle?.Progress)
-                {
-                    progressStyle.Progress.BackgroundColor = value;
-                }
-            }
+            get => progressImage.BackgroundColor;
+            set => progressImage.BackgroundColor = value;
         }
 
         /// <summary>
@@ -306,17 +249,8 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public Color BufferColor
         {
-            get
-            {
-                return progressStyle?.Buffer?.BackgroundColor?.All;
-            }
-            set
-            {
-                if (null != progressStyle?.Buffer)
-                {
-                    progressStyle.Buffer.BackgroundColor = value;
-                }
-            }
+            get => bufferImage.BackgroundColor;
+            set => bufferImage.BackgroundColor = value;
         }
 
         /// <summary>
@@ -396,6 +330,35 @@ namespace Tizen.NUI.Components
             set
             {
                 SetValue(ProgressStateProperty, value);
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnInitialize()
+        {
+            base.OnInitialize();
+            // create necessary components
+            InitializeTrack();
+            InitializeBuffer();
+            InitializeProgress();
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void ApplyStyle(ViewStyle style)
+        {
+            base.ApplyStyle(style);
+
+            if (style is ProgressStyle progressStyle)
+            {
+                Debug.Assert(trackImage != null);
+                Debug.Assert(progressImage != null);
+                Debug.Assert(bufferImage != null);
+
+                trackImage.ApplyStyle(progressStyle.Track);
+                progressImage.ApplyStyle(progressStyle.Progress);
+                bufferImage.ApplyStyle(progressStyle.Buffer);
             }
         }
 
@@ -507,14 +470,6 @@ namespace Tizen.NUI.Components
             }
         }
 
-        private void Initialize()
-        {
-            // create necessary components
-            InitializeTrack();
-            InitializeBuffer();
-            InitializeProgress();
-        }
-
         private void InitializeTrack()
         {
             if (null == trackImage)
@@ -528,7 +483,6 @@ namespace Tizen.NUI.Components
                     PivotPoint = NUI.PivotPoint.TopLeft
                 };
                 Add(trackImage);
-                trackImage.ApplyStyle(progressStyle.Track);
             }
         }
 
@@ -545,7 +499,6 @@ namespace Tizen.NUI.Components
                     PivotPoint = Tizen.NUI.PivotPoint.TopLeft
                 };
                 Add(progressImage);
-                progressImage.ApplyStyle(progressStyle.Progress);
             }
         }
 
@@ -562,7 +515,6 @@ namespace Tizen.NUI.Components
                     PivotPoint = Tizen.NUI.PivotPoint.TopLeft
                 };
                 Add(bufferImage);
-                bufferImage.ApplyStyle(progressStyle.Buffer);
             }
         }
     }

--- a/src/Tizen.NUI.Components/Controls/RadioButton.cs
+++ b/src/Tizen.NUI.Components/Controls/RadioButton.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,21 +79,6 @@ namespace Tizen.NUI.Components
             internal set
             {
                 base.ItemGroup = value;
-            }
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void ApplyStyle(ViewStyle viewStyle)
-        {
-            if (viewStyle is ButtonStyle buttonStyle)
-            {
-                if (buttonStyle.IsSelectable == null)
-                {
-                    buttonStyle.IsSelectable = true;
-                }
-
-                base.ApplyStyle(buttonStyle);
             }
         }
 

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
@@ -37,28 +37,6 @@ namespace Tizen.NUI.Components
 
         private DefaultGridItemStyle ItemStyle => ViewStyle as DefaultGridItemStyle;
 
-        /// <summary>
-        /// Return a copied Style instance of DefaultLinearItem
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the DefaultLinearItem.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new DefaultGridItemStyle Style
-        {
-            get
-            {
-                var result = new DefaultGridItemStyle(ItemStyle);
-                result.CopyPropertiesFromView(this);
-                if (itemCaption) result.Caption.CopyPropertiesFromView(itemCaption);
-                if (itemImage) result.Image.CopyPropertiesFromView(itemImage);
-                if (itemBadge) result.Badge.CopyPropertiesFromView(itemBadge);
-
-                return result;
-            }
-        }
-
         static DefaultGridItem() { }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultLinearItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultLinearItem.cs
@@ -38,30 +38,6 @@ namespace Tizen.NUI.Components
         private Size prevSize;
         private DefaultLinearItemStyle ItemStyle => ViewStyle as DefaultLinearItemStyle;
 
-        /// <summary>
-        /// Return a copied Style instance of DefaultLinearItem
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the DefaultLinearItem.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new DefaultLinearItemStyle Style
-        {
-            get
-            {
-                var result = new DefaultLinearItemStyle(ItemStyle);
-                result.CopyPropertiesFromView(this);
-                if (itemLabel) result.Label.CopyPropertiesFromView(itemLabel);
-                if (itemSubLabel) result.SubLabel.CopyPropertiesFromView(itemSubLabel);
-                if (itemIcon) result.Icon.CopyPropertiesFromView(itemIcon);
-                if (itemExtra) result.Extra.CopyPropertiesFromView(itemExtra);
-                if (itemSeperator) result.Seperator.CopyPropertiesFromView(itemSeperator);
-
-                return result;
-            }
-        }
-
         static DefaultLinearItem() { }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultTitleItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultTitleItem.cs
@@ -36,28 +36,6 @@ namespace Tizen.NUI.Components
         private Size prevSize;
         private DefaultTitleItemStyle ItemStyle => ViewStyle as DefaultTitleItemStyle;
 
-        /// <summary>
-        /// Return a copied Style instance of DefaultTitleItem
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the DefaultTitleItem.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new DefaultTitleItemStyle Style
-        {
-            get
-            {
-                var result = new DefaultTitleItemStyle(ItemStyle);
-                result.CopyPropertiesFromView(this);
-                if (itemLabel) result.Label.CopyPropertiesFromView(itemLabel);
-                if (itemIcon) result.Icon.CopyPropertiesFromView(itemIcon);
-                if (itemSeperator) result.Seperator.CopyPropertiesFromView(itemSeperator);
-
-                return result;
-            }
-        }
-
         static DefaultTitleItem() { }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -41,10 +41,6 @@ namespace Tizen.NUI.Components
                 if (instance.isEnabled != newEnabled)
                 {
                     instance.isEnabled = newEnabled;
-                    if (instance.ItemStyle != null)
-                    {
-                        instance.ItemStyle.IsEnabled = newEnabled;
-                    }
                     instance.UpdateState();
                 }
             }
@@ -64,11 +60,6 @@ namespace Tizen.NUI.Components
                 if (instance.isSelected != newSelected)
                 {
                     instance.isSelected = newSelected;
-
-                    if (instance.ItemStyle != null)
-                    {
-                        instance.ItemStyle.IsSelected = newSelected;
-                    }
 
                     if (instance.isSelectable)
                     {
@@ -96,12 +87,6 @@ namespace Tizen.NUI.Components
                 if (instance.isSelectable != newSelectable)
                 {
                     instance.isSelectable = newSelectable;
-
-                    if (instance.ItemStyle != null)
-                    {
-                        instance.ItemStyle.IsSelectable = newSelectable;
-                    }
-
                     instance.UpdateState();
                 }
             }
@@ -112,24 +97,6 @@ namespace Tizen.NUI.Components
         private bool isSelectable = true;
         private bool isEnabled = true;
         private RecyclerViewItemStyle ItemStyle => ViewStyle as RecyclerViewItemStyle;
-
-        /// <summary>
-        /// Return a copied Style instance of Toast
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the Toast.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new RecyclerViewItemStyle Style
-        {
-            get
-            {
-                var result = new RecyclerViewItemStyle(ItemStyle);
-                result.CopyPropertiesFromView(this);
-                return result;
-            }
-        }
 
         static RecyclerViewItem() { }
 

--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectButton() : base()
         {
-            Initialize();
         }
 
         /// <summary>
@@ -64,7 +63,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectButton(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -76,7 +74,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectButton(ButtonStyle buttonStyle) : base(buttonStyle)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -114,6 +111,14 @@ namespace Tizen.NUI.Components
 
                 return -1;
             }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnInitialize()
+        {
+            base.OnInitialize();
+            IsSelectable = true;
         }
 
         /// <summary>
@@ -211,11 +216,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnSelectedChanged()
         {
-        }
-
-        private void Initialize()
-        {
-            IsSelectable = true;
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -582,11 +582,11 @@ namespace Tizen.NUI.Components
             {
                 if (lowIndicatorImage != null && lowIndicatorImage != null && lowIndicatorImage.Size != null)
                 {
-                    lowIndicatorImage.Size = sliderStyle.LowIndicatorImage.Size;
+                    lowIndicatorImage.Size = lowIndicatorSize ?? (ViewStyle as SliderStyle)?.LowIndicatorImage.Size;
                 }
                 if (lowIndicatorText != null && lowIndicatorText != null && lowIndicatorText.Size != null)
                 {
-                    lowIndicatorText.Size = sliderStyle.LowIndicator.Size;
+                    lowIndicatorText.Size = lowIndicatorSize ?? (ViewStyle as SliderStyle)?.LowIndicator.Size;
                 }
             }
         }
@@ -748,7 +748,7 @@ namespace Tizen.NUI.Components
             }
             else
             {
-                if (sliderStyle != null && sliderStyle.TrackThickness != null)
+                if (ViewStyle is SliderStyle sliderStyle && sliderStyle.TrackThickness != null)
                 {
                     curTrackThickness = sliderStyle.TrackThickness.Value;
                 }
@@ -765,7 +765,7 @@ namespace Tizen.NUI.Components
             }
             else
             {
-                if (sliderStyle != null && sliderStyle.TrackPadding != null)
+                if (ViewStyle is SliderStyle sliderStyle && sliderStyle.TrackPadding != null)
                 {
                     curSpace = sliderStyle.TrackPadding.Start;
                 }
@@ -797,7 +797,7 @@ namespace Tizen.NUI.Components
         private IndicatorType CurrentIndicatorType()
         {
             IndicatorType type = IndicatorType.None;
-            if (sliderStyle != null)
+            if (ViewStyle is SliderStyle sliderStyle)
             {
                 type = (IndicatorType)sliderStyle.IndicatorType;
             }
@@ -813,7 +813,7 @@ namespace Tizen.NUI.Components
             }
             else
             {
-                if (sliderStyle != null && sliderStyle.LowIndicatorImage != null && sliderStyle.LowIndicatorImage.Size != null)
+                if (ViewStyle is SliderStyle sliderStyle && sliderStyle.LowIndicatorImage != null && sliderStyle.LowIndicatorImage.Size != null)
                 {
                     size = sliderStyle.LowIndicatorImage.Size;
                 }
@@ -830,7 +830,7 @@ namespace Tizen.NUI.Components
             }
             else
             {
-                if (sliderStyle != null && sliderStyle.HighIndicatorImage != null && sliderStyle.HighIndicatorImage.Size != null)
+                if (ViewStyle is SliderStyle sliderStyle && sliderStyle.HighIndicatorImage != null && sliderStyle.HighIndicatorImage.Size != null)
                 {
                     size = sliderStyle.HighIndicatorImage.Size;
                 }
@@ -847,7 +847,7 @@ namespace Tizen.NUI.Components
             }
             else
             {
-                if (sliderStyle != null && sliderStyle.LowIndicator != null && sliderStyle.LowIndicator.Size != null)
+                if (ViewStyle is SliderStyle sliderStyle && sliderStyle.LowIndicator != null && sliderStyle.LowIndicator.Size != null)
                 {
                     size = sliderStyle.LowIndicator.Size;
                 }
@@ -864,7 +864,7 @@ namespace Tizen.NUI.Components
             }
             else
             {
-                if (sliderStyle != null && sliderStyle.HighIndicator != null && sliderStyle.HighIndicator.Size != null)
+                if (ViewStyle is SliderStyle sliderStyle && sliderStyle.HighIndicator != null && sliderStyle.HighIndicator.Size != null)
                 {
                     size = sliderStyle.HighIndicator.Size;
                 }

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -153,10 +153,6 @@ namespace Tizen.NUI.Components
             {
                 string newText = (string)newValue;
                 instance.valueIndicatorText.Text = newText;
-                if (instance.sliderStyle != null)
-                {
-                    instance.sliderStyle.ValueIndicatorText.Text = newText;
-                }
             }
         },
         defaultValueCreator: (bindable) =>
@@ -334,36 +330,13 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Return a copied Style instance of Slider
+        /// Return currently applied style.
         /// </summary>
         /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the Slider.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// Modifying contents in style may cause unexpected behaviour.
         /// </remarks>
         /// <since_tizen> 8 </since_tizen>
-        public new SliderStyle Style
-        {
-            get
-            {
-                var result = new SliderStyle(sliderStyle);
-                result.CopyPropertiesFromView(this);
-                result.Track.CopyPropertiesFromView(bgTrackImage);
-                result.Progress.CopyPropertiesFromView(slidedTrackImage);
-                result.Thumb.CopyPropertiesFromView(thumbImage);
-                result.LowIndicatorImage.CopyPropertiesFromView(lowIndicatorImage);
-                result.HighIndicatorImage.CopyPropertiesFromView(highIndicatorImage);
-                result.LowIndicator.CopyPropertiesFromView(lowIndicatorText);
-                result.HighIndicator.CopyPropertiesFromView(highIndicatorText);
-                result.ValueIndicatorText.CopyPropertiesFromView(valueIndicatorText);
-                result.ValueIndicatorImage.CopyPropertiesFromView(valueIndicatorImage);
-                return result;
-            }
-        }
-
-        /// <summary>
-        /// Return a copied Style instance of Slider
-        /// </summary>
-        private SliderStyle sliderStyle => ViewStyle as SliderStyle;
+        public SliderStyle Style => (SliderStyle)(ViewStyle as SliderStyle)?.Clone();
 
         /// <summary>
         /// Gets or sets the direction type of slider.
@@ -477,7 +450,6 @@ namespace Tizen.NUI.Components
                 {
                     thumbImage.Size = value;
                     thumbSize = value;
-                    sliderStyle.Thumb.Size = value;
                 }
             }
         }
@@ -500,7 +472,6 @@ namespace Tizen.NUI.Components
                 {
                     thumbImage.ResourceUrl = value;
                     thumbImageUrl = value;
-                    sliderStyle.Thumb.ResourceUrl = value;
                 }
             }
         }
@@ -580,7 +551,6 @@ namespace Tizen.NUI.Components
                 {
                     thumbImage.BackgroundColor = value;
                     thumbColor = value;
-                    sliderStyle.Thumb.BackgroundColor = value;
                 }
             }
         }
@@ -600,7 +570,6 @@ namespace Tizen.NUI.Components
                 if (null != bgTrackImage)
                 {
                     bgTrackImage.BackgroundColor = value;
-                    sliderStyle.Track.BackgroundColor = value;
                 }
             }
         }
@@ -620,7 +589,6 @@ namespace Tizen.NUI.Components
                 if (null != slidedTrackImage)
                 {
                     slidedTrackImage.BackgroundColor = value;
-                    sliderStyle.Progress.BackgroundColor = value;
                 }
             }
         }
@@ -675,7 +643,6 @@ namespace Tizen.NUI.Components
                 if (null != warningTrackImage)
                 {
                     warningTrackImage.BackgroundColor = value;
-                    sliderStyle.WarningTrack.BackgroundColor = value;
                 }
             }
         }
@@ -696,7 +663,6 @@ namespace Tizen.NUI.Components
                 if (null != warningSlidedTrackImage)
                 {
                     warningSlidedTrackImage.BackgroundColor = value;
-                    sliderStyle.WarningProgress.BackgroundColor = value;
                 }
             }
         }
@@ -774,7 +740,6 @@ namespace Tizen.NUI.Components
             {
                 if (null == lowIndicatorImage) lowIndicatorImage = new ImageView();
                 lowIndicatorImage.ResourceUrl = value;
-                sliderStyle.LowIndicatorImage.ResourceUrl = value;
             }
         }
 
@@ -792,7 +757,6 @@ namespace Tizen.NUI.Components
             {
                 if (null == highIndicatorImage) highIndicatorImage = new ImageView();
                 highIndicatorImage.ResourceUrl = value;
-                sliderStyle.HighIndicatorImage.ResourceUrl = value;
             }
         }
 
@@ -811,7 +775,6 @@ namespace Tizen.NUI.Components
                 if (null != lowIndicatorText)
                 {
                     lowIndicatorText.Text = value;
-                    sliderStyle.LowIndicator.Text = value;
                 }
             }
         }
@@ -831,7 +794,6 @@ namespace Tizen.NUI.Components
                 if (null != highIndicatorText)
                 {
                     highIndicatorText.Text = value;
-                    sliderStyle.HighIndicator.Text = value;
                 }
             }
         }
@@ -871,7 +833,6 @@ namespace Tizen.NUI.Components
                 if (null != highIndicatorText)
                 {
                     highIndicatorText.Size = value;
-                    sliderStyle.HighIndicator.Size = value;
                 }
             }
         }
@@ -942,7 +903,6 @@ namespace Tizen.NUI.Components
                 if (null != valueIndicatorImage)
                 {
                     valueIndicatorImage.Size = value;
-                    sliderStyle.ValueIndicatorImage.Size = value;
                 }
             }
         }
@@ -963,7 +923,6 @@ namespace Tizen.NUI.Components
                 if (null != valueIndicatorImage)
                 {
                     valueIndicatorImage.ResourceUrl = value;
-                    sliderStyle.ValueIndicatorImage.ResourceUrl = value;
                 }
             }
         }

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -39,7 +39,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public Switch() : base()
         {
-            Initialize();
         }
 
         /// <summary>
@@ -49,7 +48,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Switch(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -59,7 +57,6 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Switch(SwitchStyle switchStyle) : base(switchStyle)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -70,6 +67,10 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             SetAccessibilityConstructor(Role.ToggleButton);
+            IsSelectable = true;
+#if PROFILE_MOBILE
+            Feedback = true;
+#endif
         }
 
         /// <summary>
@@ -97,24 +98,13 @@ namespace Tizen.NUI.Components
         public event EventHandler<SelectedChangedEventArgs> SelectedChanged;
 
         /// <summary>
-        /// Return a copied Style instance of Switch
+        /// Return currently applied style.
         /// </summary>
         /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the Switch.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// Modifying contents in style may cause unexpected behaviour.
         /// </remarks>
         /// <since_tizen> 8 </since_tizen>
-        public new SwitchStyle Style
-        {
-            get
-            {
-                var result = new SwitchStyle(ViewStyle as SwitchStyle);
-                result.CopyPropertiesFromView(this);
-                result.Track.CopyPropertiesFromView(Track);
-                result.Thumb.CopyPropertiesFromView(Thumb);
-                return result;
-            }
-        }
+        public new SwitchStyle Style => (SwitchStyle)(ViewStyle as SwitchStyle)?.Clone();
 
         /// <summary>
         /// Apply style to switch.
@@ -123,8 +113,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void ApplyStyle(ViewStyle viewStyle)
         {
-            base.ApplyStyle(viewStyle);
-
             SwitchStyle swStyle = viewStyle as SwitchStyle;
 
             if (null != swStyle)
@@ -139,6 +127,8 @@ namespace Tizen.NUI.Components
                     Thumb.ApplyStyle(swStyle.Thumb);
                 }
             }
+
+            base.ApplyStyle(viewStyle);
         }
 
         /// <summary>
@@ -333,14 +323,6 @@ namespace Tizen.NUI.Components
             {
                 OnSelect();
             }
-        }
-
-        private void Initialize()
-        {
-            IsSelectable = true;
-#if PROFILE_MOBILE
-                Feedback = true;
-#endif
         }
 
         private void OnSelect()

--- a/src/Tizen.NUI.Components/Controls/Tab.cs
+++ b/src/Tizen.NUI.Components/Controls/Tab.cs
@@ -78,23 +78,13 @@ namespace Tizen.NUI.Components
         public event EventHandler<ItemChangedEventArgs> ItemChangedEvent;
 
         /// <summary>
-        /// Return a copied Style instance of Tab
+        /// Return currently applied style.
         /// </summary>
         /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the Tab.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
+        /// Modifying contents in style may cause unexpected behaviour.
         /// </remarks>
         /// <since_tizen> 8 </since_tizen>
-        public new TabStyle Style
-        {
-            get
-            {
-                var result = new TabStyle(tabStyle);
-                result.CopyPropertiesFromView(this);
-                result.UnderLine.CopyPropertiesFromView(underline);
-                return result;
-            }
-        }
+        public TabStyle Style => (TabStyle)(ViewStyle as TabStyle)?.Clone();
 
         /// <summary>
         /// Get underline of Tab.

--- a/src/Tizen.NUI.Components/Controls/Toast.cs
+++ b/src/Tizen.NUI.Components/Controls/Toast.cs
@@ -58,7 +58,6 @@ namespace Tizen.NUI.Components
             var instance = (Toast)bindable;
             if (newValue != null)
             {
-                instance.toastStyle.Duration = (uint)newValue;
                 if (instance.timer == null)
                 {
                     instance.timer = new Timer(instance.duration);
@@ -69,7 +68,7 @@ namespace Tizen.NUI.Components
         defaultValueCreator: (bindable) =>
         {
             var instance = (Toast)bindable;
-            return instance.toastStyle.Duration ?? instance.duration;
+            return instance.timer == null ? instance.duration : instance.timer.Interval;
         });
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -89,26 +88,7 @@ namespace Tizen.NUI.Components
         private string strText = null;
         private Timer timer = null;
         private readonly uint duration = 3000;
-        private ToastStyle toastStyle => ViewStyle as ToastStyle;
 
-        /// <summary>
-        /// Return a copied Style instance of Toast
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the Toast.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new ToastStyle Style
-        {
-            get
-            {
-                var result = new ToastStyle(toastStyle);
-                result.CopyPropertiesFromView(this);
-                result.Text.CopyPropertiesFromView(textLabel);
-                return result;
-            }
-        }
         static Toast() { }
 
         /// <summary>
@@ -118,7 +98,6 @@ namespace Tizen.NUI.Components
         [Obsolete("Deprecated in API8; Will be removed in API10")]
         public Toast() : base()
         {
-            Initialize();
         }
 
         /// <summary>
@@ -128,7 +107,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Toast(ToastStyle toastStyle) : base(toastStyle)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -138,7 +116,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Toast(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -314,6 +291,33 @@ namespace Tizen.NUI.Components
             }
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            WidthResizePolicy = ResizePolicyType.FitToChildren;
+            HeightResizePolicy = ResizePolicyType.FitToChildren;
+
+            textLabel = new TextLabel()
+            {
+                PositionUsesPivotPoint = true,
+                ParentOrigin = Tizen.NUI.ParentOrigin.Center,
+                PivotPoint = Tizen.NUI.PivotPoint.Center,
+                WidthResizePolicy = ResizePolicyType.UseNaturalSize,
+                HeightResizePolicy = ResizePolicyType.UseNaturalSize,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                TextColor = Color.White,
+            };
+            this.Add(textLabel);
+
+            this.VisibilityChanged += OnVisibilityChanged;
+            timer = new Timer(duration);
+            timer.Tick += OnTick;
+        }
+
         /// <summary>
         /// Apply style to toast.
         /// </summary>
@@ -321,30 +325,10 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void ApplyStyle(ViewStyle viewStyle)
         {
-            WidthResizePolicy = ResizePolicyType.FitToChildren;
-            HeightResizePolicy = ResizePolicyType.FitToChildren;
-
             base.ApplyStyle(viewStyle);
 
-            ToastStyle toastStyle = viewStyle as ToastStyle;
-
-            if (null != toastStyle)
+            if (viewStyle is ToastStyle toastStyle)
             {
-                if (null == textLabel)
-                {
-                    textLabel = new TextLabel()
-                    {
-                        PositionUsesPivotPoint = true,
-                        ParentOrigin = Tizen.NUI.ParentOrigin.Center,
-                        PivotPoint = Tizen.NUI.PivotPoint.Center,
-                        WidthResizePolicy = ResizePolicyType.UseNaturalSize,
-                        HeightResizePolicy = ResizePolicyType.UseNaturalSize,
-                        HorizontalAlignment = HorizontalAlignment.Center,
-                        VerticalAlignment = VerticalAlignment.Center,
-                        TextColor = Color.White,
-                    };
-                    this.Add(textLabel);
-                }
                 textLabel.ApplyStyle(toastStyle.Text);
             }
         }
@@ -391,29 +375,6 @@ namespace Tizen.NUI.Components
         protected override ViewStyle CreateViewStyle()
         {
             return new ToastStyle();
-        }
-
-        private void Initialize()
-        {
-            if (null == textLabel)
-            {
-                textLabel = new TextLabel()
-                {
-                    PositionUsesPivotPoint = true,
-                    ParentOrigin = Tizen.NUI.ParentOrigin.Center,
-                    PivotPoint = Tizen.NUI.PivotPoint.Center,
-                    WidthResizePolicy = ResizePolicyType.UseNaturalSize,
-                    HeightResizePolicy = ResizePolicyType.UseNaturalSize,
-                    HorizontalAlignment = HorizontalAlignment.Center,
-                    VerticalAlignment = VerticalAlignment.Center,
-                    TextColor = Color.White,
-                };
-                this.Add(textLabel);
-            }
-
-            this.VisibilityChanged += OnVisibilityChanged;
-            timer = new Timer(toastStyle.Duration ?? duration);
-            timer.Tick += OnTick;
         }
 
         private bool OnTick(object sender, EventArgs e)

--- a/src/Tizen.NUI.Components/Style/PaginationStyle.cs
+++ b/src/Tizen.NUI.Components/Style/PaginationStyle.cs
@@ -39,9 +39,9 @@ namespace Tizen.NUI.Components
 
         /// <summary>The IndicatorImageUrlSelector bindable property.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IndicatorImageUrlSelectorProperty = BindableProperty.Create("IndicatorImageUrlSelector", typeof(Selector<string>), typeof(PaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty IndicatorImageUrlSelectorProperty = BindableProperty.Create("IndicatorImageUrl", typeof(Selector<string>), typeof(PaginationStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
-            ((PaginationStyle)bindable).indicatorImageUrl = ((Selector<string>)newValue)?.Clone();
+            ((PaginationStyle)bindable).indicatorImageUrl = (Selector<string>)newValue;
         },
         defaultValueCreator: (bindable) =>
         {

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -250,7 +250,9 @@ namespace Tizen.NUI.Components
                 {
                     Normal = FrameworkInformation.ResourcePath + "nui_component_default_pagination_normal_dot.png",
                     Selected = FrameworkInformation.ResourcePath + "nui_component_default_pagination_focus_dot.png",
-                }
+                },
+                IndicatorSize = new Size(10, 10),
+                IndicatorSpacing = 10,
             });
 
             theme.AddStyleWithoutClone("Tizen.NUI.Components.Scrollbar", new ScrollbarStyle()

--- a/src/Tizen.NUI.Wearable/src/public/CircularPagination.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularPagination.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -616,7 +616,7 @@ namespace Tizen.NUI.Wearable
 
         private void Initialize()
         {
-            circularPaginationStyle = Style as CircularPaginationStyle;
+            circularPaginationStyle = ViewStyle as CircularPaginationStyle;
             if (circularPaginationStyle == null)
             {
                 throw new Exception("CircularPagination style is null.");

--- a/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularProgress.cs
@@ -201,24 +201,6 @@ namespace Tizen.NUI.Wearable
         #region Properties
 
         /// <summary>
-        /// Return a copied Style instance of CircularProgress
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the CircularProgress.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new CircularProgressStyle Style
-        {
-            get
-            {
-                var result = new CircularProgressStyle(ViewStyle as CircularProgressStyle);
-                result.CopyPropertiesFromView(this);
-                return result;
-            }
-        }
-
-        /// <summary>
         /// The thickness of the track and progress.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularScrollbar.cs
@@ -146,24 +146,6 @@ namespace Tizen.NUI.Wearable
         #region Properties
 
         /// <summary>
-        /// Return a copied Style instance of CircularScrollbar
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the CircularScrollbar.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public CircularScrollbarStyle Style
-        {
-            get
-            {
-                var result = new CircularScrollbarStyle(ViewStyle as CircularScrollbarStyle);
-                result.CopyPropertiesFromView(this);
-                return result;
-            }
-        }
-
-        /// <summary>
         /// The thickness of the scrollbar and track.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI.Wearable/src/public/CircularSlider.cs
+++ b/src/Tizen.NUI.Wearable/src/public/CircularSlider.cs
@@ -252,24 +252,6 @@ namespace Tizen.NUI.Wearable
         #region Properties
 
         /// <summary>
-        /// Return a copied Style instance of CircularSlider
-        /// </summary>
-        /// <remarks>
-        /// It returns copied Style instance and changing it does not effect to the CircularSlider.
-        /// Style setting is possible by using constructor or the function of ApplyStyle(ViewStyle viewStyle)
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new CircularSliderStyle Style
-        {
-            get
-            {
-                var result = new CircularSliderStyle(ViewStyle as CircularSliderStyle);
-                result.CopyPropertiesFromView(this);
-                return result;
-            }
-        }
-
-        /// <summary>
         /// The thickness of the track and progress.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI.Wearable/src/public/Title.cs
+++ b/src/Tizen.NUI.Wearable/src/public/Title.cs
@@ -79,16 +79,6 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Return a copied Style instance of the Title.
-        /// </summary>
-        /// <remarks>
-        /// It returns copied style instance so that changing it does not effect to the view.
-        /// Style setting is possible by using constructor or the function of <see cref="View.ApplyStyle"/>.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public new TextLabelStyle Style => ViewStyle as TextLabelStyle;
-
-        /// <summary>
         /// The constructor of the Title class with specific Style.
         /// </summary>
         /// <param name="textLabelStyle">Construct Style</param>

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,9 +65,9 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="behaviour">CustomView Behaviour</param>
         /// <param name="viewStyle">CustomView ViewStyle</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public CustomView(string typeName, CustomViewBehaviour behaviour, ViewStyle viewStyle) : base(typeName, new ViewWrapperImpl(behaviour), viewStyle)
+        public CustomView(string typeName, CustomViewBehaviour behaviour, ViewStyle viewStyle) : this(typeName, behaviour)
         {
-            Initialize();
+            InitializeStyle(viewStyle);
         }
 
         /// <summary>
@@ -138,7 +138,8 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// This method is called after the control has been initialized.<br />
+        /// This method is called after the CustomView has been initialized.<br />
+        /// After OnInitialize, the view will apply the style if it exists in the theme or it was given from constructor.<br />
         /// Derived classes should do any second phase initialization by overriding this method.<br />
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
@@ -916,13 +917,12 @@ namespace Tizen.NUI.BaseComponents
             viewWrapperImpl.OnTap = new ViewWrapperImpl.OnTapDelegate(OnTap);
             viewWrapperImpl.OnLongPress = new ViewWrapperImpl.OnLongPressDelegate(OnLongPress);
 
-            // Make sure CustomView is initialized.
-            OnInitialize();
-
             // Set the StyleName the name of the View
             // We have to do this because the StyleManager on Native side can't workout it out
             // This will also ensure that the style of views/visuals initialized above are applied by the style manager.
             SetStyleName(this.GetType().Name);
+
+            OnInitialize();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Selector.cs
@@ -346,6 +346,62 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        private bool EqualsItem(T a, T b)
+        {
+            return Object.ReferenceEquals(a, b) || (a != null && a.Equals(b));
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(System.Object other)
+        {
+            var x = other as Selector<T>;
+
+            if (x == null || x.SelectorItems.Count != SelectorItems.Count)
+            {
+                return false;
+            }
+
+            if (!EqualsItem(All, x.All))
+            {
+                return false;
+            }
+
+            foreach (var item in SelectorItems)
+            {
+                var found = SelectorItems.Find(i => i.State == item.State);
+
+                if (found == null || !EqualsItem(item.Value, found.Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            int hash = 17;
+            hash = (hash * 23) + (All == null ? 0 : All.GetHashCode());
+            hash = (hash * 23) + SelectorItems.Count;
+            
+            // Order of items should not effect to the result value.
+            int itemSum = 0;
+            foreach (var item in SelectorItems)
+            {
+                itemSum += item.State.GetHashCode() + (item.Value == null ? 0 : item.Value.GetHashCode());
+            }
+
+            return (hash * 23) + itemSum;
+        }
+
         internal bool HasMultiValue()
         {
             return SelectorItems.Count > 1;

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -434,13 +434,6 @@ namespace Tizen.NUI.BaseComponents
             return cloned;
         }
 
-        /// <summary>Create a cloned ViewStyle.</summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Merge(ViewStyle other)
-        {
-            CopyFrom(other);
-        }
-
         /// <summary>
         /// Release instance.
         /// </summary>
@@ -534,6 +527,30 @@ namespace Tizen.NUI.BaseComponents
         internal ViewStyle CreateInstance()
         {
             return (ViewStyle)Activator.CreateInstance(GetType());
+        }
+
+        /// <summary>Merge other style into the current style without creating new one.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal void MergeDirectly(ViewStyle other)
+        {
+            CopyFrom(other);
+        }
+    }
+
+    /// <summary> Extension methods for ViewStyle class.</summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ViewStyleExtension
+    {
+        /// <summary>Merge two styles into the new one.</summary>
+        /// <exception cref="ArgumentException">Thrown when failed because of an invalid parameter.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static TOut Merge<TOut>(this TOut value, TOut other) where TOut : Tizen.NUI.BaseComponents.ViewStyle
+        {
+            var newStyle = value.Clone() as TOut;
+
+            newStyle.CopyFrom(other);
+
+            return newStyle;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/CustomView/ViewWrapper.cs
+++ b/src/Tizen.NUI/src/public/CustomView/ViewWrapper.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,17 +27,11 @@ namespace Tizen.NUI
     {
         internal ViewWrapperImpl viewWrapperImpl;
 
-        internal ViewWrapper(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, null)
+        internal ViewWrapper(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }
 
         internal ViewWrapper(string typeName, ViewWrapperImpl implementation) : this(Interop.ViewWrapper.New(typeName, ViewWrapperImpl.getCPtr(implementation)), true)
-        {
-            viewWrapperImpl = implementation;
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        internal ViewWrapper(string typeName, ViewWrapperImpl implementation, ViewStyle viewStyle) : base(Interop.ViewWrapper.New(typeName, ViewWrapperImpl.getCPtr(implementation)), true, viewStyle)
         {
             viewWrapperImpl = implementation;
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/public/Theme/Theme.cs
+++ b/src/Tizen.NUI/src/public/Theme/Theme.cs
@@ -121,7 +121,7 @@ namespace Tizen.NUI
                         var baseStyle = item.Value?.Clone();
                         if (map.ContainsKey(item.Key))
                         {
-                            baseStyle.Merge(map[item.Key]);
+                            baseStyle.MergeDirectly(map[item.Key]);
                         }
                         map[item.Key] = baseStyle;
                     }
@@ -181,7 +181,7 @@ namespace Tizen.NUI
 
                 if (map.TryGetValue(styleName, out ViewStyle style) && style != null && style.GetType() == value.GetType())
                 {
-                    style.Merge(value);
+                    style.MergeDirectly(value);
                 }
                 else
                 {
@@ -311,7 +311,7 @@ namespace Tizen.NUI
                 }
                 else if (map.ContainsKey(item.Key) && !item.Value.SolidNull)
                 {
-                    map[item.Key].Merge(item.Value);
+                    map[item.Key].MergeDirectly(item.Value);
                 }
                 else
                 {
@@ -343,7 +343,7 @@ namespace Tizen.NUI
                 }
                 else if (map.ContainsKey(item.Key) && !item.Value.SolidNull)
                 {
-                    map[item.Key].Merge(item.Value);
+                    map[item.Key].MergeDirectly(item.Value);
                 }
                 else
                 {

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -75,7 +75,7 @@ namespace Tizen.NUI
             }
         }
 
-        internal static bool ThemeApplied => defaultTheme.Count > 0 || (currentTheme != null && currentTheme.Count > 0);
+        private static bool ThemeApplied => defaultTheme.Count > 0 || (currentTheme != null && currentTheme.Count > 0);
 
         /// <summary>
         /// Apply theme to the NUI.
@@ -114,7 +114,8 @@ namespace Tizen.NUI
 
             if (theme != null)
             {
-                CurrentTheme = theme;
+                defaultTheme = theme;
+                NotifyThemeChanged();
                 return true;
             }
 
@@ -133,10 +134,7 @@ namespace Tizen.NUI
         public static ViewStyle GetStyle(string styleName)
         {
             if (styleName == null) throw new ArgumentNullException(nameof(styleName));
-
-            if (!ThemeApplied) return null;
-
-            return (currentTheme?.GetStyle(styleName) ?? defaultTheme.GetStyle(styleName))?.Clone();
+            return GetStyleWithoutClone(styleName)?.Clone();
         }
 
         /// <summary>
@@ -148,10 +146,31 @@ namespace Tizen.NUI
         public static ViewStyle GetStyle(Type viewType)
         {
             if (viewType == null) throw new ArgumentNullException(nameof(viewType));
+            return GetStyleWithoutClone(viewType)?.Clone();
+        }
 
+        /// <summary>
+        /// Load a style with style name in the current theme.
+        /// </summary>
+        /// <param name="styleName">The style name.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static ViewStyle GetStyleWithoutClone(string styleName)
+        {
             if (!ThemeApplied) return null;
 
-            return (currentTheme?.GetStyle(viewType) ?? defaultTheme.GetStyle(viewType))?.Clone();
+            return currentTheme?.GetStyle(styleName) ?? defaultTheme.GetStyle(styleName);
+        }
+
+        /// <summary>
+        /// Load a style with View type in the current theme.
+        /// </summary>
+        /// <param name="viewType">The type of View.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static ViewStyle GetStyleWithoutClone(Type viewType)
+        {
+            if (!ThemeApplied) return null;
+
+            return currentTheme?.GetStyle(viewType) ?? defaultTheme.GetStyle(viewType);
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
* Note that this works only for the bindable properties.
* To implement this feature, components shares theme style so the component should not modify connected style instance.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
