### PR TITLE
[NUI][ATSPI] remove build warning messages

### DIFF
--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -177,64 +177,6 @@ namespace Tizen.NUI.Accessibility
 
         #region Event, Enum, Struct, ETC
         /// <summary>
-        ///  Say Finished event arguments
-        /// </summary>
-        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public class SayFinishedEventArgs : EventArgs
-        {
-            /// <summary>
-            /// The state of Say finished
-            /// </summary>
-            // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public SayFinishedState State
-            {
-                private set;
-                get;
-            }
-
-            internal SayFinishedEventArgs(int result)
-            {
-                State = (SayFinishedState)(result);
-                tlog.Fatal(tag, $"SayFinishedEventArgs Constructor! State={State}");
-            }
-        }
-
-        /// <summary>
-        /// Enum of Say finished event argument status
-        /// </summary>
-        [Obsolete("Please do not use! This will be removed. Please use Accessibility.SayFinishedState instead!")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public enum SayFinishedStates
-        {
-            /// <summary>
-            /// Invalid
-            /// </summary>
-            [Obsolete("Please do not use! This will be removed. Please use Accessibility.SayFinishedState.Invalid instead!")]
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            Invalid = -1,
-            /// <summary>
-            /// Cancelled
-            /// </summary>
-            [Obsolete("Please do not use! This will be removed. Please use Accessibility.SayFinishedState.Invalid instead!")]
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            Cancelled = 1,
-            /// <summary>
-            /// Stopped
-            /// </summary>
-            [Obsolete("Please do not use! This will be removed. Please use Accessibility.SayFinishedState.Invalid instead!")]
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            Stopped = 2,
-            /// <summary>
-            /// Skipped
-            /// </summary>
-            [Obsolete("Please do not use! This will be removed. Please use Accessibility.SayFinishedState.Invalid instead!")]
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            Skipped = 3
-        }
-
-        /// <summary>
         /// Enum of Say finished event argument status
         /// </summary>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
@@ -334,5 +276,30 @@ namespace Tizen.NUI.Accessibility
 
         private static string tag = "NUITEST";
         #endregion Private
+    }
+
+    /// <summary>
+    ///  Say Finished event arguments
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class SayFinishedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The state of Say finished
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Accessibility.SayFinishedState State
+        {
+            private set;
+            get;
+        }
+
+        internal SayFinishedEventArgs(int result)
+        {
+            State = (Accessibility.SayFinishedState)(result);
+            tlog.Fatal("NUITEST", $"SayFinishedEventArgs Constructor! State={State}");
+        }
     }
 }

--- a/test/NUITestSample/NUITestSample/examples/AtspiTest.cs
+++ b/test/NUITestSample/NUITestSample/examples/AtspiTest.cs
@@ -113,7 +113,7 @@ namespace Tizen.TV.NUI.Example
         private void Instance_SayFinished(object sender, Accessibility.SayFinishedEventArgs e)
         {
             tlog.Fatal(tag, $"Instance_SayFinished()! State={e.State}");
-            if (e.State == Accessibility.SayFinishedStates.Stopped)
+            if (e.State == Accessibility.SayFinishedState.Stopped)
             {
                 Accessibility.Instance.Say("이건 콜백 테스트 입니다. this is callback test!  콜백을 빼려면 확인키를 누르세요. to remove callback please push Return key", true);
             }


### PR DESCRIPTION
This patch is for removing following build warnings.

(1) Do not nest type SayFinishedEventArgs. Alternatively,
  change its accessibility so that it is not externally visible.

(2) Only FlagsAttribute enums should have plural names

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
