### PR TITLE
[NUI] Add LayoutPolicy, WidthDimension and HeightDimension as hidden API

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2721,5 +2721,83 @@ namespace Tizen.NUI.BaseComponents
                 return transitionOptions;
             }
         }
+
+        /// <summary>
+        /// Layout policy to decide the size of View when the View is laid out in its parent View.
+        /// </summary>
+        ///<remarks>
+        /// Hidden API (Inhouse API) : This API is for internal usage, can be changed at any time.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum LayoutPolicy
+        {
+            /// <summary>
+            /// Indicates child size should match parent size.
+            /// </summary>
+            ///<remarks>
+            /// Hidden API (Inhouse API) : This API is for internal usage, can be changed at any time.
+            /// </remarks>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            MatchParent = -1,
+
+            /// <summary>
+            /// Indicates parent should take the smallest size possible to wrap its children with their desired size.
+            /// </summary>
+            ///<remarks>
+            /// Hidden API (Inhouse API) : This API is for internal usage, can be changed at any time.
+            /// </remarks>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            WrapContent = -2,
+            /// <summary>
+            /// Indicates that the Size is fixed so WidthSpecification or HeightSpecification needs be set a specific value. 
+            /// The WidthSpecification or HeightSpecification value should be positive value or zero which represents a fixed size.
+            /// </summary>
+            ///<remarks>
+            /// Hidden API (Inhouse API) : This API is for internal usage, can be changed at any time.
+            /// </remarks>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            FixedSize = -3,
+        }
+
+        /// <summary>
+        /// The required layout policy for width dimension
+        /// </summary>
+        ///<remarks>
+        /// Hidden API (Inhouse API) : This API is for internal usage, can be changed at any time.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public LayoutPolicy WidthDimension
+        {
+            get
+            {
+                return (LayoutPolicy)GetValue(WidthDimensionProperty);
+            }
+            set
+            {
+                SetValue(WidthDimensionProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The required layout policy for height dimension
+        /// </summary>
+        ///<remarks>
+        /// Hidden API (Inhouse API) : This API is for internal usage, can be changed at any time.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public LayoutPolicy HeightDimension
+        {
+            get
+            {
+                return (LayoutPolicy)GetValue(HeightDimensionProperty);
+            }
+            set
+            {
+                SetValue(HeightDimensionProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1822,6 +1822,80 @@ namespace Tizen.NUI.BaseComponents
             return temp;
         });
 
+        /// <summary>
+        /// WidthDimensionProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty WidthDimensionProperty = BindableProperty.Create(
+            propertyName: nameof(WidthDimension),
+            returnType: typeof(LayoutPolicy),
+            declaringType: typeof(View),
+            defaultValue: LayoutPolicy.FixedSize,
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+                if (newValue != null && view.HasBody())
+                {
+                    var widthSpecification = (int)((LayoutPolicy)newValue);
+                    if (widthSpecification == LayoutParamPolicies.MatchParent || widthSpecification == LayoutParamPolicies.WrapContent)
+                    {
+                        view.WidthSpecification = widthSpecification;
+                    }
+                    else
+                    {
+                        view.WidthSpecification = view.Size2D.Width;
+                    }
+                }
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                var widthSpecification = view.WidthSpecification;
+                if (widthSpecification >= 0)
+                {
+                    return LayoutPolicy.FixedSize;
+                }
+                return (LayoutPolicy)widthSpecification;
+            }
+        );
+
+        /// <summary>
+        /// HeightDimensionProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty HeightDimensionProperty = BindableProperty.Create(
+            propertyName: nameof(HeightDimension),
+            returnType: typeof(LayoutPolicy),
+            declaringType: typeof(View),
+            defaultValue: LayoutPolicy.FixedSize,
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+                if (newValue != null && view.HasBody())
+                {
+                    var heightSpecification = (int)((LayoutPolicy)newValue);
+                    if (heightSpecification == LayoutParamPolicies.MatchParent || heightSpecification == LayoutParamPolicies.WrapContent)
+                    {
+                        view.HeightSpecification = heightSpecification;
+                    }
+                    else
+                    {
+                        view.HeightSpecification = view.Size2D.Height;
+                    }
+                }
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                var heightSpecification = view.HeightSpecification;
+                if (heightSpecification >= 0)
+                {
+                    return LayoutPolicy.FixedSize;
+                }
+                return (LayoutPolicy)heightSpecification;
+            }
+        );
+
         private void SetBackgroundImage(string value)
         {
             if (string.IsNullOrEmpty(value))


### PR DESCRIPTION
### Description of Change ###
[NUI] Add LayoutPolicy, WidthDimension and HeightDimension as hidden API
- Current LayoutParamPolicies type is class and WidthSpecification/HeightSpecification propery type is int
- This different types disable to use them in XAML
- Introduce new LayoutPolicy, WidthDimension and HeightDimension as hidden API
**- A discussion is required for the naming of these APIs**
- These are equivalent in XAML
` <View WidthDimension="MatchParent" HeightDimension="WrapContent">`
` <View WidthSpecification="-1" HeightSpecification="-2">`

### API Changes ###
none
