### PR TITLE
[NUI] Calculate correct MatchParent size for ContentPage and TabView

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -168,17 +168,20 @@ namespace Tizen.NUI.Components
 
                 appBar.Position2D = new Position2D(appBarPosX, appBarPosY);
 
-                if ((appBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (appBar.HeightSpecification == LayoutParamPolicies.MatchParent))
+                // FIXME: Now, WidthSpecification/HeightSpecification are updated internally.
+                //        When this is resolved, comparing Specification with Size is removed.
+                if ((appBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (appBar.HeightSpecification == LayoutParamPolicies.MatchParent) ||
+                    (appBar.WidthSpecification > Size2D.Width) || (appBar.HeightSpecification > Size2D.Height))
                 {
                     int appBarSizeW = appBar.Size2D.Width;
                     int appBarSizeH = appBar.Size2D.Height;
 
-                    if (appBar.WidthSpecification == LayoutParamPolicies.MatchParent)
+                    if ((appBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (appBar.WidthSpecification > Size2D.Width))
                     {
                         appBarSizeW = Size2D.Width - Padding.Start - Padding.End - appBar.Margin.Start - appBar.Margin.End;
                     }
 
-                    if (appBar.HeightSpecification == LayoutParamPolicies.MatchParent)
+                    if ((appBar.HeightSpecification == LayoutParamPolicies.MatchParent) || (appBar.HeightSpecification > Size2D.Height))
                     {
                         appBarSizeH = Size2D.Height - Padding.Top - Padding.Bottom - appBar.Margin.Top - appBar.Margin.Bottom;
                     }
@@ -194,7 +197,10 @@ namespace Tizen.NUI.Components
 
                 content.Position2D = new Position2D(contentPosX, contentPosY);
 
-                if ((content.WidthSpecification == LayoutParamPolicies.MatchParent) || (content.HeightSpecification == LayoutParamPolicies.MatchParent))
+                // FIXME: Now, WidthSpecification/HeightSpecification are updated internally.
+                //        When this is resolved, comparing Specification with Size is removed.
+                if ((content.WidthSpecification == LayoutParamPolicies.MatchParent) || (content.HeightSpecification == LayoutParamPolicies.MatchParent) ||
+                    (content.WidthSpecification > Size2D.Width) || (content.HeightSpecification > Size2D.Height))
                 {
                     int contentSizeW = content.Size2D.Width;
                     int contentSizeH = content.Size2D.Height;


### PR DESCRIPTION
Currently, WidthSpecification and HeightSpecification are updated
internally.

e.g.
In the beginning, WidthSpecification = LayoutParamPolicies.MatchParent;
After size calculation, WidthSpecification = 1280;

Until the above issue is resolved, ContentPage and TabView changes its
size calculation logic to calculate its MatchParent children size
correctly.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
