### PR TITLE
[NUI][Xaml] Fix issue that BindingContext can't be used in C# code

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1021,6 +1021,8 @@ namespace Tizen.NUI.BaseComponents
                 };
                 ChildRemoved(this, e);
             }
+
+            RemoveChildBindableObject(child);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -166,7 +166,7 @@ namespace Tizen.NUI.BaseComponents
                     };
                     ChildAdded(this, e);
                 }
-                BindableObject.SetInheritedBindingContext(child, this?.BindingContext);
+                this.AddChildBindableObject(child);
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

1. Fix issue that BindingContext can't effect the child of child.
2. Fix issue that BindingContext can't effect the binding which setted by C# code.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
