### PR TITLE
[NUI] : Add ScrollPosition in ScrollEventArgs for user convenience.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -31,15 +31,17 @@ namespace Tizen.NUI.Components
     public class ScrollEventArgs : EventArgs
     {
         private Position position;
+        private Position scrollPosition;
 
         /// <summary>
         /// Default constructor.
         /// </summary>
-        /// <param name="position">Current scroll position</param>
+        /// <param name="position">Current contianer position</param>
         /// <since_tizen> 8 </since_tizen>
         public ScrollEventArgs(Position position)
         {
             this.position = position;
+            this.scrollPosition = new Position(-position);
         }
 
         /// <summary>
@@ -51,6 +53,18 @@ namespace Tizen.NUI.Components
             get
             {
                 return position;
+            }
+        }
+        /// <summary>
+        /// Current scroll position of scrollableBase pan.
+        /// This is the position in the opposite direction to the current position of ContentContainer.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Position ScrollPosition
+        {
+            get
+            {
+                return scrollPosition;
             }
         }
     }


### PR DESCRIPTION
### Description of Change ###
Add ScrollPosition in ScrollEventArgs.

Current Position property in ScrollEventArgs is position of
ContentContainer which is negative.
user controls scrollableBase via ScrollTo and other API with
positive position of pan not ContentContainer so user must convert
current Position Property to use.

By this patch, we provide positive ScrollPosition which represent
position of scroll pan, so no need to convert value for using it.

### API Changes ###
No API Changes.