### PR TITLE
[NUI] Add SpaceEvenly to FlexJustification

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -451,7 +451,7 @@ namespace Tizen.NUI
             get => (FlexJustification)Interop.FlexLayout.GetFlexJustification(swigCPtr);
             set
             {
-                if (value < FlexJustification.FlexStart || value > FlexJustification.SpaceAround)
+                if (value < FlexJustification.FlexStart || value > FlexJustification.SpaceEvenly)
                     throw new InvalidEnumArgumentException(nameof(Justification));
 
                 Interop.FlexLayout.SetFlexJustification(swigCPtr, (int)value);
@@ -570,11 +570,15 @@ namespace Tizen.NUI
             /// </summary>
             SpaceBetween,
             /// <summary>
-            /// Items are positioned with equal space before, between, and after the lines.<br/>
-            /// Compared to <see cref="FlexJustification.SpaceBetween"/> using <see cref="FlexJustification.SpaceAround"/>
-            /// will result in space being distributed to the beginning of the first child and end of the last child.
+            /// Items are positioned with equal space before, and after the lines.<br/>
             /// </summary>
-            SpaceAround
+            SpaceAround,
+            /// <summary>
+            /// Items are positioned with equal space before, between, and after the lines.<br/>
+            /// Spaces are distributed equally to the beginning of the first child, between each child, and the end of the last child.
+            /// </summary>
+            /// <since_tizen> 9 </since_tizen>
+            SpaceEvenly
         }
 
         /// <summary>


### PR DESCRIPTION
SpaceAround distributes the equal space to before, and after each item.
Therefore, the space between adjacent items is twice bigger than the
space between the beginning edge and the first item.

To distribute the equal space to before, between, and after each item,
SpaceEvenly is added to FlexJustification.

Requires:
https://review.tizen.org/gerrit/259252/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: TCSACR-426
https://code.sec.samsung.net/jira/browse/TCSACR-426

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
