### PR TITLE
[NUI] VectorGraphics: Add DrawableGroup Class

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.DrawableGroup.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DrawableGroup.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class DrawableGroup
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_New")]
+            public static extern global::System.IntPtr New();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_AddDrawable")]
+            public static extern bool AddDrawable(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_Clear")]
+            public static extern bool Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/DrawableGroup.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/DrawableGroup.cs
@@ -16,6 +16,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Tizen.NUI.BaseComponents.VectorGraphics
@@ -26,6 +27,8 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class DrawableGroup : Drawable
     {
+        private List<Drawable> drawables; //The list of added drawables
+
         /// <summary>
         /// Creates an initialized DrawableGroup.
         /// </summary>
@@ -37,6 +40,7 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
 
         internal DrawableGroup(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
+            drawables = new List<Drawable>();
         }
 
         /// <summary>
@@ -53,6 +57,10 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
             }
             Interop.DrawableGroup.AddDrawable(View.getCPtr(this), BaseHandle.getCPtr(drawable));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            if (!drawables.Contains(drawable))
+            {
+                drawables.Add(drawable);
+            }
         }
 
         /// <summary>
@@ -65,6 +73,10 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         {
             bool ret = Interop.DrawableGroup.Clear(BaseHandle.getCPtr(this));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            if (ret)
+            {
+                drawables.Clear();
+            }
             return ret;
         }
     }

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/DrawableGroup.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/DrawableGroup.cs
@@ -1,0 +1,71 @@
+/* 
+* Copyright(c) 2021 Samsung Electronics Co., Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.BaseComponents.VectorGraphics
+{
+    /// <summary>
+    /// A class enabling to hold many Drawable objects. As a whole they can be transformed, their transparency can be changed.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class DrawableGroup : Drawable
+    {
+        /// <summary>
+        /// Creates an initialized DrawableGroup.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DrawableGroup() : this(Interop.DrawableGroup.New(), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal DrawableGroup(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Add drawable object to the DrawableGroup. This method is similar to registration.
+        /// </summary>
+        /// <param name="drawable">Drawable object</param>
+        /// <exception cref="ArgumentNullException"> Thrown when drawable is null. </exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddDrawable(Drawable drawable)
+        {
+            if (drawable == null)
+            {
+                throw new ArgumentNullException(nameof(drawable));
+            }
+            Interop.DrawableGroup.AddDrawable(View.getCPtr(this), BaseHandle.getCPtr(drawable));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Clears the drawable object added to the DrawableGroup. 
+        /// This method does not free the memory of the added drawable object.
+        /// </summary>
+        /// <returns>True when it's successful. False otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Clear()
+        {
+            bool ret = Interop.DrawableGroup.Clear(BaseHandle.getCPtr(this));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+    }
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSamsple.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSamsple.cs
@@ -17,6 +17,8 @@ namespace Tizen.NUI.Samples
         private Shape circleShape;
         private Shape arcShape;
         private Shape starShape;
+        private DrawableGroup group1;
+        private DrawableGroup group2;
         private Timer timer;
         private int count = 0;
 
@@ -52,8 +54,6 @@ namespace Tizen.NUI.Samples
             roundedRectShape.Rotate(45.0f);
             roundedRectShape.AddRect(-50.0f, -50.0f, 100.0f, 100.0f, 0.0f, 0.0f);
 
-            canvasView.AddDrawable(roundedRectShape);
-
             circleShape = new Shape()
             {
                 Opacity = 0.5f,
@@ -65,8 +65,6 @@ namespace Tizen.NUI.Samples
             circleShape.AddCircle(0.0f, 0.0f, 150.0f, 100.0f);
             circleShape.Transform(new float[] { 0.6f, 0.0f, 350.0f, 0.0f, 0.6f, 100.0f, 0.0f, 0.0f, 1.0f });
 
-            canvasView.AddDrawable(circleShape);
-
             arcShape = new Shape()
             {
                 StrokeColor = new Color(0.0f, 0.5f, 0.0f, 0.5f),
@@ -75,8 +73,6 @@ namespace Tizen.NUI.Samples
             };
             arcShape.AddArc(0.0f, 0.0f, 80.0f, 0.0f, 0.0f, true);
             arcShape.Translate(100.0f, 300.0f);
-
-            canvasView.AddDrawable(arcShape);
 
             Shape shape = new Shape()
             {
@@ -121,6 +117,16 @@ namespace Tizen.NUI.Samples
             starShape.Close();
 
             canvasView.AddDrawable(starShape);
+
+
+            group1 = new DrawableGroup();
+            group1.AddDrawable(roundedRectShape);
+            group1.AddDrawable(arcShape);
+
+            group2 = new DrawableGroup();
+            group2.AddDrawable(group1);
+            group2.AddDrawable(circleShape);
+            canvasView.AddDrawable(group2);
 
             // Test Getter
             log.Debug(tag, "circleShape Color : " + circleShape.FillColor.R + " " + circleShape.FillColor.G + " " + circleShape.FillColor.B + " " + circleShape.FillColor.A + "\n");
@@ -196,6 +202,9 @@ namespace Tizen.NUI.Samples
 
             starShape.Rotate((count * 2.0f) % 360);
             starShape.Scale((float)(count % 50) * 0.01f + 0.6f);
+
+            group1.Scale((float)(count % 100) * 0.002f + 0.8f);
+            group2.Opacity = 1.0f - (float)(count % 80) * 0.01f;
 
             count++;
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This feature can add and control multiple Drawable objects.
Since this class inherits Drawable, user can use Drawable's Opacity and Transformation methods.

[Dependancy]
dali-adaptor: https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/257538/
dali-csharp-binder: https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/257607/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: No ACR

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
