### PR TITLE
[NUI] Fix Shadow issue when we set BoxShadow = null

### DIFF
--- a/src/Tizen.NUI/src/public/ViewProperty/Shadow.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/Shadow.cs
@@ -70,7 +70,7 @@ namespace Tizen.NUI
         /// </summary>
         internal Shadow(PropertyMap propertyMap) : base(propertyMap)
         {
-            Color = noColor;
+            Color = new Color(noColor);
             PropertyValue pValue = propertyMap.Find(ColorVisualProperty.MixColor);
             pValue?.Get(Color);
             pValue?.Dispose();

--- a/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
@@ -57,8 +57,8 @@ namespace Tizen.NUI
         {
             Debug.Assert(propertyMap != null);
 
-            Offset = noOffset;
-            Extents = noExtents;
+            Offset = new Vector2(noOffset);
+            Extents = new Vector2(noExtents);
 
             var transformProperty = propertyMap.Find(Visual.Property.Transform);
 


### PR DESCRIPTION
When we set view.BoxShadow.Color = new Color(~~);
BoxShadow.Color have same reference with noColor.
So noColor also become changed

We make another refernce when setup Color by noColor.
Now Color doesn't have same reference with noColor.

(Same jobs doing for noOffset and noExtents)

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
