### PR TITLE
[NUI] Change default Navigator Animation

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -270,7 +270,7 @@ namespace Tizen.NUI.Components
             if (page is DialogPage == false)
             {
                 curAnimation = new Animation(1000);
-                curAnimation.AnimateTo(curTop, "Opacity", 0.0f, 0, 1000);
+                curAnimation.AnimateTo(curTop, "Opacity", 1.0f, 0, 1000);
                 curAnimation.EndAction = Animation.EndActions.StopFinal;
                 curAnimation.Finished += (object sender, EventArgs args) =>
                 {
@@ -347,7 +347,7 @@ namespace Tizen.NUI.Components
                 };
                 curAnimation.Play();
 
-                newTop.Opacity = 0.0f;
+                newTop.Opacity = 1.0f;
                 newTop.SetVisible(true);
                 newAnimation = new Animation(1000);
                 newAnimation.AnimateTo(newTop, "Opacity", 1.0f, 0, 1000);


### PR DESCRIPTION
Default Navigator Animation is changed not to show the background behind the
pages.

During Push(), alpha animation is not applied to the current page.
During Pop(), alpha animation is not applied to the previous page.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
