### PR TITLE
fix nullable member access code to prevent future crash.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -212,18 +212,16 @@ namespace Tizen.NUI.Components
                     {
                         prevNotifyCollectionChanged.CollectionChanged -= CollectionChanged;
                     }
-                    itemsLayouter.Clear();
+                    itemsLayouter?.Clear();
                     if (selectedItem != null) selectedItem = null;
-                    if (selectedItems != null)
-                    {
-                        selectedItems.Clear();
-                    }
+                    selectedItems?.Clear();
                 }
 
                 itemsSource = value;
                 if (value == null)
                 {
-                    if (InternalItemSource != null) InternalItemSource.Dispose();
+                    InternalItemSource?.Dispose();
+                    InternalItemSource = null;
                     //layouter.Clear()
                     return;
                 }
@@ -232,7 +230,7 @@ namespace Tizen.NUI.Components
                     newNotifyCollectionChanged.CollectionChanged += CollectionChanged;
                 }
 
-                if (InternalItemSource != null) InternalItemSource.Dispose();
+                InternalItemSource?.Dispose();
                 InternalItemSource = ItemsSourceFactory.Create(this);
 
                 if (itemsLayouter == null) return;


### PR DESCRIPTION
nullable members need to be check it is null or not,
and carefully null set after disposing.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
