### PR TITLE
[NUI] Fix issue of SetValue to the property which hasn't DefaultValue Create delegate

### DIFF
--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -266,6 +266,16 @@ namespace Tizen.NUI.Binding
                 {
                     throw new ArgumentNullException(nameof(property));
                 }
+
+                if (null == property.DefaultValueCreator)
+                {
+                    BindablePropertyContext context = GetOrCreateContext(property);
+                    if (null != context)
+                    {
+                        context.Value = value;
+                    }
+                }
+
                 property.PropertyChanged?.Invoke(this, null, value);
 
                 OnPropertyChanged(property.PropertyName);


### PR DESCRIPTION
[NUI] Fix issue of SetValue to the property which hasn't DefaultValue Create delegate

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
