### PR TITLE
[NUI] Add GetHeightForWidth(), GetWidthForHeight()

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -480,7 +480,6 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width to use.</param>
         /// <returns>The height based on the width.</returns>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated in API9, will be removed in API11. Please use HeightForWidth property instead!")]
         public float GetHeightForWidth(float width)
         {
             float ret = Interop.Actor.GetHeightForWidth(SwigCPtr, width);
@@ -497,7 +496,6 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="height">The height to use.</param>
         /// <returns>The width based on the height.</returns>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated in API9, will be removed in API11. Please use WidthForHeight property instead!")]
         public float GetWidthForHeight(float height)
         {
             float ret = Interop.Actor.GetWidthForHeight(SwigCPtr, height);


### PR DESCRIPTION
### Description of Change ###
[NUI] Add Add GetHeightForWidth(), GetWidthForHeight()
 - In https://code.sec.samsung.net/jira/browse/TCSACR-402, the GetHeightForWidth() and GetWidthForHeight() were deprecated, and the ACR had explained that those can be replaced by HeightForWidth and WidthForHeight.
 - But this was wrong, HeightForWidth and WidthForHeight are related to ResizePolicy to determine width and heigh dependency, so that those APIs which have different purpose and behavior can not be replaced.
  Therefore, the deprecated methods , GetHeightForWidth() and GetWidthForHeight(), need be added again. 

### API Changes ###
https://code.sec.samsung.net/jira/browse/TCSACR-428