### PR TITLE
[DO NOT MERGE][NUI] Add IsPreEdit property

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -285,6 +285,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_FONT_SIZE_SCALE_get")]
             public static extern int FontSizeScaleGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_PRE_EDIT_get")]
+            public static extern int PreEditGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -269,6 +269,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_FONT_SIZE_SCALE_get")]
             public static extern int FontSizeScaleGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_PRE_EDIT_get")]
+            public static extern int PreEditGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1316,6 +1316,23 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// It is possible to know whether the state of TextEditor is in PreEdit state.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsPreEdit
+        {
+            get
+            {
+                return (bool)GetValue(IsPreEditProperty);
+            }
+            set
+            {
+                SetValue(IsPreEditProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// Scroll the text control by specific amount..
         /// </summary>
         /// <param name="scroll">The amount (in pixels) of scrolling in horizontal &amp; vertical directions.</param>
@@ -1558,6 +1575,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int VerticalScrollPosition = Interop.TextEditor.VerticalScrollPositionGet();
             internal static readonly int PrimaryCursorPosition = Interop.TextEditor.PrimaryCursorPositionGet();
             internal static readonly int FontSizeScale = Interop.TextEditor.FontSizeScaleGet();
+            internal static readonly int IsPreEdit = Interop.TextEditor.PreEditGet();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -955,5 +955,22 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.FontSizeScale).Get(out temp);
             return temp;
         }));
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IsPreEditProperty = BindableProperty.Create(nameof(TextEditor.IsPreEdit), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.IsPreEdit, new Tizen.NUI.PropertyValue((bool)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            bool temp = false;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.IsPreEdit).Get(out temp);
+            return (bool)temp;
+        }));
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1390,6 +1390,23 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// It is possible to know whether the state of TextField is in PreEdit state.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsPreEdit
+        {
+            get
+            {
+                return (bool)GetValue(IsPreEditProperty);
+            }
+            set
+            {
+                SetValue(IsPreEditProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
         /// Only used by the IL of xaml, will never changed to not hidden.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool IsCreateByXaml
@@ -1659,6 +1676,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EnableEditing = Interop.TextField.EnableEditingGet();
             internal static readonly int PrimaryCursorPosition = Interop.TextField.PrimaryCursorPositionGet();
             internal static readonly int FontSizeScale = Interop.TextField.FontSizeScaleGet();
+            internal static readonly int IsPreEdit = Interop.TextField.PreEditGet();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -1007,6 +1007,24 @@ namespace Tizen.NUI.BaseComponents
             return temp;
         }));
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IsPreEditProperty = BindableProperty.Create(nameof(TextField.IsPreEdit), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textField = (TextField)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.IsPreEdit, new Tizen.NUI.PropertyValue((bool)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textField = (TextField)bindable;
+            bool temp = false;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.IsPreEdit).Get(out temp);
+            return (bool)temp;
+        }));
+
+
         #region Selectors
         internal static readonly BindableProperty TranslatableTextSelectorProperty = BindableProperty.Create("TranslatableTextSelector", typeof(Selector<string>), typeof(TextField), null, propertyChanged: (bindable, oldValue, newValue) =>
         {


### PR DESCRIPTION
It is possible to know whether the state of TextField and TextEditor is in PreEdit state.

example)

            field.TextChanged += (obj, e) => {
              Tizen.Log.Debug("NUI", $"Text[{e.TextField.Text}], {e.TextField.IsPreEdit}\n");
            };

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
