### PR TITLE
[NUI] Implement certificate & authentication APIs of WebView.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebCertificate.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebCertificate.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WebCertificate
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_Allow")]
+            public static extern void Allow(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_IsFromMainFrame")]
+            public static extern bool IsFromMainFrame(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_GetPem")]
+            public static extern string GetPem(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebCertificate_IsContextSecure")]
+            public static extern bool IsContextSecure(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpAuthHandler.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpAuthHandler.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WebHttpAuthHandler
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_GetRealm")]
+            public static extern string GetRealm(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_Suspend")]
+            public static extern void Suspend(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_UseCredential")]
+            public static extern void UseCredential(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebHttpAuthHandler_CancelCredential")]
+            public static extern void CancelCredential(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}
+

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
@@ -317,6 +317,33 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebViewPolicyDecisionSignal_Disconnect")]
             public static extern void WebViewPolicyDecisionSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WebViewCertificateSignal_CertificateConfirm")]
+            public static extern global::System.IntPtr NewWebViewCertificateSignalCertificateConfirm(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WebViewCertificateSignal_SslCertificateChanged")]
+            public static extern global::System.IntPtr NewWebViewCertificateSignalSslCertificateChanged(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebViewCertificateSignal")]
+            public static extern void DeleteWebViewCertificateSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebViewCertificateSignal_Connect")]
+            public static extern void WebViewCertificateSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebViewCertificateSignal_Disconnect")]
+            public static extern void WebViewCertificateSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WebViewHttpAuthHandlerSignal_HttpAuthHandler")]
+            public static extern global::System.IntPtr NewWebViewHttpAuthHandlerSignalHttpAuthHandler(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebViewHttpAuthHandlerSignal")]
+            public static extern void DeleteWebViewHttpAuthHandlerSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebViewHttpAuthHandlerSignal_Connect")]
+            public static extern void WebViewHttpAuthHandlerSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebViewHttpAuthHandlerSignal_Disconnect")]
+            public static extern void WebViewHttpAuthHandlerSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/WebView/WebCertificate.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebCertificate.cs
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// It is a class for certificate of web view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebCertificate : Disposable
+    {
+        internal WebCertificate(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Checks whether the certificate comes from main frame.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsFromMainFrame
+        {
+            get
+            {
+                bool result = Interop.WebCertificate.IsFromMainFrame(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) return false;
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Queries certificate's PEM data.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string PemData
+        {
+            get
+            {
+                string result = Interop.WebCertificate.GetPem(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) return null;
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Queries if the context loaded with a given certificate is secure.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsContextSecure
+        {
+            get
+            {
+                bool result = Interop.WebCertificate.IsContextSecure(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) return false;
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Allows the site access about certificate error.
+        /// <param name="allowed">allowed or not</param>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Allow(bool allowed)
+        {
+            Interop.WebCertificate.Allow(SwigCPtr, allowed);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebView/WebHttpAuthHandler.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebHttpAuthHandler.cs
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// It is a class for http authencation handler of web view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebHttpAuthHandler : Disposable
+    {
+        internal WebHttpAuthHandler(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Gets the realm of authentication challenge received.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Realm
+        {
+            get
+            {
+                string result = Interop.WebHttpAuthHandler.GetRealm(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) return null;
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Suspends the operation for authentication challenge.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Suspend()
+        {
+            Interop.WebHttpAuthHandler.Suspend(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Sends credential for authentication challenge.
+        /// <param name="userId">user id from user input.</param>
+        /// <param name="password">user password from user input.</param>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void UseCredential(string userId, string password)
+        {
+            Interop.WebHttpAuthHandler.UseCredential(SwigCPtr, userId, password);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Sends cancellation notification for authentication challenge.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void CancelCredential()
+        {
+            Interop.WebHttpAuthHandler.CancelCredential(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebView.cs
@@ -74,6 +74,18 @@ namespace Tizen.NUI
         private EventHandler<WebViewNewWindowPolicyDecidedEventArgs> newWindowPolicyDecidedEventHandler;
         private WebViewNewWindowPolicyDecidedCallbackDelegate newWindowPolicyDecidedCallback;
 
+        private readonly WebViewCertificateReceivedSignal certificateConfirmedSignal;
+        private EventHandler<WebViewCertificateReceivedEventArgs> certificateConfirmedEventHandler;
+        private WebViewCertificateReceivedCallbackDelegate certificateConfirmedCallback;
+
+        private readonly WebViewCertificateReceivedSignal sslCertificateChangedSignal;
+        private EventHandler<WebViewCertificateReceivedEventArgs> sslCertificateChangedEventHandler;
+        private WebViewCertificateReceivedCallbackDelegate sslCertificateChangedCallback;
+
+        private readonly WebViewHttpAuthRequestedSignal httpAuthRequestedSignal;
+        private EventHandler<WebViewHttpAuthRequestedEventArgs> httpAuthRequestedEventHandler;
+        private WebViewHttpAuthRequestedCallbackDelegate httpAuthRequestedCallback;
+
         /// <summary>
         /// Creates a WebView.
         /// </summary>
@@ -125,6 +137,9 @@ namespace Tizen.NUI
             formRepostPolicyDecidedSignal = new WebViewFormRepostPolicyDecidedSignal(Interop.WebView.NewWebViewFormRepostDecisionSignalFormRepostDecision(SwigCPtr));
             frameRenderedSignal = new WebViewFrameRenderedSignal(Interop.WebView.WebViewFrameRenderedSignalFrameRenderedGet(SwigCPtr));
             newWindowPolicyDecidedSignal = new WebViewNewWindowPolicyDecidedSignal(Interop.WebView.NewWebViewPolicyDecisionSignalPolicyDecision(SwigCPtr));
+            certificateConfirmedSignal = new WebViewCertificateReceivedSignal(Interop.WebView.NewWebViewCertificateSignalCertificateConfirm(SwigCPtr));
+            sslCertificateChangedSignal = new WebViewCertificateReceivedSignal(Interop.WebView.NewWebViewCertificateSignalSslCertificateChanged(SwigCPtr));
+            httpAuthRequestedSignal = new WebViewHttpAuthRequestedSignal(Interop.WebView.NewWebViewHttpAuthHandlerSignalHttpAuthHandler(SwigCPtr));
 
             screenshotAcquiredProxyCallback = OnScreenshotAcquired;
 
@@ -159,6 +174,9 @@ namespace Tizen.NUI
                 formRepostPolicyDecidedSignal.Dispose();
                 frameRenderedSignal.Dispose();
                 newWindowPolicyDecidedSignal.Dispose();
+                certificateConfirmedSignal.Dispose();
+                sslCertificateChangedSignal.Dispose();
+                httpAuthRequestedSignal.Dispose();
 
                 BackForwardList.Dispose();
                 Context.Dispose();
@@ -241,6 +259,12 @@ namespace Tizen.NUI
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void WebViewNewWindowPolicyDecidedCallbackDelegate(IntPtr data, IntPtr maker);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate void WebViewCertificateReceivedCallbackDelegate(IntPtr data, IntPtr certificate);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate void WebViewHttpAuthRequestedCallbackDelegate(IntPtr data, IntPtr handler);
 
         /// <summary>
         /// Event for the PageLoadStarted signal which can be used to subscribe or unsubscribe the event handler.<br />
@@ -472,6 +496,84 @@ namespace Tizen.NUI
                 if (newWindowPolicyDecidedEventHandler == null && newWindowPolicyDecidedCallback != null)
                 {
                     newWindowPolicyDecidedSignal.Disconnect(newWindowPolicyDecidedCallback);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event for the CertificateConfirmed signal which can be used to subscribe or unsubscribe the event handler.<br />
+        /// This signal is emitted when certificate would be confirmed.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<WebViewCertificateReceivedEventArgs> CertificateConfirmed
+        {
+            add
+            {
+                if (certificateConfirmedEventHandler == null)
+                {
+                    certificateConfirmedCallback = OnCertificateConfirmed;
+                    certificateConfirmedSignal.Connect(certificateConfirmedCallback);
+                }
+                certificateConfirmedEventHandler += value;
+            }
+            remove
+            {
+                certificateConfirmedEventHandler -= value;
+                if (certificateConfirmedEventHandler == null && certificateConfirmedCallback != null)
+                {
+                    certificateConfirmedSignal.Disconnect(certificateConfirmedCallback);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event for the SslCertificateChanged signal which can be used to subscribe or unsubscribe the event handler.<br />
+        /// This signal is emitted when SSL certificate is changed.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<WebViewCertificateReceivedEventArgs> SslCertificateChanged
+        {
+            add
+            {
+                if (sslCertificateChangedEventHandler == null)
+                {
+                    sslCertificateChangedCallback = OnSslCertificateChanged;
+                    sslCertificateChangedSignal.Connect(sslCertificateChangedCallback);
+                }
+                sslCertificateChangedEventHandler += value;
+            }
+            remove
+            {
+                sslCertificateChangedEventHandler -= value;
+                if (sslCertificateChangedEventHandler == null && sslCertificateChangedCallback != null)
+                {
+                    sslCertificateChangedSignal.Disconnect(sslCertificateChangedCallback);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Event for the HttpAuthRequested signal which can be used to subscribe or unsubscribe the event handler.<br />
+        /// This signal is emitted when http authentication is requested.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<WebViewHttpAuthRequestedEventArgs> HttpAuthRequested
+        {
+            add
+            {
+                if (httpAuthRequestedEventHandler == null)
+                {
+                    httpAuthRequestedCallback = OnHttpAuthRequested;
+                    httpAuthRequestedSignal.Connect(httpAuthRequestedCallback);
+                }
+                httpAuthRequestedEventHandler += value;
+            }
+            remove
+            {
+                httpAuthRequestedEventHandler -= value;
+                if (httpAuthRequestedEventHandler == null && httpAuthRequestedCallback != null)
+                {
+                    httpAuthRequestedSignal.Disconnect(httpAuthRequestedCallback);
                 }
             }
         }
@@ -1800,6 +1902,21 @@ namespace Tizen.NUI
         private void OnNewWindowPolicyDecided(IntPtr data, IntPtr maker)
         {
             newWindowPolicyDecidedEventHandler?.Invoke(this, new WebViewNewWindowPolicyDecidedEventArgs(new WebNewWindowPolicyDecisionMaker(maker, false)));
+        }
+
+        private void OnCertificateConfirmed(IntPtr data, IntPtr certificate)
+        {
+            certificateConfirmedEventHandler?.Invoke(this, new WebViewCertificateReceivedEventArgs(new WebCertificate(certificate, false)));
+        }
+
+        private void OnSslCertificateChanged(IntPtr data, IntPtr certificate)
+        {
+            sslCertificateChangedEventHandler?.Invoke(this, new WebViewCertificateReceivedEventArgs(new WebCertificate(certificate, false)));
+        }
+
+        private void OnHttpAuthRequested(IntPtr data, IntPtr handler)
+        {
+            httpAuthRequestedEventHandler?.Invoke(this, new WebViewHttpAuthRequestedEventArgs(new WebHttpAuthHandler(handler, false)));
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/WebView/WebViewCertificateReceivedEventArgs.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebViewCertificateReceivedEventArgs.cs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Event arguments that passed via the WebView.CertificateConfirmed / WebView.SslCertificateChanged.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebViewCertificateReceivedEventArgs : EventArgs
+    {
+        internal WebViewCertificateReceivedEventArgs(WebCertificate certificate)
+        {
+            Certificate = certificate;
+        }
+
+        /// <summary>
+        /// The certificate of web view.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebCertificate Certificate { get; }
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebView/WebViewCertificateReceivedSignal.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebViewCertificateReceivedSignal.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal class WebViewCertificateReceivedSignal : Disposable
+    {
+        public WebViewCertificateReceivedSignal(global::System.IntPtr cPtr) : base(cPtr, true)
+        {
+        }
+
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WebView.DeleteWebViewCertificateSignal(swigCPtr);
+        }
+
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
+            {
+                Interop.WebView.WebViewCertificateSignalConnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                {
+                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                }
+            }
+        }
+
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WebView.WebViewCertificateSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                {
+                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                }
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebView/WebViewHttpAuthRequestedEventArgs.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebViewHttpAuthRequestedEventArgs.cs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Event arguments that passed via the WebView.HttpAuthRequested.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WebViewHttpAuthRequestedEventArgs : EventArgs
+    {
+        internal WebViewHttpAuthRequestedEventArgs(WebHttpAuthHandler handler)
+        {
+            HttpAuthHandler = handler;
+        }
+
+        /// <summary>
+        /// The http auth handler of web view.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebHttpAuthHandler HttpAuthHandler { get; }
+    }
+}

--- a/src/Tizen.NUI/src/internal/WebView/WebViewHttpAuthRequestedSignal.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebViewHttpAuthRequestedSignal.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal class WebViewHttpAuthRequestedSignal : Disposable
+    {
+        public WebViewHttpAuthRequestedSignal(global::System.IntPtr cPtr) : base(cPtr, true)
+        {
+        }
+
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WebView.DeleteWebViewHttpAuthHandlerSignal(swigCPtr);
+        }
+
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
+            {
+                Interop.WebView.WebViewHttpAuthHandlerSignalConnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                {
+                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                }
+            }
+        }
+
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WebView.WebViewHttpAuthHandlerSignalDisconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                {
+                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch is to implement ssl certificate & http authentication
of WebView.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
