### PR TITLE
[NUI] Make Page Navigation APIs public

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -55,7 +55,7 @@ namespace Tizen.NUI.Components
         /// Navigator which has pushed the Page into its stack.
         /// If this Page has not been pushed into any Navigator, then Navigator is null.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public Navigator Navigator
         {
             get


### PR DESCRIPTION
This is ACR patch to make Page Navigation APIs public.

This pull request includes properties and methods of Navigator and Page
classes.

NavigationPages are not going to be public not to make List<T> public
API.

To cover the usage of NavigationPages, the following APIs are added.
- public int PageCount
- public Page GetPage(int index)
- public int IndexOf(Page page)

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: TCSACR-417

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
