### PR TITLE
[NUI] Fix ScrollableBase Remove issue

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -729,8 +729,7 @@ namespace Tizen.NUI.Components
             {
                 // Target View is current page and also last child.
                 // CurrentPage should be changed to previous page.
-                CurrentPage = Math.Max(0, CurrentPage - 1);
-                ScrollToIndex(CurrentPage);
+                ScrollToIndex(CurrentPage - 1);
             }
 
             ContentContainer.Remove(view);


### PR DESCRIPTION
 - [TDAF-1430] ScrollableaBase Child remove issue
 If the ScrollableBase has one child, it does not need to move the page

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
