### PR TITLE
[NUI] Fix TabButton not to invoke duplicate SelectedChanged

### DIFF
--- a/src/Tizen.NUI.Components/Controls/TabBar.cs
+++ b/src/Tizen.NUI.Components/Controls/TabBar.cs
@@ -130,7 +130,6 @@ namespace Tizen.NUI.Components
             if (SelectedIndex == -1)
             {
                 tabButton.IsSelected = true;
-                tabButton.SetTabButtonState(ControlState.Pressed);
                 SelectedIndex = 0;
 
                 if (TabButtonSelected != null)
@@ -184,7 +183,6 @@ namespace Tizen.NUI.Components
             if ((SelectedIndex != -1) && (selectedTabButton != tabButtons[SelectedIndex]))
             {
                 tabButtons[SelectedIndex].IsSelected = true;
-                tabButtons[SelectedIndex].SetTabButtonState(ControlState.Pressed);
             }
 
             //TODO: To support non-unified tab button size.

--- a/src/Tizen.NUI.Components/Controls/TabButtonGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/TabButtonGroup.cs
@@ -28,6 +28,15 @@ namespace Tizen.NUI.Components
     public class TabButtonGroup : SelectGroup
     {
         /// <summary>
+        /// Constructs TabButtonGroup
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabButtonGroup() : base()
+        {
+            EnableMultiSelection = false;
+        }
+
+        /// <summary>
         /// Adds a tab button to the end of TabButtonGroup.
         /// </summary>
         /// <param name="tabButton">A tab button to be added to the group.</param>
@@ -57,38 +66,6 @@ namespace Tizen.NUI.Components
             }
 
             base.RemoveSelection(tabButton);
-        }
-
-        /// <summary>
-        /// Sets the state of the rest of tab buttons in TabButtonGroup as normal
-        /// when a selection is made by a user.
-        /// </summary>
-        /// <param name="selection">The handler of the SelectButton selected by a user.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the argument selection is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the argument selection does not exist in TabButtonGroup.</exception>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void SelectionHandler(SelectButton selection)
-        {
-            TabButton selectedTab = selection as TabButton;
-
-            if (selectedTab == null)
-            {
-                throw new ArgumentNullException(nameof(selection), "selection should not be null.");
-            }
-
-            if (ItemGroup.Contains(selectedTab) == false)
-            {
-                throw new ArgumentException("selection does not exist in TabButtonGroup.", nameof(selection));
-            }
-
-            foreach (TabButton tabButton in ItemGroup)
-            {
-                if ((tabButton != null) && (tabButton != selectedTab) && (selectedTab.IsEnabled == true))
-                {
-                    tabButton.IsSelected = false;
-                    tabButton.SetTabButtonState(ControlState.Normal);
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
TabButton does not change its state to unselected if button or key is
unpressed while its state is selected.

Previously, TabButton invoked duplicate SelectedChanged if button or key
is unpressed while its state is selected.

Now, TabButton does not invoke duplicate SelectedChanged if button or
key is unpressed while its state is selected.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
