### PR TITLE
[NUI] Fix Progress size issue

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -134,6 +134,7 @@ namespace Tizen.NUI.Components
         /// This needs to be considered more if public-open is necessary.
         private ProgressStatusType state = ProgressStatusType.Determinate;
 
+        private Vector2 size = null;
         private const float round = 0.5f;
         private ImageView trackImage = null;
         private ImageView progressImage = null;
@@ -502,6 +503,21 @@ namespace Tizen.NUI.Components
             ChangeImageState(state);
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnRelayout(Vector2 size, RelayoutContainer container)
+        {
+            if (size == null) return;
+
+            if (size.Equals(this.size))
+            {
+                return;
+            }
+
+            this.size = new Vector2(size);
+            UpdateValue();
+        }
+
         /// <summary>
         /// Update progress value
         /// </summary>
@@ -595,7 +611,7 @@ namespace Tizen.NUI.Components
                 {
                     indeterminateImage.Opacity = 0.0f;
                 }
-                bufferImage.Show();
+                bufferImage.Hide();
                 progressImage.Show();
 
                 UpdateValue();
@@ -663,6 +679,7 @@ namespace Tizen.NUI.Components
                     PivotPoint = Tizen.NUI.PivotPoint.TopLeft
                 };
                 Add(bufferImage);
+                bufferImage.Hide(); // At first, buffer image does not show.
             }
         }
 

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -129,8 +129,13 @@ namespace Tizen.NUI.Components
                 Size = new Size(200, 25),
                 Track = new ImageViewStyle()
                 {
-                    ResourceUrl = FrameworkInformation.ResourcePath + "IoT_progressindicator_empty.png",
-                    BackgroundColor = new Color(0, 0, 0, 0.1f),
+                    BorderlineWidth = 0.5f,
+                    BorderlineColor = new Color(0.92f, 0.93f, 0.94f, 1.0f),
+                    BackgroundColor = new Selector<Color>()
+                    {
+                        Normal = new Color(1.0f, 1.0f, 1.0f, 0.5f),
+                        Disabled = new Color(0.73f, 0.76f, 0.79f, 1),
+                    },
                 },
                 Buffer = new ImageViewStyle()
                 {
@@ -138,12 +143,7 @@ namespace Tizen.NUI.Components
                 },
                 Progress = new ImageViewStyle()
                 {
-                    ResourceUrl = new Selector<string>()
-                    {
-                        Normal = FrameworkInformation.ResourcePath + "IoT_progressindicator_progress.png",
-                        Disabled = FrameworkInformation.ResourcePath + "IoT_progressindicator_progressdisabled.png",
-                    },
-                    BackgroundColor = new Color(0.05f, 0.63f, 0.9f, 1),
+                    BackgroundColor = new Color(0.03f, 0.05f, 0.29f, 1),
                 },
                 IndeterminateImageUrl = FrameworkInformation.ResourcePath + "nui_component_default_progress_indeterminate.png",
             });


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- If Progress size is set as relative properties, such as MatchParent or WrapContent,
 the size of progress track is not drawn properly.
- Fixed to get the correct size of progress.
- Updated Progress theme.


### API Changes ###
- N/A
- 