### PR TITLE
[NUI] Replace duplicate documentation of CopyFrom with inheritdoc

### DIFF
--- a/src/Tizen.NUI.Components/Style/ButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ButtonStyle.cs
@@ -244,10 +244,7 @@ namespace Tizen.NUI.Components
             set => SetValue(ItemSpacingProperty, value);
         }
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         /// <since_tizen> 8 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/DatePickerStyle.cs
+++ b/src/Tizen.NUI.Components/Style/DatePickerStyle.cs
@@ -54,10 +54,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Size2D CellPadding { get; set; } = new Size2D();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that needs to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/DefaultGridItemStyle.cs
+++ b/src/Tizen.NUI.Components/Style/DefaultGridItemStyle.cs
@@ -67,10 +67,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ViewStyle Badge { get; set; } = new ViewStyle();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/DefaultLinearItemStyle.cs
+++ b/src/Tizen.NUI.Components/Style/DefaultLinearItemStyle.cs
@@ -77,10 +77,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ViewStyle Seperator { get; set; } = new ViewStyle();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/DefaultTitleItemStyle.cs
+++ b/src/Tizen.NUI.Components/Style/DefaultTitleItemStyle.cs
@@ -65,10 +65,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ViewStyle Seperator { get; set; } = new ViewStyle();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/ImageScrollBarStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ImageScrollBarStyle.cs
@@ -79,10 +79,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public uint Duration { get; set; }
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/LoadingStyle.cs
+++ b/src/Tizen.NUI.Components/Style/LoadingStyle.cs
@@ -134,10 +134,7 @@ namespace Tizen.NUI.Components
             set => SetValue(FrameRateSelectorProperty, value);
         }
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         /// <since_tizen> 8 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/Navigation/AppBarStyle.cs
+++ b/src/Tizen.NUI.Components/Style/Navigation/AppBarStyle.cs
@@ -95,10 +95,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Size2D ActionCellPadding { get; set; } = new Size2D();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that needs to copy.</param>
+        /// <inheritdoc/>
         /// <since_tizen> 9 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/PaginationStyle.cs
+++ b/src/Tizen.NUI.Components/Style/PaginationStyle.cs
@@ -110,10 +110,7 @@ namespace Tizen.NUI.Components
             set => SetValue(IndicatorSpacingProperty, value);
         }
 
-        /// <summary>
-        /// Retrieves a copy of PaginationStyle.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         /// <since_tizen> 8 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/PickerStyle.cs
+++ b/src/Tizen.NUI.Components/Style/PickerStyle.cs
@@ -61,10 +61,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Size StartScrollOffset { get; set; } = new Size();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that needs to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/ProgressStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ProgressStyle.cs
@@ -69,10 +69,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 9 </since_tizen>
         public string IndeterminateImageUrl { get; set; }
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         /// <since_tizen> 8 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/RecyclerViewItemStyle.cs
+++ b/src/Tizen.NUI.Components/Style/RecyclerViewItemStyle.cs
@@ -118,10 +118,7 @@ namespace Tizen.NUI.Components
             set => SetValue(IsEnabledProperty, value);
         }
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/SliderStyle.cs
+++ b/src/Tizen.NUI.Components/Style/SliderStyle.cs
@@ -227,10 +227,7 @@ namespace Tizen.NUI.Components
             set => SetValue(TrackPaddingProperty, value);
         }
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         /// <since_tizen> 8 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/SwitchStyle.cs
+++ b/src/Tizen.NUI.Components/Style/SwitchStyle.cs
@@ -58,10 +58,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public ImageViewStyle Track { get; set; } = new ImageViewStyle();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         /// <since_tizen> 8 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/TabButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/TabButtonStyle.cs
@@ -56,10 +56,7 @@ namespace Tizen.NUI.Components
         /// </summary>
         internal ViewStyle BottomLine { get; set; } = new ViewStyle();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that need to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI.Components/Style/TimePickerStyle.cs
+++ b/src/Tizen.NUI.Components/Style/TimePickerStyle.cs
@@ -54,10 +54,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Size2D CellPadding { get; set; } = new Size2D();
 
-        /// <summary>
-        /// Style's clone function.
-        /// </summary>
-        /// <param name="bindableObject">The style that needs to copy.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject bindableObject)
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -464,8 +464,7 @@ namespace Tizen.NUI.BaseComponents
             global::System.GC.SuppressFinalize(this);
         }
 
-        /// <summary>Copy properties of other ViewStyle to this.</summary>
-        /// <param name="other">The other BindableProperty merge to this.</param>
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void CopyFrom(BindableObject other)
         {


### PR DESCRIPTION
The duplicate documentation of BindableObject.CopyFrom is replaced with
inheritdoc.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
