### PR TITLE
[NUI] Replace NavigationPages.Count with PageCount

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AlertDialogSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AlertDialogSample.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.Samples
         {
             var window = NUIApplication.GetDefaultWindow();
 
-            oldPageCount = window.GetDefaultNavigator().NavigationPages.Count;
+            oldPageCount = window.GetDefaultNavigator().PageCount;
 
             var button = new Button()
             {
@@ -47,7 +47,7 @@ namespace Tizen.NUI.Samples
         public void Deactivate()
         {
             var window = NUIApplication.GetDefaultWindow();
-            var newPageCount = window.GetDefaultNavigator().NavigationPages.Count;
+            var newPageCount = window.GetDefaultNavigator().PageCount;
 
             for (int i = 0; i < (newPageCount - oldPageCount); i++)
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DialogSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DialogSample.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.Samples
         {
             var window = NUIApplication.GetDefaultWindow();
 
-            oldPageCount = window.GetDefaultNavigator().NavigationPages.Count;
+            oldPageCount = window.GetDefaultNavigator().PageCount;
 
             var button = new Button()
             {
@@ -43,7 +43,7 @@ namespace Tizen.NUI.Samples
         public void Deactivate()
         {
             var window = NUIApplication.GetDefaultWindow();
-            var newPageCount = window.GetDefaultNavigator().NavigationPages.Count;
+            var newPageCount = window.GetDefaultNavigator().PageCount;
 
             for (int i = 0; i < (newPageCount - oldPageCount); i++)
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/MenuSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/MenuSample.cs
@@ -59,7 +59,7 @@ namespace Tizen.NUI.Samples
         {
             var window = NUIApplication.GetDefaultWindow();
             var navigator = window.GetDefaultNavigator();
-            var newPageCount = window.GetDefaultNavigator().NavigationPages.Count;
+            var newPageCount = window.GetDefaultNavigator().PageCount;
 
             for (int i = 0; i < newPageCount; i++)
             {


### PR DESCRIPTION
Not to provide List property to users, NavigationPages is removed from
Navigator class.
Instead of NavigationPages.Count, PageCount is added to Navigator class.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
