### PR TITLE
[NUI]Fix SetAvailableOrientation

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -75,7 +75,7 @@ namespace Tizen.NUI
             public static extern int GetCurrentOrientation(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetAvailableOrientations")]
-            public static extern void SetAvailableOrientations(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static extern void SetAvailableOrientations(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetPositionSize")]
             public static extern void SetPositionSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1181,21 +1181,20 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetAvailableOrientations(List<Window.WindowOrientation> orientations)
         {
-            PropertyArray orientationArray = new PropertyArray();
-            if (null != orientations)
+            if (null == orientations)
             {
-                for (int i = 0; i < orientations.Count; i++)
-                {
-                    PropertyValue value = new PropertyValue((int)orientations[i]);
-                    orientationArray.PushBack(value);
-                }
+                throw new ArgumentNullException(nameof(orientations));
             }
 
-            Interop.Window.SetAvailableOrientations(SwigCPtr, PropertyArray.getCPtr(orientationArray));
-            for (uint i = 0; i < orientationArray.Count(); i++)
+            PropertyArray orientationArray = new PropertyArray();
+            for (int i = 0; i < orientations.Count; i++)
             {
-                orientationArray[i].Dispose();
+                PropertyValue value = new PropertyValue((int)orientations[i]);
+                orientationArray.PushBack(value);
+                value.Dispose();
             }
+
+            Interop.Window.SetAvailableOrientations(SwigCPtr, PropertyArray.getCPtr(orientationArray), orientations.Count);
             orientationArray.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION
### Description of Change ###
Fix SetAvaiableOrienation() in Window.
Previous the related functions were implemented incorrect both dali-csharp-binder and TizenFX.
They need the count of list.
This patch is for that.

