### PR TITLE
[NUI] Fix Utility.Dispose not to set null to method parameter

### DIFF
--- a/src/Tizen.NUI.Components/Utils/Utility.cs
+++ b/src/Tizen.NUI.Components/Utils/Utility.cs
@@ -34,7 +34,6 @@ namespace Tizen.NUI.Components
                 }
 
                 child.Dispose();
-                child = null;
             }
         }
     }


### PR DESCRIPTION
Setting a value to method parameter does not work unless the method
parameter is defined with out keyword.

Not to confuse users, setting null to method parameter is removed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
