### PR TITLE
[NUI][AT-SPI] Simplify AccessibilityStates

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -410,7 +410,7 @@ namespace Tizen.NUI.Components
         protected override AccessibilityStates AccessibilityCalculateStates()
         {
             var states = base.AccessibilityCalculateStates();
-            states.Set(AccessibilityState.Modal, true);
+            FlagSetter(ref states, AccessibilityStates.Modal, true);
             return states;
         }
 

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -100,7 +100,7 @@ namespace Tizen.NUI.Components
 
                     if (instance.IsHighlighted)
                     {
-                        instance.EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, newSelected);
+                        instance.EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, newSelected);
                     }
                 }
             }
@@ -220,8 +220,8 @@ namespace Tizen.NUI.Components
         protected override AccessibilityStates AccessibilityCalculateStates()
         {
             var states = base.AccessibilityCalculateStates();
-            states.Set(AccessibilityState.Checked, this.IsSelected);
-            states.Set(AccessibilityState.Enabled, this.IsEnabled);
+            FlagSetter(ref states, AccessibilityStates.Checked, this.IsSelected);
+            FlagSetter(ref states, AccessibilityStates.Enabled, this.IsEnabled);
             return states;
         }
 

--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -114,7 +114,7 @@ namespace Tizen.NUI.Components
         protected override AccessibilityStates AccessibilityCalculateStates()
         {
             var states = base.AccessibilityCalculateStates();
-            states.Set(AccessibilityState.Modal, true);
+            FlagSetter(ref states, AccessibilityStates.Modal, true);
             return states;
         }
 

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -729,7 +729,7 @@ namespace Tizen.NUI.Components
         protected override AccessibilityStates AccessibilityCalculateStates()
         {
             var states = base.AccessibilityCalculateStates();
-            states.Set(AccessibilityState.Modal, true);
+            FlagSetter(ref states, AccessibilityStates.Modal, true);
             return states;
         }
 

--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -215,7 +215,7 @@ namespace Tizen.NUI.Components
             {
                 if (IsHighlighted)
                 {
-                    EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, info.CurrentState.Contains(ControlState.Selected));
+                    EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, info.CurrentState.Contains(ControlState.Selected));
                 }
 
                 // SelectedChanged is invoked when button or key is unpressed.

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -89,7 +89,7 @@ namespace Tizen.NUI.Components
         protected override AccessibilityStates AccessibilityCalculateStates()
         {
             var states = base.AccessibilityCalculateStates();
-            states.Set(AccessibilityState.Checked, this.IsSelected);
+            FlagSetter(ref states, AccessibilityStates.Checked, this.IsSelected);
             return states;
         }
 
@@ -321,7 +321,7 @@ namespace Tizen.NUI.Components
         {
             if (IsHighlighted)
             {
-                EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, IsSelected);
+                EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, IsSelected);
             }
 
             ((SwitchExtension)Extension)?.OnSelectedChanged(this);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -120,32 +120,16 @@ namespace Tizen.NUI
             public static extern bool DaliToolkitDevelControlGrabAccessibilityHighlight(global::System.Runtime.InteropServices.HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_new_GetAccessibilityStates")]
-            public static extern global::System.IntPtr DaliToolkitDevelControlNewGetAccessibilityStates(global::System.Runtime.InteropServices.HandleRef arg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityState")]
+            public static extern ulong DaliToolkitDevelControlGetAccessibilityStates(global::System.Runtime.InteropServices.HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_new_States")]
-            public static extern global::System.IntPtr DaliToolkitDevelControlNewStates();
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ConvertState")]
+            public static extern IntPtr DaliToolkitDevelControlConvertState(ulong arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_delete_States")]
-            public static extern void DaliToolkitDevelControlDeleteStates(IntPtr arg1);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_States_Copy")]
-            public static extern IntPtr DaliToolkitDevelControlStatesCopy(Tizen.NUI.BaseComponents.AccessibilityStates arg1);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_States_Get")]
-            public static extern bool DaliToolkitDevelControlStatesGet(Tizen.NUI.BaseComponents.AccessibilityStates arg1, int arg2);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_States_Set")]
-            public static extern void DaliToolkitDevelControlStatesSet(Tizen.NUI.BaseComponents.AccessibilityStates arg1, int arg2, int arg3);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_NotifyAccessibilityStateChange")]
-            public static extern global::System.IntPtr DaliToolkitDevelControlNotifyAccessibilityStateChange(global::System.Runtime.InteropServices.HandleRef arg1, Tizen.NUI.BaseComponents.AccessibilityStates arg2, int arg3);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_NotifyAccessibilityStateChange2")]
+            public static extern global::System.IntPtr DaliToolkitDevelControlNotifyAccessibilityStatesChange(global::System.Runtime.InteropServices.HandleRef arg1, ulong arg2, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetBoundAccessibilityObject")]
@@ -156,8 +140,8 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr DaliAccessibilityEmitAccessibilityEvent(global::System.Runtime.InteropServices.HandleRef arg1, int arg2_event);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityStateChangedEvent")]
-            public static extern global::System.IntPtr DaliAccessibilityEmitAccessibilityStateChangedEvent(global::System.Runtime.InteropServices.HandleRef arg1, int arg2_state, int arg3);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityStateChangedEvent2")]
+            public static extern global::System.IntPtr DaliAccessibilityEmitAccessibilityStatesChangedEvent(global::System.Runtime.InteropServices.HandleRef arg1, ulong arg2_state, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextInsertedEvent")]

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -471,7 +471,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-
         /// <summary>
         /// Whether the CornerRadius property value is relative (percentage [0.0f to 1.0f] of the view size) or absolute (in world units).
         /// It is absolute by default.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -82,52 +82,6 @@ namespace Tizen.NUI.BaseComponents
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public partial class AccessibilityStates : SafeHandle
-    {
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public AccessibilityStates() : base(IntPtr.Zero, true)
-        {
-            var obj = Interop.ControlDevel.DaliToolkitDevelControlNewStates();
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            this.SetHandle(obj);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public AccessibilityStates(IntPtr states) : base(states, true) { }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool IsInvalid { get { return this.handle == IntPtr.Zero; } }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Set(AccessibilityState type, bool v)
-        {
-            Interop.ControlDevel.DaliToolkitDevelControlStatesSet(this, (int)type, Convert.ToInt32(v));
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Get(AccessibilityState type)
-        {
-            bool result = Interop.ControlDevel.DaliToolkitDevelControlStatesGet(this, (int)type);
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return result;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool ReleaseHandle()
-        {
-            Interop.ControlDevel.DaliToolkitDevelControlDeleteStates(handle);
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            this.SetHandle(IntPtr.Zero);
-            return true;
-        }
-    }
-
-    [EditorBrowsable(EditorBrowsableState.Never)]
     public class AccessibilityRange
     {
         public int StartOffset { get; set; } = 0;
@@ -274,13 +228,13 @@ namespace Tizen.NUI.BaseComponents
         }
 
         ///////////////////////////////////////////////////////////////////
-        // ****************** Accessibility Relations ******************* //
+        // ******************** Accessibility States ******************* //
         ///////////////////////////////////////////////////////////////////
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void NotifyAccessibilityStateChange(AccessibilityStates states, bool recursive)
+        public void NotifyAccessibilityStatesChange(AccessibilityStates state, bool recursive)
         {
-            Interop.ControlDevel.DaliToolkitDevelControlNotifyAccessibilityStateChange(SwigCPtr, states, Convert.ToInt32(recursive));
+            Interop.ControlDevel.DaliToolkitDevelControlNotifyAccessibilityStatesChange(SwigCPtr, (ulong)state, Convert.ToInt32(recursive));
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -288,7 +242,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AccessibilityStates GetAccessibilityStates()
         {
-            var result = new AccessibilityStates(Interop.ControlDevel.DaliToolkitDevelControlNewGetAccessibilityStates(SwigCPtr));
+            AccessibilityStates result = (AccessibilityStates) Interop.ControlDevel.DaliToolkitDevelControlGetAccessibilityStates(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return result;
@@ -307,9 +261,9 @@ namespace Tizen.NUI.BaseComponents
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void EmitAccessibilityStateChangedEvent(AccessibilityState e, bool b)
+        public void EmitAccessibilityStatesChangedEvent(AccessibilityStates e, bool b)
         {
-            Interop.ControlDevel.DaliAccessibilityEmitAccessibilityStateChangedEvent(SwigCPtr, Convert.ToInt32(e), Convert.ToInt32(b));
+            Interop.ControlDevel.DaliAccessibilityEmitAccessibilityStatesChangedEvent(SwigCPtr, (ulong)e, Convert.ToInt32(b));
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -365,7 +319,7 @@ namespace Tizen.NUI.BaseComponents
 
         private IntPtr statesdup(AccessibilityStates states)
         {
-            return Interop.ControlDevel.DaliToolkitDevelControlStatesCopy(states);
+            return Interop.ControlDevel.DaliToolkitDevelControlConvertState((ulong)states);
         }
 
         private IntPtr rangedup(AccessibilityRange range)
@@ -486,17 +440,19 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual AccessibilityStates AccessibilityCalculateStates()
         {
-            var states = new AccessibilityStates();
-            states.Set(AccessibilityState.Highlightable, this.AccessibilityHighlightable);
-            states.Set(AccessibilityState.Focusable, this.Focusable);
-            states.Set(AccessibilityState.Focused, this.State == States.Focused);
-            states.Set(AccessibilityState.Highlighted, this.IsHighlighted);
-            states.Set(AccessibilityState.Enabled, this.State != States.Disabled);
-            states.Set(AccessibilityState.Sensitive, this.Sensitive);
-            states.Set(AccessibilityState.Animated, this.AccessibilityAnimated);
-            states.Set(AccessibilityState.Visible, true);
-            states.Set(AccessibilityState.Showing, this.Visibility);
-            states.Set(AccessibilityState.Defunct, !this.IsOnWindow);
+            AccessibilityStates states = 0;
+
+            FlagSetter(ref states, AccessibilityStates.Highlightable, this.AccessibilityHighlightable);
+            FlagSetter(ref states, AccessibilityStates.Focusable, this.Focusable);
+            FlagSetter(ref states, AccessibilityStates.Focused, this.State == States.Focused);
+            FlagSetter(ref states, AccessibilityStates.Highlighted, this.IsHighlighted);
+            FlagSetter(ref states, AccessibilityStates.Enabled, this.State != States.Disabled);
+            FlagSetter(ref states, AccessibilityStates.Sensitive, this.Sensitive);
+            FlagSetter(ref states, AccessibilityStates.Animated, this.AccessibilityAnimated);
+            FlagSetter(ref states, AccessibilityStates.Visible, true);
+            FlagSetter(ref states, AccessibilityStates.Showing, this.Visibility);
+            FlagSetter(ref states, AccessibilityStates.Defunct, !this.IsOnWindow);
+
             return states;
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -89,55 +89,56 @@ namespace Tizen.NUI.BaseComponents
 
 
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public enum AccessibilityState
+    [Flags]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1028:EnumStorageShouldBeInt32", Justification = "System.Int32 type wouldn't have sufficient capacity")]
+    public enum AccessibilityStates : ulong
     {
-        Invalid = 0,
-        Active,
-        Armed,
-        Busy,
-        Checked,
-        Collapsed,
-        Defunct,
-        Editable,
-        Enabled,
-        Expandable,
-        Expanded,
-        Focusable,
-        Focused,
-        HasTooltip,
-        Horizontal,
-        Iconified,
-        Modal,
-        MultiLine,
-        MultiSelectable,
-        Opaque,
-        Pressed,
-        Resizeable,
-        Selectable,
-        Selected,
-        Sensitive,
-        Showing,
-        SingleLine,
-        Stale,
-        Transient,
-        Vertical,
-        Visible,
-        ManagesDescendants,
-        Indeterminate,
-        Required,
-        Truncated,
-        Animated,
-        InvalidEntry,
-        SupportsAutocompletion,
-        SelectableText,
-        IsDefault,
-        Visited,
-        Checkable,
-        HasPopup,
-        ReadOnly,
-        Highlighted,
-        Highlightable,
-        MaxCount,
+        Invalid                = (1UL << 0),
+        Active                 = (1UL << 1),
+        Armed                  = (1UL << 2),
+        Busy                   = (1UL << 3),
+        Checked                = (1UL << 4),
+        Collapsed              = (1UL << 5),
+        Defunct                = (1UL << 6),
+        Editable               = (1UL << 7),
+        Enabled                = (1UL << 8),
+        Expandable             = (1UL << 9),
+        Expanded               = (1UL << 10),
+        Focusable              = (1UL << 11),
+        Focused                = (1UL << 12),
+        HasTooltip             = (1UL << 13),
+        Horizontal             = (1UL << 14),
+        Iconified              = (1UL << 15),
+        Modal                  = (1UL << 16),
+        MultiLine              = (1UL << 17),
+        MultiSelectable        = (1UL << 18),
+        Opaque                 = (1UL << 19),
+        Pressed                = (1UL << 20),
+        Resizeable             = (1UL << 21),
+        Selectable             = (1UL << 22),
+        Selected               = (1UL << 23),
+        Sensitive              = (1UL << 24),
+        Showing                = (1UL << 25),
+        SingleLine             = (1UL << 26),
+        Stale                  = (1UL << 27),
+        Transient              = (1UL << 28),
+        Vertical               = (1UL << 29),
+        Visible                = (1UL << 30),
+        ManagesDescendants     = (1UL << 31),
+        Indeterminate          = (1UL << 32),
+        Required               = (1UL << 33),
+        Truncated              = (1UL << 34),
+        Animated               = (1UL << 35),
+        InvalidEntry           = (1UL << 36),
+        SupportsAutocompletion = (1UL << 37),
+        SelectableText         = (1UL << 38),
+        IsDefault              = (1UL << 39),
+        Visited                = (1UL << 40),
+        Checkable              = (1UL << 41),
+        HasPopup               = (1UL << 42),
+        ReadOnly               = (1UL << 43),
+        Highlighted            = (1UL << 44),
+        Highlightable          = (1UL << 45),
     };
 
     /// <summary>
@@ -146,6 +147,27 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class View
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <summary>
+        /// A helper method to manipulate individual bit flags (e.g. turn them on or off)
+        /// </summary>
+        /// <param name="obj">An object that accumulates combination of bit flags</param>
+        /// <param name="bit">A bit flag to be operated</param>
+        /// <param name="state">A state of the bit flag to be set (0 == off, 1 == on)</param>
+        static public void FlagSetter<T>(ref T obj ,T bit, bool state)
+        {
+            dynamic result = obj;
+            dynamic param = bit;
+            if (state)
+            {
+                result |= param;
+            }
+            else
+            {
+                result &= (~param);
+            }
+            obj = result;
+        }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public enum RelationType

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -302,7 +302,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public void Show()
         {
-            if (AccessibilityCalculateStates().Get(AccessibilityState.Modal))
+            if ((AccessibilityCalculateStates() & AccessibilityStates.Modal) != 0)
                 AddPopup();
 
             SetVisible(true);
@@ -321,7 +321,7 @@ namespace Tizen.NUI.BaseComponents
         {
             SetVisible(false);
 
-            if (AccessibilityCalculateStates().Get(AccessibilityState.Modal))
+            if ((AccessibilityCalculateStates() & AccessibilityStates.Modal) != 0)
                 RemovePopup();
         }
 


### PR DESCRIPTION
Replace class AccessibilityStates with enum flag.

Requires:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/256381/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/257412/

### Description of Change ###
Simplify usage of AccessibilityStates. This change also reduce number of interops required to support States.


### API Changes ###
None

Changed:
- Replaced AccessibilityStates class with enum flag
