### PR TITLE
[NUI] Change the type of Consumed property for GestureInfo

### DIFF
--- a/src/Tizen.NUI/src/internal/Accessibility/AccessibilityDoGestureSignal.cs
+++ b/src/Tizen.NUI/src/internal/Accessibility/AccessibilityDoGestureSignal.cs
@@ -43,15 +43,15 @@ namespace Tizen.NUI
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        static internal int GetResult(global::System.IntPtr data)
+        static internal bool GetResult(global::System.IntPtr data)
         {
-            int ret = Interop.DoGestureSignal.GetResult(data);
+            bool ret = Interop.DoGestureSignal.GetResult(data);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        static internal void SetResult(global::System.IntPtr data, int res)
+        static internal void SetResult(global::System.IntPtr data, bool res)
         {
             Interop.DoGestureSignal.SetResult(data, res);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DoGestureSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DoGestureSignal.cs
@@ -49,10 +49,10 @@ namespace Tizen.NUI
             public static extern uint GetSizeOfGestureInfo();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_GetResult")]
-            public static extern int GetResult(global::System.IntPtr jarg1);
+            public static extern bool GetResult(global::System.IntPtr jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Signal_GesturePairToVoid_SetResult")]
-            public static extern void SetResult(global::System.IntPtr jarg1, int result);
+            public static extern void SetResult(global::System.IntPtr jarg1, bool result);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -161,7 +161,7 @@ namespace Tizen.NUI.BaseComponents
         /// True if the event is consumed.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public int Consumed { get; set; }
+        public bool Consumed { get; set; }
     }
 
     /// <summary>
@@ -256,7 +256,7 @@ namespace Tizen.NUI.BaseComponents
             };
             gestureInfoHandler?.Invoke(this, arg);
 
-            AccessibilityDoGestureSignal.SetResult(data, Convert.ToInt32(arg.Consumed));
+            AccessibilityDoGestureSignal.SetResult(data, arg.Consumed);
         }
 
         /// <summary>


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- In dali, the property is originally bool type.
- So, `Consumed` property should be bool value, just same as dali.
 Changed the type and its binding.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/259004

### API Changes ###
- N/A