### PR TITLE
[NUI] Fix AppBar Content's Layout properties

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/AppBar.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/AppBar.cs
@@ -609,7 +609,6 @@ namespace Tizen.NUI.Components
             return new TextLabel()
             {
                 HeightSpecification = LayoutParamPolicies.MatchParent,
-                Weight = 1.0f,
             };
         }
 
@@ -620,8 +619,10 @@ namespace Tizen.NUI.Components
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
+                    LinearAlignment = LinearLayout.Alignment.End,
                 },
-                Weight = 0.0f,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
             };
         }
 

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -449,13 +449,13 @@ namespace Tizen.NUI.Components
                 },
                 ActionView = new ViewStyle()
                 {
-                    Size = new Size(-1, 120),
+                    Size = new Size(48, 120),
                     CornerRadius = 0,
                     BackgroundColor = new Color(0, 0, 0, 0),
                 },
                 ActionButton = new ButtonStyle()
                 {
-                    Size = new Size(-1, 120),
+                    Size = new Size(-2, 120),
                     CornerRadius = 0,
                     BackgroundColor = new Color(0, 0, 0, 0),
                     Text = new TextLabelStyle()
@@ -471,7 +471,7 @@ namespace Tizen.NUI.Components
                     },
                     Icon = new ImageViewStyle()
                     {
-                        Size = new Size(-1, 48),
+                        Size = new Size(48, 48),
                         Color = new Selector<Color>()
                         {
                             Normal = new Color("#0A0E4A"),


### PR DESCRIPTION
Since LinearLayout's size calculation logic has been fixed, AppBar Content's
Layout properties are fixed to calculate size correctly.

After fixing LinearLayout's size calculation logic, Weight is valid only if
Width/HeightSpecification is MatchParent.

AppBarStyle's ActionView and ActionButton's default size is fixed to show its
own size.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
