### PR TITLE
[NUI] Add InputMethodSettings property to TextEditor

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -297,6 +297,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_ENABLE_GRAB_HANDLE_POPUP_get")]
             public static extern int EnableGrabHandlePopupGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_METHOD_SETTINGS_get")]
+            public static extern int InputMethodSettingsGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1347,6 +1347,23 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The InputMethodSettings property.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PropertyMap InputMethodSettings
+        {
+            get
+            {
+                return (PropertyMap)GetValue(InputMethodSettingsProperty);
+            }
+            set
+            {
+                SetValue(InputMethodSettingsProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// Scroll the text control by specific amount..
         /// </summary>
         /// <param name="scroll">The amount (in pixels) of scrolling in horizontal &amp; vertical directions.</param>
@@ -1626,6 +1643,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int GrabHandleColor = Interop.TextEditor.GrabHandleColorGet();
             internal static readonly int EnableGrabHandle = Interop.TextEditor.EnableGrabHandleGet();
             internal static readonly int EnableGrabHandlePopup = Interop.TextEditor.EnableGrabHandlePopupGet();
+            internal static readonly int InputMethodSettings = Interop.TextEditor.InputMethodSettingsGet();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -1008,6 +1008,21 @@ namespace Tizen.NUI.BaseComponents
             return temp;
         }));
 
-
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty InputMethodSettingsProperty = BindableProperty.Create(nameof(TextEditor.InputMethodSettings), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputMethodSettings, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            PropertyMap temp = new PropertyMap();
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputMethodSettings).Get(temp);
+            return temp;
+        }));
     }
 }


### PR DESCRIPTION
Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
This property is already provided in TextField.
TextEditor also needs a property that controls the options of the input method.

* Below patch should be applied first.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/258649/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/258650/