### PR TITLE
[NUI] Reset XamlParser's xamlns definitions whenever it starts to parse

### DIFF
--- a/src/Tizen.NUI/src/internal/Xaml/XamlParser.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/XamlParser.cs
@@ -63,6 +63,9 @@ namespace Tizen.NUI.Xaml
 
         public static void ParseXaml(RootNode rootNode, XmlReader reader)
         {
+            // Reset xmlnsDefinitions to re-gather them for the new assembly.
+            s_xmlnsDefinitions = null;
+
             IList<KeyValuePair<string, string>> xmlns;
             var attributes = ParseXamlAttributes(reader, out xmlns);
             var prefixes = PrefixesToIgnore(xmlns);


### PR DESCRIPTION
Previously, XamlParser referenced a xamlns list that is created based on the root assembly of previously parsed xaml file.
That leads wrong result of searching types for the next xaml parsing.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
