### PR TITLE
[NUI][AT-SPI] Add API for blocking automatic Bridge initialization

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
@@ -35,6 +35,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_supress_screen_reader")]
             public static extern bool SuppressScreenReader(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeEnableAutoInit")]
+            public static extern void BridgeEnableAutoInit();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeDisableAutoInit")]
+            public static extern void BridgeDisableAutoInit();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -135,6 +135,33 @@ namespace Tizen.NUI.Accessibility
         }
 
         /// <summary>
+        /// Re-enables auto-initialization of AT-SPI bridge
+        /// </summary>
+        /// <remarks>
+        /// Normal applications do not have to call this function. The AT-SPI bridge is initialized on demand.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BridgeEnableAutoInit()
+        {
+            Interop.Accessibility.BridgeEnableAutoInit();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Blocks auto-initialization of AT-SPI bridge
+        /// </summary>
+        /// <remarks>
+        /// Use this only if your application starts before DBus does, and call it early in Main().
+        /// When DBus is ready, call BridgeEnableAutoInit().
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BridgeDisableAutoInit()
+        {
+            Interop.Accessibility.BridgeDisableAutoInit();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         ///  Get View that is used to highlight widget.
         /// </summary>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Dependencies:
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/256959/ (merged)
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/258012/ (merged)
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/257536/ (merged)

This is meant to be used by applications that start before DBus is available.

```
static void Main(string[] args)
{
    Accessibility.BridgeDisableAutoInit();
    // Rest of application code
}


// When DBus is available
Accessibility.BridgeEnableAutoInit();
```

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
