### PR TITLE
[Build] Add a github workflow to deploy documents

### DIFF
--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -1,0 +1,68 @@
+name: "Deploy Documents"
+
+on:
+  schedule:
+  - cron: "0 16 * * *"
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    runs-on: [self-hosted, linux, x64]
+    container:
+      image: tizendotnet/tizenfx-build-worker:2.1
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: TizenAPI/TizenFX-Docs
+
+    - name: Checkout TizenFX sources
+      run: |
+        ./build.sh clone
+
+    - name: Cache DocFX output
+      id: cache-site
+      uses: actions/cache@v2
+      with:
+        path: _site
+        key: docfx-gh-pages-site-${{ hashFiles('repos/commits') }}
+
+    - name: Build Documents
+      if: steps.cache-site.outputs.cache-hit != 'true'
+      run: |
+        ./build.sh restore
+        ./build.sh build
+        ./build.sh index
+
+    - name: Archive Artifacts
+      run: |
+        tar cfz site.tar.gz _site/
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: documents
+        path: site.tar.gz
+
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: documents
+
+    - name: Extract Artifacts
+      run: |
+        tar xfz site.tar.gz
+
+    - name: Deploy GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_site
+        publish_branch: gh-pages
+        user_name: 'TizenAPI-Bot'
+        user_email: 'tizenapi@samsung.com'
+        full_commit_message: 'Update documents'


### PR DESCRIPTION
### Description of Change ###
Add a github workflow to deploy documents in https://samsung.github.io/TizenFX/
This workflow uses the DocFX with https://github.com/TizenAPI/TizenFX-Docs configurations.
