### PR TITLE
[NUI] Fix Window.Instance null issue

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -490,8 +490,8 @@ namespace Tizen.NUI
                 appControlSignal = null;
             }
 
-            win?.Dispose();
-            win = null;
+            window?.Dispose();
+            window = null;
 
             base.Dispose(type);
         }
@@ -575,7 +575,7 @@ namespace Tizen.NUI
         private NUIApplicationAppControlEventCallbackDelegate applicationAppControlEventCallbackDelegate;
         private ApplicationControlSignal appControlSignal;
 
-        private Window win;
+        private Window window;
 
         /**
           * @brief Event for Initialized signal which can be used to subscribe/unsubscribe the event handler
@@ -613,6 +613,7 @@ namespace Tizen.NUI
         {
             // Initialize DisposeQueue Singleton class. This is also required to create DisposeQueue on main thread.
             DisposeQueue.Instance.Initialize();
+            Window.Instance = GetWindow();
 
             // Notify that the window is displayed to the app core.
             if (NUIApplication.IsPreload)
@@ -1259,14 +1260,15 @@ namespace Tizen.NUI
 
         public Window GetWindow()
         {
-            win = Registry.GetManagedBaseHandleFromNativePtr(Interop.Application.GetWindow(SwigCPtr)) as Window;
-            if (win == null)
+            if (window != null)
             {
-                win = new Window(Interop.Application.GetWindow(SwigCPtr), true);
+                return window;
             }
 
+            window = (Registry.GetManagedBaseHandleFromNativePtr(Interop.Application.GetWindow(SwigCPtr)) as Window) ?? new Window(Interop.Application.GetWindow(SwigCPtr), true);
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return win;
+            return window;
         }
 
         public static string GetResourcePath()

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -34,8 +34,6 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public partial class Window : BaseHandle
     {
-        private static readonly Window instance = Application.Instance?.GetWindow();
-
         private HandleRef stageCPtr;
         private Layer rootLayer;
         private string windowTitle;
@@ -264,13 +262,7 @@ namespace Tizen.NUI
         /// Gets the current window.<br />
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public static Window Instance
-        {
-            get
-            {
-                return instance;
-            }
-        }
+        public static Window Instance { get; internal set; }
 
         /// <summary>
         /// Gets or sets a window type.


### PR DESCRIPTION
If call Window.Instance before initializing, Window.Instance is always null

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
