### PR TITLE
[NUI] Set Notification Window transparent

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Notification.cs
+++ b/src/Tizen.NUI.Components/Controls/Notification.cs
@@ -119,6 +119,7 @@ namespace Tizen.NUI.Components
                     notificationWindow = new Window(null, true)
                     {
                         Type = WindowType.Notification,
+                        BackgroundColor = Color.Transparent,
                     };
                     notificationWindow.Show();
                 }


### PR DESCRIPTION
Notification creates its own Window.
Not to cover the existing view behind Notification Window, Notification
Window's BackgroundColor is set to be transparent.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
