### PR TITLE
[NUI] Fix argument issue when launch application on ubuntu

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
@@ -144,7 +144,7 @@ namespace Tizen.NUI
             args[0] = Tizen.Applications.Application.Current.ApplicationInfo.ExecutablePath;
             if (string.IsNullOrEmpty(args[0]))
             {
-                args[0] = this.GetType().Assembly.FullName;
+                args[0] = this.GetType().Assembly.FullName.Replace(" ", "");
             }
 
             if (windowRectangle != null)


### PR DESCRIPTION
args[0] value is this.
 ->Tizen.NUI, Version=4.0.0.0, Culture=neutral, PublicKeyToken=eba370b203a2e242

So can't set using argument value.
 ex) dotnet run --width 100 --height --100

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
