### PR TITLE
[NUI] Refactoring itemSelectionMode names and adding SingleAlways

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -827,14 +827,15 @@ namespace Tizen.NUI.Components
 
             switch (SelectionMode)
             {
-                case ItemSelectionMode.SingleSelection:
+                case ItemSelectionMode.Single:
+                case ItemSelectionMode.SingleAlways:
                     if (item.BindingContext != null && item.BindingContext == SelectedItem)
                     {
                         item.IsSelected = true;
                     }
                     break;
 
-                case ItemSelectionMode.MultipleSelections:
+                case ItemSelectionMode.Multiple:
                     if ((item.BindingContext != null) && (SelectedItems?.Contains(item.BindingContext) ?? false))
                     {
                         item.IsSelected = true;
@@ -1040,13 +1041,13 @@ namespace Tizen.NUI.Components
             {
                 case ItemSelectionMode.None:
                     break;
-                case ItemSelectionMode.SingleSelection:
+                case ItemSelectionMode.Single:
                     if (colView.SelectedItem != null)
                     {
                         previousSelection.Add(colView.SelectedItem);
                     }
                     break;
-                case ItemSelectionMode.MultipleSelections:
+                case ItemSelectionMode.Multiple:
                     previousSelection = colView.SelectedItems;
                     break;
             }
@@ -1055,13 +1056,13 @@ namespace Tizen.NUI.Components
             {
                 case ItemSelectionMode.None:
                     break;
-                case ItemSelectionMode.SingleSelection:
+                case ItemSelectionMode.Single:
                     if (colView.SelectedItem != null)
                     {
                         newSelection.Add(colView.SelectedItem);
                     }
                     break;
-                case ItemSelectionMode.MultipleSelections:
+                case ItemSelectionMode.Multiple:
                     newSelection = colView.SelectedItems;
                     break;
             }

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
@@ -145,10 +145,16 @@ namespace Tizen.NUI.Components
                                 CollectionView colView = ParentItemsView as CollectionView;
                                 switch (colView.SelectionMode)
                                 {
-                                    case ItemSelectionMode.SingleSelection:
+                                    case ItemSelectionMode.Single:
                                         colView.SelectedItem = IsSelected ? null : BindingContext;
                                         break;
-                                    case ItemSelectionMode.MultipleSelections:
+                                    case ItemSelectionMode.SingleAlways:
+                                        if (colView.SelectedItem != BindingContext)
+                                        {
+                                            colView.SelectedItem = BindingContext;
+                                        }
+                                        break;
+                                    case ItemSelectionMode.Multiple:
                                         var selectedItems = colView.SelectedItems;
                                         if (selectedItems.Contains(BindingContext)) selectedItems.Remove(BindingContext);
                                         else selectedItems.Add(BindingContext);

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -219,10 +219,14 @@ namespace Tizen.NUI.Components
                             CollectionView colView = ParentItemsView as CollectionView;
                             switch (colView.SelectionMode)
                             {
-                                case ItemSelectionMode.SingleSelection:
+                                case ItemSelectionMode.Single:
                                     colView.SelectedItem = IsSelected ? null : BindingContext;
                                     break;
-                                case ItemSelectionMode.MultipleSelections:
+                                case ItemSelectionMode.SingleAlways:
+                                    if (colView.SelectedItem != BindingContext)
+                                        colView.SelectedItem = BindingContext;
+                                    break;
+                                case ItemSelectionMode.Multiple:
                                     var selectedItems = colView.SelectedItems;
                                     if (selectedItems.Contains(BindingContext)) selectedItems.Remove(BindingContext);
                                     else selectedItems.Add(BindingContext);

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSelectionMode.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSelectionMode.cs
@@ -15,6 +15,7 @@
  */
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Tizen.NUI.Components
 {
@@ -22,6 +23,9 @@ namespace Tizen.NUI.Components
     /// Selection mode of CollecitonView.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Microsoft.Naming",
+                     "CA1720: Identifiers should not contain type names",
+                     Justification = "Single is the member of enum ItemSelectionMode. there are no possible danger to miss using Single Identifiers.")]
     public enum ItemSelectionMode
     {
         /// <summary>
@@ -33,11 +37,17 @@ namespace Tizen.NUI.Components
         /// Single selection. select item exclusively so previous selected item will be unselected.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        SingleSelection,
+        Single,
+        /// <summary>
+        /// Single selection always. select item exclusively but selection is always exist after being selected.
+        /// to deselect item, clear selection forcely.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        SingleAlways,
         /// <summary>
         /// Multiple selections. select multiple items and previous selected item still remains selected.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        MultipleSelections
+        Multiple
     }
 }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/CollectionViewGridSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/CollectionViewGridSample.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI.Samples
             gallerySource.Insert(0, deleteMenu);
             gallerySource.Insert(0, insertMenu);
 
-            selMode = ItemSelectionMode.MultipleSelections;
+            selMode = ItemSelectionMode.Multiple;
             DefaultTitleItem myTitle = new DefaultTitleItem();
             myTitle.Text = "Grid Sample Count["+itemCount+"]";
             //Set Width Specification as MatchParent to fit the Item width with parent View.
@@ -52,7 +52,7 @@ namespace Tizen.NUI.Samples
                     //Decorate Badge checkbox.
                     //[NOTE] This is sample of CheckBox usage in CollectionView.
                     // Checkbox change their selection by IsSelectedProperty bindings with
-                    // SelectionChanged event with MulitpleSelections ItemSelectionMode of CollectionView.
+                    // SelectionChanged event with Mulitple ItemSelectionMode of CollectionView.
                     item.Badge = new CheckBox();
                     //FIXME : SetBinding in RadioButton crashed as Sensitive Property is disposed.
                     //item.Badge.SetBinding(CheckBox.IsSelectedProperty, "Selected");

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/CollectionViewLinearSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/CollectionViewLinearSample.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI.Samples
             gallerySource.Insert(0, deleteMenu);
             gallerySource.Insert(0, insertMenu);
 
-            selMode = ItemSelectionMode.SingleSelection;
+            selMode = ItemSelectionMode.Single;
             DefaultTitleItem myTitle = new DefaultTitleItem();
             myTitle.Text = "Linear Sample Count["+itemCount+"]";
             //Set Width Specification as MatchParent to fit the Item width with parent View.
@@ -66,7 +66,7 @@ namespace Tizen.NUI.Samples
                     //Decorate Extra RadioButton.
                     //[NOTE] This is sample of RadioButton usage in CollectionView.
                     // RadioButton change their selection by IsSelectedProperty bindings with
-                    // SelectionChanged event with SingleSelection ItemSelectionMode of CollectionView.
+                    // SelectionChanged event with Single ItemSelectionMode of CollectionView.
                     // be aware of there are no RadioButtonGroup.
                     item.Extra = new RadioButton();
                     //FIXME : SetBinding in RadioButton crashed as Sensitive Property is disposed.

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/Group/CollectionViewGridGroupSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/Group/CollectionViewGridGroupSample.cs
@@ -31,7 +31,7 @@ namespace Tizen.NUI.Samples
             insertDeleteGroup.Add(deleteMenu);
             albumSource.Insert(0, insertDeleteGroup);
 
-            selMode = ItemSelectionMode.MultipleSelections;
+            selMode = ItemSelectionMode.Multiple;
             DefaultTitleItem myTitle = new DefaultTitleItem();
             myTitle.Text = "Grid Sample Count["+ albumSource.Count+"]";
             //Set Width Specification as MatchParent to fit the Item width with parent View.
@@ -56,7 +56,7 @@ namespace Tizen.NUI.Samples
                     //Decorate Badge checkbox.
                     //[NOTE] This is sample of CheckBox usage in CollectionView.
                     // Checkbox change their selection by IsSelectedProperty bindings with
-                    // SelectionChanged event with MulitpleSelections ItemSelectionMode of CollectionView.
+                    // SelectionChanged event with Mulitple ItemSelectionMode of CollectionView.
                     item.Badge = new CheckBox();
                     //FIXME : SetBinding in RadioButton crashed as Sensitive Property is disposed.
                     //item.Badge.SetBinding(CheckBox.IsSelectedProperty, "Selected");

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/Group/CollectionViewLinearGroupSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CollectionViewDemo/Group/CollectionViewLinearGroupSample.cs
@@ -32,7 +32,7 @@ namespace Tizen.NUI.Samples
             insertDeleteGroup.Add(deleteMenu);
             albumSource.Insert(0, insertDeleteGroup);
 
-            selMode = ItemSelectionMode.SingleSelection;
+            selMode = ItemSelectionMode.Single;
             DefaultTitleItem myTitle = new DefaultTitleItem();
             //To Bind the Count property changes, need to create custom property for count.
             myTitle.Text = "Linear Sample Group["+ albumSource.Count+"]";
@@ -58,7 +58,7 @@ namespace Tizen.NUI.Samples
                     //Decorate Extra RadioButton.
                     //[NOTE] This is sample of RadioButton usage in CollectionView.
                     // RadioButton change their selection by IsSelectedProperty bindings with
-                    // SelectionChanged event with SingleSelection ItemSelectionMode of CollectionView.
+                    // SelectionChanged event with Single ItemSelectionMode of CollectionView.
                     // be aware of there are no RadioButtonGroup. 
                     item.Extra = new RadioButton();
                     //FIXME : SetBinding in RadioButton crashed as Sensitive Property is disposed.


### PR DESCRIPTION
Change names in ItemSelectionMode

SingleSelection and MultipleSelections overlapped "Selection" keyward
with their enum name.
Removing Unnecessary keyward from enum members,
and adding Suppress condition to avoid CA1720 warnings.
Single is class Identifier name but there are no harm to using name
Single in a member of enum.

Single allow deselection by clicking selected item again,
but we have another demands who want to act single selection like radio,
which always have one single selected item after once selected.

this Singlelways for that demands,
even click again on selected item, item will not deselected,
and will not occurs any SelectionChanged events.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
