### PR TITLE
[NUI] Fix implicit dispose exception defect

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1144,14 +1144,17 @@ namespace Tizen.NUI.BaseComponents
             //Release your own unmanaged resources here.
             //You should not access any managed member here except static instance.
             //because the execution order of Finalizes is non-deterministic.
-            if (this != null)
+
+            // equivalent to "if (this != null)". more clear to understand.
+            if (this.HasBody())
             {
                 DisConnectFromSignals();
-            }
 
-            foreach (View view in Children)
-            {
-                view.InternalParent = null;
+                foreach (View view in Children)
+                {
+                    view.InternalParent = null;
+                }
+
             }
 
             base.Dispose(type);


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix implicit dispose exception defect

- when implicit dispose is done by DisposeQueue, the view which has empty body of dali gives exception.
- the "in Children" => this.Children give null reference exception.

### API Changes ###
none