### PR TITLE
[NUI] fix disposing crash when layouter is null

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
@@ -374,7 +374,7 @@ namespace Tizen.NUI.Components
                     }
                     RecycleCache.Clear();
                 }
-                InternalItemsLayouter.Clear();
+                InternalItemsLayouter?.Clear();
                 InternalItemsLayouter = null;
                 ItemsSource = null;
                 ItemTemplate = null;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
