### PR TITLE
[NUI] Support Ellipsis Position Property 

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -301,6 +301,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_METHOD_SETTINGS_get")]
             public static extern int InputMethodSettingsGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_get")]
+            public static extern int EllipsisGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_LOCATION_get")]
+            public static extern int EllipsisLocationGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -305,8 +305,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_get")]
             public static extern int EllipsisGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_LOCATION_get")]
-            public static extern int EllipsisLocationGet();
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_ELLIPSIS_POSITION_get")]
+            public static extern int EllipsisPositionGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -244,6 +244,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_get")]
             public static extern int EllipsisGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_LOCATION_get")]
+            public static extern int EllipsisLocationGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectWholeText")]
             public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -244,8 +244,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_get")]
             public static extern int EllipsisGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_LOCATION_get")]
-            public static extern int EllipsisLocationGet();
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ELLIPSIS_POSITION_get")]
+            public static extern int EllipsisPositionGet();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectWholeText")]
             public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -108,8 +108,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_get")]
             public static extern int EllipsisGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_LOCATION_get")]
-            public static extern int EllipsisLocationGet();
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_POSITION_get")]
+            public static extern int EllipsisPositionGet();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_COUNT_get")]
             public static extern int LineCountGet();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -108,6 +108,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_get")]
             public static extern int EllipsisGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_LOCATION_get")]
+            public static extern int EllipsisLocationGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_COUNT_get")]
             public static extern int LineCountGet();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
@@ -38,7 +38,7 @@ namespace Tizen.NUI.BaseComponents
         internal static readonly BindableProperty PointSizeProperty = BindableProperty.Create(nameof(PointSize), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).pointSize = (float?)newValue,
             defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).pointSize);
-        
+
         /// <summary> The bindable property of PixelSize. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty PixelSizeProperty = BindableProperty.Create(nameof(PixelSize), typeof(float?), typeof(TextEditorStyle), null,
@@ -218,6 +218,19 @@ namespace Tizen.NUI.BaseComponents
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).fontStyle = (PropertyMap)newValue,
             defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).fontStyle);
 
+        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textEditorStyle = (TextEditorStyle)bindable;
+            textEditorStyle.ellipsis = (bool?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textEditorStyle = (TextEditorStyle)bindable;
+            return textEditorStyle.ellipsis;
+        });
+
         private HorizontalAlignment? horizontalAlignment;
         private Vector4 secondaryCursorColor;
         private bool? enableCursorBlink;
@@ -250,6 +263,7 @@ namespace Tizen.NUI.BaseComponents
         private Color placeholderTextColor;
         private Vector4 primaryCursorColor;
         private PropertyMap fontStyle;
+        private bool? ellipsis;
 
         static TextEditorStyle() { }
 
@@ -586,6 +600,14 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (PropertyMap)GetValue(FontStyleProperty);
             set => SetValue(FontStyleProperty, value);
+        }
+
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool? Ellipsis
+        {
+            get => (bool?)GetValue(EllipsisProperty);
+            set => SetValue(EllipsisProperty, value);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
@@ -269,15 +269,15 @@ namespace Tizen.NUI.BaseComponents
         });
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
-            textLabelStyle.ellipsisLocation = (EllipsisLocation?)newValue;
+            textLabelStyle.ellipsisPosition = (EllipsisPosition?)newValue;
         },
         defaultValueCreator: (bindable) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
-            return textLabelStyle.ellipsisLocation;
+            return textLabelStyle.ellipsisPosition;
         });
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -330,7 +330,7 @@ namespace Tizen.NUI.BaseComponents
         private AutoScrollStopMode? autoScrollStopMode;
         private LineWrapMode? lineWrapMode;
         private VerticalLineAlignment? verticalLineAlignment;
-        private EllipsisLocation? ellipsisLocation;
+        private EllipsisPosition? ellipsisPosition;
         private bool? matchSystemLanguageDirection;
         private Selector<string> translatableTextSelector;
         private Selector<string> fontFamilySelector;
@@ -504,10 +504,10 @@ namespace Tizen.NUI.BaseComponents
 
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public EllipsisLocation? EllipsisLocation
+        public EllipsisPosition? EllipsisPosition
         {
-            get => (EllipsisLocation?)GetValue(EllipsisLocationProperty);
-            set => SetValue(EllipsisLocationProperty, value);
+            get => (EllipsisPosition?)GetValue(EllipsisPositionProperty);
+            set => SetValue(EllipsisPositionProperty, value);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
@@ -267,6 +267,18 @@ namespace Tizen.NUI.BaseComponents
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.verticalLineAlignment;
         });
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            textLabelStyle.ellipsisLocation = (EllipsisLocation?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            return textLabelStyle.ellipsisLocation;
+        });
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -318,6 +330,7 @@ namespace Tizen.NUI.BaseComponents
         private AutoScrollStopMode? autoScrollStopMode;
         private LineWrapMode? lineWrapMode;
         private VerticalLineAlignment? verticalLineAlignment;
+        private EllipsisLocation? ellipsisLocation;
         private bool? matchSystemLanguageDirection;
         private Selector<string> translatableTextSelector;
         private Selector<string> fontFamilySelector;
@@ -487,6 +500,14 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (VerticalLineAlignment?)GetValue(VerticalLineAlignmentProperty);
             set => SetValue(VerticalLineAlignmentProperty, value);
+        }
+
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EllipsisLocation? EllipsisLocation
+        {
+            get => (EllipsisLocation?)GetValue(EllipsisLocationProperty);
+            set => SetValue(EllipsisLocationProperty, value);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1339,6 +1339,47 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The Ellipsis property.<br />
+        /// Enable or disable the ellipsis.<br />
+        /// </summary>
+        /// <since_tizen> 6.5 </since_tizen>
+        /// This will be released at Tizen.NET API Level 6.5, so currently this would be used as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Ellipsis
+        {
+            get
+            {
+                return (bool)GetValue(EllipsisProperty);
+            }
+            set
+            {
+                SetValue(EllipsisProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The ellipsis location of the text.
+        /// The ellipsis location type when the text size over the layout size.<br />
+        /// The ellipsis location: End, Start or Middle.<br />
+        /// </summary>
+        /// <since_tizen> 6.5 </since_tizen>
+        /// This will be released at Tizen.NET API Level 6.5, so currently this would be used as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EllipsisLocation EllipsisLocation
+        {
+            get
+            {
+                return (EllipsisLocation)GetValue(EllipsisLocationProperty);
+            }
+            set
+            {
+                SetValue(EllipsisLocationProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The LineWrapMode property.<br />
         /// The line wrap mode when the text lines over the layout width.<br />
         /// </summary>
@@ -1790,6 +1831,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EnableGrabHandle = Interop.TextEditor.EnableGrabHandleGet();
             internal static readonly int EnableGrabHandlePopup = Interop.TextEditor.EnableGrabHandlePopupGet();
             internal static readonly int InputMethodSettings = Interop.TextEditor.InputMethodSettingsGet();
+            internal static readonly int ELLIPSIS = Interop.TextEditor.EllipsisGet();
+            internal static readonly int EllipsisLocation = Interop.TextEditor.EllipsisLocationGet();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1338,7 +1338,10 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
+        /// <summary>
+        /// The Ellipsis property.<br />
+        /// Enable or disable the ellipsis.<br />
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Ellipsis
         {
@@ -1353,7 +1356,12 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
+
+        /// <summary>
+        /// The ellipsis position of the text.
+        /// The ellipsis position type when the text size over the layout size.<br />
+        /// The ellipsis position: End, Start or Middle.<br />
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public EllipsisPosition EllipsisPosition
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1338,12 +1338,7 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// <summary>
-        /// The Ellipsis property.<br />
-        /// Enable or disable the ellipsis.<br />
-        /// </summary>
-        /// <since_tizen> 6.5 </since_tizen>
-        /// This will be released at Tizen.NET API Level 6.5, so currently this would be used as inhouse API.
+        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Ellipsis
         {
@@ -1358,23 +1353,17 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// <summary>
-        /// The ellipsis location of the text.
-        /// The ellipsis location type when the text size over the layout size.<br />
-        /// The ellipsis location: End, Start or Middle.<br />
-        /// </summary>
-        /// <since_tizen> 6.5 </since_tizen>
-        /// This will be released at Tizen.NET API Level 6.5, so currently this would be used as inhouse API.
+        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public EllipsisLocation EllipsisLocation
+        public EllipsisPosition EllipsisPosition
         {
             get
             {
-                return (EllipsisLocation)GetValue(EllipsisLocationProperty);
+                return (EllipsisPosition)GetValue(EllipsisPositionProperty);
             }
             set
             {
-                SetValue(EllipsisLocationProperty, value);
+                SetValue(EllipsisPositionProperty, value);
                 NotifyPropertyChanged();
             }
         }
@@ -1832,7 +1821,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EnableGrabHandlePopup = Interop.TextEditor.EnableGrabHandlePopupGet();
             internal static readonly int InputMethodSettings = Interop.TextEditor.InputMethodSettingsGet();
             internal static readonly int ELLIPSIS = Interop.TextEditor.EllipsisGet();
-            internal static readonly int EllipsisLocation = Interop.TextEditor.EllipsisLocationGet();
+            internal static readonly int EllipsisPosition = Interop.TextEditor.EllipsisPositionGet();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -1043,20 +1043,20 @@ namespace Tizen.NUI.BaseComponents
         }));
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation), typeof(TextEditor), EllipsisLocation.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition), typeof(TextEditor), EllipsisPosition.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var textEditor = (TextEditor)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisLocation, new Tizen.NUI.PropertyValue((int)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition, new Tizen.NUI.PropertyValue((int)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textEditor = (TextEditor)bindable;
             int temp = 0;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisLocation).Get(out temp);
-            return (EllipsisLocation)temp;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition).Get(out temp);
+            return (EllipsisPosition)temp;
         }));
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -1024,5 +1024,39 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputMethodSettings).Get(temp);
             return temp;
         }));
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(TextEditor.Ellipsis), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS, new Tizen.NUI.PropertyValue((bool)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            bool temp = false;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS).Get(out temp);
+            return temp;
+        }));
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation), typeof(TextEditor), EllipsisLocation.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisLocation, new Tizen.NUI.PropertyValue((int)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            int temp = 0;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisLocation).Get(out temp);
+            return (EllipsisLocation)temp;
+        }));
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1348,7 +1348,11 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
+        /// <summary>
+        /// The ellipsis position of the text.
+        /// The ellipsis position type when the text size over the layout size.<br />
+        /// The ellipsis position: End, Start or Middle.<br />
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public EllipsisPosition EllipsisPosition
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1348,6 +1348,21 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EllipsisPosition EllipsisPosition
+        {
+            get
+            {
+                return (EllipsisPosition)GetValue(EllipsisPositionProperty);
+            }
+            set
+            {
+                SetValue(EllipsisPositionProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
         /// <summary>
         /// The Placeholder property.
         /// The placeholder map contains the following keys :<br />
@@ -1833,6 +1848,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int PrimaryCursorPosition = Interop.TextField.PrimaryCursorPositionGet();
             internal static readonly int FontSizeScale = Interop.TextField.FontSizeScaleGet();
             internal static readonly int GrabHandleColor = Interop.TextField.GrabHandleColorGet();
+            internal static readonly int EllipsisPosition = Interop.TextField.EllipsisPositionGet();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -952,6 +952,23 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ELLIPSIS).Get(out temp);
             return temp;
         }));
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation), typeof(TextField), EllipsisLocation.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textField = (TextField)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisLocation, new Tizen.NUI.PropertyValue((int)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textField = (TextField)bindable;
+            int temp = 0;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisLocation).Get(out temp);
+            return (EllipsisLocation)temp;
+        }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableShiftSelectionProperty = BindableProperty.Create(nameof(TextField.EnableShiftSelection), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -954,20 +954,20 @@ namespace Tizen.NUI.BaseComponents
         }));
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation), typeof(TextField), EllipsisLocation.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition), typeof(TextField), EllipsisPosition.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var textField = (TextField)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisLocation, new Tizen.NUI.PropertyValue((int)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisPosition, new Tizen.NUI.PropertyValue((int)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textField = (TextField)bindable;
             int temp = 0;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisLocation).Get(out temp);
-            return (EllipsisLocation)temp;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisPosition).Get(out temp);
+            return (EllipsisPosition)temp;
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -789,15 +789,15 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 6.5 </since_tizen>
         /// This will be released at Tizen.NET API Level 6.5, so currently this would be used as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public EllipsisLocation EllipsisLocation
+        public EllipsisPosition EllipsisPosition
         {
             get
             {
-                return (EllipsisLocation)GetValue(EllipsisLocationProperty);
+                return (EllipsisPosition)GetValue(EllipsisPositionProperty);
             }
             set
             {
-                SetValue(EllipsisLocationProperty, value);
+                SetValue(EllipsisPositionProperty, value);
                 NotifyPropertyChanged();
             }
         }
@@ -1177,7 +1177,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int TextFit = Interop.TextLabel.TextFitGet();
             internal static readonly int MinLineSize = Interop.TextLabel.MinLineSizeGet();
             internal static readonly int FontSizeScale = Interop.TextLabel.FontSizeScaleGet();
-            internal static readonly int EllipsisLocation = Interop.TextLabel.EllipsisLocationGet();
+            internal static readonly int EllipsisPosition = Interop.TextLabel.EllipsisPositionGet();
         }
 
         private void OnShadowColorChanged(float x, float y, float z, float w)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -782,6 +782,27 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The ellipsis location of the text.
+        /// The ellipsis location type when the text size over the layout size.<br />
+        /// The ellipsis location: End, Start or Middle.<br />
+        /// </summary>
+        /// <since_tizen> 6.5 </since_tizen>
+        /// This will be released at Tizen.NET API Level 6.5, so currently this would be used as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EllipsisLocation EllipsisLocation
+        {
+            get
+            {
+                return (EllipsisLocation)GetValue(EllipsisLocationProperty);
+            }
+            set
+            {
+                SetValue(EllipsisLocationProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The AutoScrollLoopDelay property.<br />
         /// Do something.<br />
         /// </summary>
@@ -1156,6 +1177,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int TextFit = Interop.TextLabel.TextFitGet();
             internal static readonly int MinLineSize = Interop.TextLabel.MinLineSizeGet();
             internal static readonly int FontSizeScale = Interop.TextLabel.FontSizeScaleGet();
+            internal static readonly int EllipsisLocation = Interop.TextLabel.EllipsisLocationGet();
         }
 
         private void OnShadowColorChanged(float x, float y, float z, float w)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -781,13 +781,7 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// <summary>
-        /// The ellipsis location of the text.
-        /// The ellipsis location type when the text size over the layout size.<br />
-        /// The ellipsis location: End, Start or Middle.<br />
-        /// </summary>
-        /// <since_tizen> 6.5 </since_tizen>
-        /// This will be released at Tizen.NET API Level 6.5, so currently this would be used as inhouse API.
+        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public EllipsisPosition EllipsisPosition
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -781,7 +781,11 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// This will be released at Tizen.NET API Level 9, so currently this would be used as inhouse API.
+        /// <summary>
+        /// The ellipsis position of the text.
+        /// The ellipsis position type when the text size over the layout size.<br />
+        /// The ellipsis position: End, Start or Middle.<br />
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public EllipsisPosition EllipsisPosition
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -461,20 +461,20 @@ namespace Tizen.NUI.BaseComponents
         }));
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation), typeof(TextLabel), EllipsisLocation.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition), typeof(TextLabel), EllipsisPosition.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisLocation, new Tizen.NUI.PropertyValue((int)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition, new Tizen.NUI.PropertyValue((int)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textLabel = (TextLabel)bindable;
             int temp = 0;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisLocation).Get(out temp);
-            return (EllipsisLocation)temp;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition).Get(out temp);
+            return (EllipsisPosition)temp;
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -459,6 +459,23 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS).Get(out temp);
             return temp;
         }));
+        /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty EllipsisLocationProperty = BindableProperty.Create(nameof(EllipsisLocation), typeof(EllipsisLocation), typeof(TextLabel), EllipsisLocation.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisLocation, new Tizen.NUI.PropertyValue((int)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            int temp = 0;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisLocation).Get(out temp);
+            return (EllipsisLocation)temp;
+        }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollLoopDelayProperty = BindableProperty.Create(nameof(AutoScrollLoopDelay), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -883,28 +883,11 @@ namespace Tizen.NUI
         Bottom
     }
 
-    /// <summary>
-    /// An enum of ellipsis location.
-    /// </summary>
-    /// <since_tizen> 6 </since_tizen>
-    public enum EllipsisLocation
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum EllipsisPosition
     {
-        /// <summary>
-        /// ellipsis location at end.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         End,
-
-        /// <summary>
-        /// ellipsis location at start.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         Start,
-
-        /// <summary>
-        /// ellipsis location in middle.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
         Middle
     }
 

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -884,6 +884,31 @@ namespace Tizen.NUI
     }
 
     /// <summary>
+    /// An enum of ellipsis location.
+    /// </summary>
+    /// <since_tizen> 6 </since_tizen>
+    public enum EllipsisLocation
+    {
+        /// <summary>
+        /// ellipsis location at end.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        End,
+
+        /// <summary>
+        /// ellipsis location at start.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        Start,
+
+        /// <summary>
+        /// ellipsis location in middle.
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        Middle
+    }
+
+    /// <summary>
     /// Enumeration type for the font's slant.
     /// </summary>
     /// <since_tizen> 5 </since_tizen>

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -883,11 +883,28 @@ namespace Tizen.NUI
         Bottom
     }
 
+    /// <summary>
+    /// An enum of ellipsis position.
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum EllipsisPosition
     {
+        /// <summary>
+        /// ellipsis position at end.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         End,
+
+        /// <summary>
+        /// ellipsis position at start.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         Start,
+
+        /// <summary>
+        /// ellipsis position in middle.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         Middle
     }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Bind EllipsisPosition Property with DALi. 

**Patches:** 

- Support Ellipsis Position Property: https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/259560 
- [NUI] Support Ellipsis Position Property: https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/260614

Added new property Ellipsis to TextEditor
Added new property Ellipsis_Position to TextLabel, TextField and TextEditor

Handled Ellipsis location for below cases:

- Locations: END, START and MIDDLE
- TextController: TextLabel, TextField and TextEditor
- SingleLine and Muilt-lines with different LineWrap modes
- Text direction LTR and RTL

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

**Added:**
 - EllipsisPosition TextLabel.EllipsisPosition { get; set; } // Property
 - EllipsisPosition TextField.EllipsisPosition { get; set; } // Property
 - EllipsisPosition TextEditor.EllipsisPosition { get; set; } // Property
 - bool TextEditor.Ellipsis { get; set; } // Property


