### PR TITLE
[NUI] Add SpaceEvenly to FlexJustification

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -379,7 +379,7 @@ namespace Tizen.NUI
             get => (FlexJustification)Interop.FlexLayout.FlexLayout_GetFlexJustification(swigCPtr);
             set
             {
-                if (value < FlexJustification.FlexStart || value > FlexJustification.SpaceAround)
+                if (value < FlexJustification.FlexStart || value > FlexJustification.SpaceEvenly)
                     throw new InvalidEnumArgumentException(nameof(Justification));
 
                 Interop.FlexLayout.FlexLayout_SetFlexJustification(swigCPtr, (int)value);
@@ -498,11 +498,16 @@ namespace Tizen.NUI
             /// </summary>
             SpaceBetween,
             /// <summary>
+            /// Items are positioned with equal space before, and after the lines.<br/>
+            /// </summary>
+            SpaceAround,
+            /// <summary>
             /// Items are positioned with equal space before, between, and after the lines.<br/>
-            /// Compared to <see cref="FlexJustification.SpaceBetween"/> using <see cref="FlexJustification.SpaceAround"/>
+            /// Compared to <see cref="FlexJustification.SpaceBetween"/> using <see cref="FlexJustification.SpaceEvenly"/>
             /// will result in space being distributed to the beginning of the first child and end of the last child.
             /// </summary>
-            SpaceAround
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            SpaceEvenly
         }
 
         /// <summary>


### PR DESCRIPTION
SpaceAround distributes the equal space to before, and after each item.
Therefore, the space between adjacent items is twice bigger than the
space between the beginning edge and the first item.

To distribute the equal space to before, between, and after each item,
SpaceEvenly is added to FlexJustification.

Requires:
https://review.tizen.org/gerrit/259554/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
