### PR TITLE
[Build] Downgrade tizenfx-build-worker to 2.0

### DIFF
--- a/.github/workflows/deploy-documents-for-tizen-docs.yml
+++ b/.github/workflows/deploy-documents-for-tizen-docs.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: [self-hosted, linux, x64]
     container:
-      image: tizendotnet/tizenfx-build-worker:2.1
+      image: tizendotnet/tizenfx-build-worker:2.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: [self-hosted, linux, x64]
     container:
-      image: tizendotnet/tizenfx-build-worker:2.1
+      image: tizendotnet/tizenfx-build-worker:2.0
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Use tizenfx-build-worker 2.0 to use DocFX 2.56.1 version
