### PR TITLE
[NUI] Add GLWindow Rendering mode

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLWindow.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLWindow.cs
@@ -110,6 +110,12 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_RenderOnce")]
             public static extern void GlWindowRenderOnce(HandleRef jarg1);
 
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_GetRenderingMode")]
+            public static extern int GlWindowGetRenderingMode(HandleRef jarg1);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SetRenderingMode")]
+            public static extern void GlWindowSetRenderingMode(HandleRef jarg1, int jarg2);
+
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlWindow_SWIGUpcast")]
             public static extern global::System.IntPtr GlWindowUpcast(global::System.IntPtr jarg1);
 

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -1885,4 +1885,49 @@ namespace Tizen.NUI
     {
         public readonly static string ResourcePath = "/usr/share/dotnet.tizen/framework/res/";
     }
+
+    /// <summary>
+    /// This Enumeration is used the GLES version for EGL configuration.<br />
+    /// If the device can not support GLES version 3.0 over, the version will be chosen with GLES version 2.0.<br />
+    /// It is for GLWindow and GLView.<br />
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum GLESVersion
+    {
+      /// <summary>
+      /// GLES version 2.0
+      /// </summary>
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      Version20 = 0,
+
+      /// <summary>
+      /// GLES version 3.0
+      /// </summary>
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      Version30
+    }
+
+    /// <summary>
+    /// Enumeration for rendering mode
+    /// This Enumeration is used to choose the rendering mode.
+    /// It has two options.
+    /// One of them is continuous mode. It is rendered continuously.
+    /// The other is on demand mode. It is rendered by application.
+    /// It is for GLWindow and GLView.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum GLRenderingMode
+    {
+      /// <summary>
+      /// continuous mode
+      /// </summary>
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      Continuous = 0,
+
+      /// <summary>
+      /// on demand by application
+      /// </summary>
+      [EditorBrowsable(EditorBrowsableState.Never)]
+      OnDemand = 1
+    }
 }

--- a/src/Tizen.NUI/src/public/Window/GLWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/GLWindow.cs
@@ -136,26 +136,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// This Enumeration is used the GLES version for EGL configuration.<br />
-        /// If the device can not support GLES version 3.0 over, the version will be chosen with GLES version 2.0<br />
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public enum GLESVersion
-        {
-            /// <summary>
-            /// GLES version 2.0
-            /// </summary>
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            Version_2_0 = 0,
-
-            /// <summary>
-            /// GLES version 3.0
-            /// </summary>
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            Version_3_0
-        }
-
-        /// <summary>
         /// Sets egl configuration for GLWindow
         /// </summary>
         /// <param name="depth">The flag of depth buffer. If true is set, 24bit depth buffer is enabled.</param>
@@ -492,6 +472,27 @@ namespace Tizen.NUI
         public void Destroy()
         {
             this.Dispose();
+        }
+
+        /// <summary>
+        /// Gets or sets a Rendeirng Mode of GLWindow.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public GLRenderingMode RenderingMode
+        {
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            get
+            {
+                GLRenderingMode mode = (GLRenderingMode)Interop.GLWindow.GlWindowGetRenderingMode(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
+                return mode;
+            }
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            set
+            {
+                Interop.GLWindow.GlWindowSetRenderingMode(SwigCPtr, (int)value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Add GLWindow rendering mode.
It has two mode as continuous and on demand.
If the mode is continuous, the rendering user callback is called continuously.
If the mode is on demand, the rendering user callback is called by call renderOnce().

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
