### PR TITLE
[NUI] Fix wrong name

### DIFF
--- a/src/Tizen.NUI/src/internal/XamlBinding/NUIConstantExtension.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/NUIConstantExtension.cs
@@ -80,6 +80,7 @@ namespace Tizen.NUI.Binding
             { "ImageVisualProperty.AuxiliaryImageAlpha", ImageVisualProperty.AuxiliaryImageAlpha },
             // MeshVisualProperty
             { "MeshVisualProperty.ObjectURL", MeshVisualProperty.ObjectURL },
+            { "MeshVisualProperty.MaterialURL", MeshVisualProperty.MaterialURL },
             { "MeshVisualProperty.MaterialtURL", MeshVisualProperty.MaterialtURL },
             { "MeshVisualProperty.TexturesPath", MeshVisualProperty.TexturesPath },
             { "MeshVisualProperty.ShadingMode", MeshVisualProperty.ShadingMode },

--- a/src/Tizen.NUI/src/public/Visuals/MeshVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/MeshVisual.cs
@@ -15,6 +15,8 @@
  *
  */
 
+using System.ComponentModel;
+
 namespace Tizen.NUI
 {
     /// <summary>
@@ -23,13 +25,13 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class MeshVisual : VisualMap
     {
-        private string _objectURL = null;
-        private string _materialtURL = null;
-        private string _texturesPath = null;
-        private MeshVisualShadingModeValue? _shadingMode = null;
-        private bool? _useMipmapping = null;
-        private bool? _useSoftNormals = null;
-        private Vector3 _lightPosition = null;
+        private string objectURL = null;
+        private string materialURL = null;
+        private string texturesPath = null;
+        private MeshVisualShadingModeValue? shadingMode = null;
+        private bool? useMipmapping = null;
+        private bool? useSoftNormals = null;
+        private Vector3 lightPosition = null;
 
         /// <summary>
         /// Constructor.
@@ -48,11 +50,30 @@ namespace Tizen.NUI
         {
             get
             {
-                return _objectURL;
+                return objectURL;
             }
             set
             {
-                _objectURL = value;
+                objectURL = value;
+                UpdateVisual();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the location of the ".mtl" file.<br />
+        /// If not specified, then a textureless object is assumed.<br />
+        /// Optional.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string MaterialURL
+        {
+            get
+            {
+                return materialURL;
+            }
+            set
+            {
+                materialURL = value;
                 UpdateVisual();
             }
         }
@@ -67,11 +88,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return _materialtURL;
+                return materialURL;
             }
             set
             {
-                _materialtURL = value;
+                materialURL = value;
                 UpdateVisual();
             }
         }
@@ -85,11 +106,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return _texturesPath;
+                return texturesPath;
             }
             set
             {
-                _texturesPath = value;
+                texturesPath = value;
                 UpdateVisual();
             }
         }
@@ -105,11 +126,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return _shadingMode ?? (MeshVisualShadingModeValue.TexturedWithDetailedSpecularLighting);
+                return shadingMode ?? (MeshVisualShadingModeValue.TexturedWithDetailedSpecularLighting);
             }
             set
             {
-                _shadingMode = value;
+                shadingMode = value;
                 UpdateVisual();
             }
         }
@@ -124,11 +145,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return _useMipmapping ?? (true);
+                return useMipmapping ?? (true);
             }
             set
             {
-                _useMipmapping = value;
+                useMipmapping = value;
                 UpdateVisual();
             }
         }
@@ -143,11 +164,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return _useSoftNormals ?? (true);
+                return useSoftNormals ?? (true);
             }
             set
             {
-                _useSoftNormals = value;
+                useSoftNormals = value;
                 UpdateVisual();
             }
         }
@@ -164,11 +185,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return _lightPosition;
+                return lightPosition;
             }
             set
             {
-                _lightPosition = value;
+                lightPosition = value;
                 UpdateVisual();
             }
         }
@@ -179,44 +200,44 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         protected override void ComposingPropertyMap()
         {
-            if (_objectURL != null)
+            if (objectURL != null)
             {
                 _outputVisualMap = new PropertyMap();
                 PropertyValue temp = new PropertyValue((int)Visual.Type.Mesh);
                 _outputVisualMap.Add(Visual.Property.Type, temp);
                 temp.Dispose();
 
-                temp = new PropertyValue(_objectURL);
+                temp = new PropertyValue(objectURL);
                 _outputVisualMap.Add(MeshVisualProperty.ObjectURL, temp);
                 temp.Dispose();
 
-                if (_materialtURL != null)
+                if (materialURL != null)
                 {
-                    temp = new PropertyValue(_materialtURL);
+                    temp = new PropertyValue(materialURL);
                     _outputVisualMap.Add(MeshVisualProperty.MaterialtURL, temp);
                     temp.Dispose();
                 }
-                if (_texturesPath != null)
+                if (texturesPath != null)
                 {
-                    temp = new PropertyValue(_texturesPath);
+                    temp = new PropertyValue(texturesPath);
                     _outputVisualMap.Add(MeshVisualProperty.TexturesPath, temp);
                     temp.Dispose();
                 }
-                if (_shadingMode != null)
+                if (shadingMode != null)
                 {
-                    temp = new PropertyValue((int)_shadingMode);
+                    temp = new PropertyValue((int)shadingMode);
                     _outputVisualMap.Add(MeshVisualProperty.ShadingMode, temp);
                     temp.Dispose();
                 }
-                if (_useMipmapping != null)
+                if (useMipmapping != null)
                 {
-                    temp = new PropertyValue((bool)_useMipmapping);
+                    temp = new PropertyValue((bool)useMipmapping);
                     _outputVisualMap.Add(MeshVisualProperty.UseMipmapping, temp);
                     temp.Dispose();
                 }
-                if (_useSoftNormals != null)
+                if (useSoftNormals != null)
                 {
-                    temp = new PropertyValue((bool)_useSoftNormals);
+                    temp = new PropertyValue((bool)useSoftNormals);
                     _outputVisualMap.Add(MeshVisualProperty.UseSoftNormals, temp);
                     temp.Dispose();
                 }

--- a/src/Tizen.NUI/src/public/Visuals/PrimitiveVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/PrimitiveVisual.cs
@@ -85,7 +85,7 @@ namespace Tizen.NUI
 
         /// <summary>
         /// Gets or sets the number of slices as you go around the shape.<br />
-        /// For spheres and conical frustrums, this determines how many divisions there are as you go around the object.<br />
+        /// For spheres and conical frustums, this determines how many divisions there are as you go around the object.<br />
         /// If not specified, the default is 128.<br />
         /// The range is from 1 to 255.<br />
         /// Optional.
@@ -126,7 +126,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Gets or sets the scale of the radius of the top circle of a conical frustrum.<br />
+        /// Gets or sets the scale of the radius of the top circle of a conical frustum.<br />
         /// If not specified, the default is 1.0f.<br />
         /// Applies to: - PrimitiveVisualShapeType.ConicalFrustrum<br />
         /// Only values greater than or equal to 0.0f are accepted.<br />
@@ -147,7 +147,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Gets or sets the scale of the radius of the bottom circle of a conical frustrum.<br />
+        /// Gets or sets the scale of the radius of the bottom circle of a conical frustum.<br />
         /// If not specified, the default is 1.5f.<br />
         /// Applies to:  - PrimitiveVisualShapeType.ConicalFrustrum<br />
         ///              - PrimitiveVisualShapeType.Cone<br />

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -274,15 +274,15 @@ namespace Tizen.NUI
         /// </summary>
         ConicalFrustrum,
         /// <summary>
-        /// Equivalent to a conical frustrum with the top radius of zero.
-        /// </summary>Equivalent to a conical frustrum with the top radius of zero.
+        /// Equivalent to a conical frustum with the top radius of zero.
+        /// </summary>Equivalent to a conical frustum with the top radius of zero.
         Cone,
         /// <summary>
-        /// Equivalent to a conical frustrum with the top radius of zero.
+        /// Equivalent to a conical frustum with the top radius of zero.
         /// </summary>
         Cylinder,
         /// <summary>
-        /// Equivalent to a conical frustrum with equal radii for the top and bottom circles.
+        /// Equivalent to a conical frustum with equal radii for the top and bottom circles.
         /// </summary>
         Cube,
         /// <summary>
@@ -961,6 +961,11 @@ namespace Tizen.NUI
         /// <summary>
         /// The location of the ".mtl" file.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly int MaterialURL = NDalic.MeshVisualMaterialUrl;
+        /// <summary>
+        /// The location of the ".mtl" file.
+        /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public static readonly int MaterialtURL = NDalic.MeshVisualMaterialUrl;
         /// <summary>
@@ -1017,12 +1022,12 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public static readonly int Stacks = NDalic.PrimitiveVisualStacks;
         /// <summary>
-        /// The scale of the radius of the top circle of a conical frustrum.
+        /// The scale of the radius of the top circle of a conical frustum.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public static readonly int ScaleTopRadius = NDalic.PrimitiveVisualScaleTopRadius;
         /// <summary>
-        /// The scale of the radius of the bottom circle of a conical frustrum.
+        /// The scale of the radius of the bottom circle of a conical frustum.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public static readonly int ScaleBottomRadius = NDalic.PrimitiveVisualScaleBottomRadius;


### PR DESCRIPTION
frustrum -> frustum
MaterialtURL -> MaterialURL

We need to change name 'ConicalFrsutrum' and delete 'MaterialtURL'.
but this process is required ACR.
I will upload ACR and change it.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
