### PR TITLE
[NUI] Fix to support simple MatchParent in RelativeLayout

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
@@ -348,28 +348,7 @@ namespace Tizen.NUI
                 LayoutItem childLayout = LayoutChildren[i];
                 if (childLayout != null)
                 {
-                    var childWidthMeasureSpec = new MeasureSpecification(widthMeasureSpec.Size, widthMeasureSpec.Mode);
-                    var childHeightMeasureSpec = new MeasureSpecification(heightMeasureSpec.Size, heightMeasureSpec.Mode);
-
-                    // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
-                    // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
-                    // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
-                    if (childLayout.Owner.WidthSpecification == LayoutParamPolicies.MatchParent)
-                    {
-                        childWidthMeasureSpec.SetSize(new LayoutLength(widthMeasureSpec.Size));
-                        childWidthMeasureSpec.SetMode(MeasureSpecification.ModeType.AtMost);
-                    }
-
-                    // RelativeLayout's MatchParent children should not fill to the RelativeLayout.
-                    // Because the children's sizes and positions are calculated by RelativeLayout's APIs.
-                    // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
-                    if (childLayout.Owner.HeightSpecification == LayoutParamPolicies.MatchParent)
-                    {
-                        childHeightMeasureSpec.SetSize(new LayoutLength(heightMeasureSpec.Size));
-                        childHeightMeasureSpec.SetMode(MeasureSpecification.ModeType.AtMost);
-                    }
-
-                    MeasureChildWithMargins(childLayout, childWidthMeasureSpec, new LayoutLength(0), childHeightMeasureSpec, new LayoutLength(0));
+                    MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
 
                     if (childLayout.MeasuredWidth.State == MeasuredSize.StateType.MeasuredSizeTooSmall)
                     {


### PR DESCRIPTION
This reverts a part of d5ac94d24b3ca635034b57324e527e253e2ed789 to
support simple MatchParent in RelativeLayout.

For easier use, child fills its parent if child has MatchParent without
using RelativeLayout APIs.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
