### PR TITLE
[NUI] Fix flickering buttons in ActionContent of AlertDialog

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -556,6 +556,9 @@ namespace Tizen.NUI.Components
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
                     LinearAlignment = LinearLayout.Alignment.Center,
+                    // FIXME: This CellPadding value should be written in AlertDialogStyle.
+                    //        However, if this is called in other place, then flicking issue happens.
+                    CellPadding = new Size2D(80, 0),
                 },
             };
         }
@@ -607,8 +610,6 @@ namespace Tizen.NUI.Components
                 return;
             }
 
-            CalculateActionsCellPadding();
-
             var size = Size2D;
             var parent = GetParent();
             Size2D parentSize;
@@ -623,59 +624,6 @@ namespace Tizen.NUI.Components
             }
 
             Position2D = new Position2D((parentSize.Width - size.Width) / 2, (parentSize.Height - size.Height) / 2);
-        }
-
-        // Calculate CellPadding among Actions if ActionContent is LinearLayout.
-        private void CalculateActionsCellPadding()
-        {
-            if ((ActionContent != DefaultActionContent) || (ActionContent.Layout is LinearLayout == false))
-            {
-                return;
-            }
-
-            if (Actions == null)
-            {
-                return;
-            }
-
-            var size = Size2D;
-            var layout = ActionContent.Layout as LinearLayout;
-            int count = 0;
-
-            if (layout.LinearOrientation == LinearLayout.Orientation.Horizontal)
-            {
-                int actionsWidth = 0;
-
-                foreach (var action in Actions)
-                {
-                    actionsWidth += ((View)action).Size2D.Width + ((((View)action).Margin?.Start + ((View)action).Margin?.End) ?? 0);
-                    count++;
-                }
-
-                if (count > 1)
-                {
-                    actionsWidth += (Padding?.Start + Padding?.End) ?? 0;
-                    var cellPaddingWidth = (size.Width - actionsWidth) / (count - 1);
-                    layout.CellPadding = new Size2D(cellPaddingWidth , 0);
-                }
-            }
-            else
-            {
-                int actionsHeight = 0;
-
-                foreach (var action in Actions)
-                {
-                    actionsHeight += ((View)action).Size2D.Height + ((((View)action).Margin?.Top + ((View)action).Margin?.Bottom) ?? 0);
-                    count++;
-                }
-
-                if (count > 1)
-                {
-                    actionsHeight += (Padding?.Top + Padding?.Bottom) ?? 0;
-                    var cellPaddingHeight = (size.Height - actionsHeight) / (count - 1);
-                    layout.CellPadding = new Size2D(0, cellPaddingHeight);
-                }
-            }
         }
     }
 }

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -589,7 +589,7 @@ namespace Tizen.NUI.Components
                 BoxShadow = new Shadow(2.0f, new Color("#00000029"), new Vector2(2.0f, 2.0f)),
                 TitleTextLabel = new TextLabelStyle()
                 {
-                    Size = new Size(600, -2),
+                    Size = new Size(720, -2),
                     Margin = new Extents(0, 0, 40, 40),
                     PixelSize = 40,
                     HorizontalAlignment = HorizontalAlignment.Center,
@@ -599,7 +599,7 @@ namespace Tizen.NUI.Components
                 },
                 MessageTextLabel = new TextLabelStyle()
                 {
-                    Size = new Size(600, -2),
+                    Size = new Size(720, -2),
                     Margin = new Extents(0, 0, 0, 64),
                     PixelSize = 32,
                     MultiLine = true,
@@ -610,7 +610,7 @@ namespace Tizen.NUI.Components
                 },
                 ActionContent = new ViewStyle()
                 {
-                    Size = new Size(600, -2),
+                    Size = new Size(720, -2),
                 },
             });
 


### PR DESCRIPTION
The buttons in the ActionContent of AlertDialog are flickering because
the CellPadding of ActionContent's LinearLayout did not set initially.

To resolve this issue, the CellPadding of ActionContent's LinearLayout
is set initially.

However, this should be updated to apply CellPadding from
AlertDialogStyle.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
