### PR TITLE
[NUI] Add extension method to help use PropertyMap class

### DIFF
--- a/src/Tizen.NUI/src/public/Common/PropertyMap.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyMap.cs
@@ -317,4 +317,25 @@ namespace Tizen.NUI
             Interop.PropertyMap.DeletePropertyMap(swigCPtr);
         }
     }
+
+    internal static class PropertyMapSetterHelper
+    {
+        internal static PropertyMap Add<T>(this PropertyMap propertyMap, int key, T value)
+        {
+            using (var pv = PropertyValue.CreateFromObject(value))
+            {
+                propertyMap.Add(key, pv);
+            }
+            return propertyMap;
+        }
+
+        internal static PropertyMap Add<T>(this PropertyMap propertyMap, string key, T value)
+        {
+            using (var pv = PropertyValue.CreateFromObject(value))
+            {
+                propertyMap.Add(key, pv);
+            }
+            return propertyMap;
+        }
+    }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
 Add extension method to help use `PropertyMap` class

 Currently, NUI developer have to create a temporary `PropertyValue` object to set a value on `PropertyMap` like below
``` c#
temp = new PropertyValue((int)panelLayout);
outputMap.Add("PANEL_LAYOUT", temp);
temp.Dispose();

PropertyValue temp = new PropertyValue(alphaFunction);
animator.Add("alphaFunction", temp);
temp.Dispose();

```
But, now easily can set with primitive value like below
``` c#
outputMap.Add("PANEL_LAYOUT", (int)panelLayout);

animator.Add("alphaFunction", alphaFunction);
```

And also easily inlining a propertMap build code without wasted memory 
``` c#
FontStyle = new PropertyMap().Add("weight", new PropertyValue("light")),
```
`new PropertyValue("light")` is disposable object and no more used after create `PropertyMap` but does not disposed, 

It could be change like below and it does not waste the memory, it dispose `PropertyValue` after adding a value
``` c#
FontStyle = new PropertyMap().Add("weight", "light"),
```

It also did not change API, I just add a extension method as internal
I hope to NUI developer save their time

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
