### PR TITLE
[NUI][AT-SPI] Remove AccessibilityAnimated

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
@@ -86,9 +86,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_ATTRIBUTES_get")]
             public static extern int AccessibilityAttributesGet();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_ANIMATED_get")]
-            public static extern int AccessibilityAnimatedGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -599,7 +599,6 @@ namespace Tizen.NUI.BaseComponents
             FlagSetter(ref states, AccessibilityStates.Highlighted, this.IsHighlighted);
             FlagSetter(ref states, AccessibilityStates.Enabled, this.State != States.Disabled);
             FlagSetter(ref states, AccessibilityStates.Sensitive, this.Sensitive);
-            FlagSetter(ref states, AccessibilityStates.Animated, this.AccessibilityAnimated);
             FlagSetter(ref states, AccessibilityStates.Visible, true);
             FlagSetter(ref states, AccessibilityStates.Showing, this.Visibility);
             FlagSetter(ref states, AccessibilityStates.Defunct, !this.IsOnWindow);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
@@ -118,27 +118,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Gets or sets whether the view is animated for accessibility or not.
-        /// </summary>
-        /// <remarks>
-        /// For views, which intend to block notification of theirs position or size change to AT-SPI2, this value should be set as true.
-        /// Otherwise it is set to false by default and the object position or size change is notified to AT-SPI2.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool AccessibilityAnimated
-        {
-            get
-            {
-                return (bool)GetValue(AccessibilityAnimatedProperty);
-            }
-            set
-            {
-                SetValue(AccessibilityAnimatedProperty, value);
-                NotifyPropertyChanged();
-            }
-        }
-
-        /// <summary>
         /// Gets or sets a value that allows the automation framework to find and interact with this element.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1796,26 +1796,6 @@ namespace Tizen.NUI.BaseComponents
             return temp;
         });
 
-        /// <summary>
-        /// AccessibilityAnimatedProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AccessibilityAnimatedProperty = BindableProperty.Create(nameof(AccessibilityAnimated), typeof(bool), typeof(View), false, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var view = (View)bindable;
-            if (newValue != null)
-            {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.AccessibilityAnimated, new Tizen.NUI.PropertyValue((bool)newValue));
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var view = (View)bindable;
-            bool temp = false;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.AccessibilityAnimated).Get(out temp);
-            return temp;
-        });
-
         private void SetBackgroundImage(string value)
         {
             if (string.IsNullOrEmpty(value))

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -226,7 +226,6 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int AccessibilityRole = Interop.ViewProperty.AccessibilityRoleGet();
             internal static readonly int AccessibilityHighlightable = Interop.ViewProperty.AccessibilityHighlightableGet();
             internal static readonly int AccessibilityAttributes = Interop.ViewProperty.AccessibilityAttributesGet();
-            internal static readonly int AccessibilityAnimated = Interop.ViewProperty.AccessibilityAnimatedGet();
         }
     }
 }


### PR DESCRIPTION
This property was used to control automatic emission of the
BoundsChanged event. However, we no longer emit this event, so this
property serves no purpose.

Not to be confused with AT-SPI state Animated which is still available.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

### Dependencies
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/258789/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/259070/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/258790/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/258788/
