### PR TITLE
[NUI] fix crash on collecitonView which looks like bug action..

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -265,12 +265,10 @@ namespace Tizen.NUI.Components
                 needInitalizeLayouter = true;
 
                 var styleName = "Tizen.NUI.Components." + (itemsLayouter is LinearLayouter? "LinearLayouter" : (itemsLayouter is GridLayouter ? "GridLayouter" : "ItemsLayouter"));
-                using (ViewStyle layouterStyle = ThemeManager.GetStyle(styleName))
+                ViewStyle layouterStyle = ThemeManager.GetStyle(styleName);
+                if (layouterStyle != null)
                 {
-                    if (layouterStyle != null)
-                    {
-                        itemsLayouter.Padding = new Extents(layouterStyle.Padding);
-                    }
+                    itemsLayouter.Padding = new Extents(layouterStyle.Padding);
                 }
                 Init();
             }
@@ -716,11 +714,9 @@ namespace Tizen.NUI.Components
             if (itemsLayouter != null)
             {
                 string styleName = "Tizen.NUI.Compoenents." + (itemsLayouter is LinearLayouter? "LinearLayouter" : (itemsLayouter is GridLayouter ? "GridLayouter" : "ItemsLayouter"));
-                using (ViewStyle layouterStyle = ThemeManager.GetStyle(styleName))
-                {
-                    if (layouterStyle != null)
-                        itemsLayouter.Padding = new Extents(layouterStyle.Padding);
-                }
+                ViewStyle layouterStyle = ThemeManager.GetStyle(styleName);
+                if (layouterStyle != null)
+                    itemsLayouter.Padding = new Extents(layouterStyle.Padding);
             }
         }
 


### PR DESCRIPTION
currently create two collectionView can be aborted while
accessing padding of layouter style.

use "using" keyword as GetViewStyle simply Copy the original
ViewStyle and will be disposed by using keyword,
but it occurs crash as CopyFrom only new the parent and copy
all existing values.

This looks issue on CopyFrom but to fix collectionView issue quickly,
remove using keyward on first step.

Need to discuss more regarding the issue.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
