### PR TITLE
[NUI] Add source type to TapGesture.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
@@ -62,6 +62,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_localPoint_get")]
             public static extern global::System.IntPtr LocalPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_sourceType_get")]
+            public static extern int SourceTypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Events/TapGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGesture.cs
@@ -87,6 +87,20 @@ namespace Tizen.NUI
             }
         }
 
+        /// <summary>
+        /// The gesture source type of touches property (read-only).
+        /// If you tap with a mouse button, this will tell you which mouse input you tapped.
+        /// Primary(Left), Secondary(Right). Tertiary(Wheel).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public GestureSourceType SourceType
+        {
+            get
+            {
+                return sourceType;
+            }
+        }
+
         private uint numberOfTaps
         {
             set
@@ -149,6 +163,16 @@ namespace Tizen.NUI
             }
         }
 
+        private GestureSourceType sourceType
+        {
+            get
+            {
+                GestureSourceType ret = (GestureSourceType)Interop.TapGesture.SourceTypeGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
         internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TapGesture obj)
         {
             return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
@@ -172,5 +196,33 @@ namespace Tizen.NUI
         {
             Interop.TapGesture.DeleteTapGesture(swigCPtr);
         }
+    }
+
+    /// <summary>
+    /// Gesture source type.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum GestureSourceType
+    {
+        /// <summary>
+        /// invalid data.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Invalid = -1,
+        /// <summary>
+        /// Primary.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Primary = 1,
+        /// <summary>
+        /// Secondary.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Secondary = 3,
+        /// <summary>
+        /// Third (tertiary)
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Tertiary = 2,
     }
 }


### PR DESCRIPTION
This is similar to MouseButton in TouchEvent.

Now, you can see from which input the tap was made.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
