### PR TITLE
[NUI] Set AlertDialog's LinearLayout center aligned

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -481,6 +481,7 @@ namespace Tizen.NUI.Components
             Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Vertical,
+                LinearAlignment = LinearLayout.Alignment.CenterHorizontal,
             };
 
             this.Relayout += OnRelayout;


### PR DESCRIPTION
To show AlertDialog's Content at the center of AlertDialog,
AlertDialog's LinearLayout is center aligned.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
