### PR TITLE
[NUI] Fix to pass touch event when DialogPage's Scrim is disabled

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
@@ -44,6 +44,10 @@ namespace Tizen.NUI.Components
             WidthResizePolicy = ResizePolicyType.FillToParent;
             HeightResizePolicy = ResizePolicyType.FillToParent;
 
+            // FIXME: To pass touch event when Scrim is disabled.
+            //        When proper way to pass touch event is introduced, this code should be fixed.
+            EnableControlState = false;
+
             Scrim = CreateDefaultScrim();
         }
 


### PR DESCRIPTION
To pass touch event when DialogPage's Scrim is disabled, DialogPage's
EnableControlState is set to be false.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
