### PR TITLE
[NUI] fix property binding error message

### DIFF
--- a/src/Tizen.NUI/src/internal/XamlBinding/BindingExpression.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/BindingExpression.cs
@@ -153,7 +153,7 @@ namespace Tizen.NUI.Binding
                 {
                     if ((needsGetter && part.LastGetter == null) || (needsSetter && part.NextPart == null && part.LastSetter == null))
                     {
-                        Console.WriteLine($"Binding, {PropertyNotFoundErrorMessage}, {part.Content}, {current}, {target.GetType()}, {property.PropertyName}");
+                        Console.WriteLine("Binding, " + PropertyNotFoundErrorMessage, part.Content, current, target.GetType(), property.PropertyName);
                         break;
                     }
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
