### PR TITLE
[NUI] Rename functions, variables, etc related to policy decision.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebPolicyDecisionMaker.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebPolicyDecisionMaker.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal static partial class Interop
     {
-        internal static partial class WebNewWindowPolicyDecisionMaker
+        internal static partial class WebPolicyDecisionMaker
         {
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebPolicyDecision_GetUrl")]
             public static extern string GetUrl(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
@@ -312,11 +312,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebViewFrameRenderedSignal_Disconnect")]
             public static extern void WebViewFrameRenderedSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WebViewPolicyDecisionSignal_PolicyDecision")]
-            public static extern global::System.IntPtr NewWebViewPolicyDecisionSignalPolicyDecision(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WebViewResponsePolicyDecisionSignal_ResponsePolicyDecision")]
+            public static extern global::System.IntPtr NewWebViewResponsePolicyDecisionSignalPolicyDecision(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebViewPolicyDecisionSignal")]
-            public static extern void DeleteWebViewPolicyDecisionSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WebViewResponsePolicyDecisionSignal")]
+            public static extern void DeleteWebViewResponsePolicyDecisionSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebViewPolicyDecisionSignal_Connect")]
             public static extern void WebViewPolicyDecisionSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);

--- a/src/Tizen.NUI/src/internal/WebView/WebPolicyDecisionMaker.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebPolicyDecisionMaker.cs
@@ -21,12 +21,12 @@ using System.ComponentModel;
 namespace Tizen.NUI
 {
     /// <summary>
-    /// It is a class for new window policy decision maker of web view.
+    /// It is a class for policy decision maker of web view.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class WebNewWindowPolicyDecisionMaker : Disposable
+    public class WebPolicyDecisionMaker : Disposable
     {
-        internal WebNewWindowPolicyDecisionMaker(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal WebPolicyDecisionMaker(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }
 
@@ -106,7 +106,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return Interop.WebNewWindowPolicyDecisionMaker.GetUrl(SwigCPtr);
+                return Interop.WebPolicyDecisionMaker.GetUrl(SwigCPtr);
             }
         }
 
@@ -118,7 +118,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return Interop.WebNewWindowPolicyDecisionMaker.GetCookie(SwigCPtr);
+                return Interop.WebPolicyDecisionMaker.GetCookie(SwigCPtr);
             }
         }
 
@@ -130,7 +130,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return (DecisionType)Interop.WebNewWindowPolicyDecisionMaker.GetDecisionType(SwigCPtr);
+                return (DecisionType)Interop.WebPolicyDecisionMaker.GetDecisionType(SwigCPtr);
             }
         }
 
@@ -142,7 +142,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return Interop.WebNewWindowPolicyDecisionMaker.GetResponseMime(SwigCPtr);
+                return Interop.WebPolicyDecisionMaker.GetResponseMime(SwigCPtr);
             }
         }
 
@@ -154,7 +154,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return Interop.WebNewWindowPolicyDecisionMaker.GetResponseStatusCode(SwigCPtr);
+                return Interop.WebPolicyDecisionMaker.GetResponseStatusCode(SwigCPtr);
             }
         }
 
@@ -166,7 +166,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return (NavigationType)Interop.WebNewWindowPolicyDecisionMaker.GetNavigationType(SwigCPtr);
+                return (NavigationType)Interop.WebPolicyDecisionMaker.GetNavigationType(SwigCPtr);
             }
         }
 
@@ -178,7 +178,7 @@ namespace Tizen.NUI
         {
             get
             {
-                IntPtr result = Interop.WebNewWindowPolicyDecisionMaker.GetFrame(SwigCPtr);
+                IntPtr result = Interop.WebPolicyDecisionMaker.GetFrame(SwigCPtr);
                 return new WebFrame(result, false);
             }
         }
@@ -191,7 +191,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return Interop.WebNewWindowPolicyDecisionMaker.GetScheme(SwigCPtr);
+                return Interop.WebPolicyDecisionMaker.GetScheme(SwigCPtr);
             }
         }
 
@@ -201,7 +201,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Use()
         {
-            bool result = Interop.WebNewWindowPolicyDecisionMaker.Use(SwigCPtr);
+            bool result = Interop.WebPolicyDecisionMaker.Use(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return result;
         }
@@ -212,7 +212,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Ignore()
         {
-            bool result = Interop.WebNewWindowPolicyDecisionMaker.Ignore(SwigCPtr);
+            bool result = Interop.WebPolicyDecisionMaker.Ignore(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return result;
         }
@@ -223,7 +223,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Suspend()
         {
-            bool result = Interop.WebNewWindowPolicyDecisionMaker.Suspend(SwigCPtr);
+            bool result = Interop.WebPolicyDecisionMaker.Suspend(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return result;
         }

--- a/src/Tizen.NUI/src/internal/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebView.cs
@@ -73,9 +73,9 @@ namespace Tizen.NUI
         private HitTestFinishedCallback hitTestFinishedCallback;
         private readonly WebViewHitTestFinishedProxyCallback hitTestFinishedProxyCallback;
 
-        private readonly WebViewNewWindowPolicyDecidedSignal newWindowPolicyDecidedSignal;
-        private EventHandler<WebViewNewWindowPolicyDecidedEventArgs> newWindowPolicyDecidedEventHandler;
-        private WebViewNewWindowPolicyDecidedCallbackDelegate newWindowPolicyDecidedCallback;
+        private readonly WebViewResponsePolicyDecidedSignal responsePolicyDecidedSignal;
+        private EventHandler<WebViewResponsePolicyDecidedEventArgs> responsePolicyDecidedEventHandler;
+        private WebViewResponsePolicyDecidedCallbackDelegate responsePolicyDecidedCallback;
 
         private readonly WebViewCertificateReceivedSignal certificateConfirmedSignal;
         private EventHandler<WebViewCertificateReceivedEventArgs> certificateConfirmedEventHandler;
@@ -155,7 +155,7 @@ namespace Tizen.NUI
             urlChangedSignal = new WebViewUrlChangedSignal(Interop.WebView.NewWebViewUrlChangedSignalUrlChanged(SwigCPtr));
             formRepostPolicyDecidedSignal = new WebViewFormRepostPolicyDecidedSignal(Interop.WebView.NewWebViewFormRepostDecisionSignalFormRepostDecision(SwigCPtr));
             frameRenderedSignal = new WebViewFrameRenderedSignal(Interop.WebView.WebViewFrameRenderedSignalFrameRenderedGet(SwigCPtr));
-            newWindowPolicyDecidedSignal = new WebViewNewWindowPolicyDecidedSignal(Interop.WebView.NewWebViewPolicyDecisionSignalPolicyDecision(SwigCPtr));
+            responsePolicyDecidedSignal = new WebViewResponsePolicyDecidedSignal(Interop.WebView.NewWebViewResponsePolicyDecisionSignalPolicyDecision(SwigCPtr));
             certificateConfirmedSignal = new WebViewCertificateReceivedSignal(Interop.WebView.NewWebViewCertificateSignalCertificateConfirm(SwigCPtr));
             sslCertificateChangedSignal = new WebViewCertificateReceivedSignal(Interop.WebView.NewWebViewCertificateSignalSslCertificateChanged(SwigCPtr));
             httpAuthRequestedSignal = new WebViewHttpAuthRequestedSignal(Interop.WebView.NewWebViewHttpAuthHandlerSignalHttpAuthHandler(SwigCPtr));
@@ -197,7 +197,7 @@ namespace Tizen.NUI
                 urlChangedSignal.Dispose();
                 formRepostPolicyDecidedSignal.Dispose();
                 frameRenderedSignal.Dispose();
-                newWindowPolicyDecidedSignal.Dispose();
+                responsePolicyDecidedSignal.Dispose();
                 certificateConfirmedSignal.Dispose();
                 sslCertificateChangedSignal.Dispose();
                 httpAuthRequestedSignal.Dispose();
@@ -304,7 +304,7 @@ namespace Tizen.NUI
         private delegate void WebViewHitTestFinishedProxyCallback(IntPtr data);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void WebViewNewWindowPolicyDecidedCallbackDelegate(IntPtr data, IntPtr maker);
+        private delegate void WebViewResponsePolicyDecidedCallbackDelegate(IntPtr data, IntPtr maker);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void WebViewCertificateReceivedCallbackDelegate(IntPtr data, IntPtr certificate);
@@ -533,27 +533,27 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Event for the NewWindowPolicyDecided signal which can be used to subscribe or unsubscribe the event handler.<br />
-        /// This signal is emitted when new window policy would be decided.<br />
+        /// Event for the ResponsePolicyDecided signal which can be used to subscribe or unsubscribe the event handler.<br />
+        /// This signal is emitted when response policy would be decided.<br />
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public event EventHandler<WebViewNewWindowPolicyDecidedEventArgs> NewWindowPolicyDecided
+        public event EventHandler<WebViewResponsePolicyDecidedEventArgs> ResponsePolicyDecided
         {
             add
             {
-                if (newWindowPolicyDecidedEventHandler == null)
+                if (responsePolicyDecidedEventHandler == null)
                 {
-                    newWindowPolicyDecidedCallback = OnNewWindowPolicyDecided;
-                    newWindowPolicyDecidedSignal.Connect(newWindowPolicyDecidedCallback);
+                    responsePolicyDecidedCallback = OnResponsePolicyDecided;
+                    responsePolicyDecidedSignal.Connect(responsePolicyDecidedCallback);
                 }
-                newWindowPolicyDecidedEventHandler += value;
+                responsePolicyDecidedEventHandler += value;
             }
             remove
             {
-                newWindowPolicyDecidedEventHandler -= value;
-                if (newWindowPolicyDecidedEventHandler == null && newWindowPolicyDecidedCallback != null)
+                responsePolicyDecidedEventHandler -= value;
+                if (responsePolicyDecidedEventHandler == null && responsePolicyDecidedCallback != null)
                 {
-                    newWindowPolicyDecidedSignal.Disconnect(newWindowPolicyDecidedCallback);
+                    responsePolicyDecidedSignal.Disconnect(responsePolicyDecidedCallback);
                 }
             }
         }
@@ -1188,6 +1188,8 @@ namespace Tizen.NUI
             get
             {
                 global::System.IntPtr imageView = Interop.WebView.GetFavicon(SwigCPtr);
+                if (imageView == IntPtr.Zero)
+                    return null;
                 return new ImageView(imageView, false);
             }
         }
@@ -2104,9 +2106,9 @@ namespace Tizen.NUI
             image.Dispose();
         }
 
-        private void OnNewWindowPolicyDecided(IntPtr data, IntPtr maker)
+        private void OnResponsePolicyDecided(IntPtr data, IntPtr maker)
         {
-            newWindowPolicyDecidedEventHandler?.Invoke(this, new WebViewNewWindowPolicyDecidedEventArgs(new WebNewWindowPolicyDecisionMaker(maker, false)));
+            responsePolicyDecidedEventHandler?.Invoke(this, new WebViewResponsePolicyDecidedEventArgs(new WebPolicyDecisionMaker(maker, false)));
         }
 
         private void OnCertificateConfirmed(IntPtr data, IntPtr certificate)

--- a/src/Tizen.NUI/src/internal/WebView/WebViewResponsePolicyDecidedEventArgs.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebViewResponsePolicyDecidedEventArgs.cs
@@ -21,20 +21,20 @@ using System.ComponentModel;
 namespace Tizen.NUI
 {
     /// <summary>
-    /// Event arguments that passed via the WebView.NewWindowPolicyDecided.
+    /// Event arguments that passed via the WebView.ResponsePolicyDecided.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class WebViewNewWindowPolicyDecidedEventArgs : EventArgs
+    public class WebViewResponsePolicyDecidedEventArgs : EventArgs
     {
-        internal WebViewNewWindowPolicyDecidedEventArgs(WebNewWindowPolicyDecisionMaker maker)
+        internal WebViewResponsePolicyDecidedEventArgs(WebPolicyDecisionMaker maker)
         {
-            NewWindowPolicyDecisionMaker = maker;
+            ResponsePolicyDecisionMaker = maker;
         }
 
         /// <summary>
-        /// The new window policy decision maker.
+        /// The response policy decision maker.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public WebNewWindowPolicyDecisionMaker NewWindowPolicyDecisionMaker { get; }
+        public WebPolicyDecisionMaker ResponsePolicyDecisionMaker { get; }
     }
 }

--- a/src/Tizen.NUI/src/internal/WebView/WebViewResponsePolicyDecidedSignal.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebViewResponsePolicyDecidedSignal.cs
@@ -17,15 +17,15 @@
 
 namespace Tizen.NUI
 {
-    internal class WebViewNewWindowPolicyDecidedSignal : Disposable
+    internal class WebViewResponsePolicyDecidedSignal : Disposable
     {
-        public WebViewNewWindowPolicyDecidedSignal(global::System.IntPtr cPtr) : base(cPtr, true)
+        public WebViewResponsePolicyDecidedSignal(global::System.IntPtr cPtr) : base(cPtr, true)
         {
         }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            Interop.WebView.DeleteWebViewPolicyDecisionSignal(swigCPtr);
+            Interop.WebView.DeleteWebViewResponsePolicyDecisionSignal(swigCPtr);
         }
 
         public void Connect(System.Delegate func)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Originally new window policy is not needed, actually response policy is needed.
This patch is to rename functions related to policy decision.
The patch related to csharp-binder :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/257751/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
