### PR TITLE
[NUI][AT-SPI] Add Value interface to Pagination

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -367,7 +367,8 @@ namespace Tizen.NUI.Components
 
                 SelectIn(indicatorList[selectedIndex]);
 
-                if (IsHighlighted) {
+                if (IsHighlighted) 
+                {
                     EmitAccessibilityEvent(ObjectPropertyChangeEvent.Value);
                 }
             }
@@ -421,11 +422,11 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override bool AccessibilitySetCurrent(double value)
         {
-            int f = (int)value;
+            int integerValue = (int)value;
 
-            if (f >= 0 && f <= IndicatorCount)
+            if (integerValue >= 0 && integerValue <= IndicatorCount)
             {
-                SelectedIndex = f;
+                SelectedIndex = integerValue;
                 return true;
             }
 

--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -366,6 +366,10 @@ namespace Tizen.NUI.Components
                 selectedIndex = refinedValue;
 
                 SelectIn(indicatorList[selectedIndex]);
+
+                if (IsHighlighted) {
+                    EmitAccessibilityEvent(ObjectPropertyChangeEvent.Value);
+                }
             }
         }
 
@@ -384,11 +388,67 @@ namespace Tizen.NUI.Components
             return new Position(indicatorList[index].Position.X + container.PositionX, indicatorList[index].Position.Y + container.PositionY);
         }
 
+        /// <summary>
+        /// Minimum value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override double AccessibilityGetMinimum()
+        {
+            return 0.0;
+        }
+
+        /// <summary>
+        /// Current value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override double AccessibilityGetCurrent()
+        {
+            return (double)SelectedIndex;
+        }
+
+        /// <summary>
+        /// Maximum value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override double AccessibilityGetMaximum()
+        {
+            return (double)IndicatorCount;
+        }
+
+        /// <summary>
+        /// Current value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override bool AccessibilitySetCurrent(double value)
+        {
+            int f = (int)value;
+
+            if (f >= 0 && f <= IndicatorCount)
+            {
+                SelectedIndex = f;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Minimum increment.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override double AccessibilityGetMinimumIncrement()
+        {
+            return 1.0;
+        }
+
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void OnInitialize()
         {
             base.OnInitialize();
+            SetAccessibilityConstructor(Role.ScrollBar, AccessibilityInterface.Value);
+            AccessibilityHighlightable = true;
+            AppendAccessibilityAttribute("style", "pagecontrolbyvalue");
 
             container = new VisualView()
             {


### PR DESCRIPTION
### Description of Change ###
Add support value interface in pagination widget.

Old implementation in screen-reader reads information by analyzing
widget structures. This causes problem with pagination widget in nui
library as this one may have multiple "visual" elements that are inside
containers. As a result nui pagination widget always have two
children.

This problem was solved by using value interface to inform screen-reader
about number of visual elements and position of selected one.

### API Changes ###
NONE