### PR TITLE
[NUI]CanvasView: Add BoundingBox property

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Drawable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Drawable.cs
@@ -38,6 +38,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_Transform")]
             public static extern bool Transform(global::System.Runtime.InteropServices.HandleRef jarg1, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] float[] jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_GetBoundingBox")]
+            public static extern global::System.IntPtr GetBoundingBox(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
@@ -53,6 +53,38 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         }
 
         /// <summary>
+        /// The bounding box of the drawable object to which no transformation has been applied.
+        /// </summary>
+        /// <remarks>
+        /// The bounding box doesn't indicate the rendering region in the result but primitive region of the object.
+        /// </remarks>
+        /// <remarks>
+        /// The float type Rectangle class is not ready yet.
+        /// Therefore, it transmits data in Vector4 class.
+        /// This type should later be changed to the appropriate data type.
+        /// </remarks>
+        /// <code>
+        ///  Shape shape = new Shape()
+        ///  {      
+        ///      FillColor = new Color(1.0f, 0.0f, 0.0f, 1.0f)
+        ///  };
+        ///  shape.AddRect(0.0f, 0.0f, 100.0f, 100.0f, 0.0f, 0.0f);
+        ///  float boundingBoxX = shape.BoundingBox[0];      // boundingBoxX will be 0.
+        ///  float boundingBoxY = shape.BoundingBox[1];      // boundingBoxY will be 0.
+        ///  float boundingBoxWidth = shape.BoundingBox[2];  // boundingBoxWidth will be 100.
+        ///  float boundingBoxHeight = shape.BoundingBox[3]; // boundingBoxHeight will be 100.
+        /// </code>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Vector4 BoundingBox
+        {
+            get
+            {
+                global::System.IntPtr cPtr = Interop.Drawable.GetBoundingBox(BaseHandle.getCPtr(this));
+                return Vector4.GetVector4FromPtr(cPtr);
+            }
+        }
+
+        /// <summary>
         /// Set the angle of rotation transformation.
         /// </summary>
         /// <param name="degree">The degree value of angle.</param>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Add BoundingBox property that uses Dali::CanvasRenderer::Drawable::GetBoundingBox api.

+)The float type Rectangle class is not ready yet.
Therefore, it transmits data in Vector4 class.
This type should later be changed to the appropriate data type.

dependancy patch
dali-adaptor : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/257837/
dali-csharp-binder : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/257846/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:no acr

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
