### PR TITLE
[Inputmethod] Fix the crash issue when setting PreEditString's attribute

### DIFF
--- a/src/Tizen.Uix.InputMethod/Tizen.Uix.InputMethod/InputMethodEditor.cs
+++ b/src/Tizen.Uix.InputMethod/Tizen.Uix.InputMethod/InputMethodEditor.cs
@@ -1758,23 +1758,20 @@ namespace Tizen.Uix.InputMethod
         public static void UpdatePreEditString(string str, IEnumerable<PreEditAttribute> attrs)
         {
             IntPtr einaList = IntPtr.Zero;
-            List<GCHandle> attributeHandleList = new List<GCHandle>();
             foreach (PreEditAttribute attribute in attrs)
             {
+                IntPtr attr = IntPtr.Zero;
                 ImePreEditAttributeStruct imePreEditAttribute = new ImePreEditAttributeStruct();
                 imePreEditAttribute.start = attribute.Start;
                 imePreEditAttribute.length = attribute.Length;
                 imePreEditAttribute.type = (int)attribute.Type;
                 imePreEditAttribute.value = attribute.Value;
-                GCHandle attributeHandle = GCHandle.Alloc(imePreEditAttribute, GCHandleType.Pinned);
-                attributeHandleList.Add(attributeHandle);
-                einaList = Interop.EinaList.EinaListAppend(einaList, attributeHandle.AddrOfPinnedObject());
+                attr = Marshal.AllocHGlobal(Marshal.SizeOf(imePreEditAttribute));
+                Marshal.WriteIntPtr(attr, IntPtr.Zero);
+                Marshal.StructureToPtr(imePreEditAttribute, attr, false);
+                einaList = Interop.EinaList.EinaListAppend(einaList, attr);
             }
             ErrorCode error = ImeUpdatePreeditString(str, einaList);
-            foreach (GCHandle handle in attributeHandleList)
-            {
-                handle.Free();
-            }
             if (error != ErrorCode.None)
             {
                 Log.Error(LogTag, "UpdatePreEditString Failed with error " + error);


### PR DESCRIPTION
### Description of Change ###
The crash issue occurred when C library released memory for string attribute.
So I modified to use Malshal class instead of GCHandle.

### API Changes ###
There is no need for ACR.
