### PR TITLE
[NUI] Remove unused property of Transition

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItem.cs
@@ -38,9 +38,6 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Transition_Assign")]
             public static extern IntPtr Assign(HandleRef destination, HandleRef source);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Transition_ShowSourceAfterFinished")]
-            public static extern void ShowSourceAfterFinished(HandleRef transition, bool showSourceAfterFinished);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItemBase.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TransitionItemBase.cs
@@ -39,20 +39,11 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_Assign")]
             public static extern IntPtr Assign(HandleRef destination, HandleRef source);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetDuration")]
-            public static extern void SetDuration(HandleRef transition, float seconds);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_GetDuration")]
-            public static extern float GetDuration(HandleRef transition);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetDelay")]
-            public static extern void SetDelay(HandleRef transition, float seconds);
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_GetDelay")]
-            public static extern float GetDelay(HandleRef transition);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetTimePeriod")]
             public static extern void SetTimePeriod(HandleRef transition, HandleRef seconds);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_GetTimePeriod")]
+            public static extern IntPtr GetTimePeriod(HandleRef transition);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TransitionBase_SetAlphaFunction")]
             public static extern void SetAlphaFunction(HandleRef transition, HandleRef seconds);

--- a/src/Tizen.NUI/src/internal/Transition/TransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionItem.cs
@@ -42,18 +42,6 @@ namespace Tizen.NUI
         {
         }
 
-        /// <summary>
-        /// Sets the source View will be shown after transition finished.
-        /// </summary>
-        public bool ShowSourceAfterFinished
-        {
-            set
-            {
-                Interop.TransitionItem.ShowSourceAfterFinished(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-        }
-
         internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TransitionItem obj)
         {
             return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;

--- a/src/Tizen.NUI/src/internal/Transition/TransitionItemBase.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionItemBase.cs
@@ -37,42 +37,6 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Gets or sets the duration in milliseconds of the transition.
-        /// </summary>
-        public int Duration
-        {
-            set
-            {
-                Interop.TransitionItemBase.SetDuration(SwigCPtr, MilliSecondsToSeconds(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-            get
-            {
-                float ret = Interop.TransitionItemBase.GetDuration(SwigCPtr);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return SecondsToMilliSeconds(ret);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the delay in milliseconds of the transition.
-        /// </summary>
-        public int Delay
-        {
-            set
-            {
-                Interop.TransitionItemBase.SetDelay(SwigCPtr, MilliSecondsToSeconds(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-            get
-            {
-                float ret = Interop.TransitionItemBase.GetDelay(SwigCPtr);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return SecondsToMilliSeconds(ret);
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the TimePeriod
         /// </summary>
         public TimePeriod TimePeriod
@@ -81,6 +45,12 @@ namespace Tizen.NUI
             {
                 Interop.TransitionItemBase.SetTimePeriod(SwigCPtr, value.SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            get
+            {
+                TimePeriod ret = new TimePeriod(Interop.TransitionItemBase.GetTimePeriod(SwigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
             }
         }
 


### PR DESCRIPTION
Some internal properties of Transition are not used.
This patch remove the unused property

Signed-off-by: Seungho Baek <sbsh.baek@samsung.com>