### PR TITLE
Revert "[NUI] Calculate correct MatchParent size for ContentPage and …

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -168,20 +168,17 @@ namespace Tizen.NUI.Components
 
                 appBar.Position2D = new Position2D(appBarPosX, appBarPosY);
 
-                // FIXME: Now, WidthSpecification/HeightSpecification are updated internally.
-                //        When this is resolved, comparing Specification with Size is removed.
-                if ((appBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (appBar.HeightSpecification == LayoutParamPolicies.MatchParent) ||
-                    (appBar.WidthSpecification > Size2D.Width) || (appBar.HeightSpecification > Size2D.Height))
+                if ((appBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (appBar.HeightSpecification == LayoutParamPolicies.MatchParent))
                 {
                     int appBarSizeW = appBar.Size2D.Width;
                     int appBarSizeH = appBar.Size2D.Height;
 
-                    if ((appBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (appBar.WidthSpecification > Size2D.Width))
+                    if (appBar.WidthSpecification == LayoutParamPolicies.MatchParent)
                     {
                         appBarSizeW = Size2D.Width - Padding.Start - Padding.End - appBar.Margin.Start - appBar.Margin.End;
                     }
 
-                    if ((appBar.HeightSpecification == LayoutParamPolicies.MatchParent) || (appBar.HeightSpecification > Size2D.Height))
+                    if (appBar.HeightSpecification == LayoutParamPolicies.MatchParent)
                     {
                         appBarSizeH = Size2D.Height - Padding.Top - Padding.Bottom - appBar.Margin.Top - appBar.Margin.Bottom;
                     }
@@ -197,10 +194,7 @@ namespace Tizen.NUI.Components
 
                 content.Position2D = new Position2D(contentPosX, contentPosY);
 
-                // FIXME: Now, WidthSpecification/HeightSpecification are updated internally.
-                //        When this is resolved, comparing Specification with Size is removed.
-                if ((content.WidthSpecification == LayoutParamPolicies.MatchParent) || (content.HeightSpecification == LayoutParamPolicies.MatchParent) ||
-                    (content.WidthSpecification > Size2D.Width) || (content.HeightSpecification > Size2D.Height))
+                if ((content.WidthSpecification == LayoutParamPolicies.MatchParent) || (content.HeightSpecification == LayoutParamPolicies.MatchParent))
                 {
                     int contentSizeW = content.Size2D.Width;
                     int contentSizeH = content.Size2D.Height;

--- a/src/Tizen.NUI.Components/Controls/TabView.cs
+++ b/src/Tizen.NUI.Components/Controls/TabView.cs
@@ -91,16 +91,12 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 9 </since_tizen>
         public TabView()
         {
-            // FIXME: Now, WidthSpecification/HeightSpecification are updated internally.
-            //        When this is resolved, LinearLayout can be used.
-            Layout = new AbsoluteLayout();
+            Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Vertical };
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
 
-            InitContent();
             InitTabBar();
-
-            CalculatePosition();
+            InitContent();
         }
 
         private void InitTabBar()
@@ -206,15 +202,6 @@ namespace Tizen.NUI.Components
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnRelayout(Vector2 size, RelayoutContainer container)
-        {
-            base.OnRelayout(size, container);
-
-            CalculatePosition();
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(DisposeTypes type)
         {
             if (disposed)
@@ -237,76 +224,6 @@ namespace Tizen.NUI.Components
             }
 
             base.Dispose(type);
-        }
-
-        private void CalculatePosition()
-        {
-            // If TabView size has not been set yet, then content size cannot be calculated.
-            if ((Size2D.Width == 0) && (Size2D.Height == 0))
-            {
-                return;
-            }
-
-            if (tabBar != null)
-            {
-                // FIXME: Now, WidthSpecification/HeightSpecification are updated internally.
-                //        When this is resolved, comparing Specification with Size is removed.
-                if ((tabBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (tabBar.HeightSpecification == LayoutParamPolicies.MatchParent) ||
-                    (tabBar.WidthSpecification > Size.Width) || (tabBar.HeightSpecification > Size.Height))
-                {
-                    int tabBarSizeW = tabBar.Size2D.Width;
-                    int tabBarSizeH = tabBar.Size2D.Height;
-
-                    if ((tabBar.WidthSpecification == LayoutParamPolicies.MatchParent) || (tabBar.WidthSpecification > Size.Width))
-                    {
-                        tabBarSizeW = Size2D.Width - Padding.Start - Padding.End - tabBar.Margin.Start - tabBar.Margin.End;
-                    }
-
-                    if ((tabBar.HeightSpecification == LayoutParamPolicies.MatchParent) || (tabBar.HeightSpecification > Size.Height))
-                    {
-                        tabBarSizeH = Size2D.Height - Padding.Top - Padding.Bottom - tabBar.Margin.Top - tabBar.Margin.Bottom;
-                    }
-
-                    tabBar.Size2D = new Size2D(tabBarSizeW, tabBarSizeH);
-                }
-            }
-
-            if (content != null)
-            {
-                int contentPosX = Padding.Start + content.Margin.Start;
-                int contentPosY = Padding.Top + content.Margin.Top;
-
-                content.Position = new Position(contentPosX, contentPosY);
-
-                // FIXME: Now, WidthSpecification/HeightSpecification are updated internally.
-                //        When this is resolved, comparing Specification with Size is removed.
-                if ((content.WidthSpecification == LayoutParamPolicies.MatchParent) || (content.HeightSpecification == LayoutParamPolicies.MatchParent) ||
-                    (content.WidthSpecification > Size.Width) || (content.HeightSpecification > Size.Height))
-                {
-                    int contentSizeW = content.Size2D.Width;
-                    int contentSizeH = content.Size2D.Height;
-
-                    if ((content.WidthSpecification == LayoutParamPolicies.MatchParent) || (content.WidthSpecification > Size.Width))
-                    {
-                        contentSizeW = Size2D.Width - Padding.Start - Padding.End - content.Margin.Start - content.Margin.End;
-                    }
-
-                    if ((content.HeightSpecification == LayoutParamPolicies.MatchParent) || (content.HeightSpecification > Size.Height))
-                    {
-                        contentSizeH = Size2D.Height - Padding.Top - Padding.Bottom - content.Margin.Top - content.Margin.Bottom - (tabBar?.Size2D.Height ?? 0);
-                    }
-
-                    content.Size2D = new Size2D(contentSizeW, contentSizeH);
-                }
-            }
-
-            if (tabBar != null)
-            {
-                int tabBarPosX = Padding.Start + tabBar.Margin.Start;
-                int tabBarPosY = /*Padding.Top +*/ tabBar.Margin.Top + (content?.Size2D.Height ?? 0);
-
-                tabBar.Position = new Position(tabBarPosX, tabBarPosY);
-            }
         }
     }
 }


### PR DESCRIPTION
…TabView"

This reverts commit b3195f4d51c73a80a1b3c287cf703d4ad36d2efa.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
