### PR TITLE
[NUI] set Internal SizingStrategy to hide MeasureAll option.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -344,12 +344,6 @@ namespace Tizen.NUI.Components
         public object SelectionChangedCommandParameter { set; get; }
 
         /// <summary>
-        /// Size strategy of measuring scroll content. see details in ItemSizingStrategy.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ItemSizingStrategy SizingStrategy { get; set; }
-
-        /// <summary>
         /// Header item which placed in top-most position.
         /// note : internal index and count will be increased.
         /// </summary>
@@ -464,7 +458,6 @@ namespace Tizen.NUI.Components
             }
         }
 
-
         /// <summary>
         /// Internal encapsulated items data source.
         /// </summary>
@@ -479,6 +472,13 @@ namespace Tizen.NUI.Components
                 base.InternalItemSource = value;
             }
         }
+
+        /// <summary>
+        /// Size strategy of measuring scroll content. see details in ItemSizingStrategy.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal ItemSizingStrategy SizingStrategy { get; set; }
+
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void OnRelayout(Vector2 size, RelayoutContainer container)

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSizingStrategy.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSizingStrategy.cs
@@ -24,7 +24,12 @@ namespace Tizen.NUI.Components
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum ItemSizingStrategy
     {
-
+        /// <summary>
+        /// Measure first item and deligate size for all items.
+        /// if template is selector, the size of first item from each template will be deligated.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        MeasureFirst,
         /// <summary>
         /// Measure all items in advanced.
         /// Estimate first item size for all, and when scroll reached position,
@@ -32,11 +37,5 @@ namespace Tizen.NUI.Components
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         MeasureAll,
-        /// <summary>
-        /// Measure first item and deligate size for all items.
-        /// if template is selector, the size of first item from each template will be deligated.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        MeasureFirst,
     }
 }


### PR DESCRIPTION
Currently CollectionView only support MeasureFirst,
and MeasureAll need to be implemented.

before this feature is ready,
make setter internal to disallow unimplemented mode.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
