### PR TITLE
[NUI] fix layouter and cache clearing when property changed

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -217,7 +217,6 @@ namespace Tizen.NUI.Components
                     {
                         prevNotifyCollectionChanged.CollectionChanged -= CollectionChanged;
                     }
-                    itemsLayouter?.Clear();
                     if (selectedItem != null) selectedItem = null;
                     selectedItems?.Clear();
                 }
@@ -227,7 +226,8 @@ namespace Tizen.NUI.Components
                 {
                     InternalItemSource?.Dispose();
                     InternalItemSource = null;
-                    //layouter.Clear()
+                    itemsLayouter?.Clear();
+                    ClearCache();
                     return;
                 }
                 if (itemsSource is INotifyCollectionChanged newNotifyCollectionChanged)
@@ -263,7 +263,6 @@ namespace Tizen.NUI.Components
                 itemTemplate = value;
                 if (value == null)
                 {
-                    //layouter.clear()
                     return;
                 }
 
@@ -288,8 +287,11 @@ namespace Tizen.NUI.Components
             }
             set
             {
+                itemsLayouter?.Clear();
+                ClearCache();
+
                 itemsLayouter = value;
-                base.InternalItemsLayouter = ItemsLayouter;
+                base.InternalItemsLayouter = itemsLayouter;
                 if (value == null)
                 {
                     needInitalizeLayouter = false;
@@ -982,6 +984,24 @@ namespace Tizen.NUI.Components
             return ItemsLayouter?.CalculateCandidateScrollPosition(position) ?? position;
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ClearCache()
+        {
+            foreach (RecyclerViewItem item in recycleGroupHeaderCache)
+            {
+                Utility.Dispose(item);
+            }
+            recycleGroupHeaderCache.Clear();
+            foreach (RecyclerViewItem item in recycleGroupFooterCache)
+            {
+                Utility.Dispose(item);
+            }
+            recycleGroupFooterCache.Clear();
+            base.ClearCache();
+        }
+
+
         /// <summary>
         /// OnScroll event callback. Requesting layout to the layouter with given scrollPosition.
         /// </summary>
@@ -1048,22 +1068,6 @@ namespace Tizen.NUI.Components
                 {
                     InternalItemSource.Dispose();
                     InternalItemSource = null;
-                }
-                if (recycleGroupHeaderCache != null)
-                {
-                    foreach(RecyclerViewItem item in recycleGroupHeaderCache)
-                    {
-                        UnrealizeItem(item, false);
-                    }
-                    recycleGroupHeaderCache.Clear();
-                }
-                if (recycleGroupFooterCache != null)
-                {
-                    foreach(RecyclerViewItem item in recycleGroupFooterCache)
-                    {
-                        UnrealizeItem(item, false);
-                    }
-                    recycleGroupFooterCache.Clear();
                 }
             }
 
@@ -1174,6 +1178,9 @@ namespace Tizen.NUI.Components
 
             if (needInitalizeLayouter)
             {
+                itemsLayouter.Clear();
+                ClearCache();
+
                 ItemsLayouter.Initialize(this);
                 needInitalizeLayouter = false;
             }

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/ItemsLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/ItemsLayouter.cs
@@ -159,8 +159,13 @@ namespace Tizen.NUI.Components
                 CandidateMargin.Dispose();
                 CandidateMargin = null;
             }
+            if (Container)
+            {
+                Container.SizeHeight = 0;
+                Container.Position = new Position(0.0f, 0.0f);
+                Container = null;
+            }
             ItemsView = null;
-            Container = null;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
@@ -338,6 +338,19 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Clear all remaining caches.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual void ClearCache()
+        {
+            foreach (RecyclerViewItem item in RecycleCache)
+            {
+                Utility.Dispose(item);
+            }
+            RecycleCache.Clear();
+        }
+
+        /// <summary>
         /// On scroll event callback.
         /// </summary>        
         /// <since_tizen> 9 </since_tizen>
@@ -368,11 +381,7 @@ namespace Tizen.NUI.Components
                 // call the clear!
                 if (RecycleCache != null)
                 {
-                    foreach (RecyclerViewItem item in RecycleCache)
-                    {
-                        UnrealizeItem(item, false);
-                    }
-                    RecycleCache.Clear();
+                    ClearCache();
                 }
                 InternalItemsLayouter?.Clear();
                 InternalItemsLayouter = null;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
