### PR TITLE
[NUI] Fix RelativeLayout's descendant size and position calculations

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -354,7 +354,12 @@ namespace Tizen.NUI
                     {
                         needToMeasure = true;
                     }
-                    else
+                    // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
+                    // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
+                    // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
+                    //
+                    // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
+                    else if (Owner.HeightSpecification == LayoutParamPolicies.WrapContent)
                     {
                         if (childDesiredHeight == LayoutParamPolicies.MatchParent)
                         {
@@ -378,7 +383,12 @@ namespace Tizen.NUI
                             widthMeasureSpec.SetSize(new LayoutLength((int)(remainingWidth / childrenMatchParentCount) + Padding.Start + Padding.End));
                             needToMeasure = true;
                         }
-                        else
+                        // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
+                        // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
+                        // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
+                        //
+                        // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
+                        else if (Owner.WidthSpecification == LayoutParamPolicies.WrapContent)
                         {
                             if (childDesiredWidth == LayoutParamPolicies.MatchParent)
                             {
@@ -432,7 +442,12 @@ namespace Tizen.NUI
                                                  widthMeasureSpec, heightMeasureSpec, childState,
                                                  Orientation.Horizontal);
                         }
-                        else
+                        // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
+                        // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
+                        // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
+                        //
+                        // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
+                        else if (Owner.WidthSpecification == LayoutParamPolicies.WrapContent)
                         {
                             if (childDesiredWidth == LayoutParamPolicies.MatchParent)
                             {
@@ -572,7 +587,12 @@ namespace Tizen.NUI
                     {
                         needToMeasure = true;
                     }
-                    else
+                    // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
+                    // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
+                    // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
+                    //
+                    // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
+                    else if (Owner.WidthSpecification == LayoutParamPolicies.WrapContent)
                     {
                         if (childDesiredWidth == LayoutParamPolicies.MatchParent)
                         {
@@ -596,7 +616,12 @@ namespace Tizen.NUI
                             heightMeasureSpec.SetSize(new LayoutLength((int)(remainingHeight / childrenMatchParentCount) + Padding.Top + Padding.Bottom));
                             needToMeasure = true;
                         }
-                        else
+                        // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
+                        // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
+                        // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
+                        //
+                        // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
+                        else if (Owner.HeightSpecification == LayoutParamPolicies.WrapContent)
                         {
                             if (childDesiredHeight == LayoutParamPolicies.MatchParent)
                             {
@@ -650,7 +675,12 @@ namespace Tizen.NUI
                                                  widthMeasureSpec, heightMeasureSpec, childState,
                                                  Orientation.Vertical);
                         }
-                        else
+                        // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
+                        // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
+                        // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
+                        //
+                        // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
+                        else if (Owner.HeightSpecification == LayoutParamPolicies.WrapContent)
                         {
                             if (childDesiredHeight == LayoutParamPolicies.MatchParent)
                             {


### PR DESCRIPTION
Previously, 2 descendant sizes and positions calculation problems
exitsted on RelativeLayout as follows.

1. MatchParent grand children's sizes and positions were not calculated.
 - RelativeLayout set its children's sizes and positions but it did not
   set its children's MeasuredWidth/Height.
 - If children's MeasuredWidth/Height are not set, then the MatchParent
   grand children's sizes and positions are not calculated.

2. MatchParent children's sizes fill to the RelativeLayout by default.
 - MatchParent children's sizes should not fill to the RelativeLayout by
   default because children's sizes and positions should be calculated
   by RelativeLayout's APIs.

Now, the above problems have been fixed as follows.

1. RelativeLayout sets its children's MeasuredWidth/Height, so its
   MatchParent grand children's sizes and positions are calculated
   correctly.

2. MatchParent children's sizes are calculated by RelativeLayout's APIs.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
