### PR TITLE
[NUI] Fix AlertDialog not to use ViewStyle.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -43,8 +43,6 @@ namespace Tizen.NUI.Components
         //        Until the bug is fixed, padding view is added after action content.
         private View defaultActionContentPadding = null;
 
-        private AlertDialogStyle alertDialogStyle => ViewStyle as AlertDialogStyle;
-
         private bool styleApplied = false;
 
         /// <summary>
@@ -124,20 +122,27 @@ namespace Tizen.NUI.Components
 
             base.ApplyStyle(viewStyle);
 
+            var alertDialogStyle = viewStyle as AlertDialogStyle;
+
+            if (alertDialogStyle == null)
+            {
+                return;
+            }
+
             // Apply Title style.
-            if ((alertDialogStyle?.TitleTextLabel != null) && (DefaultTitleContent is TextLabel))
+            if ((alertDialogStyle.TitleTextLabel != null) && (DefaultTitleContent is TextLabel))
             {
                 ((TextLabel)DefaultTitleContent)?.ApplyStyle(alertDialogStyle.TitleTextLabel);
             }
 
             // Apply Message style.
-            if ((alertDialogStyle?.MessageTextLabel != null) && (DefaultContent is TextLabel))
+            if ((alertDialogStyle.MessageTextLabel != null) && (DefaultContent is TextLabel))
             {
                 ((TextLabel)DefaultContent)?.ApplyStyle(alertDialogStyle.MessageTextLabel);
             }
 
             // Apply ActionContent style.
-            if (alertDialogStyle?.ActionContent != null)
+            if (alertDialogStyle.ActionContent != null)
             {
                 DefaultActionContent?.ApplyStyle(alertDialogStyle.ActionContent);
             }


### PR DESCRIPTION
ViewStyle is the last applied style which is not the same as the current style.
Hence it is not recommanded to use ViewStyle inside components code.
(Please note that View.ViewStyle is deprecated and better not to use.)

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
