### PR TITLE
[NUI][ATSPI] Not highlightable for AlertDialog

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -490,7 +490,6 @@ namespace Tizen.NUI.Components
             Content = DefaultContent;
 
             ActionContent = DefaultActionContent;
-            AccessibilityHighlightable = true;
         }
 
         private void ResetContent()


### PR DESCRIPTION
Since AlertDialog is a container, it is not needed to be highlightable.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
