### PR TITLE
[NUI][EXaml] Support ResourcePath in Xaml

### DIFF
--- a/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
@@ -21,6 +21,7 @@ using System.Text;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 using Tizen.NUI.Binding.Internals;
+using Tizen.NUI.Xaml;
 
 namespace Tizen.NUI.EXaml
 {
@@ -69,6 +70,10 @@ namespace Tizen.NUI.EXaml
                             paramList[i] = globalDataList.GatheredInstances[instance.Index];
                         }
 
+                        if (paramList[i] is ApplicationResourcePathExtension applicationResourcePath)
+                        {
+                            paramList[i] = applicationResourcePath.ProvideValue(null);
+                        }
                     }
 
                     if (null == xFactoryMethod)

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
@@ -70,9 +70,9 @@ namespace Tizen.NUI.EXaml
                             paramList[i] = globalDataList.GatheredInstances[instance.Index];
                         }
 
-                        if (paramList[i] is ApplicationResourcePathExtension applicationResourcePath)
+                        if (paramList[i] is ResourcePathExtension resourcePath)
                         {
-                            paramList[i] = applicationResourcePath.ProvideValue(null);
+                            paramList[i] = resourcePath.ProvideValue(null);
                         }
                     }
 

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/SetBindalbeProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/SetBindalbeProperty.cs
@@ -21,6 +21,7 @@ using System.Text;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 using Tizen.NUI.Binding.Internals;
+using Tizen.NUI.Xaml;
 
 namespace Tizen.NUI.EXaml
 {
@@ -48,6 +49,11 @@ namespace Tizen.NUI.EXaml
                 {
                     int valueIndex = valueInstance.Index;
                     value = globalDataList.GatheredInstances[valueIndex];
+                }
+
+                if (value is ApplicationResourcePathExtension applicationResourcePath)
+                {
+                    value = applicationResourcePath.ProvideValue(null);
                 }
 
                 instance.SetValue(property, value);

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/SetBindalbeProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/SetBindalbeProperty.cs
@@ -51,9 +51,9 @@ namespace Tizen.NUI.EXaml
                     value = globalDataList.GatheredInstances[valueIndex];
                 }
 
-                if (value is ApplicationResourcePathExtension applicationResourcePath)
+                if (value is ResourcePathExtension resourcePath)
                 {
-                    value = applicationResourcePath.ProvideValue(null);
+                    value = resourcePath.ProvideValue(null);
                 }
 
                 instance.SetValue(property, value);

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/SetProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/SetProperty.cs
@@ -21,6 +21,7 @@ using System.Text;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 using Tizen.NUI.Binding.Internals;
+using Tizen.NUI.Xaml;
 
 namespace Tizen.NUI.EXaml
 {
@@ -65,6 +66,11 @@ namespace Tizen.NUI.EXaml
                 {
                     throw new Exception(String.Format("Can't get instance of value by index {0}", valueIndex));
                 }
+            }
+
+            if (value is ApplicationResourcePathExtension applicationResourcePath)
+            {
+                value = applicationResourcePath.ProvideValue(null);
             }
 
             property.SetMethod.Invoke(instance, new object[] { value });

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/SetProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/SetProperty.cs
@@ -68,9 +68,9 @@ namespace Tizen.NUI.EXaml
                 }
             }
 
-            if (value is ApplicationResourcePathExtension applicationResourcePath)
+            if (value is ResourcePathExtension resourcePath)
             {
-                value = applicationResourcePath.ProvideValue(null);
+                value = resourcePath.ProvideValue(null);
             }
 
             property.SetMethod.Invoke(instance, new object[] { value });

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -41,22 +41,6 @@ namespace Tizen.NUI
         private WidgetUpdatePeriodChangedEventCallbackType widgetUpdatePeriodChangedEventCallback;
         private EventHandler<WidgetViewEventArgs> widgetFaultedEventHandler;
         private WidgetFaultedEventCallbackType widgetFaultedEventCallback;
-
-        /// <summary>
-        /// Used in xaml as factory method to create WidgetView.
-        /// </summary>
-        /// <param name="widgetId"></param>
-        /// <param name="contentInfo"></param>
-        /// <param name="width"></param>
-        /// <param name="height"></param>
-        /// <param name="updatePeriod"></param>
-        /// <returns></returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static WidgetView CreateWidgetView(string widgetId, string contentInfo, int width, int height, float updatePeriod)
-        {
-            return WidgetViewManager.Instance.AddWidget(widgetId, contentInfo, width, height, updatePeriod);
-        }
-
         /// <summary>
         /// Creates a new WidgetView.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -41,6 +41,22 @@ namespace Tizen.NUI
         private WidgetUpdatePeriodChangedEventCallbackType widgetUpdatePeriodChangedEventCallback;
         private EventHandler<WidgetViewEventArgs> widgetFaultedEventHandler;
         private WidgetFaultedEventCallbackType widgetFaultedEventCallback;
+
+        /// <summary>
+        /// Used in xaml as factory method to create WidgetView.
+        /// </summary>
+        /// <param name="widgetId"></param>
+        /// <param name="contentInfo"></param>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        /// <param name="updatePeriod"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static WidgetView CreateWidgetView(string widgetId, string contentInfo, int width, int height, float updatePeriod)
+        {
+            return WidgetViewManager.Instance.AddWidget(widgetId, contentInfo, width, height, updatePeriod);
+        }
+
         /// <summary>
         /// Creates a new WidgetView.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Xaml/MarkupExtensions/ResourcePathExtension.cs
+++ b/src/Tizen.NUI/src/public/Xaml/MarkupExtensions/ResourcePathExtension.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.NUI.Binding;
+
+namespace Tizen.NUI.Xaml
+{
+    /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [ContentProperty(nameof(FilePath))]
+    [AcceptEmptyServiceProvider]
+    public class ResourcePathExtension : IMarkupExtension<string>
+    {
+        /// <summary></summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ResourcePathExtension()
+        {
+        }
+
+        /// <summary></summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string FilePath { get; set; }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string ProvideValue(IServiceProvider serviceProvider) => Tizen.Applications.Application.Current.DirectoryInfo.Resource + FilePath;
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+        {
+            return (this as IMarkupExtension<string>).ProvideValue(serviceProvider);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Fix JIRA: https://code.sec.samsung.net/jira/browse/GRE-2334
now user can set the relative path to Url in Xaml

sample:
`<ImageView x:Name="imageView" ResourceUrl="{ResourcePath FilePath=images/a.jpg}" />`

when the xaml is loaded, the path "Tizen.Applications.Application.Current.DirectoryInfo.Resource + "images/a.jpg"" will be set to the ResourceUrl.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
