### PR TITLE
[NUI][AT-SPI] Improve StringToVoid implementation

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/StringToVoidSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/StringToVoidSignal.cs
@@ -35,11 +35,18 @@ namespace Tizen.NUI
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        static internal string ConvertParam1(global::System.IntPtr data)
+        static internal string GetResult(global::System.IntPtr data)
         {
-            string result = Interop.StringToVoidSignal.ConvertParam1(data);
+            string result = Interop.StringToVoidSignal.GetResult(data);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return result;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        static internal void SetResult(global::System.IntPtr data, string res)
+        {
+            Interop.StringToVoidSignal.SetResult(data, res);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -88,13 +95,6 @@ namespace Tizen.NUI
                 Interop.StringToVoidSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Emit()
-        {
-            Interop.StringToVoidSignal.Emit(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StringToVoidSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StringToVoidSignal.cs
@@ -42,11 +42,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_Disconnect")]
             public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_Emit")]
-            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_GetResult")]
+            public static extern string GetResult(global::System.IntPtr jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_Convert_Param1")]
-            public static extern string ConvertParam1(global::System.IntPtr jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_StringToVoid_SetResult")]
+            public static extern void SetResult(global::System.IntPtr jarg1, string jarg2);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -106,13 +106,13 @@ namespace Tizen.NUI.BaseComponents
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class GetDescriptionEventArgs : EventArgs
     {
-        public string Description { get; internal set; }
+        public string Description { get; set; }
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class GetNameEventArgs : EventArgs
     {
-        public string Description { get; internal set; }
+        public string Name { get; set; }
     }
 
     /// <summary>
@@ -229,9 +229,11 @@ namespace Tizen.NUI.BaseComponents
                 return;
 
             var arg = new GetDescriptionEventArgs();
-            arg.Description = StringToVoidSignal.ConvertParam1(data);
+            arg.Description = StringToVoidSignal.GetResult(data);
 
             getDescriptionHandler?.Invoke(this, arg);
+
+            StringToVoidSignal.SetResult(data, arg.Description);
         }
 
         // This uses GetDescription signal from C++ API.
@@ -283,9 +285,11 @@ namespace Tizen.NUI.BaseComponents
                 return;
 
             var arg = new GetNameEventArgs();
-            arg.Description = StringToVoidSignal.ConvertParam1(data);
+            arg.Name = StringToVoidSignal.GetResult(data);
 
             getNameHandler?.Invoke(this, arg);
+
+            StringToVoidSignal.SetResult(data, arg.Name);
         }
 
         // This uses GetName signal from C++ API.


### PR DESCRIPTION
This commit must be merged first: https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/256117/

### Description of Change ###
This pull request allows to return result to caller of Dali::Signal<>::Emit() by first parameter.

In this case Bridge implemented inside dali is the caller.

This pull request also remove Emit function from C# api.
Emit function should be used only by Bridge and there is
no reason to allow call of this function from C# api.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
NONE
