### PR TITLE
[NUI] Fix to require Layout to fit to children or fill to parent

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -247,7 +247,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the width resize policy to be used.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Deprecated. Please use Tizen.NUI.View.WidthSpecification instead.")]
+        [Obsolete("Deprecated. Please set Tizen.NUI.View.Layout and use Tizen.NUI.View.WidthSpecification instead.")]
         public ResizePolicyType? WidthResizePolicy
         {
             get => (ResizePolicyType?)GetValue(WidthResizePolicyProperty);
@@ -258,7 +258,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the height resize policy to be used.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Deprecated. Please use Tizen.NUI.View.HeightSpecification instead.")]
+        [Obsolete("Deprecated. Please set Tizen.NUI.View.Layout and use Tizen.NUI.View.HeightSpecification instead.")]
         public ResizePolicyType? HeightResizePolicy
         {
             get => (ResizePolicyType?)GetValue(HeightResizePolicyProperty);

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1705,7 +1705,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the width resize policy to be used.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated. Please use WidthSpecification instead.")]
+        [Obsolete("Deprecated. Please set Layout and use WidthSpecification instead.")]
         public ResizePolicyType WidthResizePolicy
         {
             get
@@ -1723,7 +1723,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the height resize policy to be used.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated. Please use HeightSpecification instead.")]
+        [Obsolete("Deprecated. Please set Layout and use HeightSpecification instead.")]
         public ResizePolicyType HeightResizePolicy
         {
             get
@@ -2160,19 +2160,6 @@ namespace Tizen.NUI.BaseComponents
                         Size2D = new Size2D(widthPolicy, heightPolicy);
                     }
                 }
-                else
-                {
-                    if (value == LayoutParamPolicies.MatchParent)
-                    {
-                        SetValue(WidthResizePolicyProperty, ResizePolicyType.FillToParent);
-                        NotifyPropertyChanged();
-                    }
-                    else if (value == LayoutParamPolicies.WrapContent)
-                    {
-                        SetValue(WidthResizePolicyProperty, ResizePolicyType.FitToChildren);
-                        NotifyPropertyChanged();
-                    }
-                }
                 layout?.RequestLayout();
             }
         }
@@ -2214,19 +2201,6 @@ namespace Tizen.NUI.BaseComponents
                     {
                         // Create Size2D only both _widthPolicy and _heightPolicy are set.
                         Size2D = new Size2D(widthPolicy, heightPolicy);
-                    }
-                }
-                else
-                {
-                    if (value == LayoutParamPolicies.MatchParent)
-                    {
-                        SetValue(HeightResizePolicyProperty, ResizePolicyType.FillToParent);
-                        NotifyPropertyChanged();
-                    }
-                    else if (value == LayoutParamPolicies.WrapContent)
-                    {
-                        SetValue(HeightResizePolicyProperty, ResizePolicyType.FitToChildren);
-                        NotifyPropertyChanged();
                     }
                 }
                 layout?.RequestLayout();

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -136,7 +136,7 @@ namespace Tizen.NUI
     /// Enumeration for size negotiation resize policies.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    [Obsolete("Deprecated. Please use Tizen.NUI.BaseComponents.LayoutParamPolicies instead.")]
+    [Obsolete("Deprecated. Please set Tizen.NUI.View.Layout and use Tizen.NUI.BaseComponents.LayoutParamPolicies instead.")]
     public enum ResizePolicyType
     {
         /// <summary>
@@ -156,7 +156,7 @@ namespace Tizen.NUI
         /// Size is to fill up to the actor's parent's bounds. Aspect ratio is not maintained.
         /// </summary>
         [Description("FILL_TO_PARENT")]
-        [Obsolete("Deprecated. Instead, please set Tizen.NUI.BaseComponents.LayoutParamPolicies.MatchParent to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
+        [Obsolete("Deprecated. Instead, please set Tizen.NUI.View.Layout and also set Tizen.NUI.BaseComponents.LayoutParamPolicies.MatchParent to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
         FillToParent,
         /// <summary>
         /// The actors size will be ( ParentSize * SizeRelativeToParentFactor ).
@@ -174,7 +174,7 @@ namespace Tizen.NUI
         /// The size will adjust to wrap around all children.
         /// </summary>
         [Description("FIT_TO_CHILDREN")]
-        [Obsolete("Deprecated. Instead, please set Tizen.NUI.BaseComponents.LayoutParamPolicies.WrapContent to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
+        [Obsolete("Deprecated. Instead, please set Tizen.NUI.View.Layout and also set Tizen.NUI.BaseComponents.LayoutParamPolicies.WrapContent to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
         FitToChildren,
         /// <summary>
         /// One dimension is dependent on the other.


### PR DESCRIPTION
This patch is necessary to the following patch.
"[NUI] Deprecate ResizePolicyType"

It is impossible that LayoutParamPolicies.WrapContent supports both
ResizePolicyType.UseNaturalSize and FitToChildren.

Therefore, LayoutParamPolicies.WrapContent does not support
ResizePolicyType.UseNaturalSize nor FitToChildren.
Instead, LayoutParamPolicies.WrapContent makes View fit to its children
only if the View sets its Layout.

In the same way, LayoutParamPolicies.MatchParent does not support
ResizePolicyType.FillToParent.
Instead, LayoutParamPolicies.MatchParent makes View fill to its parent
only if the View sets its Layout.

If View uses LayoutParamPolicies.WrapContent or MatchParent while it
does not set its Layout, then the View does not fit to its children nor
fill to its parent.
Instead, ResizePolicyType.UseNaturalSize is supported by default.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
