### PR TITLE
[NUI] Deprecate BaseHandle.PropertySet and Add BindableProperty.PropertyChanged

### DIFF
--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -115,6 +115,8 @@ namespace Tizen.NUI
         /// Event when a property is set.
         /// </summary>
         /// <since_tizen> 5 </since_tizen>
+        /// <seealso cref="BindableObject.PropertyChanged"/>
+        [Obsolete("Deprecated in API9, Will be removed in API11, Please use BindableObject.PropertyChanged instead!")]
         public event PropertyChangedEventHandler PropertySet;
 
         internal global::System.Runtime.InteropServices.HandleRef GetBaseHandleCPtrHandleRef

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -26,9 +26,9 @@ using Tizen.NUI.Binding.Internals;
 namespace Tizen.NUI.Binding
 {
     /// <summary>
-    /// Provides a mechanism by which application developers can propagate changes that are made to data in one object to another, by enabling validation, type coercion, and an event system.
+    /// Provides a mechanism by which application developers can propagate changes that are made to data in one object to another.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    /// <since_tizen> 9 </since_tizen>
     public abstract class BindableObject : INotifyPropertyChanged, IDynamicResourceHandler
     {
         /// <summary>
@@ -63,8 +63,7 @@ namespace Tizen.NUI.Binding
         /// <summary>
         /// Raised when a property has changed.
         /// </summary>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>Copy properties of other ViewStyle to this.</summary>


### PR DESCRIPTION
### Description of Change ###
Deprecate BaseHandle.PropertySet and Add BindableProperty.PropertyChanged

PropertySet has been added before the NUI XAML is added.
PropertySet is duplicated of PropertyChanged so it can be deprecated.
BindableProperty class is parent of BaseHandle class, so PropertyChanged is better to be used.

### API Changes ###
https://code.sec.samsung.net/jira/browse/TCSACR-413