### PR TITLE
[NUI] fix Initialize collectionView to apply property values regardless of it's sequences.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -208,13 +208,13 @@ namespace Tizen.NUI.Components
                     //layouter.Clear()
                     return;
                 }
-                if (InternalItemSource != null) InternalItemSource.Dispose();
-                InternalItemSource = ItemsSourceFactory.Create(this);
+                //if (InternalItemSource != null) InternalItemSource.Dispose();
+                //InternalItemSource = ItemsSourceFactory.Create(this);
 
                 if (itemsLayouter == null) return;
 
                 needInitalizeLayouter = true;
-                Init();
+                Initialize();
             }
         }
 
@@ -238,7 +238,7 @@ namespace Tizen.NUI.Components
                 }
 
                 needInitalizeLayouter = true;
-                Init();
+                Initialize();
             }
         }
 
@@ -272,7 +272,7 @@ namespace Tizen.NUI.Components
                         itemsLayouter.Padding = new Extents(layouterStyle.Padding);
                     }
                 }
-                Init();
+                Initialize();
             }
         }
 
@@ -373,7 +373,7 @@ namespace Tizen.NUI.Components
                 }
                 header = value;
                 needInitalizeLayouter = true;
-                Init();
+                Initialize();
             }
         }
 
@@ -401,7 +401,7 @@ namespace Tizen.NUI.Components
                 }
                 footer = value;
                 needInitalizeLayouter = true;
-                Init();
+                Initialize();
             }
         }
 
@@ -417,6 +417,7 @@ namespace Tizen.NUI.Components
                 isGrouped = value;
                 needInitalizeLayouter = true;
                 //Need to re-intialize Internal Item Source.
+                /*
                 if (InternalItemSource != null)
                 {
                     InternalItemSource.Dispose();
@@ -424,7 +425,8 @@ namespace Tizen.NUI.Components
                 }
                 if (ItemsSource != null)
                     InternalItemSource = ItemsSourceFactory.Create(this);
-                Init();
+                */
+                Initialize();
             }
         }
 
@@ -442,7 +444,7 @@ namespace Tizen.NUI.Components
             {
                 groupHeaderTemplate = value;
                 needInitalizeLayouter = true;
-                Init();
+                Initialize();
             }
         }
 
@@ -460,7 +462,7 @@ namespace Tizen.NUI.Components
             {
                 groupFooterTemplate = value;
                 needInitalizeLayouter = true;
-                Init();
+                Initialize();
             }
         }
 
@@ -486,7 +488,7 @@ namespace Tizen.NUI.Components
             base.OnRelayout(size, container);
 
             wasRelayouted = true;
-            if (needInitalizeLayouter) Init();
+            if (needInitalizeLayouter) Initialize();
         }
 
         /// <inheritdoc/>
@@ -874,6 +876,46 @@ namespace Tizen.NUI.Components
             //Selection Callback
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Initialize()
+        {
+            if (ItemsSource == null) return;
+            if (ItemsLayouter == null) return;
+            if (ItemTemplate == null) return;
+
+            if (disposed) return;
+
+            if (!wasRelayouted) return;
+
+            if (isGrouped)
+            {
+                if (GroupHeaderTemplate == null)
+                {
+                    throw new Exception("GroupHeaderTemplate must be exist in grouped ItemSource!");                    
+                }
+            }
+
+            if (needInitalizeLayouter)
+            {
+                //Need to re-intialize Internal Item Source.
+                if (InternalItemSource != null)
+                {
+                    InternalItemSource.Dispose();
+                    InternalItemSource = null;
+                }
+                InternalItemSource = ItemsSourceFactory.Create(this);
+
+                InternalItemSource.HasHeader = (header != null);
+                InternalItemSource.HasFooter = (footer != null);
+                ItemsLayouter.Clear();
+                ItemsLayouter.Initialize(this);
+                needInitalizeLayouter = false;
+            }
+
+            ItemsLayouter.RequestLayout(0.0f, true);
+        }
+
         /// <summary>
         /// Adjust scrolling position by own scrolling rules.
         /// Override this function when developer wants to change destination of flicking.(e.g. always snap to center of item)
@@ -897,12 +939,6 @@ namespace Tizen.NUI.Components
         protected override void OnScrolling(object source, ScrollEventArgs args)
         {
             if (disposed) return;
-
-            if (needInitalizeLayouter)
-            {
-                ItemsLayouter.Initialize(this);
-                needInitalizeLayouter = false;
-            }
             base.OnScrolling(source, args);
         }
 
@@ -1026,40 +1062,6 @@ namespace Tizen.NUI.Components
 
             var args = new SelectionChangedEventArgs(previousSelection, newSelection);
             SelectionPropertyChanged(colView, args);
-        }
-
-        private void Init()
-        {
-            if (ItemsSource == null) return;
-            if (ItemsLayouter == null) return;
-            if (ItemTemplate == null) return;
-
-            if (disposed) return;
-            if (needInitalizeLayouter)
-            {
-                if (InternalItemSource == null) return;
-
-                InternalItemSource.HasHeader = (header != null);
-                InternalItemSource.HasFooter = (footer != null);
-            }
-
-            if (!wasRelayouted) return;
-
-            if (needInitalizeLayouter)
-            {
-                ItemsLayouter.Initialize(this);
-                needInitalizeLayouter = false;
-            }
-            ItemsLayouter.RequestLayout(0.0f, true);
-
-            if (ScrollingDirection == Direction.Horizontal)
-            {
-                ContentContainer.SizeWidth = ItemsLayouter.CalculateLayoutOrientationSize();
-            }
-            else
-            {
-                ContentContainer.SizeHeight = ItemsLayouter.CalculateLayoutOrientationSize();
-            }
         }
 
         private bool PushRecycleGroupCache(RecyclerViewItem item)

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -293,7 +293,8 @@ namespace Tizen.NUI.Components
                                 GroupSize = groupHeaderSize,
                                 GroupPosition = Current
                             };
-                            currentGroup.ItemPosition.Add(0);
+                            if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
+                                currentGroup.ItemPosition.Add(0);
                             groups.Add(currentGroup);
                             Current += groupHeaderSize;
                         }
@@ -303,14 +304,16 @@ namespace Tizen.NUI.Components
                             //currentGroup.hasFooter = true;
                             currentGroup.Count++;
                             currentGroup.GroupSize += groupFooterSize;
-                            currentGroup.ItemPosition.Add(Current - currentGroup.GroupPosition);
+                            if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
+                                currentGroup.ItemPosition.Add(Current - currentGroup.GroupPosition);
                             Current += groupFooterSize;
                         }
                         else
                         {
                             currentGroup.Count++;
                             currentGroup.GroupSize += StepCandidate;
-                            currentGroup.ItemPosition.Add(Current - currentGroup.GroupPosition);
+                            if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
+                                currentGroup.ItemPosition.Add(Current - currentGroup.GroupPosition);
                             Current += StepCandidate;
                         }
                     }
@@ -353,7 +356,8 @@ namespace Tizen.NUI.Components
             {
                 for (int i = ItemSizeChanged; i <= LastIndex; i++)
                     UpdatePosition(i);
-                ScrollContentSize = ItemPosition[LastIndex - 1] + GetItemStepSize(LastIndex) + (IsHorizontal? Padding.End : Padding.Bottom);
+                (float updateX, float updateY) = GetItemPosition(LastIndex);
+                ScrollContentSize = GetItemStepSize(LastIndex) + (IsHorizontal? updateX + Padding.End : updateY + Padding.Bottom);
             }
 
             int prevFirstVisible = FirstVisible;
@@ -393,7 +397,7 @@ namespace Tizen.NUI.Components
                 }
                 if (item == null) item = colView.RealizeItem(i);
                 VisibleItems.Add(item);
-
+/*
                 // 5. Placing item.
                 float posX = 0F, posY = 0F;
                 int spaceStartX = Padding.Start + item.Margin.Start;
@@ -428,7 +432,8 @@ namespace Tizen.NUI.Components
                     posX = (IsHorizontal? ItemPosition[i] + item.Margin.Start : spaceStartX);
                     posY = (IsHorizontal? spaceStartY : ItemPosition[i] + item.Margin.Top);
                 }
-
+*/
+                (float posX, float posY) = GetItemPosition(i);
                 item.Position = new Position(posX, posY);
             
                 if (IsHorizontal && item.HeightSpecification == LayoutParamPolicies.MatchParent)
@@ -579,8 +584,8 @@ namespace Tizen.NUI.Components
                                     break;
 
                                 }
-                                else if (gInfo.ItemPosition[i] <= visibleArea.X - gInfo.GroupPosition &&
-                                        gInfo.ItemPosition[i + 1] >= visibleArea.X - gInfo.GroupPosition)
+                                else if (GetGroupPosition(gInfo, gInfo.StartIndex + i) <= visibleArea.X &&
+                                        GetGroupPosition(gInfo, gInfo.StartIndex + i + 1) >= visibleArea.X)
                                 {
                                     found.start = gInfo.StartIndex + i - adds;
                                     failed = false;
@@ -631,8 +636,8 @@ namespace Tizen.NUI.Components
                                     break;
 
                                 }
-                                else if (gInfo.ItemPosition[i] <= visibleArea.Y - gInfo.GroupPosition &&
-                                        gInfo.ItemPosition[i + 1] >= visibleArea.Y - gInfo.GroupPosition)
+                                else if (GetGroupPosition(gInfo, gInfo.StartIndex + i) <= visibleArea.Y &&
+                                        GetGroupPosition(gInfo, gInfo.StartIndex + i + 1) >= visibleArea.Y)
                                 {
                                     found.end = gInfo.StartIndex + i + adds;
                                     failed = false;
@@ -671,17 +676,37 @@ namespace Tizen.NUI.Components
             else if (isGrouped)
             {
                 GroupInfo gInfo = GetGroupInfo(index);
+                float current = GetGroupPosition(gInfo, index);
+                Extents itemMargin = CandidateMargin;
+
+                if (colView.InternalItemSource.IsGroupHeader(index))
+                {
+                    itemMargin = groupHeaderMargin;
+                }
+                else if (colView.InternalItemSource.IsGroupFooter(index))
+                {
+                    itemMargin = groupFooterMargin;
+                }
                 return ((IsHorizontal?
-                            CandidateMargin.Start + gInfo.GroupPosition + gInfo.ItemPosition[index - gInfo.StartIndex]:
-                            spaceStartX),
+                        itemMargin.Start + GetGroupPosition(gInfo, index):
+                        spaceStartX + itemMargin.Start),
                         (IsHorizontal?
-                            spaceStartY:
-                            CandidateMargin.Top + gInfo.GroupPosition + gInfo.ItemPosition[index - gInfo.StartIndex]));
+                        spaceStartY + itemMargin.Top:
+                        itemMargin.Top + GetGroupPosition(gInfo, index)));
+            }
+            else if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
+            {
+                //FIXME : CandidateMargin need to be actual itemMargin
+                return ((IsHorizontal? ItemPosition[index] + CandidateMargin.Start : spaceStartX + CandidateMargin.Start),
+                        (IsHorizontal? spaceStartY + CandidateMargin.Top : ItemPosition[index] + CandidateMargin.Top));
             }
             else
             {
-                return ((IsHorizontal? ItemPosition[index] + CandidateMargin.Start : spaceStartX + CandidateMargin.Start),
-                        (IsHorizontal? spaceStartY + CandidateMargin.Top : ItemPosition[index] + CandidateMargin.Top));
+                int adjustIndex = index - (hasHeader ? 1 : 0);
+                float current = (hasHeader? headerSize : 0) + adjustIndex * StepCandidate;
+                //FIXME : CandidateMargin need to be actual itemMargin
+                return ((IsHorizontal? current + CandidateMargin.Start : spaceStartX + CandidateMargin.Start),
+                        (IsHorizontal? spaceStartY + CandidateMargin.Top : current + CandidateMargin.Top));
             }
         }
 
@@ -759,8 +784,8 @@ namespace Tizen.NUI.Components
                     //IsGroupFooter = (colView.InternalItemSource as IGroupableItemSource).IsGroupFooter(index);
                     //Do Something
                 }
-
-            ItemPosition[index] = ItemPosition[index - 1] + GetItemStepSize(index - 1);
+            if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
+                ItemPosition[index] = ItemPosition[index - 1] + GetItemStepSize(index - 1);
         }
 
         private RecyclerViewItem GetVisibleItem(int index)
@@ -791,6 +816,21 @@ namespace Tizen.NUI.Components
             Visited = null;
             return null;
         }
+
+        private float GetGroupPosition(GroupInfo groupInfo, int index)
+        {
+            if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
+                return groupInfo.GroupPosition + groupInfo.ItemPosition[index - groupInfo.StartIndex];
+            else
+            {
+                float pos = groupInfo.GroupPosition;
+                if (groupInfo.StartIndex == index) return pos;
+
+                pos = pos + groupHeaderSize + StepCandidate * (index - groupInfo.StartIndex - 1);
+
+                return pos;
+            }
+        }
         /*
                 private object GetGroupParent(int index)
                 {
@@ -819,7 +859,7 @@ namespace Tizen.NUI.Components
             public int Count;
             public float GroupSize;
             public float GroupPosition;
-            //Items relative position from the GroupPosition
+            //Items relative position from the GroupPosition. Only use for MeasureAll.
             public List<float> ItemPosition = new List<float>();
         }
     }

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -320,7 +320,9 @@ namespace Tizen.NUI.Components
                 }
                 else
                 {
-                    ItemPosition.Add(Current);
+
+                    if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
+                        ItemPosition.Add(Current);
 
                     if (i == 0 && hasHeader) Current += headerSize;
                     else if (i == count - 1 && hasFooter) Current += footerSize;
@@ -331,7 +333,6 @@ namespace Tizen.NUI.Components
             ScrollContentSize = Current + (IsHorizontal? Padding.End : Padding.Bottom);
             if (IsHorizontal) colView.ContentContainer.SizeWidth = ScrollContentSize;
             else colView.ContentContainer.SizeHeight = ScrollContentSize;
-
 
             base.Initialize(view);
             //Console.WriteLine("[NUI] Init Done, StepCnadidate{0}, Scroll{1}", StepCandidate, ScrollContentSize);
@@ -397,42 +398,8 @@ namespace Tizen.NUI.Components
                 }
                 if (item == null) item = colView.RealizeItem(i);
                 VisibleItems.Add(item);
-/*
-                // 5. Placing item.
-                float posX = 0F, posY = 0F;
-                int spaceStartX = Padding.Start + item.Margin.Start;
-                int spaceStartY = Padding.Top + item.Margin.Top;
 
-                if (isGrouped)
-                {
-                    //isHeader?
-                    if (colView.Header == item)
-                    {
-                        posX = spaceStartX;
-                        posY = spaceStartY;
-                    }
-                    else if (colView.Footer == item)
-                    {
-                        posX = (IsHorizontal? ScrollContentSize - footerSize - Padding.End + footerMargin.Start : spaceStartX);
-                        posY = (IsHorizontal? spaceStartY : ScrollContentSize - footerSize - Padding.Bottom - footerMargin.Top);
-                    }
-                    else
-                    {
-                        GroupInfo gInfo = GetGroupInfo(i);
-                        posX = (IsHorizontal?
-                                item.Margin.Start + gInfo.GroupPosition + gInfo.ItemPosition[i - gInfo.StartIndex]:
-                                spaceStartX);
-                        posY = (IsHorizontal?
-                                spaceStartY:
-                                item.Margin.Top + gInfo.GroupPosition + gInfo.ItemPosition[i - gInfo.StartIndex]);
-                    }
-                }
-                else
-                {
-                    posX = (IsHorizontal? ItemPosition[i] + item.Margin.Start : spaceStartX);
-                    posY = (IsHorizontal? spaceStartY : ItemPosition[i] + item.Margin.Top);
-                }
-*/
+                // 5. Placing item.
                 (float posX, float posY) = GetItemPosition(i);
                 item.Position = new Position(posX, posY);
             

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -320,7 +320,6 @@ namespace Tizen.NUI.Components
                 }
                 else
                 {
-
                     if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
                         ItemPosition.Add(Current);
 

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
@@ -77,11 +77,7 @@ namespace Tizen.NUI.Components
         {
             //Console.WriteLine("[NUI] On ReLayout [{0} {0}]", size.X, size.Y);
             base.OnRelayout(size, container);
-            if (InternalItemsLayouter != null && ItemsSource != null && ItemTemplate != null)
-            {
-                InternalItemsLayouter.Initialize(this);
-                InternalItemsLayouter.RequestLayout(ScrollingDirection == Direction.Horizontal ? ContentContainer.CurrentPosition.X : ContentContainer.CurrentPosition.Y, true);
-            }
+            Initialize();
         }
 
         /// <summary>
@@ -269,6 +265,20 @@ namespace Tizen.NUI.Components
             {
                 //ContentContainer.Remove(item);
                 Utility.Dispose(item);
+            }
+        }
+
+        /// <summary>
+        /// Initialize Layouter and Request first layout.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual void Initialize()
+        {
+            if (InternalItemsLayouter != null && ItemsSource != null && ItemTemplate != null)
+            {
+                InternalItemsLayouter.Clear();
+                InternalItemsLayouter.Initialize(this);
+                InternalItemsLayouter.RequestLayout(ScrollingDirection == Direction.Horizontal ? ContentContainer.CurrentPosition.X : ContentContainer.CurrentPosition.Y, true);
             }
         }
 


### PR DESCRIPTION
few optimize and bug fix is done.
    1. now InternalItemSource will be created right before the
    layouterIntialize. every changes before the layout Initalize() will be
    properly applied in InternalItemSource.
    2. Init() is being Initlize() protected override method from
    recyclerView to avoid redundant Initialize call.
    3. GroupHeaderTemplate is essential for grouped collectionView.
    now throw exception when GroupHeaderTemplate is not exist but IsGrouped
    is true.