### PR TITLE
[NUI] Add NeedGesturePropagation

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1324,6 +1324,10 @@ namespace Tizen.NUI.Components
         private void OnPanGestureDetected(object source, PanGestureDetector.DetectedEventArgs e)
         {
             OnPanGesture(e.PanGesture);
+            if(!((SnapToPage && scrollAnimation != null && scrollAnimation.State == Animation.States.Playing) || e.PanGesture.State == Gesture.StateType.Started))
+            {
+                e.Handled = !((int)finalTargetPosition == 0 || -(int)finalTargetPosition == (int)maxScrollDistance);
+            }
         }
 
         private void OnPanGesture(PanGesture panGesture)
@@ -1370,6 +1374,7 @@ namespace Tizen.NUI.Components
                     DragOverShootingShadow(totalDisplacementForPan, panGesture.Displacement.Y);
                 }
                 Debug.WriteLineIf(LayoutDebugScrollableBase, "OnPanGestureDetected Continue totalDisplacementForPan:" + totalDisplacementForPan);
+
             }
             else if (panGesture.State == Gesture.StateType.Finished || panGesture.State == Gesture.StateType.Cancelled)
             {

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
@@ -140,6 +140,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetSuggestedMinimumHeight")]
             public static extern float GetSuggestedMinimumHeight(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetNeedGesturePropagation")]
+            public static extern float SetNeedGesturePropagation(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
@@ -241,6 +241,7 @@ namespace Tizen.NUI
         {
             private View view;
             private LongPressGesture longPressGesture;
+            private bool handled = true;
 
             /// <summary>
             /// View the attached view.
@@ -275,6 +276,22 @@ namespace Tizen.NUI
                 set
                 {
                     longPressGesture = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a value that indicates whether the event handler has completely handled the event or whether the system should continue its own processing.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool Handled
+            {
+                get => handled;
+                set
+                {
+                    handled = value;
+                    Interop.Actor.SetNeedGesturePropagation(View.getCPtr(view), !value);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending)
+                        throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -565,6 +565,7 @@ namespace Tizen.NUI
         {
             private View view;
             private PanGesture panGesture;
+            private bool handled = true;
 
             /// <summary>
             /// The attached view.
@@ -599,6 +600,22 @@ namespace Tizen.NUI
                 set
                 {
                     panGesture = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a value that indicates whether the event handler has completely handled the event or whether the system should continue its own processing.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool Handled
+            {
+                get => handled;
+                set
+                {
+                    handled = value;
+                    Interop.Actor.SetNeedGesturePropagation(View.getCPtr(view), !value);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending)
+                        throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
@@ -163,6 +163,7 @@ namespace Tizen.NUI
         {
             private View view;
             private PinchGesture pinchGesture;
+            private bool handled = true;
 
             /// <summary>
             /// The attached view.
@@ -197,6 +198,22 @@ namespace Tizen.NUI
                 set
                 {
                     pinchGesture = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a value that indicates whether the event handler has completely handled the event or whether the system should continue its own processing.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool Handled
+            {
+                get => handled;
+                set
+                {
+                    handled = value;
+                    Interop.Actor.SetNeedGesturePropagation(View.getCPtr(view), !value);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending)
+                        throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
@@ -163,6 +163,7 @@ namespace Tizen.NUI
         {
             private View view;
             private RotationGesture rotationGesture;
+            private bool handled = true;
 
             /// <summary>
             /// The attached view.
@@ -197,6 +198,22 @@ namespace Tizen.NUI
                 set
                 {
                     rotationGesture = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a value that indicates whether the event handler has completely handled the event or whether the system should continue its own processing.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool Handled
+            {
+                get => handled;
+                set
+                {
+                    handled = value;
+                    Interop.Actor.SetNeedGesturePropagation(View.getCPtr(view), !value);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending)
+                        throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
@@ -214,6 +214,7 @@ namespace Tizen.NUI
 
             if (_detectedEventHandler != null)
             {
+                e.Handled = true;
                 //here we send all data to user event handlers
                 _detectedEventHandler(this, e);
             }
@@ -229,6 +230,7 @@ namespace Tizen.NUI
         {
             private View _view;
             private TapGesture _tapGesture;
+            private bool handled = true;
 
             /// <summary>
             /// The attached view.
@@ -263,6 +265,22 @@ namespace Tizen.NUI
                 set
                 {
                     _tapGesture = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a value that indicates whether the event handler has completely handled the event or whether the system should continue its own processing.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool Handled
+            {
+                get => handled;
+                set
+                {
+                    handled = value;
+                    Interop.Actor.SetNeedGesturePropagation(View.getCPtr(_view), !value);
+                    if (NDalicPINVOKE.SWIGPendingException.Pending)
+                        throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }


### PR DESCRIPTION
This is used when the parent view wants to listen to gesture events.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
