### PR TITLE
[NUI] CanvasView: Manage added drawables as a list

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
@@ -16,6 +16,7 @@
 */
 using System;
 using System.ComponentModel;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Tizen.NUI.BaseComponents.VectorGraphics
@@ -26,6 +27,8 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
     /// <since_tizen> 9 </since_tizen>
     public class CanvasView : View
     {
+        private List<Drawable> drawables; //The list of added drawables
+
         static CanvasView() { }
 
         /// <summary>
@@ -42,6 +45,7 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
 
         internal CanvasView(global::System.IntPtr cPtr, bool shown = true) : base(cPtr, shown)
         {
+            drawables = new List<Drawable>();
             if (!shown)
             {
                 SetVisible(false);
@@ -59,6 +63,12 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
             {
                 return;
             }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                drawables.Clear();
+            }
+
             base.Dispose(type);
         }
 
@@ -75,11 +85,20 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// This method is similar to registration. The added shape is drawn on the inner canvas.
         /// </summary>
         /// <param name="drawable">Drawable object</param>
+        /// <exception cref="ArgumentNullException"> Thrown when drawable is null. </exception>
         /// <since_tizen> 9 </since_tizen>
         public void AddDrawable(Drawable drawable)
         {
+            if (drawable == null)
+            {
+                throw new ArgumentNullException(nameof(drawable));
+            }
             Interop.CanvasView.AddDrawable(View.getCPtr(this), BaseHandle.getCPtr(drawable));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            if (!drawables.Contains(drawable))
+            {
+                drawables.Add(drawable);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Canvasview manages drawables as a list so that added drawables
used in canvasview are not released by gc.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:no acr

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
