### PR TITLE
[NUI][AT-SPI] Bindings for ScrollToChild

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -840,6 +840,28 @@ namespace Tizen.NUI.Components
             }
         }
 
+
+        /// <summary>
+        /// Scroll to specified item
+        /// </summary>
+        /// <remarks>
+        /// Make sure that the item that is about to receive the accessibility highlight is visible.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override bool AccessibilityScrollToChild(View child)
+        {
+            foreach (RecyclerViewItem item in ContentContainer.Children.Where((item) => item is RecyclerViewItem))
+            {
+                if (child == item)
+                {
+                    ScrollToIndex(item.Index);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         // Realize and Decorate the item.
         internal override RecyclerViewItem RealizeItem(int index)
         {

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -319,6 +319,11 @@ namespace Tizen.NUI
                 public delegate bool AccessibilityDeleteText(int startPosition, int endPosition);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityDeleteText DeleteText; // 26
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityScrollToChild(IntPtr child);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityScrollToChild ScrollToChild; // 27
             }
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityConstructor_NUI")]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -504,6 +504,12 @@ namespace Tizen.NUI.BaseComponents
                     InsertText = (startPosition, text) => AccessibilityInsertText(startPosition, Marshal.PtrToStringAnsi(text)),
                     SetTextContents = (newContents) => AccessibilitySetTextContents(Marshal.PtrToStringAnsi(newContents)),
                     DeleteText = (startPosition, endPosition) => AccessibilityDeleteText(startPosition, endPosition),
+                    ScrollToChild = (child) => {
+                        using (var view = new View(child,  true))
+                        {
+                            return AccessibilityScrollToChild(view);
+                        }
+                    },
                 };
 
                 accessibilityDelegatePtr = Marshal.AllocHGlobal(size);
@@ -744,6 +750,12 @@ namespace Tizen.NUI.BaseComponents
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual bool AccessibilityDeleteText(int startPosition, int endPosition)
+        {
+            return false;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual bool AccessibilityScrollToChild(View child)
         {
             return false;
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

`ScrollToChild()` is used by `GrabHighlight()` to ensure that the item to be highlighted is visible on the screen (if it is inside a scrollable container). An override for `CollectionView` is also provided.

Dependencies:
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/255698/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/255699/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
