### PR TITLE
[NUI] Fix Menu's BackgroundColor

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -387,6 +387,8 @@ namespace Tizen.NUI.Components
             WidthSpecification = LayoutParamPolicies.WrapContent;
             HeightSpecification = LayoutParamPolicies.WrapContent;
 
+            BackgroundColor = Color.Transparent;
+
             // Menu is added to Anchor so Menu should exclude layouting because
             // if Anchor has Layout, then Menu is displayed at an incorrect position.
             ExcludeLayouting = true;
@@ -412,6 +414,9 @@ namespace Tizen.NUI.Components
                 ScrollingDirection = ScrollableBase.Direction.Vertical,
                 ScrollEnabled = true,
                 HideScrollbar = false,
+
+                // FIXME: This color should be in DefaultThemeCommon.cs.
+                BackgroundColor = new Color("#EEEFF1"),
             };
         }
 

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -682,12 +682,6 @@ namespace Tizen.NUI.Components
                 }
             });
 
-            // Menu base style
-            theme.AddStyleWithoutClone("Tizen.NUI.Components.Menu", new ViewStyle()
-            {
-                BackgroundColor = new Color("#EEEFF1"),
-            });
-
             // MenuItem base style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.MenuItem", new ButtonStyle()
             {


### PR DESCRIPTION
Menu covers the window size to dismiss Menu when outside of Menu is touched.

Therefore, Menu's BackgroundColor should be transparent and Menu Content's
BackgroundColor should be set instead.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
