### PR TITLE
[NUI] Add Page's Appeared and Disappeared events

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -164,6 +164,10 @@ namespace Tizen.NUI.Components
             transitionSet.Finished += (object sender, EventArgs e) =>
             {
                 topPage.SetVisible(false);
+
+                //Invoke Page events
+                page.InvokeAppeared();
+                topPage.InvokeDisappeared();
             };
             transitionFinished = false;
         }
@@ -207,6 +211,10 @@ namespace Tizen.NUI.Components
             {
                 Remove(topPage);
                 topPage.SetVisible(true);
+
+                //Invoke Page events
+                newTopPage.InvokeAppeared();
+                topPage.InvokeDisappeared();
             };
             transitionFinished = false;
 
@@ -263,6 +271,9 @@ namespace Tizen.NUI.Components
                 curAnimation.Finished += (object sender, EventArgs args) =>
                 {
                     curTop.SetVisible(false);
+
+                    //Invoke Page events
+                    curTop.InvokeDisappeared();
                 };
                 curAnimation.Play();
 
@@ -271,6 +282,11 @@ namespace Tizen.NUI.Components
                 newAnimation = new Animation(1000);
                 newAnimation.AnimateTo(page, "Opacity", 1.0f, 0, 1000);
                 newAnimation.EndAction = Animation.EndActions.StopFinal;
+                newAnimation.Finished += (object sender, EventArgs e) =>
+                {
+                    //Invoke Page events
+                    page.InvokeAppeared();
+                };
                 newAnimation.Play();
             }
         }
@@ -321,6 +337,9 @@ namespace Tizen.NUI.Components
                     //Removes the current top page after transition is finished.
                     Remove(curTop);
                     curTop.Opacity = 1.0f;
+
+                    //Invoke Page events
+                    curTop.InvokeDisappeared();
                 };
                 curAnimation.Play();
 
@@ -329,6 +348,11 @@ namespace Tizen.NUI.Components
                 newAnimation = new Animation(1000);
                 newAnimation.AnimateTo(newTop, "Opacity", 1.0f, 0, 1000);
                 newAnimation.EndAction = Animation.EndActions.StopFinal;
+                newAnimation.Finished += (object sender, EventArgs e) =>
+                {
+                    //Invoke Page events
+                    newTop.InvokeAppeared();
+                };
                 newAnimation.Play();
             }
             else

--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -36,6 +36,22 @@ namespace Tizen.NUI.Components
     }
 
     /// <summary>
+    /// PageAppearedEventArgs is a class to record page appeared event arguments which will be sent to user.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class PageAppearedEventArgs : EventArgs
+    {
+    }
+
+    /// <summary>
+    /// PageDisappearedEventArgs is a class to record page disappeared event arguments which will be sent to user.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class PageDisappearedEventArgs : EventArgs
+    {
+    }
+
+    /// <summary>
     /// The Page class is a class which is an element of navigation.
     /// </summary>
     /// <since_tizen> 9 </since_tizen>
@@ -85,6 +101,18 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<PageDisappearingEventArgs> Disappearing;
 
+        /// <summary>
+        /// An event for the page appeared signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<PageAppearedEventArgs> Appeared;
+
+        /// <summary>
+        /// An event for the page disappeared signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<PageDisappearedEventArgs> Disappeared;
+
         internal void InvokeAppearing()
         {
             Appearing?.Invoke(this, new PageAppearingEventArgs());
@@ -93,6 +121,16 @@ namespace Tizen.NUI.Components
         internal void InvokeDisappearing()
         {
             Disappearing?.Invoke(this, new PageDisappearingEventArgs());
+        }
+
+        internal void InvokeAppeared()
+        {
+            Appeared?.Invoke(this, new PageAppearedEventArgs());
+        }
+
+        internal void InvokeDisappeared()
+        {
+            Disappeared?.Invoke(this, new PageDisappearedEventArgs());
         }
     }
 }


### PR DESCRIPTION
Page's Appeared event is invoked when the Navigator's animation is
finished and the page becomes visible.

Page's Disappeared event is invoked when the Navigator's animation is
finished and the page becomes invisible.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
