### PR TITLE
[NUI] Update Application(internal & public) TCs.

### DIFF
--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSApplication.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSApplication.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using NUnit.Framework.TUnit;
 using Tizen.NUI.Components;
 using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
 
 namespace Tizen.NUI.Devel.Tests
 {
@@ -13,10 +14,22 @@ namespace Tizen.NUI.Devel.Tests
     public class InternalApplicationTest
     {
         private const string tag = "NUITEST";
+
         private delegate bool dummyCallback(IntPtr application);
         private bool OnDummyCallback(IntPtr data)
         {
             return false;
+        }
+
+        internal class MyApplication : Application
+        {
+            public MyApplication(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+            { }
+
+            public void OnDispose(DisposeTypes type)
+            {
+                base.Dispose(type);
+            }
         }
 
         [SetUp]
@@ -32,7 +45,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationInitEventArgs Get")]
+        [Category("P1")]
+        [Description("NUIApplicationInitEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationInitEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationInitEventArgsGet()
         {
@@ -49,7 +66,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationInitEventArgs Set")]
+        [Category("P1")]
+        [Description("NUIApplicationInitEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationInitEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationInitEventArgsSet()
         {
@@ -70,7 +91,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationTerminatingEventArgs Get")]
+        [Category("P1")]
+        [Description("NUIApplicationTerminatingEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationTerminatingEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationTerminatingEventArgsGet()
         {
@@ -87,7 +112,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationTerminatingEventArgs Set")]
+        [Category("P1")]
+        [Description("NUIApplicationTerminatingEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationTerminatingEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationTerminatingEventArgsSet()
         {
@@ -108,7 +137,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationPausedEventArgs Get")]
+        [Category("P1")]
+        [Description("NUIApplicationPausedEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationPausedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationPausedEventArgsGet()
         {
@@ -125,7 +158,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationPausedEventArgs Set")]
+        [Category("P1")]
+        [Description("NUIApplicationPausedEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationPausedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationPausedEventArgsSet()
         {
@@ -146,7 +183,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationResumedEventArgs Get")]
+        [Category("P1")]
+        [Description("NUIApplicationResumedEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationResumedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationResumedEventArgsGet()
         {
@@ -163,7 +204,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationResumedEventArgs Set")]
+        [Category("P1")]
+        [Description("NUIApplicationResumedEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationResumedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationResumedEventArgsSet()
         {
@@ -184,7 +229,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationResetEventArgs Get")]
+        [Category("P1")]
+        [Description("NUIApplicationResetEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationResetEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationResetEventArgsGet()
         {
@@ -201,7 +250,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationResetEventArgs Set")]
+        [Category("P1")]
+        [Description("NUIApplicationResetEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationResetEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationResetEventArgsSet()
         {
@@ -222,7 +275,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationLanguageChangedEventArgs Get")]
+        [Category("P1")]
+        [Description("NUIApplicationLanguageChangedEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationLanguageChangedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationLanguageChangedEventArgsGet()
         {
@@ -239,7 +296,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationLanguageChangedEventArgs Set")]
+        [Category("P1")]
+        [Description("NUIApplicationLanguageChangedEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationLanguageChangedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationLanguageChangedEventArgsSet()
         {
@@ -260,7 +321,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationRegionChangedEventArgs Get")]
+        [Category("P1")]
+        [Description("NUIApplicationRegionChangedEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationRegionChangedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationRegionChangedEventArgsGet()
         {
@@ -277,7 +342,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationRegionChangedEventArgs Set")]
+        [Category("P1")]
+        [Description("NUIApplicationRegionChangedEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationRegionChangedEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationRegionChangedEventArgsSet()
         {
@@ -298,7 +367,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationBatteryLowEventArgs BatteryStatus Get")]
+        [Category("P1")]
+        [Description("NUIApplicationBatteryLowEventArgs BatteryStatus.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationBatteryLowEventArgs.BatteryStatus A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationBatteryLowEventArgsBatteryStatusGet()
         {
@@ -315,7 +388,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationBatteryLowEventArgs BatteryStatus Set")]
+        [Category("P1")]
+        [Description("NUIApplicationBatteryLowEventArgs BatteryStatus.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationBatteryLowEventArgs.BatteryStatus A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationBatteryLowEventArgsBatteryStatusSet()
         {
@@ -336,7 +413,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationMemoryLowEventArgs MemoryStatus Get")]
+        [Category("P1")]
+        [Description("NUIApplicationMemoryLowEventArgs MemoryStatus.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationMemoryLowEventArgs.MemoryStatus A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationMemoryLowEventArgsMemoryStatusGet()
         {
@@ -353,7 +434,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationMemoryLowEventArgs MemoryStatus Set")]
+        [Category("P1")]
+        [Description("NUIApplicationMemoryLowEventArgs MemoryStatus.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationMemoryLowEventArgs.MemoryStatus A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationMemoryLowEventArgsMemoryStatusSet()
         {
@@ -374,7 +459,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationAppControlEventArgs Application Get")]
+        [Category("P1")]
+        [Description("NUIApplicationAppControlEventArgs Application.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationAppControlEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationAppControlEventArgsApplicationGet()
         {
@@ -391,7 +480,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationAppControlEventArgs Application Set")]
+        [Category("P1")]
+        [Description("NUIApplicationAppControlEventArgs Application.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationAppControlEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationAppControlEventArgsApplicationSet()
         {
@@ -412,7 +505,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationAppControlEventArgs VoidP Get")]
+        [Category("P1")]
+        [Description("NUIApplicationAppControlEventArgs VoidP.Get.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationAppControlEventArgs.VoidP A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationAppControlEventArgsVoidPGet()
         {
@@ -429,7 +526,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIApplicationAppControlEventArgs VoidP Set")]
+        [Category("P1")]
+        [Description("NUIApplicationAppControlEventArgs VoidP.Set.")]
+        [Property("SPEC", "Tizen.NUI.Application.NUIApplicationAppControlEventArgs.VoidP A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIApplicationAppControlEventArgsVoidPSet()
         {
@@ -447,6 +548,823 @@ namespace Tizen.NUI.Devel.Tests
             Assert.AreEqual(dummy, result, "Retrieved result should be equal to dummy.");
 
             tlog.Debug(tag, $"NUIApplicationAppControlEventArgsVoidPSet END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("GetResourcesProvider IResourcesProvider Get")]
+        [Property("SPEC", "Tizen.NUI.GetResourcesProvider.IResourcesProvider.Get A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void GetResourcesProviderIResourcesProviderGet()
+        {
+            tlog.Debug(tag, $"GetResourcesProviderIResourcesProviderGet START");
+
+            try
+            {
+                var testingTarget = GetResourcesProvider.Get();
+                Assert.IsNotNull(testingTarget, "should be not null");
+                Assert.IsInstanceOf<Tizen.NUI.Binding.IResourcesProvider>(testingTarget, "should be an instance of testing target class!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"GetResourcesProviderIResourcesProviderGet END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application constructor.")]
+        [Property("SPEC", "Tizen.NUI.Application.Application C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationConstructor()
+        {
+            tlog.Debug(tag, $"ApplicationConstructor START");
+
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false);
+
+            try
+            {
+                var testingTarget = new Application(application);
+                Assert.IsNotNull(testingTarget, "should be not null");
+                Assert.IsInstanceOf<Application>(testingTarget, "should be an instance of testing target class!");
+
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"ApplicationConstructor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application GetApplicationFromPtr.")]
+        [Property("SPEC", "Tizen.NUI.Application.GetApplicationFromPtr M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationGetApplicationFromPtr()
+        {
+            tlog.Debug(tag, $"ApplicationGetApplicationFromPtr START");
+
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false);
+            
+            try
+            {
+                Application.GetApplicationFromPtr(application.SwigCPtr.Handle);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"ApplicationGetApplicationFromPtr END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application SystemResources.")]
+        [Property("SPEC", "Tizen.NUI.Application.SystemResources A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationSystemResources()
+        {
+            tlog.Debug(tag, $"ApplicationSystemResources START");
+
+            try
+            {
+                var result = Application.Instance.SystemResources;
+                tlog.Debug(tag, "SystemResources : " + result);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationSystemResources END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application IsResourcesCreated.")]
+        [Property("SPEC", "Tizen.NUI.Application.IsResourcesCreated A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationIsResourcesCreated()
+        {
+            tlog.Debug(tag, $"ApplicationIsResourcesCreated START");
+
+            try
+            {
+                var result = Application.Instance.IsResourcesCreated;
+                tlog.Debug(tag, "IsResourcesCreated : " + result);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationIsResourcesCreated END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application AddResourceChangedCallback.")]
+        [Property("SPEC", "Tizen.NUI.Application.AddResourceChangedCallback A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationAddResourceChangedCallback()
+        {
+            tlog.Debug(tag, $"ApplicationAddResourceChangedCallback START");
+
+            try
+            {
+                Application.AddResourceChangedCallback(new ImageView() as object, AddResourceChangedCallback);      
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationAddResourceChangedCallback END (OK)");
+        }
+
+        private void AddResourceChangedCallback(object sender, ResourcesChangedEventArgs e) { }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Paused.")]
+        [Property("SPEC", "Tizen.NUI.Application.Paused A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationPaused()
+        {
+            tlog.Debug(tag, $"ApplicationPaused START");
+
+            try
+            {
+                Application.Instance.Paused += MyOnPaused;
+                Application.Instance.Paused -= MyOnPaused;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationPaused END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Resumed.")]
+        [Property("SPEC", "Tizen.NUI.Application.Paused A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationResumed()
+        {
+            tlog.Debug(tag, $"ApplicationResumed START");
+
+            try
+            {
+                Application.Instance.Resumed += MyOnResumed;
+                Application.Instance.Resumed -= MyOnResumed;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationResumed END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Reset.")]
+        [Property("SPEC", "Tizen.NUI.Application.Reset A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationReset()
+        {
+            tlog.Debug(tag, $"ApplicationReset START");
+
+            try
+            {
+                Application.Instance.Reset += MyOnReset;
+                Application.Instance.Reset -= MyOnReset;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationReset END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application LanguageChanged.")]
+        [Property("SPEC", "Tizen.NUI.Application.LanguageChanged A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationLanguageChanged()
+        {
+            tlog.Debug(tag, $"ApplicationLanguageChanged START");
+
+            try
+            {
+                Application.Instance.LanguageChanged += MyOnLanguageChanged;
+                Application.Instance.LanguageChanged -= MyOnLanguageChanged;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationLanguageChanged END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application AppControl.")]
+        [Property("SPEC", "Tizen.NUI.Application.AppControl A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationAppControl()
+        {
+            tlog.Debug(tag, $"ApplicationAppControl START");
+
+            try
+            {
+                Application.Instance.AppControl += MyOnAppControl;
+                Application.Instance.AppControl -= MyOnAppControl;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationAppControl END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application MemoryLow.")]
+        [Property("SPEC", "Tizen.NUI.Application.MemoryLow A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationMemoryLow()
+        {
+            tlog.Debug(tag, $"ApplicationMemoryLow START");
+
+            try
+            {
+                Application.Instance.MemoryLow += MyOnMemoryLow;
+                Application.Instance.MemoryLow -= MyOnMemoryLow;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationMemoryLow END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application BatteryLow.")]
+        [Property("SPEC", "Tizen.NUI.Application.BatteryLow A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationBatteryLow()
+        {
+            tlog.Debug(tag, $"ApplicationBatteryLow START");
+
+            try
+            {
+                Application.Instance.BatteryLow += MyOnBatteryLow;
+                Application.Instance.BatteryLow -= MyOnBatteryLow;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationBatteryLow END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application RegionChanged.")]
+        [Property("SPEC", "Tizen.NUI.Application.RegionChanged A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationRegionChanged()
+        {
+            tlog.Debug(tag, $"ApplicationRegionChanged START");
+
+            try
+            {
+                Application.Instance.RegionChanged += MyOnRegionChanged;
+                Application.Instance.RegionChanged -= MyOnRegionChanged;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationRegionChanged END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Terminating.")]
+        [Property("SPEC", "Tizen.NUI.Application.Terminating A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationTerminating()
+        {
+            tlog.Debug(tag, $"ApplicationTerminating START");
+
+            try
+            {
+                Application.Instance.Terminating += MyOnTerminating;
+                Application.Instance.Terminating -= MyOnTerminating;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationTerminating END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Initialized.")]
+        [Property("SPEC", "Tizen.NUI.Application.Initialized A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationInitialized()
+        {
+            tlog.Debug(tag, $"ApplicationInitialized START");
+
+            try
+            {
+                Application.Instance.Initialized += MyOnInitialized;
+                Application.Instance.Initialized -= MyOnInitialized;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationInitialized END (OK)");
+        }
+
+        private void MyOnPaused(object sender, NUIApplicationPausedEventArgs e) { }
+        private void MyOnResumed(object sender, NUIApplicationResumedEventArgs e) { }
+        private void MyOnReset(object sender, NUIApplicationResetEventArgs e) { }
+        private void MyOnLanguageChanged(object sender, NUIApplicationLanguageChangedEventArgs e) { }
+        private void MyOnAppControl(object sender, NUIApplicationAppControlEventArgs e) { }
+        private void MyOnMemoryLow(object sender, NUIApplicationMemoryLowEventArgs e) { }
+        private void MyOnBatteryLow(object sender, NUIApplicationBatteryLowEventArgs e) { }
+        private void MyOnRegionChanged(object sender, NUIApplicationRegionChangedEventArgs e) { }
+        private void MyOnTerminating(object sender, NUIApplicationTerminatingEventArgs e) { }
+        private void MyOnInitialized(object sender, NUIApplicationInitEventArgs e) { }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Application.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationDispose()
+        {
+            tlog.Debug(tag, $"ApplicationDispose START");
+
+            try
+            {
+                var testingTarget = new MyApplication(Application.Instance.SwigCPtr.Handle, false);
+
+                tlog.Debug(tag, "testingTarget : " + testingTarget);
+
+                testingTarget.Initialized += MyOnInitialized;
+                testingTarget.Terminating += MyOnTerminating;
+                testingTarget.Paused += MyOnPaused;
+                testingTarget.Resumed += MyOnResumed;
+                testingTarget.Reset += MyOnReset;
+                testingTarget.LanguageChanged += MyOnLanguageChanged;
+                testingTarget.RegionChanged += MyOnRegionChanged;
+                testingTarget.BatteryLow += MyOnBatteryLow;
+                testingTarget.MemoryLow += MyOnMemoryLow;
+                testingTarget.AppControl += MyOnAppControl;
+
+                testingTarget.OnDispose(DisposeTypes.Explicit);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationDispose END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application SetCurrentApplication")]
+        [Property("SPEC", "Tizen.NUI.Application.SetCurrentApplication M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationSetCurrentApplication()
+        {
+            tlog.Debug(tag, $"ApplicationSetCurrentApplication START");
+
+            try
+            {
+                Widget widget = new Widget();
+                WidgetApplication application = new WidgetApplication(widget.GetIntPtr(), false);
+                Application.SetCurrentApplication(application);
+
+                tlog.Debug(tag, "Application.Current : " + Application.Current);
+
+                widget.Dispose();
+                widget = null;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationSetCurrentApplication END (OK)");
+        }
+
+        [Test]
+        [Category("P2")]
+        [Description("Application Current. With existing application.")]
+        [Property("SPEC", "Tizen.NUI.Application.Current A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationCurrentSetWithExistingApplication()
+        {
+            tlog.Debug(tag, $"ApplicationCurrentSetWithExistingApplication START");
+
+            Widget widget = new Widget();
+            WidgetApplication application = new WidgetApplication(widget.GetIntPtr(), false);
+            Application.SetCurrentApplication(application);
+
+            try
+            {
+                Application.Current = application;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            widget.Dispose();
+            widget = null;
+
+            tlog.Debug(tag, $"ApplicationCurrentSetWithExistingApplication END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application XamlResources.")]
+        [Property("SPEC", "Tizen.NUI.Application.XamlResources A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationXamlResources()
+        {
+            tlog.Debug(tag, $"ApplicationXamlResources START");
+
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false) as Application;
+
+            tlog.Debug(tag, "application.XamlResources : " + application.XamlResources);
+
+            application.XamlResources = new Tizen.NUI.Binding.ResourceDictionary();
+            tlog.Debug(tag, "application.XamlResources : " + application.XamlResources);
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"ApplicationXamlResources END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application IsApplicationOrNull.")]
+        [Property("SPEC", "Tizen.NUI.Application.IsApplicationOrNull M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationIsApplicationOrNull()
+        {
+            tlog.Debug(tag, $"ApplicationIsApplicationOrNull START");
+
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false) as Application;
+
+            try
+            {
+                var result = Application.IsApplicationOrNull(application);
+                Assert.IsTrue(result);
+                tlog.Debug(tag, "result = " + result);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"ApplicationIsApplicationOrNull END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application ResetSignal.")]
+        [Property("SPEC", "Tizen.NUI.Application.ResetSignal M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationResetSignal()
+        {
+            tlog.Debug(tag, $"ApplicationResetSignal START");
+
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false) as Application;
+
+            application.InitSignal();
+
+            try
+            {
+                application.ResetSignal();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"ApplicationResetSignal END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application GetResourcePath.")]
+        [Property("SPEC", "Tizen.NUI.Application.GetResourcePath M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationGetResourcePath()
+        {
+            tlog.Debug(tag, $"ApplicationGetResourcePath START");
+
+            try
+            {
+                Application.GetResourcePath();
+                tlog.Debug(tag, "ResourcePath : " + Application.GetResourcePath());
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationGetResourcePath END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application GetLanguage.")]
+        [Property("SPEC", "Tizen.NUI.Application.GetLanguage M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationGetLanguage()
+        {
+            tlog.Debug(tag, $"ApplicationGetLanguage START");
+
+            try
+            {
+                Application.Instance.GetLanguage();
+                tlog.Debug(tag, "Language : " + Application.Instance.GetLanguage());
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationGetLanguage END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application GetRegion.")]
+        [Property("SPEC", "Tizen.NUI.Application.GetRegion M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationGetRegion()
+        {
+            tlog.Debug(tag, $"ApplicationGetRegion START");
+
+            try
+            {
+                Application.Instance.GetRegion();
+                tlog.Debug(tag, "Region : " + Application.Instance.GetRegion());
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationGetRegion END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application GetWindow.")]
+        [Property("SPEC", "Tizen.NUI.Application.GetWindow M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationGetWindow()
+        {
+            tlog.Debug(tag, $"ApplicationGetWindow START");
+
+            try
+            {
+                Application.Instance.GetWindow();
+                tlog.Debug(tag, "Region : " + Application.Instance.GetWindow());
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationGetWindow END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application AddIdle.")]
+        [Property("SPEC", "Tizen.NUI.Application.AddIdle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationAddIdle()
+        {
+            tlog.Debug(tag, $"ApplicationAddIdle START");
+
+            try
+            {
+                SWIGTYPE_p_Dali__CallbackBase callback = new SWIGTYPE_p_Dali__CallbackBase(new ImageView().SwigCPtr.Handle);
+                var result = Application.Instance.AddIdle(callback);
+                tlog.Debug(tag, "result : " + result);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationAddIdle END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Lower.")]
+        [Property("SPEC", "Tizen.NUI.Application.Lower M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationLower()
+        {
+            tlog.Debug(tag, $"ApplicationLower START");
+
+            try
+            {
+                Application.Instance.Lower();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationLower END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application Assign.")]
+        [Property("SPEC", "Tizen.NUI.Application.Assign M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationAssign()
+        {
+            tlog.Debug(tag, $"ApplicationAssign START");
+
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false) as Application;
+
+            try
+            {
+                var testingTarget = Application.Instance.Assign(application);
+                Assert.IsNotNull(testingTarget, "should be not null");
+                Assert.IsInstanceOf<Application>(testingTarget, "should be an instance of testing target class!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"ApplicationAssign END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Application GetWindowList.")]
+        [Property("SPEC", "Tizen.NUI.Application.GetWindowList M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ApplicationGetWindowList()
+        {
+            tlog.Debug(tag, $"ApplicationGetWindowList START");
+
+            try
+            {
+                Application.GetWindowList();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ApplicationGetWindowList END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSApplicationControlSignal.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSApplicationControlSignal.cs
@@ -32,7 +32,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationControlSignal constructor")]
+        [Category("P1")]
+        [Description("ApplicationControlSignal constructor.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationControlSignal.ApplicationControlSignal C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationControlSignalConstructor()
         {
@@ -48,7 +52,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationControlSignal Empty")]
+        [Category("P1")]
+        [Description("ApplicationControlSignal Empty.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationControlSignal.Empty M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationControlSignalEmpty()
         {
@@ -66,7 +74,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationControlSignal GetConnectionCount")]
+        [Category("P1")]
+        [Description("ApplicationControlSignal GetConnectionCount.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationControlSignal.GetConnectionCount M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationControlSignalGetConnectionCount()
         {
@@ -84,7 +96,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationControlSignal Connection")]
+        [Category("P1")]
+        [Description("ApplicationControlSignal connection.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationControlSignal.Connect M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationControlSignalConnection()
         {
@@ -103,7 +119,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationControlSignal Disconnection")]
+        [Category("P1")]
+        [Description("ApplicationControlSignal disconnection.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationControlSignal.Disconnect M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationControlSignalDisconnection()
         {
@@ -122,7 +142,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationControlSignal Emit")]
+        [Category("P1")]
+        [Description("ApplicationControlSignal Emit.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationControlSignal.Emit M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationControlSignalEmit()
         {

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSApplicationSignal.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSApplicationSignal.cs
@@ -32,7 +32,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationSignal constructor")]
+        [Category("P1")]
+        [Description("ApplicationSignal constructor.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationSignal.ApplicationSignal C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationSignalConstructor()
         {
@@ -48,7 +52,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationSignal Empty")]
+        [Category("P1")]
+        [Description("ApplicationSignal Empty.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationSignal.Empty M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationSignalEmpty()
         {
@@ -66,7 +74,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationSignal GetConnectionCount")]
+        [Category("P1")]
+        [Description("ApplicationSignal GetConnectionCount.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationSignal.GetConnectionCount M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationSignalGetConnectionCount()
         {
@@ -84,7 +96,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationSignal Connection")]
+        [Category("P1")]
+        [Description("ApplicationSignal connection.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationSignal.Connect M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationSignalConnection()
         {
@@ -103,7 +119,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationSignal Disconnection")]
+        [Category("P1")]
+        [Description("ApplicationSignal disconnection.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationSignal.Disconnect M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationSignalDisconnection()
         {
@@ -122,7 +142,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("ApplicationSignal Emit")]
+        [Category("P1")]
+        [Description("ApplicationSignal Emit.")]
+        [Property("SPEC", "Tizen.NUI.ApplicationSignal.Emit M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void ApplicationSignalEmit()
         {

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSComponentApplication.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSComponentApplication.cs
@@ -21,6 +21,17 @@ namespace Tizen.NUI.Devel.Tests
             return false;
         }
 
+        internal class MyComponentApplication : ComponentApplication
+        {
+            public MyComponentApplication(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+            { }
+
+            public void OnDispose(DisposeTypes type)
+            {
+                base.Dispose(type);
+            }
+        }
+
         [SetUp]
         public void Init()
         {
@@ -44,16 +55,39 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"ComponentApplicationConstructor START");
 
-            using (Widget widget = new Widget())
-            {
-                var testingTarget = new ComponentApplication(widget.SwigCPtr.Handle, true);
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<ComponentApplication>(testingTarget, "should be an instance of testing target class!");
+            ImageView view = new ImageView();
+            var testingTarget = new ComponentApplication(view.SwigCPtr.Handle, false);
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<ComponentApplication>(testingTarget, "should be an instance of testing target class!");
 
-                testingTarget.Dispose();
-            }
-
+            view.Dispose();
+            testingTarget.Dispose();
             tlog.Debug(tag, $"ComponentApplicationConstructor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ComponentApplication constructor. With ComponentApplication.")]
+        [Property("SPEC", "Tizen.NUI.ComponentApplication.ComponentApplication C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ComponentApplicationConstructorWithComponentApplication()
+        {
+            tlog.Debug(tag, $"ComponentApplicationConstructorWithComponentApplication START");
+
+            ImageView view = new ImageView();
+            ComponentApplication componentApplication = new ComponentApplication(view.SwigCPtr.Handle, false);
+            Assert.IsNotNull(componentApplication, "should be not null");
+            Assert.IsInstanceOf<ComponentApplication>(componentApplication, "should be an instance of testing target class!");
+
+            var testingTarget = new ComponentApplication(componentApplication);
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<ComponentApplication>(testingTarget, "should be an instance of testing target class!");
+
+            view.Dispose();
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ComponentApplicationConstructorWithComponentApplication END (OK)");
         }
 
         [Test]
@@ -67,20 +101,85 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"ComponentApplicationCreateNativeSignal START");
 
-            using (Widget widget = new Widget())
-            {
-                var testingTarget = new ComponentApplication(widget.SwigCPtr.Handle, true);
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<ComponentApplication>(testingTarget, "should be an instance of testing target class!");
+            ImageView view = new ImageView();
+            var testingTarget = new ComponentApplication(view.SwigCPtr.Handle, false);
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<ComponentApplication>(testingTarget, "should be an instance of testing target class!");
 
+            try
+            {
                 var result = testingTarget.CreateNativeSignal();
                 Assert.IsNotNull(result, "should be not null");
                 Assert.IsInstanceOf<ApplicationSignal>(result, "should be an instance of ApplicationSignal class!");
-
-                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
             }
 
+            view.Dispose();
+            testingTarget.Dispose();
             tlog.Debug(tag, $"ComponentApplicationCreateNativeSignal END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ComponentApplication Dispose.")]
+        [Property("SPEC", "Tizen.NUI.ComponentApplication.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ComponentApplicationDispose()
+        {
+            tlog.Debug(tag, $"ComponentApplicationDispose START");
+
+            ImageView view = new ImageView();
+            var testingTarget = new MyComponentApplication(view.SwigCPtr.Handle, false);
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<ComponentApplication>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                testingTarget.OnDispose(DisposeTypes.Explicit);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            view.Dispose();
+            tlog.Debug(tag, $"ComponentApplicationDispose END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ComponentApplication Assign.")]
+        [Property("SPEC", "Tizen.NUI.ComponentApplication.Assign M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ComponentApplicationAssign()
+        {
+            tlog.Debug(tag, $"ComponentApplicationAssign START");
+
+            ImageView view = new ImageView();
+            var testingTarget = new ComponentApplication(view.SwigCPtr.Handle, false);
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<ComponentApplication>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                testingTarget.Assign(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"ComponentApplicationAssign END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSNUIComponentCoreBackend.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSNUIComponentCoreBackend.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using NUnit.Framework.TUnit;
 using Tizen.NUI.Components;
 using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+using Tizen.Applications.CoreBackend;
 
 namespace Tizen.NUI.Devel.Tests
 {
@@ -28,7 +30,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIComponentCoreBackend constructor")]
+        [Category("P1")]
+        [Description("NUIComponentCoreBackend constructor.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentCoreBackend.NUIComponentCoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIComponentCoreBackendConstructor()
         {
@@ -43,13 +49,108 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIComponentCoreBackend constructor with stylesheet")]
+        [Category("P1")]
+        [Description("NUIComponentCoreBackend ComponentFactories. Get.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentCoreBackend.ComponentFactories A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentCoreBackendComponentFactoriesGet()
+        {
+            tlog.Debug(tag, $"NUIComponentCoreBackendComponentFactoriesGet START");
+
+            var testingTarget = new NUIComponentCoreBackend();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<NUIComponentCoreBackend>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                var result = testingTarget.ComponentFactories;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentCoreBackendComponentFactoriesGet END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIComponentCoreBackend ComponentFactories. Set.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentCoreBackend.ComponentFactories A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentCoreBackendComponentFactoriesSet()
+        {
+            tlog.Debug(tag, $"NUIComponentCoreBackendComponentFactoriesSet START");
+
+            var testingTarget = new NUIComponentCoreBackend();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<NUIComponentCoreBackend>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                testingTarget.ComponentFactories = null;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentCoreBackendComponentFactoriesSet END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIComponentCoreBackend AddEventHandler.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentCoreBackend.AddEventHandler A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentCoreBackendAddEventHandler()
+        {
+            tlog.Debug(tag, $"NUIComponentCoreBackendAddEventHandler START");
+
+            var testingTarget = new NUIComponentCoreBackend();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<NUIComponentCoreBackend>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                testingTarget.AddEventHandler(EventType.PreCreated, MyOnPreCreate);
+                testingTarget.AddEventHandler<Tizen.Applications.LowBatteryEventArgs >(EventType.LowBattery, MyOnLowBattery);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentCoreBackendAddEventHandler END (OK)");
+        }
+
+        private void MyOnLowBattery(Tizen.Applications.LowBatteryEventArgs obj) { }
+        private void MyOnPreCreate() { }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIComponentCoreBackend constructor. With stylesheet")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentCoreBackend.NUIComponentCoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIComponentCoreBackendConstructorWithStylesheet()
         {
             tlog.Debug(tag, $"NUIComponentCoreBackendConstructorWithStylesheet START");
 
-            var dummy = resource + "/style/Test_Style_Manager.json";
+            var dummy = resource + "style/Test_Style_Manager.json";
             var testingTarget = new NUIComponentCoreBackend(dummy);
             Assert.IsNotNull(testingTarget, "should be not null");
             Assert.IsInstanceOf<NUIComponentCoreBackend>(testingTarget, "should be an instance of testing target class!");
@@ -59,31 +160,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIComponentCoreBackend dispose")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void NUIComponentCoreBackendDispose()
-        {
-            tlog.Debug(tag, $"NUIComponentCoreBackendDispose START");
-
-            var testingTarget = new NUIComponentCoreBackend();
-            Assert.IsNotNull(testingTarget, "should be not null");
-            Assert.IsInstanceOf<NUIComponentCoreBackend>(testingTarget, "should be an instance of testing target class!");
-
-            try
-            {
-                testingTarget.Dispose();
-            }
-            catch (Exception e)
-            {
-                tlog.Error(tag, "Caught Exception" + e.ToString());
-                Assert.Fail("Caught Exception" + e.ToString());
-            }
-            
-            tlog.Debug(tag, $"NUIComponentCoreBackendDispose END (OK)");
-        }
-
-        [Test]
-        [Description("NUIComponentCoreBackend exit")]
+        [Category("P1")]
+        [Description("NUIComponentCoreBackend exit.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentCoreBackend.Exit M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIComponentCoreBackendExit()
         {

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSNUICoreBackend.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSNUICoreBackend.cs
@@ -13,6 +13,13 @@ namespace Tizen.NUI.Devel.Tests
     {
         private const string tag = "NUITEST";
         private event EventHandler Created;
+
+        private delegate bool dummyCallback(IntPtr nuicorebackend);
+        private bool OnDummyCallback(IntPtr data)
+        {
+            return false;
+        }
+
         protected virtual void OnCreate()
         {
             Created?.Invoke(this, EventArgs.Empty);
@@ -31,7 +38,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUICoreBackend constructor")]
+        [Category("P1")]
+        [Description("NUICoreBackend constructor.")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.NUICoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUICoreBackendConstructor()
         {
@@ -46,7 +57,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUICoreBackend constructor with stylesheet")]
+        [Category("P1")]
+        [Description("NUICoreBackend constructor. With stylesheet.")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.NUICoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUICoreBackendConstructorWithStylesheet()
         {
@@ -62,7 +77,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUICoreBackend constructor with stylesheet and windowMode")]
+        [Category("P1")]
+        [Description("NUICoreBackend constructor. With stylesheet and windowMode.")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.NUICoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUICoreBackendConstructorWithStylesheetAndWindowmode()
         {
@@ -78,11 +97,15 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUICoreBackend constructor with stylesheet, window mode, window size and window position")]
+        [Category("P1")]
+        [Description("NUICoreBackend constructor. With stylesheet, mode, size, position")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.NUICoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void NUICoreBackendConstructorWithMoreArgs()
+        public void NUICoreBackendConstructorWithFourParameters()
         {
-            tlog.Debug(tag, $"NUICoreBackendConstructorWithMoreArgs START");
+            tlog.Debug(tag, $"NUICoreBackendConstructorWithFourParameters START");
 
             var dummy = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "/style/Test_Style_Manager.json";
             var testingTarget = new NUICoreBackend(dummy, NUIApplication.WindowMode.Opaque, new Size(400, 400), new Position(200, 300));
@@ -90,11 +113,15 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsInstanceOf<NUICoreBackend>(testingTarget, "should be an instance of testing target class!");
 
             testingTarget.Dispose();
-            tlog.Debug(tag, $"NUICoreBackendConstructorWithMoreArgs END (OK)");
+            tlog.Debug(tag, $"NUICoreBackendConstructorWithFourParameters END (OK)");
         }
 
         [Test]
+        [Category("P1")]
         [Description("NUICoreBackend AddEventHandler")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.AddEventHandler M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUICoreBackendAddEventHandler()
         {
@@ -111,7 +138,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUICoreBackend dispose")]
+        [Category("P1")]
+        [Description("NUICoreBackend Dispose.")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUICoreBackendDispose()
         {
@@ -135,7 +166,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUICoreBackend exit")]
+        [Category("P1")]
+        [Description("NUICoreBackend Exit.")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.Exit M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUICoreBackendExit()
         {
@@ -157,6 +192,35 @@ namespace Tizen.NUI.Devel.Tests
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"NUICoreBackendExit END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUICoreBackend ApplicationHandle.")]
+        [Property("SPEC", "Tizen.NUI.NUICoreBackend.ApplicationHandle A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUICoreBackendApplicationHandle()
+        {
+            tlog.Debug(tag, $"NUICoreBackendApplicationHandle START");
+
+            var testingTarget = new NUICoreBackend();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<NUICoreBackend>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                var result = testingTarget.ApplicationHandle;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUICoreBackendApplicationHandle END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSNUIWidgetCoreBackend.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSNUIWidgetCoreBackend.cs
@@ -4,6 +4,7 @@ using NUnit.Framework.TUnit;
 using Tizen.NUI.Components;
 using Tizen.NUI.BaseComponents;
 using System.Collections.Generic;
+using Tizen.Applications.CoreBackend;
 
 namespace Tizen.NUI.Devel.Tests
 {
@@ -29,7 +30,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIWidgetCoreBackend constructor")]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend constructor.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.NUIWidgetCoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIWidgetCoreBackendConstructor()
         {
@@ -44,13 +49,50 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIWidgetCoreBackend constructor with stylesheet")]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend AddEventHandler.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.AddEventHandler A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIWidgetCoreBackendAddEventHandler()
+        {
+            tlog.Debug(tag, $"NUIWidgetCoreBackendAddEventHandler START");
+
+            var testingTarget = new NUIWidgetCoreBackend();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<NUIWidgetCoreBackend>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                testingTarget.AddEventHandler(EventType.PreCreated, MyOnPreCreate);
+                testingTarget.AddEventHandler<Tizen.Applications.LowBatteryEventArgs>(EventType.LowBattery, MyOnLowBattery);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetCoreBackendAddEventHandler END (OK)");
+        }
+
+        private void MyOnLowBattery(Tizen.Applications.LowBatteryEventArgs obj) { }
+        private void MyOnPreCreate() { }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend constructor. With stylesheet")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.NUIWidgetCoreBackend C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIWidgetCoreBackendConstructorWithStylesheet()
         {
             tlog.Debug(tag, $"NUIWidgetCoreBackendConstructorWithStylesheet START");
 
-            var dummy = resource + "/style/Test_Style_Manager.json";
+            var dummy = resource + "style/Test_Style_Manager.json";
             var testingTarget = new NUIWidgetCoreBackend(dummy);
             Assert.IsNotNull(testingTarget, "should be not null");
             Assert.IsInstanceOf<NUIWidgetCoreBackend>(testingTarget, "should be an instance of testing target class!");
@@ -60,7 +102,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIWidgetCoreBackend dispose")]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend dispose.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIWidgetCoreBackendDispose()
         {
@@ -84,7 +130,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIWidgetCoreBackend exit")]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend exit.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.Exit M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIWidgetCoreBackendExit()
         {
@@ -109,7 +159,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIWidgetCoreBackend register widget info")]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend RegisterWidgetInfo.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.RegisterWidgetInfo M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIWidgetCoreBackendRegisterWidgetInfo()
         {
@@ -127,7 +181,11 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("NUIWidgetCoreBackend add widget info")]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend AddWidgetInfo.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.AddWidgetInfo M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void NUIWidgetCoreBackendAddWidgetInfo()
         {
@@ -142,6 +200,35 @@ namespace Tizen.NUI.Devel.Tests
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"NUIWidgetCoreBackendAddWidgetInfo END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetCoreBackend WidgetApplicationHandle.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetCoreBackend.WidgetApplicationHandle A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIWidgetCoreBackendWidgetApplicationHandle()
+        {
+            tlog.Debug(tag, $"NUIWidgetCoreBackendWidgetApplicationHandle START");
+
+            var testingTarget = new NUIWidgetCoreBackend();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<NUIWidgetCoreBackend>(testingTarget, "should be an instance of testing target class!");
+
+            try
+            {
+                var result = testingTarget.WidgetApplicationHandle;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetCoreBackendWidgetApplicationHandle END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSWatchApplication.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSWatchApplication.cs
@@ -16,6 +16,17 @@ namespace Tizen.NUI.Devel.Tests
         private const string tag = "NUITEST";
         private string resource = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
 
+        internal class MyWatchApplication : WatchApplication
+        {
+            public MyWatchApplication(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+            { }
+
+            public void OnReleaseSwigCPtr(global::System.Runtime.InteropServices.HandleRef swigCPtr)
+            {
+                base.ReleaseSwigCPtr(swigCPtr);
+            }
+        }
+
         private bool IsWearable()
         {
             string value;
@@ -41,389 +52,551 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("WatchApplication new")]
+        [Category("P1")]
+        [Description("WatchApplication constructor.")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.WatchApplication C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationNew()
+        public void WatchApplicationConstructor()
         {
-            tlog.Debug(tag, $"WatchApplicationNew START");
+            tlog.Debug(tag, $"WatchApplicationConstructor START");
 
-            if (IsWearable())
+            using (ImageView imageView = new ImageView())
             {
-                var testingTarget = Tizen.NUI.WatchApplication.New();
+                var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
                 Assert.IsNotNull(testingTarget, "should be not null");
                 Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
 
                 testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationNew END (OK)");
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationNew END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            tlog.Debug(tag, $"WatchApplicationConstructor END (OK)");
         }
 
-        [Test]
-        [Description("WatchApplication new with strings")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationNewWithStrings()
-        {
-            tlog.Debug(tag, $"WatchApplicationNewWithStrings START");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication constructor. With WatchApplication.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.WatchApplication C")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "CONSTR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationConstructorWithApplication()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationConstructorWithApplication START");
 
-            if (IsWearable())
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        WatchApplication watchApplication = new WatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(watchApplication, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(watchApplication, "should be an instance of testing target class!");
+
+        //        try
+        //        {
+        //            new WatchApplication(watchApplication);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_new_WatchApplication__SWIG_1' in shared library 'libdali2-csharp-binder.so' */
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        watchApplication.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationConstructorWithApplication END (OK)");
+        //}
+
+        [Test]
+        [Category("P1")]
+        [Description("WatchApplication getCPtr.")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.getCPtr M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void WatchApplicationgetCPtr()
+        {
+            tlog.Debug(tag, $"WatchApplicationgetCPtr START");
+
+            using (ImageView imageView = new ImageView())
             {
-                var dummy = new string[3];
-                var testingTarget = Tizen.NUI.WatchApplication.New(dummy);
+                var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
                 Assert.IsNotNull(testingTarget, "should be not null");
                 Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationNewWithStrings END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationNewWithStrings END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Description("WatchApplication new with strings and stylesheet")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationNewWithStringsAndStylesheet()
-        {
-            tlog.Debug(tag, $"WatchApplicationNewWithStringsAndStylesheet START");
-
-            if (IsWearable())
-            {
-                var args = new string[] { "Dali-demo" };
-                var stylesheet = resource + "/style/Test_Style_Manager.json";
-                var testingTarget = Tizen.NUI.WatchApplication.New(args, stylesheet);
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+                try
+                {
+                    WatchApplication.getCPtr(testingTarget);
+                }
+                catch (Exception e)
+                {
+                    tlog.Debug(tag, e.Message.ToString());
+                    Assert.Fail("Caught Exception: Failed!");
+                }
 
                 testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationNewWithStringsAndStylesheet END (OK)");
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationNewWithStringsAndStylesheet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            tlog.Debug(tag, $"WatchApplicationgetCPtr END (OK)");
         }
 
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication ReleaseSwigCPtr.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.ReleaseSwigCPtr M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationReleaseSwigCPtr()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationReleaseSwigCPtr START");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new MyWatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        try
+        //        {
+        //            testingTarget.OnReleaseSwigCPtr(imageView.SwigCPtr);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_delete_WatchApplication' in shared library 'libdali2-csharp-binder.so' */
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationReleaseSwigCPtr END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication NewWatchApplication.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.NewWatchApplication M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationNewWatchApplication()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationNewWatchApplication START");
+
+        //    try
+        //    {
+        //        var testingTarget = WatchApplication.NewWatchApplication();
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_New__SWIG_0' in shared library 'libdali2-csharp-binder.so' */
+        //        tlog.Debug(tag, e.Message.ToString());
+        //        Assert.Fail("Caught Exception: Failed!");
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationNewWatchApplication END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication NewWatchApplication. With strings")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.NewWatchApplication M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationNewWatchApplicationWithStrings()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationNewWatchApplicationWithStrings START");
+
+        //    try
+        //    {
+        //        var dummy = new string[3];
+        //        var testingTarget = WatchApplication.NewWatchApplication(dummy);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        testingTarget.Dispose();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_New__SWIG_1' in shared library 'libdali2-csharp-binder.so' */
+        //        tlog.Debug(tag, e.Message.ToString());
+        //        Assert.Fail("Caught Exception: Failed!");
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationNewWatchApplicationWithStrings END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication NewWatchApplication. With strings and style.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.NewWatchApplication M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationNewWithStringsAndStylesheet()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationNewWithStringsAndStylesheet START");
+
+        //    try
+        //    {
+        //        var args = new string[] { "Dali-demo" };
+        //        var stylesheet = resource + "style/Test_Style_Manager.json";
+        //        var testingTarget = WatchApplication.NewWatchApplication(args, stylesheet);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        testingTarget.Dispose();
+        //    }
+        //    catch (Exception e)
+        //    {
+        //        /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_New__SWIG_2' in shared library 'libdali2-csharp-binder.so' */
+        //        tlog.Debug(tag, e.Message.ToString());
+        //        Assert.Fail("Caught Exception: Failed!");
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationNewWithStringsAndStylesheet END (OK)");
+        //}
+
         [Test]
-        [Description("WatchApplication TimeTickEventArgs:Application get")]
+        [Category("P1")]
+        [Description("WatchApplication.TimeTickEventArgs. Application.")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.TimeTickEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationTimeTickEventArgsApplicationGet()
+        public void WatchApplicationTimeTickEventArgsApplication()
         {
-            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplicationGet START");
+            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplication START");
 
-            if (IsWearable())
-            {
-                TimeTickEventArgs dummy = new TimeTickEventArgs();
-                var testingTarget = dummy.Application;
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<Application>(testingTarget, "should be an instance of testing target class!");
+            var testingTarget = new TimeTickEventArgs();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<TimeTickEventArgs>(testingTarget, "should be an instance of testing target class!");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplicationGet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplicationGet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false);
+            testingTarget.Application = application;
+            Assert.IsNotNull(testingTarget.Application, "should be not null.");
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplication END (OK)");
         }
 
         [Test]
-        [Description("WatchApplication TimeTickEventArgs:Application set")]
+        [Category("P1")]
+        [Description("WatchApplication.TimeTickEventArgs. WatchTime.")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.TimeTickEventArgs.WatchTime A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationTimeTickEventArgsApplicationSet()
+        public void WatchApplicationTimeTickEventArgsWatchTime()
         {
-            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplicationSet START");
+            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTime START");
 
-            if (IsWearable())
+            var testingTarget = new TimeTickEventArgs();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<TimeTickEventArgs>(testingTarget, "should be an instance of testing target class!");
+
+            Widget widget = new Widget();
+            using (WatchTime time = new WatchTime(widget.GetIntPtr(), false))
             {
-                var dummyApplication = new Application();
-                Assert.IsNotNull(dummyApplication, "should be not null");
-                Assert.IsInstanceOf<Application>(dummyApplication, "should be an instance of testing target class!");
-
-                TimeTickEventArgs testingTarget = new TimeTickEventArgs();
-                testingTarget.Application = dummyApplication;
-
-                var result = testingTarget.Application;
-                Assert.IsNotNull(result, "should be not null.");
-                Assert.AreEqual(dummyApplication, result, "Retrieved result should be equal to dummyApplication. ");
-
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplicationSet END (OK)");
+                testingTarget.WatchTime = time;
+                Assert.IsNotNull(testingTarget.WatchTime);
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsApplicationSet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTime END (OK)");
         }
 
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication.TimeTick.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.TimeTick A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRW")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationTimeTick()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationTimeTick START");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_TimeTickSignal' in shared library 'libdali2-csharp-binder.so' */
+        //        testingTarget.TimeTick += MyOnTimeTick;
+        //        testingTarget.TimeTick -= MyOnTimeTick;
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationTimeTick END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication.TimeTickSignal.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.TimeTickSignal A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRW")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationTimeTickSignal()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationTimeTickSignal START");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        try
+        //        {
+        //            testingTarget.TimeTickSignal();
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_TimeTickSignal' in shared library 'libdali2-csharp-binder.so' */
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationTimeTickSignal END (OK)");
+        //}
+
+        private void MyOnTimeTick(object sender, TimeTickEventArgs e) { }
+
         [Test]
-        [Description("WatchApplication TimeTickEventArgs:WatchTime get")]
+        [Category("P1")]
+        [Description("WatchApplication.AmbientTickEventArgs. Application.")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.TimeTickEventArgs.Application A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationTimeTickEventArgsWatchTimeGet()
+        public void WatchApplicationAmbientTickEventArgsApplication()
         {
-            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTimeGet START");
+            tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplication START");
 
-            if (IsWearable())
-            {
-                TimeTickEventArgs dummy = new TimeTickEventArgs();
-                var testingTarget = dummy.WatchTime;
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "should be an instance of testing target class!");
+            var testingTarget = new AmbientTickEventArgs();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<AmbientTickEventArgs>(testingTarget, "should be an instance of AmbientTickEventArgs class!");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTimeGet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTimeGet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false);
+            testingTarget.Application = application;
+            Assert.IsNotNull(testingTarget.Application, "should be not null.");
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplication END (OK)");
         }
 
         [Test]
-        [Description("WatchApplication TimeTickEventArgs:WatchTime set")]
+        [Category("P1")]
+        [Description("WatchApplication.AmbientTickEventArgs.WatchTime")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.AmbientTickEventArgs.WatchTime A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationTimeTickEventArgsWatchTimeSet()
+        public void WatchApplicationAmbientTickArgsWatchTime()
         {
-            tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTimeSet START");
+            tlog.Debug(tag, $"WatchApplicationAmbientTickArgsWatchTime START");
 
-            if (IsWearable())
+            var testingTarget = new AmbientTickEventArgs();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<AmbientTickEventArgs>(testingTarget, "should be an instance of testing target class!");
+
+            Widget widget = new Widget();
+            using (WatchTime time = new WatchTime(widget.GetIntPtr(), false))
             {
-                var dummyWatchTime = new WatchTime();
-                Assert.IsNotNull(dummyWatchTime, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(dummyWatchTime, "should be an instance of testing target class!");
-
-                TimeTickEventArgs testingTarget = new TimeTickEventArgs();
-                testingTarget.WatchTime = dummyWatchTime;
-
-                var result = testingTarget.WatchTime;
-                Assert.IsNotNull(result, "should be not null.");
-                Assert.AreEqual(dummyWatchTime, result, "Retrieved result should be equal to dummyApplication. ");
-
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTimeSet END (OK)");
+                testingTarget.WatchTime = time;
+                Assert.IsNotNull(testingTarget.WatchTime);
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationTimeTickEventArgsWatchTimeSet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"WatchApplicationAmbientTickArgsWatchTime END (OK)");
         }
 
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication.AmbientTick.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.AmbientTick A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRW")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationAmbientTick()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationAmbientTick START");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_AmbientTickSignal' in shared library 'libdali2-csharp-binder.so' */
+        //        testingTarget.AmbientTick += MyOnAmbientTick;
+        //        testingTarget.AmbientTick -= MyOnAmbientTick;
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationAmbientTick END (OK)");
+        //}
+
+        //private void MyOnAmbientTick(object sender, AmbientTickEventArgs e) { }
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication.AmbientTickSignal.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.AmbientTickSignal A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRW")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationAmbientTickSignal()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationAmbientTickSignal START");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        try
+        //        {
+        //            testingTarget.AmbientTickSignal();
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_AmbientTickSignal' in shared library 'libdali2-csharp-binder.so' */
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationAmbientTickSignal END (OK)");
+        //}
+
         [Test]
-        [Description("WatchApplication AmbientTickEventArgs:Application get")]
+        [Category("P1")]
+        [Description("WatchApplication.AmbientChangedEventArgs. Application.")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.TimeTickEventArgs.WatchTime A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationAmbientTickEventArgsApplicationGet()
+        public void WatchApplicationAmbientChangedEventArgsApplication()
         {
-            tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplicationGet START");
+            tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplication START");
 
-            if (IsWearable())
-            {
-                AmbientTickEventArgs dummy = new AmbientTickEventArgs();
-                var testingTarget = dummy.Application;
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<Application>(testingTarget, "should be an instance of testing target class!");
+            var testingTarget = new AmbientChangedEventArgs();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<AmbientChangedEventArgs>(testingTarget, "should be an instance of AmbientChangedEventArgs class!");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplicationGet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplicationGet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+            Widget widget = new Widget();
+            var application = new WidgetApplication(widget.GetIntPtr(), false);
+            testingTarget.Application = application;
+            Assert.IsNotNull(testingTarget.Application, "should be not null.");
+
+            widget.Dispose();
+            widget = null;
+            tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplication END (OK)");
         }
 
         [Test]
-        [Description("WatchApplication AmbientTickEventArgs:Application set")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationAmbientTickEventArgsApplicationSet()
-        {
-            tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplicationSet START");
-
-            if (IsWearable())
-            {
-                var application = new Application();
-                Assert.IsNotNull(application, "should be not null");
-                Assert.IsInstanceOf<Application>(application, "should be an instance of testing target class!");
-
-                AmbientTickEventArgs testingTarget = new AmbientTickEventArgs();
-                testingTarget.Application = application;
-
-                var result = testingTarget.Application;
-                Assert.IsNotNull(result, "should be not null.");
-                Assert.AreEqual(application, result, "Retrieved result should be equal to dummyApplication. ");
-
-                application.Dispose();
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplicationSet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsApplicationSet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Description("WatchApplication AmbientTickEventArgs:WatchTime get")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationAmbientTickEventArgsWatchTimeGet()
-        {
-            tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsWatchTimeGet START");
-
-            if (IsWearable())
-            {
-                AmbientTickEventArgs dummy = new AmbientTickEventArgs();
-                var testingTarget = dummy.WatchTime;
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "should be an instance of testing target class!");
-
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsWatchTimeGet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsWatchTimeGet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Description("WatchApplication AmbientTickEventArgs:WatchTime set")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationAmbientTickEventArgsWatchTimeSet()
-        {
-            tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsWatchTimeSet START");
-
-            if (IsWearable())
-            {
-                var dummyWatchTime = new WatchTime();
-                Assert.IsNotNull(dummyWatchTime, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(dummyWatchTime, "should be an instance of testing target class!");
-
-                AmbientTickEventArgs testingTarget = new AmbientTickEventArgs();
-                testingTarget.WatchTime = dummyWatchTime;
-
-                var result = testingTarget.WatchTime;
-                Assert.IsNotNull(result, "should be not null.");
-                Assert.AreEqual(dummyWatchTime, result, "Retrieved result should be equal to dummyApplication. ");
-
-                dummyWatchTime.Dispose();
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsWatchTimeSet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientTickEventArgsWatchTimeSet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Description("WatchApplication AmbientChangedEventArgs:Application get")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationAmbientChangedEventArgsApplicationGet()
-        {
-            tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplicationGet START");
-
-            if (IsWearable())
-            {
-                AmbientChangedEventArgs dummy = new AmbientChangedEventArgs();
-                var testingTarget = dummy.Application;
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<Application>(testingTarget, "should be an instance of testing target class!");
-
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplicationGet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplicationGet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Description("WatchApplication AmbientChangedEventArgs:Application set")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationAmbientChangedEventArgsApplicationSet()
-        {
-            tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplicationSet START");
-
-            if (IsWearable())
-            {
-                var dummyApplication = new Application();
-                Assert.IsNotNull(dummyApplication, "should be not null");
-                Assert.IsInstanceOf<Application>(dummyApplication, "should be an instance of testing target class!");
-
-                AmbientChangedEventArgs testingTarget = new AmbientChangedEventArgs();
-                testingTarget.Application = dummyApplication;
-
-                var result = testingTarget.Application;
-                Assert.IsNotNull(result, "should be not null.");
-                Assert.AreEqual(dummyApplication, result, "Retrieved result should be equal to dummyApplication. ");
-
-                dummyApplication.Dispose();
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplicationSet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsApplicationSet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Description("WatchApplication AmbientChangedEventArgs:Changed get")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchApplicationAmbientChangedEventArgsChangedGet()
-        {
-            tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsChangedGet START");
-
-            if (IsWearable())
-            {
-                AmbientChangedEventArgs testingTarget = new AmbientChangedEventArgs();
-                var result = testingTarget.Changed;
-                Assert.IsNotNull(result, "should be not null");
-
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsChangedGet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsChangedGet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Description("WatchApplication AmbientChangedEventArgs:Changed set")]
+        [Category("P1")]
+        [Description("WatchApplication.AmbientChangedEventArgs. Changed.")]
+        [Property("SPEC", "Tizen.NUI.WatchApplication.AmbientChangedEventArgs.Changed A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void WatchApplicationAmbientChangedEventArgsChangedSet()
         {
             tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsChangedSet START");
 
-            if (IsWearable())
-            {
-                AmbientChangedEventArgs testingTarget = new AmbientChangedEventArgs();
-                testingTarget.Changed = true;
+            var testingTarget = new AmbientChangedEventArgs();
+            Assert.IsNotNull(testingTarget, "should be not null");
+            Assert.IsInstanceOf<AmbientChangedEventArgs>(testingTarget, "should be an instance of AmbientChangedEventArgs class!");
 
-                var result = testingTarget.Changed;
-                Assert.IsNotNull(result, "should be not null.");
-                Assert.AreEqual(true, result, "Retrieved result should be equal to true. ");
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsChangedSet END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsChangedSet END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+            testingTarget.Changed = true;
+            Assert.AreEqual(true, testingTarget.Changed, "Retrieved result should be equal to true. ");
+
+            testingTarget.Changed = false;
+            Assert.AreEqual(false, testingTarget.Changed, "Retrieved result should be equal to true. ");
+
+            tlog.Debug(tag, $"WatchApplicationAmbientChangedEventArgsChangedSet END (OK)");
         }
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication.AmbientChanged.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.AmbientChanged A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRW")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationAmbientChanged()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationAmbientChanged START");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_AmbientChangedSignal' in shared library 'libdali2-csharp-binder.so' */
+        //        testingTarget.AmbientChanged += MyOnAmbientChanged;
+        //        testingTarget.AmbientChanged -= MyOnAmbientChanged;
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationAmbientChanged END (OK)");
+        //}
+
+        //private void MyOnAmbientChanged(object sender, AmbientChangedEventArgs e) { }
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication.AmbientChangedSignal.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.AmbientChangedSignal A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRW")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationAmbientChangedSignal()
+        //{
+        //    tlog.Debug(tag, $"WatchApplicationAmbientChangedSignal START");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchApplication(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchApplication>(testingTarget, "should be an instance of testing target class!");
+
+        //        try
+        //        {
+        //            testingTarget.AmbientChangedSignal();
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchApplication_AmbientChangedSignal' in shared library 'libdali2-csharp-binder.so' */
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+        //    }
+
+        //    tlog.Debug(tag, $"WatchApplicationAmbientChangedSignal END (OK)");
+        //}
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSWatchBoolSignal.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSWatchBoolSignal.cs
@@ -19,16 +19,15 @@ namespace Tizen.NUI.Devel.Tests
             return false;
         }
 
-        private bool IsWearable()
+        internal class MyWatchBoolSignal : WatchBoolSignal
         {
-            string value;
-            var result = Tizen.System.Information.TryGetValue("tizen.org/feature/profile", out value);
-            if (result && value.Equals("wearable"))
-            {
-                return true;
-            }
+            public MyWatchBoolSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+            { }
 
-            return false;
+            public void OnReleaseSwigCPtr(global::System.Runtime.InteropServices.HandleRef swigCPtr)
+            {
+                base.ReleaseSwigCPtr(swigCPtr);
+            }
         }
 
         [SetUp]
@@ -44,163 +43,244 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("WatchBoolSignal constructor")]
+        [Category("P1")]
+        [Description("WatchBoolSignal constructor.")]
+        [Property("SPEC", "Tizen.NUI.WatchBoolSignal.WatchBoolSignal C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void WatchBoolSignalConstructor()
         {
             tlog.Debug(tag, $"WatchBoolSignalConstructor START");
 
-            if (IsWearable())
+            using (ImageView imageView = new ImageView())
             {
-                var testingTarget = new WatchBoolSignal();
-
+                var testingTarget = new WatchBoolSignal(imageView.SwigCPtr.Handle, false);
                 Assert.IsNotNull(testingTarget, "should be not null");
                 Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
 
                 testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchBoolSignalConstructor END (OK)");
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchBoolSignalConstructor END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            tlog.Debug(tag, $"WatchBoolSignalConstructor END (OK)");
         }
 
-        [Test]
-        [Description("WatchBoolSignal Empty")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchBoolSignalEmpty()
-        {
-            tlog.Debug(tag, $"WatchBoolSignalEmpty START");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchApplication ReleaseSwigCPtr.")]
+        //[Property("SPEC", "Tizen.NUI.WatchApplication.ReleaseSwigCPtr M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchApplicationReleaseSwigCPtr()
+        //{
+        //    tlog.Debug(tag, $"WatchBoolSignalReleaseSwigCPtr START");
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchBoolSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new MyWatchBoolSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
 
-                var result = testingTarget.Empty();
-                Assert.IsTrue(result);
+        //        try
+        //        {
+        //            testingTarget.OnReleaseSwigCPtr(imageView.SwigCPtr);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_delete_WatchBoolSignal' in shared library 'libdali2-csharp-binder.so' */
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchBoolSignalEmpty END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchBoolSignalEmpty END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        testingTarget.Dispose();
+        //    }
 
-        [Test]
-        [Description("WatchBoolSignal GetConnectionCount")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchBoolSignalGetConnectionCount()
-        {
-            tlog.Debug(tag, $"WatchBoolSignalGetConnectionCount START");
+        //    tlog.Debug(tag, $"WatchBoolSignalReleaseSwigCPtr END (OK)");
+        //}
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchBoolSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchBoolSignal Empty.")]
+        //[Property("SPEC", "Tizen.NUI.WatchBoolSignal.Empty M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchBoolSignalEmpty()
+        //{
+        //    tlog.Debug(tag, $"WatchBoolSignalEmpty START");
 
-                var result = testingTarget.GetConnectionCount();
-                Assert.IsTrue(result == 0, "result should be 0");
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchBoolSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchBoolSignalGetConnectionCount END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchBoolSignalGetConnectionCount END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchBoolSignal_Empty' in shared library 'libdali2-csharp-binder.so' */
+        //            var result = testingTarget.Empty();
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-        [Test]
-        [Description("WatchBoolSignal Connection")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchBoolSignalConnection()
-        {
-            tlog.Debug(tag, $"WatchBoolSignalConnection START");
+        //        testingTarget.Dispose();
+        //    }
+        //    tlog.Debug(tag, $"WatchBoolSignalEmpty END (OK)");
+        //}
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchBoolSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchBoolSignal GetConnectionCount.")]
+        //[Property("SPEC", "Tizen.NUI.WatchBoolSignal.GetConnectionCount M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchBoolSignalGetConnectionCount()
+        //{
+        //    tlog.Debug(tag, $"WatchBoolSignalGetConnectionCount START");
 
-                dummyCallback callback = OnDummyCallback;
-                testingTarget.Connect(callback);
-                testingTarget.Disconnect(callback);
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchBoolSignalConnection END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchBoolSignalConnection END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchBoolSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
 
-        [Test]
-        [Description("WatchBoolSignal Disconnection")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchBoolSignalDisconnection()
-        {
-            tlog.Debug(tag, $"WatchBoolSignalDisconnection START");
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchBoolSignal_GetConnectionCount' in shared library 'libdali2-csharp-binder.so' */
+        //            var result = testingTarget.GetConnectionCount();
+        //            Assert.IsTrue(result == 0, "result should be 0");
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchBoolSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
+        //        testingTarget.Dispose();
+        //    }
+        //    tlog.Debug(tag, $"WatchBoolSignalGetConnectionCount END (OK)");
+        //}
 
-                dummyCallback callback = OnDummyCallback;
-                testingTarget.Connect(callback);
-                testingTarget.Disconnect(callback);
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchBoolSignalDisconnection END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchBoolSignalDisconnection END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchBoolSignal connection.")]
+        //[Property("SPEC", "Tizen.NUI.WatchBoolSignal.Connect M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchBoolSignalConnection()
+        //{
+        //    tlog.Debug(tag, $"WatchBoolSignalConnection START");
 
-        [Test]
-        [Description("WatchBoolSignal Emit")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchBoolSignalEmit()
-        {
-            tlog.Debug(tag, $"WatchBoolSignalEmit START");
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchBoolSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
 
-            if (IsWearable())
-            {
-                var currentPid = global::System.Diagnostics.Process.GetCurrentProcess().Id;
-                var currentTid = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+        //        dummyCallback callback = OnDummyCallback;
 
-                tlog.Debug(tag, $"thread check! main pid={App.mainPid}, current pid={currentPid}, main tid={App.mainTid}, current tid={currentTid}");
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchBoolSignal_Connect' in shared library 'libdali2-csharp-binder.so' */
+        //            testingTarget.Connect(callback);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-                var testingTarget = new WatchBoolSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
+        //        testingTarget.Dispose();
+        //    }
+        //    tlog.Debug(tag, $"WatchBoolSignalConnection END (OK)");
+        //}
 
-                var dummy = new Application();
-                testingTarget.Emit(dummy, true);
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchBoolSignal disconnection.")]
+        //[Property("SPEC", "Tizen.NUI.WatchBoolSignal.Disconnect M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchBoolSignalDisconnection()
+        //{
+        //    tlog.Debug(tag, $"WatchBoolSignalDisconnection START");
 
-                dummy.Dispose();
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchBoolSignalEmit END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchBoolSignalEmit END (OK)");
-                Assert.Pass("Not Supported profile");
-            }            
-        }
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchBoolSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
+
+        //        dummyCallback callback = OnDummyCallback;
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchBoolSignal_Disconnect' in shared library 'libdali2-csharp-binder.so' */
+        //            testingTarget.Connect(callback);
+        //            testingTarget.Disconnect(callback); 
+        //        }
+        //        catch (Exception e)
+        //        {   
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchBoolSignalDisconnection END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchBoolSignal Emit.")]
+        //[Property("SPEC", "Tizen.NUI.WatchBoolSignal.Emit M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchBoolSignalEmit()
+        //{
+        //    tlog.Debug(tag, $"WatchBoolSignalEmit START");
+
+        //    var currentPid = global::System.Diagnostics.Process.GetCurrentProcess().Id;
+        //    var currentTid = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+
+        //    tlog.Debug(tag, $"thread check! main pid={App.mainPid}, current pid={currentPid}, main tid={App.mainTid}, current tid={currentTid}");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchBoolSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchBoolSignal>(testingTarget, "should be an instance of testing target class!");
+
+        //        Widget widget = new Widget();
+        //        var application = new WidgetApplication(widget.GetIntPtr(), false);
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchBoolSignal_Emit' in shared library 'libdali2-csharp-binder.so' */
+        //            testingTarget.Emit(application, true);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        widget.Dispose();
+        //        widget = null;
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchBoolSignalEmit END (OK)");         
+        //}
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSWatchTimeSignal.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Application/TSWatchTimeSignal.cs
@@ -18,18 +18,6 @@ namespace Tizen.NUI.Devel.Tests
             return false;
         }
 
-        private bool IsWearable()
-        {
-            string value;
-            var result = Tizen.System.Information.TryGetValue("tizen.org/feature/profile", out value);
-            if (result && value.Equals("wearable"))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         [SetUp]
         public void Init()
         {
@@ -43,165 +31,207 @@ namespace Tizen.NUI.Devel.Tests
         }
 
         [Test]
-        [Description("WatchTimeSignal constructor")]
+        [Category("P1")]
+        [Description("WatchTimeSignal constructor.")]
+        [Property("SPEC", "Tizen.NUI.WatchTimeSignal.WatchTimeSignal C")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
         public void WatchTimeSignalConstructor()
         {
             tlog.Debug(tag, $"WatchTimeSignalConstructor START");
 
-            if (IsWearable())
+            using (ImageView imageView = new ImageView())
             {
-                var testingTarget = new WatchTimeSignal();
-
+                var testingTarget = new WatchTimeSignal(imageView.SwigCPtr.Handle, false);
                 Assert.IsNotNull(testingTarget, "should be not null");
                 Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
 
                 testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeSignalConstructor END (OK)");
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeSignalConstructor END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            tlog.Debug(tag, $"WatchTimeSignalConstructor END (OK)");
         }
 
-        [Test]
-        [Description("WatchTimeSignal Empty")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeSignalEmpty()
-        {
-            tlog.Debug(tag, $"WatchTimeSignalEmpty START");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTimeSignal Empty.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTimeSignal.Empty M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeSignalEmpty()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeSignalEmpty START");
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTimeSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTimeSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
 
-                var result = testingTarget.Empty();
-                Assert.IsTrue(result);
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTimeSignal_Empty' in shared library 'libdali2-csharp-binder.so' */
+        //            var result = testingTarget.Empty();
+        //            Assert.IsTrue(result);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeSignalEmpty END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeSignalEmpty END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        testingTarget.Dispose();
+        //    }
 
-        [Test]
-        [Description("WatchTimeSignal GetConnectionCount")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeSignalGetConnectionCount()
-        {
-            tlog.Debug(tag, $"WatchTimeSignalGetConnectionCount START");
+        //    tlog.Debug(tag, $"WatchTimeSignalEmpty END (OK)");
+        //}
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTimeSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTimeSignal GetConnectionCount.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTimeSignal.GetConnectionCount M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeSignalGetConnectionCount()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeSignalGetConnectionCount START");
 
-                var result = testingTarget.GetConnectionCount();
-                Assert.IsTrue(result == 0, "result should be 0");
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTimeSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeSignalGetConnectionCount END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeSignalGetConnectionCount END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTimeSignal_GetConnectionCount' in shared library 'libdali2-csharp-binder.so' */
+        //            var result = testingTarget.GetConnectionCount();
+        //            Assert.IsTrue(result == 0, "result should be 0");
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-        [Test]
-        [Description("WatchTimeSignal Connection")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeSignalConnection()
-        {
-            tlog.Debug(tag, $"WatchTimeSignalConnection START");
+        //        testingTarget.Dispose();
+        //    }
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTimeSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
+        //    tlog.Debug(tag, $"WatchTimeSignalGetConnectionCount END (OK)");
+        //}
 
-                dummyCallback callback = OnDummyCallback;
-                testingTarget.Connect(callback);
-                testingTarget.Disconnect(callback);
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeSignalConnection END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeSignalConnection END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTimeSignal connection.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTimeSignal.Connect M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeSignalConnection()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeSignalConnection START");
 
-        [Test]
-        [Description("WatchTimeSignal Disconnection")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeSignalDisconnection()
-        {
-            tlog.Debug(tag, $"WatchTimeSignalDisconnection START");
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTimeSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTimeSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
+        //        dummyCallback callback = OnDummyCallback;
 
-                dummyCallback callback = OnDummyCallback;
-                testingTarget.Connect(callback);
-                testingTarget.Disconnect(callback);
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeSignalDisconnection END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeSignalDisconnection END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTimeSignal_Connect' in shared library 'libdali2-csharp-binder.so' */
+        //            testingTarget.Connect(callback);
+        //            testingTarget.Disconnect(callback);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-        [Test]
-        [Description("WatchTimeSignal Emit")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeSignalEmit()
-        {
-            tlog.Debug(tag, $"WatchTimeSignalEmit START");
+        //        testingTarget.Dispose();
+        //    }
 
-            if (IsWearable())
-            {
-                var currentPid = global::System.Diagnostics.Process.GetCurrentProcess().Id;
-                var currentTid = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+        //    tlog.Debug(tag, $"WatchTimeSignalConnection END (OK)");
+        //}
 
-                tlog.Debug(tag, $"thread check! main pid={App.mainPid}, current pid={currentPid}, main tid={App.mainTid}, current tid={currentTid}");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTimeSignal disconnection.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTimeSignal.Disconnection M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeSignalDisconnection()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeSignalDisconnection START");
 
-                var testingTarget = new WatchTimeSignal();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTimeSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
 
-                Application application = new Application();
-                WatchTime watchTime = new WatchTime();
-                testingTarget.Emit(application, watchTime);
+        //        dummyCallback callback = OnDummyCallback;
+        //        testingTarget.Connect(callback);
+        //        testingTarget.Disconnect(callback);
+        //        testingTarget.Dispose();
+        //    }
 
-                application.Dispose();
-                watchTime.Dispose();
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeSignalEmit END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeSignalEmit END (OK)");
-                Assert.Pass("Not Supported profile");
-            }           
-        }
+        //    tlog.Debug(tag, $"WatchTimeSignalDisconnection END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTimeSignal Emit.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTimeSignal.Emit M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeSignalEmit()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeSignalEmit START");
+
+        //    var currentPid = global::System.Diagnostics.Process.GetCurrentProcess().Id;
+        //    var currentTid = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+
+        //    tlog.Debug(tag, $"thread check! main pid={App.mainPid}, current pid={currentPid}, main tid={App.mainTid}, current tid={currentTid}");
+
+        //    using (ImageView imageView = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTimeSignal(imageView.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTimeSignal>(testingTarget, "should be an instance of testing target class!");
+
+        //        Widget widget = new Widget();
+        //        WidgetApplication application = new WidgetApplication(widget.GetIntPtr(), false);
+        //        WatchTime watchTime = new WatchTime(widget.GetIntPtr(), false);
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTimeSignal_Emit' in shared library 'libdali2-csharp-binder.so' */
+        //            testingTarget.Emit(application, watchTime);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        application.Dispose();
+        //        watchTime.Dispose();
+        //        testingTarget.Dispose();
+
+        //        widget.Dispose();
+        //        widget = null;
+        //    }
+
+        //    tlog.Debug(tag, $"WatchTimeSignalEmit END (OK)");          
+        //}
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIApplication.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIApplication.cs
@@ -283,42 +283,6 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("NUIApplication SendLaunchRequest")]
-        [Property("SPEC", "Tizen.NUI.NUIApplication.SendLaunchRequest M")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "MR")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void NUIApplicationSendLaunchRequest()
-        {
-            tlog.Debug(tag, $"NUIApplicationSendLaunchRequest START");
-
-            var testingTarget = new NUIApplication();
-            Assert.IsNotNull(testingTarget, "Should be not null.");
-            Assert.IsInstanceOf<NUIApplication>(testingTarget, "Should be an instance of Window type.");
-
-            TransitionOptions transitionOption = new TransitionOptions(Window.Instance);
-            testingTarget.TransitionOptions = transitionOption;
-            transitionOption.EnableTransition = true;
-
-            var appControl = new Applications.AppControl(true);
-            try
-            {
-                testingTarget.SendLaunchRequest(appControl);
-            }
-            catch (Exception e)
-            {
-                tlog.Error(tag, "Caught Exception" + e.ToString());
-                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
-                Assert.Fail("Caught Exception" + e.ToString());
-            }
-
-            transitionOption.Dispose();
-            testingTarget.Dispose();
-            tlog.Debug(tag, $"NUIApplicationSendLaunchRequest END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
         [Description("NUIApplication TransitionOptions")]
         [Property("SPEC", "Tizen.NUI.NUIApplication.TransitionOptions A")]
         [Property("SPEC_URL", "-")]

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIComponentApplication.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIComponentApplication.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using NUnit.Framework.TUnit;
 using Tizen.NUI.Components;
 using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
 
 namespace Tizen.NUI.Devel.Tests
 {
@@ -13,6 +14,18 @@ namespace Tizen.NUI.Devel.Tests
     class PublicNUIComponentApplicationTest
     {
         private const string tag = "NUITEST";
+
+        internal class MyNUIComponentApplication : NUIComponentApplication
+        {
+            public MyNUIComponentApplication(IDictionary<Type, string> typeInfo) : base(typeInfo)
+            { }
+
+            public void MyOnCreate() {   base.OnCreate();    }
+
+            public void MyOnTerminate() {   base.OnTerminate();    }
+
+            public void MyExit() { base.Exit(); }
+        }
 
         [SetUp]
         public void Init()
@@ -25,5 +38,166 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Info(tag, "Destroy() is called!");
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIComponentApplication constructor.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentApplication.NUIComponentApplication M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentApplicationConstructor()
+        {
+            tlog.Debug(tag, $"NUIComponentApplicationConstructor START");
+
+            IDictionary<Type, string> typeInfo = new Dictionary<Type, string>();
+            typeInfo.Add(typeof(Applications.ComponentBased.Common.FrameComponent), "FrameComponent");
+            typeInfo.Add(typeof(Applications.ComponentBased.Common.ServiceComponent), "ServiceComponent");
+            var testingTarget = new NUIComponentApplication(typeInfo);
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIComponentApplication>(testingTarget, "Should be an instance of NUIComponentApplication type.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentApplicationConstructor END (OK)");
+        }
+
+        [Test]
+        [Category("P2")]
+        [Description("NUIComponentApplication constructor. With illegal type.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentApplication.NUIComponentApplication M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentApplicationConstructorWithIllegalType()
+        {
+            tlog.Debug(tag, $"NUIComponentApplicationConstructorWithIllegalType START");
+
+            IDictionary<Type, string> typeInfo = new Dictionary<Type, string>();
+            typeInfo.Add(typeof(Widget), "Widget");
+
+            try
+            {
+                new NUIComponentApplication(typeInfo);
+            }
+            catch (ArgumentException e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                tlog.Debug(tag, $"NUIComponentApplicationConstructorWithIllegalType END (OK)");
+                Assert.Pass("Caught ArgumentException: Passed!");
+            }
+        }
+
+        [Test]
+        [Category("P2")]
+        [Description("NUIComponentApplication constructor. With null parameter.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentApplication.NUIComponentApplication M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentApplicationConstructorWithNull()
+        {
+            tlog.Debug(tag, $"NUIComponentApplicationConstructorWithNull START");
+
+            var testingTarget = new NUIComponentApplication(null);
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIComponentApplication>(testingTarget, "Should be an instance of NUIComponentApplication type.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentApplicationConstructorWithNull END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIComponentApplication OnCreate.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentApplication.OnCreate M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentApplicationOnCreate()
+        {
+            tlog.Debug(tag, $"NUIComponentApplicationOnCreate START");
+
+            IDictionary<Type, string> typeInfo = new Dictionary<Type, string>();
+            typeInfo.Add(typeof(Applications.ComponentBased.Common.FrameComponent), "FrameComponent");
+            var testingTarget = new MyNUIComponentApplication(typeInfo);
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIComponentApplication>(testingTarget, "Should be an instance of NUIComponentApplication type.");
+
+            try
+            {
+                testingTarget.MyOnCreate();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentApplicationOnCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIComponentApplication OnTerminate.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentApplication.OnTerminate M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentApplicationOnTerminate()
+        {
+            tlog.Debug(tag, $"NUIComponentApplicationOnCreate START");
+
+            IDictionary<Type, string> typeInfo = new Dictionary<Type, string>();
+            typeInfo.Add(typeof(Applications.ComponentBased.Common.FrameComponent), "FrameComponent");
+            var testingTarget = new MyNUIComponentApplication(typeInfo);
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIComponentApplication>(testingTarget, "Should be an instance of NUIComponentApplication type.");
+
+            try
+            {
+                testingTarget.MyOnTerminate();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentApplicationOnCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIComponentApplication Exit.")]
+        [Property("SPEC", "Tizen.NUI.NUIComponentApplication.Exit M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIComponentApplicationExit()
+        {
+            tlog.Debug(tag, $"NUIComponentApplicationExit START");
+
+            IDictionary<Type, string> typeInfo = new Dictionary<Type, string>();
+            typeInfo.Add(typeof(Applications.ComponentBased.Common.FrameComponent), "FrameComponent");
+            var testingTarget = new MyNUIComponentApplication(typeInfo);
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIComponentApplication>(testingTarget, "Should be an instance of NUIComponentApplication type.");
+
+            try
+            {
+                testingTarget.MyExit();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIComponentApplicationExit END (OK)");
+        }
+
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIFrameComponent.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIFrameComponent.cs
@@ -14,6 +14,42 @@ namespace Tizen.NUI.Devel.Tests
     {
         private const string tag = "NUITEST";
 
+        internal class MyNUIFrameComponent : NUIFrameComponent
+        {
+            public MyNUIFrameComponent() : base()
+            { }
+
+            public void MyOnCreate()
+            {
+                base.OnCreate();
+            }
+
+            public void MyOnStart(Tizen.Applications.AppControl appControl, bool restarted)
+            {
+                base.OnStart(appControl, restarted);
+            }
+
+            public void MyOnResume()
+            {
+                base.OnResume();
+            }
+
+            public void MyOnPause()
+            {
+                base.OnPause();
+            }
+
+            public void MyOnStop()
+            {
+                base.OnStop();
+            }
+
+            public void MyOnDestroy()
+            {
+                base.OnDestroy();
+            }
+        }
+
         [SetUp]
         public void Init()
         {
@@ -24,6 +60,250 @@ namespace Tizen.NUI.Devel.Tests
         public void Destroy()
         {
             tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent NUIWindowInfo")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.NUIWindowInfo A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentNUIWindowInfo()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentNUIWindowInfo START");
+
+            var testingTarget = new NUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            testingTarget.NUIWindowInfo = new NUIWindowInfo(Window.Instance);
+            tlog.Debug(tag, "testingTarget.NUIWindowInfo : " + testingTarget.NUIWindowInfo);
+            Assert.IsNotNull(testingTarget.NUIWindowInfo);
+
+            tlog.Debug(tag, $"NUIFrameComponentNUIWindowInfo END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent Window")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.Window A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentWindow()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentWindow START");
+
+            var testingTarget = new NUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            testingTarget.Window = new Window(new Rectangle(0, 0, 1920, 1080), false);
+            tlog.Debug(tag, "testingTarget.Window : " + testingTarget.Window);
+            Assert.IsNotNull(testingTarget.Window);
+
+            tlog.Debug(tag, $"NUIFrameComponentWindow END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent CreateWindowInfo")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.CreateWindowInfo M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentCreateWindowInfo()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentCreateWindowInfo START");
+
+            var testingTarget = new NUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            try
+            {
+                testingTarget.NUIWindowInfo = new NUIWindowInfo(Window.Instance);
+                testingTarget.Window = new Window(new Rectangle(0, 0, 1920, 1080), false);
+                
+                testingTarget.CreateWindowInfo();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"NUIFrameComponentCreateWindowInfo END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent OnCreate.")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.OnCreate M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentOnCreate()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentOnCreate START");
+
+            var testingTarget = new MyNUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            try
+            {
+                testingTarget.MyOnCreate();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"NUIFrameComponentOnCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent OnStart.")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.OnStart M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentOnStart()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentOnStart START");
+
+            var testingTarget = new MyNUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            try
+            {
+                Tizen.Applications.AppControl appControl = new Tizen.Applications.AppControl(true);
+                testingTarget.MyOnStart(appControl, false);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"NUIFrameComponentOnStart END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent OnResume.")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.OnResume M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentOnResume()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentOnResume START");
+
+            var testingTarget = new MyNUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            try
+            {
+                testingTarget.MyOnResume();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"NUIFrameComponentOnResume END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent OnPause.")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.OnPause M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentOnPause()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentOnPause START");
+
+            var testingTarget = new MyNUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            try
+            {
+                testingTarget.MyOnPause();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"NUIFrameComponentOnPause END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent OnStop.")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.OnStop M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentOnStop()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentOnStop START");
+
+            var testingTarget = new MyNUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            try
+            {
+                testingTarget.MyOnStop();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"NUIFrameComponentOnStop END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIFrameComponent OnDestroy.")]
+        [Property("SPEC", "Tizen.NUI.NUIFrameComponent.OnDestroy M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void NUIFrameComponentOnDestroy()
+        {
+            tlog.Debug(tag, $"NUIFrameComponentOnDestroy START");
+
+            var testingTarget = new MyNUIFrameComponent();
+            Assert.IsNotNull(testingTarget, "Should be not null.");
+            Assert.IsInstanceOf<NUIFrameComponent>(testingTarget, "Should be an instance of NUIFrameComponent type.");
+
+            try
+            {
+                testingTarget.MyOnDestroy();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            tlog.Debug(tag, $"NUIFrameComponentOnDestroy END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIWidgetApplication.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSNUIWidgetApplication.cs
@@ -24,6 +24,42 @@ namespace Tizen.NUI.Devel.Tests
         }
     }
 
+    internal class MyNUIWidgetApplication : NUIWidgetApplication
+    {
+        public MyNUIWidgetApplication(global::System.Type widgetType) : base(widgetType)
+        { }
+
+        public void MyOnCreate()
+        {
+            base.OnCreate();
+        }
+
+        public void MyOnTerminate()
+        {
+            base.OnTerminate();
+        }
+
+        public void MyOnLocaleChanged(Applications.LocaleChangedEventArgs e)
+        {
+            base.OnLocaleChanged(e);
+        }
+
+        public void MyOnLowBattery(Applications.LowBatteryEventArgs e)
+        {
+            base.OnLowBattery(e);
+        }
+
+        public void MyOnLowMemory(Applications.LowMemoryEventArgs e)
+        {
+            base.OnLowMemory(e);
+        }
+
+        public void MyOnRegionFormatChanged(Applications.RegionFormatChangedEventArgs e)
+        {
+            base.OnRegionFormatChanged(e);
+        }
+    }
+
     public class PublicNUIWidgetApplicationTest
     {
         private const string tag = "NUITEST";
@@ -151,6 +187,278 @@ namespace Tizen.NUI.Devel.Tests
             }
 
             tlog.Debug(tag, $"NUIWidgetApplicationDispose END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication AddWidgetType.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.AddWidgetType M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationAddWidgetType()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationAddWidgetType START");
+
+            var testingTarget = new NUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+            
+            try
+            {
+                testingTarget.AddWidgetType(typeof(MyWidget));
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationAddWidgetType END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication AddWidgetType. With Dictionary.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.AddWidgetType M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationAddWidgetTypeWithDictionary()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationAddWidgetTypeWithDictionary START");
+
+            var testingTarget = new NUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                Dictionary<global::System.Type, string> widgetTypes = new Dictionary<Type, string>();
+                widgetTypes.Add(typeof(MyWidget), "MyWidget");
+                testingTarget.AddWidgetType(widgetTypes);
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationAddWidgetTypeWithDictionary END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication ApplicationHandle.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.ApplicationHandle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationApplicationHandle()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationApplicationHandle START");
+
+            var testingTarget = new NUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                var result =  testingTarget.ApplicationHandle;
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationApplicationHandle END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication OnCreate.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.OnCreate M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationOnCreate()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationOnCreate START");
+
+            var testingTarget = new MyNUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                testingTarget.MyOnCreate();
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationOnCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication OnLocaleChanged.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.OnLocaleChanged M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationOnLocaleChanged()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationOnLocaleChanged START");
+
+            var testingTarget = new MyNUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                testingTarget.MyOnLocaleChanged(new Applications.LocaleChangedEventArgs("BeiJing"));
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationOnLocaleChanged END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication OnLowBattery.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.OnLowBattery M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationOnLowBattery()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationOnLowBattery START");
+
+            var testingTarget = new MyNUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                testingTarget.MyOnLowBattery(new Applications.LowBatteryEventArgs(Applications.LowBatteryStatus.PowerOff));
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationOnLowBattery END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication OnLowMemory.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.OnLowMemory M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationOnLowMemory()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationOnLowMemory START");
+
+            var testingTarget = new MyNUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                testingTarget.MyOnLowMemory(new Applications.LowMemoryEventArgs(Applications.LowMemoryStatus.Normal));
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationOnLowMemory END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication OnTerminate.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.OnTerminate M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationOnTerminate()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationOnTerminate START");
+
+            var testingTarget = new MyNUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                testingTarget.MyOnTerminate();
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationOnTerminate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("NUIWidgetApplication OnRegionFormatChanged.")]
+        [Property("SPEC", "Tizen.NUI.NUIWidgetApplication.OnRegionFormatChanged M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@partner.samsung.com")]
+        public void NUIWidgetApplicationOnRegionFormatChanged()
+        {
+            tlog.Debug(tag, $"NUIWidgetApplicationOnRegionFormatChanged START");
+
+            var testingTarget = new MyNUIWidgetApplication(typeof(MyWidget));
+            Assert.IsNotNull(testingTarget, "should be not null.");
+            Assert.IsInstanceOf<NUIWidgetApplication>(testingTarget, "Should be an instance of NUIWidgetApplication type.");
+
+            try
+            {
+                testingTarget.MyOnRegionFormatChanged(new Applications.RegionFormatChangedEventArgs("China"));
+            }
+            catch (Exception e)
+            {
+                tlog.Error(tag, "Caught Exception" + e.ToString());
+                LogUtils.Write(LogUtils.DEBUG, LogUtils.TAG, "Caught Exception" + e.ToString());
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"NUIWidgetApplicationOnRegionFormatChanged END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSWatchTime.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Application/TSWatchTime.cs
@@ -15,18 +15,6 @@ namespace Tizen.NUI.Devel.Tests
     {
         private const string tag = "NUITEST";
 
-        private bool IsWearable()
-        {
-            string value;
-            var result = Tizen.System.Information.TryGetValue("tizen.org/feature/profile", out value);
-            if (result && value.Equals("wearable"))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         [SetUp]
         public void Init()
         {
@@ -50,350 +38,492 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"WatchTimeConstructor START");
 
-            if (IsWearable())
+            using (ImageView view = new ImageView())
             {
-                var testingTarget = new WatchTime();
+                var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
                 Assert.IsNotNull(testingTarget, "should be not null");
                 Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
                 testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeConstructor END (OK)");
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeConstructor END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            tlog.Debug(tag, $"WatchTimeConstructor END (OK)"); 
         }
 
         [Test]
         [Category("P1")]
-        [Description("WatchTime Day.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Day A")]
+        [Description("WatchTime getCPtr.")]
+        [Property("SPEC", "Tizen.NUI.WatchTime.getCPtr M")]
         [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeDay()
+        public void WatchTimegetCPtr()
         {
-            tlog.Debug(tag, $"WatchTimeDay START");
+            tlog.Debug(tag, $"WatchTimegetCPtr START");
 
-            if (IsWearable())
+            using (ImageView view = new ImageView())
             {
-                var testingTarget = new WatchTime();
+                var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
                 Assert.IsNotNull(testingTarget, "should be not null");
                 Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
-                
-                int time = testingTarget.Day;
-                Assert.IsTrue(time > 0.0f);
+
+                try
+                {
+                    WatchTime.getCPtr(testingTarget);
+                }
+                catch (Exception e)
+                {
+                    tlog.Debug(tag, e.Message.ToString());
+                    Assert.Fail("Caught Exception: Failed!");
+                }
 
                 testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeDay END (OK)");
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeDay END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            tlog.Debug(tag, $"WatchTimegetCPtr END (OK)");
         }
 
         [Test]
         [Category("P1")]
-        [Description("WatchTime DaylightSavingTimeStatus.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.DaylightSavingTimeStatus A")]
+        [Description("WatchTime GetWatchTimeFromPtr.")]
+        [Property("SPEC", "Tizen.NUI.WatchTime.GetWatchTimeFromPtr M")]
         [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
+        [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeDaylightSavingTimeStatus()
+        public void WatchTimeGetWatchTimeFromPtr()
         {
-            tlog.Debug(tag, $"WatchTimeDaylightSavingTimeStatus START");
+            tlog.Debug(tag, $"WatchTimeGetWatchTimeFromPtr START");
 
-            if (IsWearable())
+            using (ImageView view = new ImageView())
             {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
-                
-                bool status = testingTarget.DaylightSavingTimeStatus;
-                Assert.AreEqual(false, status, "Should be the default value");
-
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeDaylightSavingTimeStatus END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeDaylightSavingTimeStatus END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime DayOfWeek.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.DayOfWeek A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeDayOfWeek()
-        {
-            tlog.Debug(tag, $"WatchTimeDayOfWeek START");
-
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
+                var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
                 Assert.IsNotNull(testingTarget, "should be not null");
                 Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
-                int day = testingTarget.DayOfWeek;
-                Assert.IsTrue(day > 0.0f);
+                try
+                {
+                    WatchTime.GetWatchTimeFromPtr(testingTarget.SwigCPtr.Handle);
+                }
+                catch (Exception e)
+                {
+                    tlog.Debug(tag, e.Message.ToString());
+                    Assert.Fail("Caught Exception: Failed!");
+                }
 
                 testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeDayOfWeek END (OK)");
             }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeDayOfWeek END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
+
+            tlog.Debug(tag, $"WatchTimeGetWatchTimeFromPtr END (OK)");
         }
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime Hour.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Hour A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeHour()
-        {
-            tlog.Debug(tag, $"WatchTimeHour START");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime GetUtcTime.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.GetUtcTime M")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "MR")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeGetUtcTime()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeGetUtcTime START");
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
-                int hour = testingTarget.Hour;
-                Assert.IsTrue(hour > 0.0f);
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetUtcTime' in shared library 'libdali2-csharp-binder.so' */
+        //            testingTarget.GetUtcTime();
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeHour END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeHour END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        testingTarget.Dispose();
+        //    }
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime Hour24.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Hour24 A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeHour24()
-        {
-            tlog.Debug(tag, $"WatchTimeHour24 START");
+        //    tlog.Debug(tag, $"WatchTimeGetUtcTime END (OK)");
+        //}
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Day.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Day A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeDay()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeDay START");
 
-                int hour24 = testingTarget.Hour24;
-                Assert.IsTrue(hour24 >= 0.0f);
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeHour24 END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeHour24 END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetDay' in shared library 'libdali2-csharp-binder.so' */
+        //            int time = testingTarget.Day;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime Millisecond.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Millisecond A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeMillisecond()
-        {
-            tlog.Debug(tag, $"WatchTimeMillisecond START");
+        //        testingTarget.Dispose();
+        //    }
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //    tlog.Debug(tag, $"WatchTimeDay END (OK)");
+        //}
 
-                int millisecond = testingTarget.Millisecond;
-                Assert.IsTrue(millisecond >= 0.0f);
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime DaylightSavingTimeStatus.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.DaylightSavingTimeStatus A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeDaylightSavingTimeStatus()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeDaylightSavingTimeStatus START");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeMillisecond END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeMillisecond END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime Minute.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Minute A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeMinute()
-        {
-            tlog.Debug(tag, $"WatchTimeMinute START");
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetDaylightSavingTimeStatus' in shared library 'libdali2-csharp-binder.so' */
+        //            bool status = testingTarget.DaylightSavingTimeStatus;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //        testingTarget.Dispose();
+        //    }
 
-                int minute = testingTarget.Minute;
-                Assert.IsTrue(minute >= 0.0f);
+        //    tlog.Debug(tag, $"WatchTimeDaylightSavingTimeStatus END (OK)");
+        //}
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeMinute END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeMinute END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime DayOfWeek.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.DayOfWeek A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeDayOfWeek()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeDayOfWeek START");
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime Month.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Month A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeMonth()
-        {
-            tlog.Debug(tag, $"WatchTimeMonth START");
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetDayOfWeek' in shared library 'libdali2-csharp-binder.so' */
+        //            int day = testingTarget.DayOfWeek;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-                int month = testingTarget.Month;
-                Assert.IsTrue(month > 0.0f);
+        //        testingTarget.Dispose();
+        //    }
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeMonth END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeMonth END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //    tlog.Debug(tag, $"WatchTimeDayOfWeek END (OK)"); 
+        //}
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime Second.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Second A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeSecond()
-        {
-            tlog.Debug(tag, $"WatchTimeSecond START");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Hour.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Hour A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeHour()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeHour START");
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
-                int second = testingTarget.Second;
-                Assert.IsTrue(second >= 0.0f);
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetHour' in shared library 'libdali2-csharp-binder.so' */
+        //            int hour = testingTarget.Hour;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeSecond END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeSecond END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        testingTarget.Dispose();
+        //    }
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime TimeZone.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.TimeZone A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeTimeZone()
-        {
-            tlog.Debug(tag, $"WatchTimeTimeZone START");
+        //    tlog.Debug(tag, $"WatchTimeHour END (OK)");
+        //}
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Hour24.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Hour24 A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeHour24()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeHour24 START");
 
-                string zone = testingTarget.TimeZone;
-                Assert.IsNotEmpty(zone, "TimeZone is empty");
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeTimeZone END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeTimeZone END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetHour24' in shared library 'libdali2-csharp-binder.so' */
+        //            int hour24 = testingTarget.Hour24;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
 
-        [Test]
-        [Category("P1")]
-        [Description("WatchTime Year.")]
-        [Property("SPEC", "Tizen.NUI.WatchTime.Year A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void WatchTimeYear()
-        {
-            tlog.Debug(tag, $"WatchTimeYear START");
+        //        testingTarget.Dispose();
+        //    }
 
-            if (IsWearable())
-            {
-                var testingTarget = new WatchTime();
-                Assert.IsNotNull(testingTarget, "should be not null");
-                Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+        //    tlog.Debug(tag, $"WatchTimeHour24 END (OK)");
+        //}
 
-                int year = testingTarget.Year;
-                Assert.IsTrue(year > 0.0f);
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Millisecond.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Millisecond A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeMillisecond()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeMillisecond START");
 
-                testingTarget.Dispose();
-                tlog.Debug(tag, $"WatchTimeYear END (OK)");
-            }
-            else
-            {
-                tlog.Debug(tag, $"WatchTimeYear END (OK)");
-                Assert.Pass("Not Supported profile");
-            }
-        }
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetMillisecond' in shared library 'libdali2-csharp-binder.so' */
+        //            int millisecond = testingTarget.Millisecond;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchTimeMillisecond END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Minute.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Minute A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeMinute()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeMinute START");
+
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetMinute' in shared library 'libdali2-csharp-binder.so' */
+        //            int minute = testingTarget.Minute;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchTimeMinute END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Month.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Month A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeMonth()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeMonth START");
+
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetMonth' in shared library 'libdali2-csharp-binder.so' */
+        //            int month = testingTarget.Month;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchTimeMonth END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Second.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Second A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeSecond()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeSecond START");
+
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetSecond' in shared library 'libdali2-csharp-binder.so' */
+        //            int second = testingTarget.Second;
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchTimeSecond END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime TimeZone.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.TimeZone A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeTimeZone()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeTimeZone START");
+
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetTimeZone' in shared library 'libdali2-csharp-binder.so' */
+        //            string zone = testingTarget.TimeZone;
+        //            Assert.IsNotEmpty(zone, "TimeZone is empty");
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchTimeTimeZone END (OK)");
+        //}
+
+        //[Test]
+        //[Category("P1")]
+        //[Description("WatchTime Year.")]
+        //[Property("SPEC", "Tizen.NUI.WatchTime.Year A")]
+        //[Property("SPEC_URL", "-")]
+        //[Property("CRITERIA", "PRO")]
+        //[Property("AUTHOR", "guowei.wang@samsung.com")]
+        //public void WatchTimeYear()
+        //{
+        //    tlog.Debug(tag, $"WatchTimeYear START");
+
+        //    using (ImageView view = new ImageView())
+        //    {
+        //        var testingTarget = new WatchTime(view.SwigCPtr.Handle, false);
+        //        Assert.IsNotNull(testingTarget, "should be not null");
+        //        Assert.IsInstanceOf<WatchTime>(testingTarget, "Should be an instance of WatchTime type.");
+
+        //        try
+        //        {
+        //            /** Unable to find an entry point named 'CSharp_Dali_WatchTime_GetYear' in shared library 'libdali2-csharp-binder.so' */
+        //            int year = testingTarget.Year;
+        //            Assert.IsTrue(year > 0);
+        //        }
+        //        catch (Exception e)
+        //        {
+        //            tlog.Debug(tag, e.Message.ToString());
+        //            Assert.Fail("Caught Exception: Failed!");
+        //        }
+
+        //        testingTarget.Dispose();
+        //    }
+
+        //    tlog.Debug(tag, $"WatchTimeYear END (OK)");
+        //}
     }
 }


### PR DESCRIPTION
### Description of Change ###
1. Remove IsWearable() from  internal/WatchApplication ，WatchBoolSignal ， WatchTimeSignal  and public/WatchTime.
2. Add TCs to improve line coverage.    
ps: Some cases are commented  out because they would throw similar exceptions, such as:
        Unable to find an entry point named 'CSharp_Dali_delete_WatchBoolSignal' in shared library 'libdali2-csharp-binder.so', 
        Unable to find an entry point named 'CSharp_Dali_WatchTime_GetDayOfWeek' in shared library 'libdali2-csharp-binder.so'
        ......, and so on, 
        after these issues are fixed, we can open them. 
        
         

         



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
