### PR TITLE
[NUI] Fix not to dereference nullable handle ItemsLayouter

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -938,7 +938,7 @@ namespace Tizen.NUI.Components
         {
             // Destination is depending on implementation of layout manager.
             // Get destination from layout manager.
-            return ItemsLayouter.CalculateCandidateScrollPosition(position);
+            return ItemsLayouter?.CalculateCandidateScrollPosition(position) ?? position;
         }
 
         /// <summary>
@@ -951,7 +951,7 @@ namespace Tizen.NUI.Components
         {
             if (disposed) return;
 
-            if (needInitalizeLayouter)
+            if (needInitalizeLayouter && (ItemsLayouter != null))
             {
                 ItemsLayouter.Initialize(this);
                 needInitalizeLayouter = false;


### PR DESCRIPTION
ItemsLayouter is nullable handle so it is checked before it is
dereferenced.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
