### PR TITLE
[NUI] Apply ImageUrl in CaptureTest

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
@@ -60,9 +60,9 @@ namespace Tizen.NUI.Samples
                 log.Debug(tag, $"sender is Capture \n");
                 PixelBuffer pixelBuffer = capture.GetCapturedBuffer();
                 PixelData pixelData = PixelBuffer.Convert(pixelBuffer);
-                var url = pixelData.Url;//capture.GetNativeImageSource().Url;
-                capturedImage = new ImageView(url);
-                log.Debug(tag, $"url={url} \n");
+                var imageUrl = pixelData.GenerateUrl();//capture.GetNativeImageSource().Url;
+                capturedImage = new ImageView(imageUrl.ToString());
+                log.Debug(tag, $"url={imageUrl.ToString()} \n");
 
                 capturedImage.Size = new Size(510, 510);
                 capturedImage.Position = new Position(10, 10);


### PR DESCRIPTION
CaptureTest need to use ImageUrl
So i apply it

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
