### PR TITLE
[NUI] Button text ellipsis enabled and etc.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -69,7 +69,7 @@ namespace Tizen.NUI.Components
             {
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                AccessibilityHighlightable = false
+                AccessibilityHighlightable = false,
             };
         }
 
@@ -274,6 +274,8 @@ namespace Tizen.NUI.Components
 
             buttonText = CreateText();
             buttonIcon = CreateIcon();
+            buttonText.Relayout += OnTextRelayout;
+            buttonIcon.Relayout += OnIconRelayout;
             LayoutItems();
 
 #if PROFILE_MOBILE
@@ -367,6 +369,64 @@ namespace Tizen.NUI.Components
                 overlayImage.ExcludeLayouting = true;
                 Add(overlayImage);
             }
+        }
+
+        private void OnTextOrIconUpdated()
+        {
+            if (buttonIcon == null || buttonText == null)
+            {
+                return;
+            }
+
+            float lengthWithoutText = 0;
+
+            if (iconPadding == null || buttonIcon.Size.Width == 0 || buttonIcon.Size.Height == 0)
+            {
+                buttonIcon.Margin = new Extents(0);
+                lengthWithoutText = buttonIcon.Size.Width;
+            }
+            else if (iconRelativeOrientation == IconOrientation.Left || iconRelativeOrientation == IconOrientation.Right)
+            {
+                buttonIcon.Margin = new Extents(iconPadding.Start, iconPadding.End, 0, 0);
+                lengthWithoutText = iconPadding.Start + iconPadding.End + buttonIcon.Size.Width;
+            }
+            else
+            {
+                buttonIcon.Margin = new Extents(0, 0, iconPadding.Top, iconPadding.Bottom);
+            }
+
+            if (textPadding == null || buttonText.Size.Width == 0 || buttonText.Size.Height == 0)
+            {
+                buttonText.Margin = new Extents(0);
+            }
+            else 
+            {
+                if (iconRelativeOrientation == IconOrientation.Left || iconRelativeOrientation == IconOrientation.Right)
+                {
+                    buttonText.Margin = new Extents(textPadding.Start, textPadding.End, 0, 0);
+                    lengthWithoutText += textPadding.Start + textPadding.End;
+                }
+                else
+                {
+                    buttonText.Margin = new Extents(0, 0, textPadding.Top, textPadding.Bottom);
+                }
+            }
+
+            // If the button has fixed width and the text is not empty, the text should not exceed button boundary.
+            if (WidthSpecification >= 0 && !String.IsNullOrEmpty(buttonText.Text))
+            {
+                buttonText.MaximumSize = new Size2D(Math.Max(WidthSpecification - (int)lengthWithoutText, Math.Max((int)buttonText.MinimumSize.Width, 1)), HeightSpecification);
+            }
+        }
+
+        private void OnIconRelayout(object sender, EventArgs args)
+        {
+            OnTextOrIconUpdated();
+        }
+
+        private void OnTextRelayout(object sender, EventArgs args)
+        {
+            OnTextOrIconUpdated();
         }
 
         private void OnClickedInternal(ClickedEventArgs eventArgs)

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -128,10 +128,7 @@ namespace Tizen.NUI.Components
         {
             var instance = (Button)bindable;
             instance.iconPadding = (Extents)((Extents)newValue).Clone();
-            if (instance.buttonIcon != null)
-            {
-                instance.buttonIcon.Margin = instance.iconPadding;
-            }
+            instance.OnTextOrIconUpdated();
         },
         defaultValueCreator: (bindable) => ((Button)bindable).iconPadding);
 
@@ -141,10 +138,7 @@ namespace Tizen.NUI.Components
         {
             var instance = (Button)bindable;
             instance.textPadding = (Extents)((Extents)newValue).Clone();
-            if (instance.buttonText != null)
-            {
-                instance.buttonText.Margin = instance.textPadding;
-            }
+            instance.OnTextOrIconUpdated();
         },
         defaultValueCreator: (bindable) => ((Button)bindable).textPadding);
 
@@ -736,9 +730,15 @@ namespace Tizen.NUI.Components
                 if (Extension != null)
                 {
                     buttonIcon.Unparent();
-                    buttonText.Unparent();
+                    buttonIcon.Relayout -= OnIconRelayout;
                     buttonIcon = Extension.OnCreateIcon(this, buttonIcon);
+                    buttonIcon.Relayout += OnIconRelayout;
+
+                    buttonText.Unparent();
+                    buttonText.Relayout -= OnTextRelayout;
                     buttonText = Extension.OnCreateText(this, buttonText);
+                    buttonText.Relayout += OnTextRelayout;
+
                     LayoutItems();
                 }
 

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -65,7 +65,10 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void OnInitialize()
         {
-            track = new ImageView();
+            track = new ImageView()
+            {
+                EnableControlStatePropagation = true
+            };
             thumb = new ImageView();
             track.Add(thumb);
 

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -54,7 +54,7 @@ namespace Tizen.NUI.Components
 
             theme.AddStyleWithoutClone("Tizen.NUI.Components.CheckBox", new ButtonStyle()
             {
-                IconPadding = 5,
+                TextPadding = 5,
                 Icon = new ImageViewStyle()
                 {
                     Size = new Size(30, 30),


### PR DESCRIPTION
* Button text ellipsis when the text is longer than the button width.
* Switch thumb can get control state changed callback from parent.
* Button IconPadding is ignored when the icon is not exist.
* Button TextPadding is ignored when the text is not exist.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
