### PR TITLE
[NUI] Make possible to capture on the old driver devices.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
@@ -69,7 +69,7 @@ namespace Tizen.NUI
             public static extern IntPtr GetNativeImageSourcePtr(HandleRef jarg1);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GenerateUrl")]
-            public static extern string GenerageUrl(HandleRef capture);
+            public static extern string GenerateUrl(HandleRef capture);
 
         }
     }

--- a/src/Tizen.NUI/src/public/Capture.cs
+++ b/src/Tizen.NUI/src/public/Capture.cs
@@ -292,13 +292,26 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Get Url of captured image that can be used as the resource path for the ImageView.
+        /// </summary>
+        /// <returns>Url of captured image.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1056:Uri properties should not be strings", Justification = "<Pending>")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Url
+        {
+            get
+            {
+                return Interop.Capture.GenerateUrl(SwigCPtr);
+            }
+        }
+
+        /// <summary>
         /// Get NativeImageSource that is saved captured image.
         /// </summary>
         /// <returns>NativeImageSource that is saved captured image.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NativeImageSource GetNativeImageSource()
         {
-            Tizen.Log.Debug("NUI", $"GetNativeImageSource()");
             return new NativeImageSource(Interop.Capture.GetNativeImageSourcePtr(swigCPtr), true);
         }
 
@@ -310,7 +323,7 @@ namespace Tizen.NUI
         public string GenerateUrl()
         {
             string url = "";
-            url = Interop.Capture.GenerageUrl(swigCPtr);
+            url = Interop.Capture.GenerateUrl(swigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return url;
         }


### PR DESCRIPTION
Some devices those have old gpu driver cannot use NativeImageSource for Capture.
This patch adds more option to use captured buffer with uri directly

Signed-off-by: seungho <sbsh.baek@samsung.com>