### PR TITLE
[NUI] Add TabButtonStyle class with the latest TabButton UX

### DIFF
--- a/src/Tizen.NUI.Components/Controls/TabBar.cs
+++ b/src/Tizen.NUI.Components/Controls/TabBar.cs
@@ -55,9 +55,6 @@ namespace Tizen.NUI.Components
 
         private TabButtonGroup tabButtonGroup;
 
-        //TODO: This tab button height should be implemented in TabBar style.
-        private float tabButtonHeight = 72.0f;
-
         /// <summary>
         /// Creates a new instance of TabBar.
         /// </summary>
@@ -209,9 +206,9 @@ namespace Tizen.NUI.Components
 
             foreach (TabButton tabButton in tabButtons)
             {
-                if ((tabButton.Size.Width != tabButtonWidth) || (tabButton.Size.Height != tabButtonHeight))
+                if (tabButton.Size.Width != tabButtonWidth)
                 {
-                    tabButton.Size = new Size(tabButtonWidth, tabButtonHeight);
+                    tabButton.Size = new Size(tabButtonWidth, tabButton.Size.Height);
                 }
             }
         }

--- a/src/Tizen.NUI.Components/Style/TabButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/TabButtonStyle.cs
@@ -1,0 +1,75 @@
+﻿/*
+ * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
+
+namespace Tizen.NUI.Components
+{
+    /// <summary>
+    /// TabButtonStyle is a class which saves TabButton's ux data.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class TabButtonStyle : ButtonStyle
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        static TabButtonStyle() { }
+
+        /// <summary>
+        /// Creates a new instance of a TabButtonStyle.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabButtonStyle() : base()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a TabButtonStyle with style.
+        /// </summary>
+        /// <param name="style">Create TabButtonStyle by style customized by user.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabButtonStyle(TabButtonStyle style) : base(style)
+        {
+        }
+
+        /// <summary>
+        /// Gets or Sets the Line Style at the top of TabButton.
+        /// </summary>
+        internal ViewStyle TopLine { get; set; } = new ViewStyle();
+
+        /// <summary>
+        /// Gets or Sets the Line Style at the bottom of TabButton.
+        /// </summary>
+        internal ViewStyle BottomLine { get; set; } = new ViewStyle();
+
+        /// <summary>
+        /// Style's clone function.
+        /// </summary>
+        /// <param name="bindableObject">The style that need to copy.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void CopyFrom(BindableObject bindableObject)
+        {
+            base.CopyFrom(bindableObject);
+
+            if (bindableObject is TabButtonStyle tabButtonStyle)
+            {
+                TopLine.CopyFrom(tabButtonStyle.TopLine);
+                BottomLine.CopyFrom(tabButtonStyle.BottomLine);
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
@@ -112,6 +112,22 @@ namespace Tizen.NUI.Components
                     .AddSelector("/ItemTextLabel/TextColor", (ViewStyle style, Selector<Color> value) => ((PickerStyle)style).ItemTextLabel.TextColor = value)
                     .AddSelector("/ItemTextLabel/PixelSize", (ViewStyle style, Selector<float?> value) => ((PickerStyle)style).ItemTextLabel.PixelSize = value)
                     .AddSelector("/Divider/Background", (ViewStyle style, Selector<Color> value) => ((PickerStyle)style).Divider.BackgroundColor = value),
+
+                // TabButton
+                (new ExternalThemeKeyList(typeof(TabButton), typeof(TabButtonStyle)))
+                    .Add<Size>("/Size", (ViewStyle style, Size value) => ((ViewStyle)style).Size = value)
+                    .Add<float?>("/CornerRadius", (ViewStyle style, float? value) => ((ViewStyle)style).CornerRadius = value)
+                    .AddSelector<Color>("/BackgroundColor", (ViewStyle style, Selector<Color> value) => ((ViewStyle)style).BackgroundColor = value, ControlState.Selected)
+                    .AddSelector<float?>("/Text/PixelSize", SetButtonTextPixelSize, ControlState.Selected)
+                    .Add<Size>("/Text/Size", (ViewStyle style, Size value) => ((ButtonStyle)style).Text.Size = value)
+                    .AddSelector<Color>("/Text/TextColor", SetButtonTextColor, ControlState.Selected)
+                    .Add<Size>("/Icon/Size", (ViewStyle style, Size value) => ((ButtonStyle)style).Icon.Size = value)
+                    .AddSelector<Color>("/Icon/Color", (ViewStyle style, Selector<Color> value) => ((ButtonStyle)style).Icon.Color = value, ControlState.Selected)
+                    .Add<Size>("/TopLine/Size", (ViewStyle style, Size value) => ((TabButtonStyle)style).TopLine.Size = value)
+                    .AddSelector<Color>("/TopLine/BackgroundColor", (ViewStyle style, Selector<Color> value) => ((TabButtonStyle)style).TopLine.BackgroundColor = value, ControlState.Selected)
+                    .Add<Size>("/BottomLine/Size", (ViewStyle style, Size value) => ((TabButtonStyle)style).BottomLine.Size = value)
+                    .Add<Position>("/BottomLine/Position", (ViewStyle style, Position value) => ((TabButtonStyle)style).BottomLine.Position = value)
+                    .AddSelector<Color>("/BottomLine/BackgroundColor", (ViewStyle style, Selector<Color> value) => ((TabButtonStyle)style).BottomLine.BackgroundColor = value, ControlState.Selected),
             };
 
             return actionSet;

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -435,6 +435,59 @@ namespace Tizen.NUI.Components
                 StartScrollOffset = new Size2D(0, 12),
             });
 
+            theme.AddStyleWithoutClone("Tizen.NUI.Components.TabButton", new TabButtonStyle()
+            {
+                Size = new Size(-1, 84),
+                CornerRadius = 0,
+                BackgroundColor = Color.White,
+                Text = new TextLabelStyle()
+                {
+                    PixelSize = 28,
+                    Size = new Size(-2, -2),
+                    TextColor = new Selector<Color>()
+                    {
+                        Normal = new Color("#000C2BFF"),
+                        Selected = new Color("#000C2BFF"),
+                        Pressed = new Color("#1473E6FF"),
+                        Disabled = new Color("#C3CAD2FF"),
+                    },
+                },
+                Icon = new ImageViewStyle()
+                {
+                    Size = new Size(48, 48),
+                    Color = new Selector<Color>()
+                    {
+                        Normal = new Color("#000C2BFF"),
+                        Selected = new Color("#000C2BFF"),
+                        Pressed = new Color("#1473E6FF"),
+                        Disabled = new Color("#C3CAD2FF"),
+                    },
+                },
+                TopLine = new ViewStyle()
+                {
+                    Size = new Size(-1, 1),
+                    BackgroundColor = new Selector<Color>()
+                    {
+                        Normal = new Color("#000C2BFF"),
+                        Selected = new Color("#000C2BFF"),
+                        Pressed = new Color("#1473E6FF"),
+                        Disabled = new Color("#C3CAD2FF"),
+                    },
+                },
+                BottomLine = new ViewStyle()
+                {
+                    Size = new Size(-1, 8),
+                    Position = new Position(0, 76), // 84 - 8
+                    BackgroundColor = new Selector<Color>()
+                    {
+                        Normal = Color.Transparent,
+                        Selected = new Color("#000C2BFF"),
+                        Pressed = new Color("#1473E6FF"),
+                        Disabled = Color.Transparent,
+                    },
+                },
+            });
+
             return theme;
         }
     }


### PR DESCRIPTION
To apply the latest TabButton UX, TabButtonStyle class is added.

TabButtonStyle.TopLine and TabButtonStyle.BottomLine are displayed when
TabButton is pressed or selected.
TabButtonStyle.PaddingIcon is applied as Padding when Icon or Icon with
Text is displayed.
TabButtonStyle.PaddingText is applied as Padding when only Text is
displayed.
TabButtonStyle.IconTextPadding is applied as Padding between Icon and
Text.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
