### PR TITLE
Revert "[NUI] Deprecate ResizePolicyType"

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -308,7 +308,6 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="policy">The policy being set.</param>
         /// <param name="dimension">The policy is being set for.</param>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated. Since Tizen.NUI.ResizePolicyType is deprecated, OnSetResizePolicy is no longer supported. Please do not use this.")]
         public virtual void OnSetResizePolicy(ResizePolicyType policy, DimensionType dimension)
         {
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -256,7 +256,6 @@ namespace Tizen.NUI.BaseComponents
         /// This view's size is set to the view's size multiplied by or added to this factor, depending on ResizePolicyType.<br />
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Deprecated. Since Tizen.NUI.ResizePolicyType is deprecated, OnSetResizePolicy is no longer supported. Instead, please use parent view having Tizen.NUI.RelativeLayout as its Layout.")]
         public Vector3 SizeModeFactor
         {
             get => (Vector3)GetValue(SizeModeFactorProperty);
@@ -267,7 +266,6 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the width resize policy to be used.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Deprecated. Please set Tizen.NUI.View.Layout and use Tizen.NUI.View.WidthSpecification instead.")]
         public ResizePolicyType? WidthResizePolicy
         {
             get => (ResizePolicyType?)GetValue(WidthResizePolicyProperty);
@@ -278,7 +276,6 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the height resize policy to be used.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Deprecated. Please set Tizen.NUI.View.Layout and use Tizen.NUI.View.HeightSpecification instead.")]
         public ResizePolicyType? HeightResizePolicy
         {
             get => (ResizePolicyType?)GetValue(HeightResizePolicyProperty);

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1717,7 +1717,6 @@ namespace Tizen.NUI.BaseComponents
         /// The property cascade chaining set is possible. For example, this (view.DecorationBoundingBox.X = 0.1f;) is possible.
         /// </remarks>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated. Since Tizen.NUI.ResizePolicyType is deprecated, SizeModeFactor is no longer supported. Instead, please use parent view having Tizen.NUI.RelativeLayout as its Layout.")]
         public Vector3 SizeModeFactor
         {
             get
@@ -1736,7 +1735,6 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the width resize policy to be used.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated. Please set Layout and use WidthSpecification instead.")]
         public ResizePolicyType WidthResizePolicy
         {
             get
@@ -1754,7 +1752,6 @@ namespace Tizen.NUI.BaseComponents
         /// Gets or sets the height resize policy to be used.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated. Please set Layout and use HeightSpecification instead.")]
         public ResizePolicyType HeightResizePolicy
         {
             get

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -136,57 +136,48 @@ namespace Tizen.NUI
     /// Enumeration for size negotiation resize policies.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    [Obsolete("Deprecated. Please set Tizen.NUI.View.Layout and use Tizen.NUI.BaseComponents.LayoutParamPolicies instead.")]
     public enum ResizePolicyType
     {
         /// <summary>
         /// Size is fixed as set by SetSize.
         /// </summary>
         [Description("FIXED")]
-        [Obsolete("Deprecated. Instead, please set a positive integer value to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
         Fixed,
         /// <summary>
         /// Size is to use the actor's natural size.
         /// </summary>
         /// <see cref="ViewImpl.GetNaturalSize"/>
         [Description("USE_NATURAL_SIZE")]
-        [Obsolete("Deprecated. Instead, please set a positive integer value to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
         UseNaturalSize,
         /// <summary>
         /// Size is to fill up to the actor's parent's bounds. Aspect ratio is not maintained.
         /// </summary>
         [Description("FILL_TO_PARENT")]
-        [Obsolete("Deprecated. Instead, please set Tizen.NUI.View.Layout and also set Tizen.NUI.BaseComponents.LayoutParamPolicies.MatchParent to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
         FillToParent,
         /// <summary>
         /// The actors size will be ( ParentSize * SizeRelativeToParentFactor ).
         /// </summary>
         [Description("SIZE_RELATIVE_TO_PARENT")]
-        [Obsolete("Deprecated. Instead, please use parent view having Tizen.NUI.RelativeLayout as its Layout.")]
         SizeRelativeToParent,
         /// <summary>
         /// The actors size will be ( ParentSize + SizeRelativeToParentFactor ).
         /// </summary>
         [Description("SIZE_FIXED_OFFSET_FROM_PARENT")]
-        [Obsolete("Deprecated. Instead, please use parent view having Tizen.NUI.RelativeLayout as its Layout.")]
         SizeFixedOffsetFromParent,
         /// <summary>
         /// The size will adjust to wrap around all children.
         /// </summary>
         [Description("FIT_TO_CHILDREN")]
-        [Obsolete("Deprecated. Instead, please set Tizen.NUI.View.Layout and also set Tizen.NUI.BaseComponents.LayoutParamPolicies.WrapContent to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
         FitToChildren,
         /// <summary>
         /// One dimension is dependent on the other.
         /// </summary>
         [Description("DIMENSION_DEPENDENCY")]
-        [Obsolete("Deprecated. Instead, please set positive integer values with aspect ratio to Tizen.NUI.View.WidthSpecification and Tizen.NUI.View.HeightSpecification.")]
         DimensionDependency,
         /// <summary>
         /// The size will be assigned to the actor.
         /// </summary>
         [Description("USE_ASSIGNED_SIZE")]
-        [Obsolete("Deprecated. Instead, please set a positive integer value to Tizen.NUI.View.WidthSpecification or Tizen.NUI.View.HeightSpecification.")]
         UseAssignedSize
     }
 


### PR DESCRIPTION
This reverts commit 426fc56baad122973dad5bca42073a3394e5dd6d.

Since some ResizePolicyTypes are not fully covered, ResizePolicyType is
not deprecated for now.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
