### PR TITLE
[NUI] Fix picker not to use ViewStyle.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/DatePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/DatePicker.cs
@@ -61,7 +61,6 @@ namespace Tizen.NUI.Components
         private Picker dayPicker;
         private Picker monthPicker;
         private Picker yearPicker;
-        private DatePickerStyle datePickerStyle => ViewStyle as DatePickerStyle;
         
         /// <summary>
         /// Creates a new instance of DatePicker.
@@ -69,7 +68,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public DatePicker()
         {
-            Initialize();
         }
         
         /// <summary>
@@ -79,7 +77,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public DatePicker(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -89,7 +86,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public DatePicker(DatePickerStyle datePickerStyle) : base(datePickerStyle)
         {
-            Initialize();
         }
 
 
@@ -180,18 +176,35 @@ namespace Tizen.NUI.Components
             dayPicker.CurrentValue = currentDate.Day;
             monthPicker.CurrentValue = currentDate.Month;
             yearPicker.CurrentValue = currentDate.Year;
+
+            Initialize();
         }
-    
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [SuppressMessage("Microsoft.Reliability",
                          "CA2000:DisposeObjectsBeforeLosingScope",
                          Justification = "The CellPadding will be dispose when the date picker disposed")]
+        public override void ApplyStyle(ViewStyle viewStyle)
+        {
+            base.ApplyStyle(viewStyle);
+
+            if (viewStyle is DatePickerStyle datePickerStyle && Layout is LinearLayout linearLayout)
+            {
+                linearLayout.CellPadding = new Size(datePickerStyle.CellPadding.Width, datePickerStyle.CellPadding.Height);
+
+                yearPicker.ApplyStyle(datePickerStyle.Pickers);
+                monthPicker.ApplyStyle(datePickerStyle.Pickers);
+                dayPicker.ApplyStyle(datePickerStyle.Pickers);
+            }
+        }
+
         private void Initialize()
         {
             HeightSpecification = LayoutParamPolicies.MatchParent;
 
             Layout = new LinearLayout() { 
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                CellPadding = new Size(datePickerStyle.CellPadding.Width, datePickerStyle.CellPadding.Height),
             };
 
             PickersOrderSet();

--- a/src/Tizen.NUI.Components/Controls/TimePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/TimePicker.cs
@@ -14,7 +14,6 @@
  *
  */
 using System;
-using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -63,7 +62,6 @@ namespace Tizen.NUI.Components
         private Picker hourPicker;
         private Picker minutePicker;
         private Picker ampmPicker;
-        private TimePickerStyle timePickerStyle => ViewStyle as TimePickerStyle;
 
         /// <summary>
         /// Creates a new instance of TimePicker.
@@ -71,7 +69,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public TimePicker()
         {
-            Initialize();
         }
 
         /// <summary>
@@ -81,7 +78,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public TimePicker(string style) : base(style)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -91,7 +87,6 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public TimePicker(TimePickerStyle timePickerStyle) : base(timePickerStyle)
         {
-            Initialize();
         }
 
         /// <summary>
@@ -242,6 +237,8 @@ namespace Tizen.NUI.Components
                 hourPicker.CurrentValue = currentTime.Hour;
 
             minutePicker.CurrentValue = currentTime.Minute;
+
+            Initialize();
         }
 
         /// <summary>
@@ -252,6 +249,10 @@ namespace Tizen.NUI.Components
         public override void ApplyStyle(ViewStyle viewStyle)
         {
             base.ApplyStyle(viewStyle);
+
+            var timePickerStyle = viewStyle as TimePickerStyle;
+
+            if (timePickerStyle == null) return;
 
             //Apply CellPadding.
             if (timePickerStyle?.CellPadding != null && Layout != null)
@@ -275,7 +276,6 @@ namespace Tizen.NUI.Components
 
             Layout = new LinearLayout() { 
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                CellPadding = new Size(timePickerStyle.CellPadding.Width, timePickerStyle.CellPadding.Height),
             };
             Console.WriteLine("initialize");
 


### PR DESCRIPTION
ViewStyle is the last applied style which is not same as the current style.
Hence it is not recommanded to use ViewStyle inside components code.
(Please note that View.ViewStyle is deprecated and better not to use.)

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
