### PR TITLE
[NUI] Fix crash issue when favicon is null. (#3010)

### DIFF
--- a/src/Tizen.NUI/src/internal/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebView.cs
@@ -1188,6 +1188,8 @@ namespace Tizen.NUI
             get
             {
                 global::System.IntPtr imageView = Interop.WebView.GetFavicon(SwigCPtr);
+                if (imageView == null || imageView == IntPtr.Zero)
+                    return null;
                 return new ImageView(imageView, false);
             }
         }


### PR DESCRIPTION
Co-authored-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
