### PR TITLE
[NUI] Fix not to make LinearLayout.CellPadding nullable

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -115,6 +115,11 @@ namespace Tizen.NUI
         {
             get
             {
+                if (cellPadding == null)
+                {
+                    cellPadding = new Size2D(0, 0);
+                }
+
                 return cellPadding;
             }
             set


### PR DESCRIPTION
LinearLayout.CellPadding is Size2D, so it is not nullable type.
Therefore, if null is assigned to LinearLayout.CellPadding, then it
returns Size2D(0, 0).

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
