### PR TITLE
[NUI] Add Obsolete attribute on deprecated property setter

### DIFF
--- a/src/Tizen.NUI/Tizen.NUI.csproj
+++ b/src/Tizen.NUI/Tizen.NUI.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>$(NoWarn);CS0618;CS0809;CS1591;CA1054;CA1056</NoWarn>
   </PropertyGroup>
 

--- a/src/Tizen.NUI/src/public/Common/Vector3.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector3.cs
@@ -466,6 +466,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public float Depth
         {
+            [Obsolete("Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector3(...) constructor")]
             set
             {
                 Tizen.Log.Fatal("NUI", "Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector3(...) constructor");
@@ -500,6 +501,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public float B
         {
+            [Obsolete("Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector3(...) constructor")]
             set
             {
                 Tizen.Log.Fatal("NUI", "Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector3(...) constructor");

--- a/src/Tizen.NUI/src/public/Common/Vector3.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector3.cs
@@ -260,7 +260,6 @@ namespace Tizen.NUI
         /// Vector3 vector3 = new Vector3(width, height, depth);
         /// </code>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector3(...) constructor")]
         public float Width
         {
             set
@@ -465,7 +464,6 @@ namespace Tizen.NUI
         /// Vector3 vector3 = new Vector3(width, height, depth);
         /// </code>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector3(...) constructor")]
         public float Depth
         {
             set

--- a/src/Tizen.NUI/src/public/Common/Vector4.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector4.cs
@@ -421,7 +421,6 @@ namespace Tizen.NUI
         /// Vector4 vector4 = new Vector4(r, g, b, a);
         /// </code>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector4(...) constructor")]
         public float B
         {
             set

--- a/src/Tizen.NUI/src/public/Common/Vector4.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector4.cs
@@ -423,6 +423,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public float B
         {
+            [Obsolete("Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector4(...) constructor")]
             set
             {
                 Tizen.Log.Fatal("NUI", "Please do not use this setter, Deprecated in API8, will be removed in API10. please use new Vector4(...) constructor");


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
 Remove worng Obsolete attribute
 Some Property setter was obsoleted but, Obsolete attribute make getter obsolete also. it is annoying a developer
 These obsolete attribute was removed but someone remained, So I remove it

##  Updated!! 
I found way to set Obsolete on property setter, it need to use C# version 8
I change it on some properties, but i can't apply all deprecated setter, because it is not my job. 
I hope that someone complete this PR.

I will close it when volunteer is coming

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
