### PR TITLE
[NUI][Xaml] Provide method so that user can dispose all xaml objects

### DIFF
--- a/src/Tizen.NUI/src/internal/EXaml/Action/AddExistInstanceAction.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Action/AddExistInstanceAction.cs
@@ -61,6 +61,7 @@ namespace Tizen.NUI.EXaml
 
         public void Init()
         {
+            getValueListOp = null;
         }
 
         public void OnActive()

--- a/src/Tizen.NUI/src/internal/EXaml/Action/CreateInstanceAction.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Action/CreateInstanceAction.cs
@@ -68,6 +68,10 @@ namespace Tizen.NUI.EXaml
 
         public void Init()
         {
+            getTypeIndexOp = null;
+            getXFactoryMethodIndexOp = null;
+            getParamListOp = null;
+            getStaticInstanceOp = null;
         }
 
         public void OnActive()

--- a/src/Tizen.NUI/src/internal/EXaml/Action/GetObjectByPropertyAction.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Action/GetObjectByPropertyAction.cs
@@ -56,6 +56,7 @@ namespace Tizen.NUI.EXaml
 
         public void Init()
         {
+            childOp = null;
         }
 
         public void OnActive()

--- a/src/Tizen.NUI/src/internal/EXaml/Action/GetValueAction.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Action/GetValueAction.cs
@@ -207,6 +207,7 @@ namespace Tizen.NUI.EXaml
 
         public void Init()
         {
+            getValueList = null;
             valueString = "";
         }
 

--- a/src/Tizen.NUI/src/internal/EXaml/Action/OtherActions.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Action/OtherActions.cs
@@ -56,6 +56,7 @@ namespace Tizen.NUI.EXaml
 
         public void Init()
         {
+            getValues = null;
         }
 
         public void OnActive()

--- a/src/Tizen.NUI/src/internal/EXaml/GlobalDataList.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/GlobalDataList.cs
@@ -40,6 +40,11 @@ namespace Tizen.NUI.EXaml
             get;
         } = new List<Operation>();
 
+        internal List<Operation> RemoveEventOperations
+        {
+            get;
+        } = new List<Operation>();
+
         internal List<object> GatheredInstances
         {
             get;

--- a/src/Tizen.NUI/src/internal/EXaml/LoadEXaml.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/LoadEXaml.cs
@@ -169,7 +169,7 @@ namespace Tizen.NUI.EXaml
             return globalDataList;
         }
 
-        internal static void Load(object view, string xaml)
+        internal static void Load(object view, string xaml, out object xamlData)
         {
             var globalDataList = GatherDataList(xaml);
 
@@ -179,6 +179,8 @@ namespace Tizen.NUI.EXaml
             {
                 op.Do();
             }
+
+            xamlData = globalDataList;
         }
 
         internal static void Load(object view, object preloadData)
@@ -195,6 +197,17 @@ namespace Tizen.NUI.EXaml
             foreach (var op in globalDataList.Operations)
             {
                 op.Do();
+            }
+        }
+
+        internal static void RemoveEventsInXaml(object eXamlData)
+        {
+            if (eXamlData is GlobalDataList globalDataList)
+            {
+                foreach (var op in globalDataList.RemoveEventOperations)
+                {
+                    op.Do();
+                }
             }
         }
     }

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/AddEvent.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/AddEvent.cs
@@ -45,7 +45,26 @@ namespace Tizen.NUI.EXaml
             try
             {
                 var methodInfo = globalDataList.GatheredMethods[valueIndex];
-                eventInfo.AddEventHandler(instance, methodInfo.CreateDelegate(eventInfo.EventHandlerType, element));
+                Delegate eventDelegate = null;
+
+                if (methodInfo.IsStatic)
+                {
+                    eventDelegate = methodInfo.CreateDelegate(eventInfo.EventHandlerType);
+                }
+                else
+                {
+                    eventDelegate = methodInfo.CreateDelegate(eventInfo.EventHandlerType, element);
+                }
+
+                if (null != eventDelegate)
+                {
+                    eventInfo.AddEventHandler(instance, eventDelegate);
+                    globalDataList.RemoveEventOperations.Add(new RemoveEvent(eventDelegate, instance, eventInfo));
+                }
+                else
+                {
+                    throw new Exception($"Can't create delegate for method {methodInfo.DeclaringType.FullName}.{methodInfo.Name}");
+                }
             }
             catch (ArgumentException ae)
             {

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/AddToCollectionProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/AddToCollectionProperty.cs
@@ -22,6 +22,7 @@ using System.Text;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 using Tizen.NUI.Binding.Internals;
+using Tizen.NUI.Xaml;
 
 namespace Tizen.NUI.EXaml
 {
@@ -45,12 +46,15 @@ namespace Tizen.NUI.EXaml
                 if (value is Instance)
                 {
                     int valueIndex = (value as Instance).Index;
-                    collection.Add(globalDataList.GatheredInstances[valueIndex]);
+                    value = globalDataList.GatheredInstances[valueIndex];
                 }
-                else
+
+                if (value is IMarkupExtension markupExtension)
                 {
-                    collection.Add(value);
+                    value = markupExtension.ProvideValue(null);
                 }
+
+                collection.Add(value);
             }
         }
 

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
@@ -72,9 +72,9 @@ namespace Tizen.NUI.EXaml
                             paramList[i] = globalDataList.GatheredInstances[instance.Index];
                         }
 
-                        if (paramList[i] is ResourcePathExtension resourcePath)
+                        if (paramList[i] is IMarkupExtension markupExtension)
                         {
-                            paramList[i] = resourcePath.ProvideValue(null);
+                            paramList[i] = markupExtension.ProvideValue(null);
                         }
                     }
 

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/CreateInstance.cs
@@ -40,9 +40,11 @@ namespace Tizen.NUI.EXaml
 
         public void Do()
         {
+            object obj = null;
+
             if (0 == globalDataList.GatheredInstances.Count && null != globalDataList.Root)
             {
-                globalDataList.GatheredInstances.Add(globalDataList.Root);
+                obj = globalDataList.Root;
             }
             else
             {
@@ -54,11 +56,11 @@ namespace Tizen.NUI.EXaml
                 {
                     if (null == xFactoryMethod)
                     {
-                        globalDataList.GatheredInstances.Add(Activator.CreateInstance(type));
+                        obj = Activator.CreateInstance(type);
                     }
                     else
                     {
-                        globalDataList.GatheredInstances.Add(xFactoryMethod.Invoke(null, Array.Empty<object>()));
+                        obj = xFactoryMethod.Invoke(null, Array.Empty<object>());
                     }
                 }
                 else
@@ -78,24 +80,33 @@ namespace Tizen.NUI.EXaml
 
                     if (null == xFactoryMethod)
                     {
-                        globalDataList.GatheredInstances.Add(Activator.CreateInstance(type, paramList.ToArray()));
+                        obj = Activator.CreateInstance(type, paramList.ToArray());
                     }
                     else
                     {
-                        globalDataList.GatheredInstances.Add(xFactoryMethod.Invoke(null, paramList.ToArray()));
+                        obj = xFactoryMethod.Invoke(null, paramList.ToArray());
                     }
                 }
             }
 
-            if (1 == globalDataList.GatheredInstances.Count)
+            if (null != obj)
             {
-                var rootObject = globalDataList.GatheredInstances[0] as BindableObject;
-                if (null != rootObject)
+                globalDataList.GatheredInstances.Add(obj);
+
+                if (obj is BindableObject bindableObject)
                 {
-                    rootObject.IsCreateByXaml = true;
-                    NameScope nameScope = new NameScope();
-                    NameScope.SetNameScope(rootObject, nameScope);
+                    bindableObject.IsCreateByXaml = true;
+
+                    if (1 == globalDataList.GatheredInstances.Count)
+                    {
+                        NameScope nameScope = new NameScope();
+                        NameScope.SetNameScope(bindableObject, nameScope);
+                    }
                 }
+            }
+            else
+            {
+                throw new Exception($"Can't create instance typeIndex:{typeIndex}");
             }
         }
 

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/GatherBindableProperties.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/GatherBindableProperties.cs
@@ -38,6 +38,11 @@ namespace Tizen.NUI.EXaml
         public void Do()
         {
             var type = globalDataList.GatheredTypes[typeIndex];
+            if (null == type)
+            {
+                throw new Exception($"Type of index {typeIndex} is null");
+            }
+
             var field = type.GetField(fi => fi.Name == propertyName && fi.IsStatic && fi.IsPublic);
             if (null == field)
             {

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/GatherStaticInstance.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/GatherStaticInstance.cs
@@ -42,9 +42,11 @@ namespace Tizen.NUI.EXaml
 
         public void Do()
         {
+            object obj = null;
+
             if (0 == globalDataList.GatheredInstances.Count && null != globalDataList.Root)
             {
-                globalDataList.GatheredInstances.Add(globalDataList.Root);
+                obj = globalDataList.Root;
             }
             else
             {
@@ -52,25 +54,42 @@ namespace Tizen.NUI.EXaml
 
                 if (null != fieldName)
                 {
-                    var instance = type.GetField(fieldName, BindingFlags.Static | BindingFlags.Public).GetValue(null);
-                    globalDataList.GatheredInstances.Add(instance);
+                    obj = type.GetField(fieldName, BindingFlags.Static | BindingFlags.Public).GetValue(null);
                 }
                 else
                 {
-                    var instance = type.GetProperty(propertyName, BindingFlags.Static | BindingFlags.Public).GetValue(null);
-                    globalDataList.GatheredInstances.Add(instance);
+                    obj = type.GetProperty(propertyName, BindingFlags.Static | BindingFlags.Public).GetValue(null);
                 }
             }
 
-            if (1 == globalDataList.GatheredInstances.Count)
+            if (null != obj)
             {
-                var rootObject = globalDataList.GatheredInstances[0] as BindableObject;
-                if (null != rootObject)
+                globalDataList.GatheredInstances.Add(obj);
+
+                if (obj is BindableObject bindableObject)
                 {
-                    rootObject.IsCreateByXaml = true;
-                    NameScope nameScope = new NameScope();
-                    NameScope.SetNameScope(rootObject, nameScope);
+                    bindableObject.IsCreateByXaml = true;
+
+                    if (1 == globalDataList.GatheredInstances.Count)
+                    {
+                        NameScope nameScope = new NameScope();
+                        NameScope.SetNameScope(bindableObject, nameScope);
+                    }
                 }
+            }
+            else
+            {
+                string name = null;
+                if (null != fieldName)
+                {
+                    name = fieldName;
+                }
+                else
+                {
+                    name = propertyName;
+                }
+
+                throw new Exception($"Can't gather static instance typeIndex:{typeIndex}, name:{name}");
             }
         }
 

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/RemoveEvent.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/RemoveEvent.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
+using Tizen.NUI.Binding.Internals;
+
+namespace Tizen.NUI.EXaml
+{
+    internal class RemoveEvent : Operation
+    {
+        public RemoveEvent(Delegate eventDelegate, object instance, EventInfo eventInfo)
+        {
+            this.instance = instance;
+            this.eventInfo = eventInfo;
+            this.eventDelegate = eventDelegate;
+        }
+
+        public void Do()
+        {
+            try
+            {
+                eventInfo.RemoveEventHandler(instance, eventDelegate);
+            }
+            catch (ArgumentException ae)
+            {
+                Tizen.Log.Fatal("EXaml", ae.ToString());
+            }
+        }
+
+        private object instance;
+        private EventInfo eventInfo;
+        private Delegate eventDelegate;
+    }
+}

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/SetBindalbeProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/SetBindalbeProperty.cs
@@ -51,9 +51,9 @@ namespace Tizen.NUI.EXaml
                     value = globalDataList.GatheredInstances[valueIndex];
                 }
 
-                if (value is ResourcePathExtension resourcePath)
+                if (value is IMarkupExtension markupExtension)
                 {
-                    value = resourcePath.ProvideValue(null);
+                    value = markupExtension.ProvideValue(null);
                 }
 
                 instance.SetValue(property, value);

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/SetProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/SetProperty.cs
@@ -68,9 +68,9 @@ namespace Tizen.NUI.EXaml
                 }
             }
 
-            if (value is ResourcePathExtension resourcePath)
+            if (value is IMarkupExtension markupExtension)
             {
-                value = resourcePath.ProvideValue(null);
+                value = markupExtension.ProvideValue(null);
             }
 
             property.SetMethod.Invoke(instance, new object[] { value });

--- a/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
+++ b/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
@@ -20,6 +20,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using System.Text;
+using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI.EXaml
 {
@@ -36,6 +37,33 @@ namespace Tizen.NUI.EXaml
             string xamlScript = GetXamlFromPath(path);
             LoadEXaml.Load(view, xamlScript);
             return view;
+        }
+
+        /// Internal used, will never be opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void RemoveEventsInXaml(object eXamlData)
+        {
+            LoadEXaml.RemoveEventsInXaml(eXamlData);
+        }
+
+        /// Internal used, will never be opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DisposeXamlElements(object view)
+        {
+            if (view is Container container)
+            {
+                for (int i = (int)container.ChildCount - 1; i >= 0; i--)
+                {
+                    var child = container.Children[i];
+
+                    if (child.IsCreateByXaml)
+                    {
+                        child.Unparent();
+                        DisposeXamlElements(child);
+                        child.Dispose();
+                    }
+                }
+            }
         }
 
         /// Internal used, will never be opened.
@@ -80,11 +108,13 @@ namespace Tizen.NUI.EXaml
 
         /// Internal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static T LoadFromEXamlByRelativePath<T>(this T view, string eXamlPath)
+        public static object LoadFromEXamlByRelativePath<T>(this T view, string eXamlPath)
         {
+            object eXamlData = null;
+
             if (null == eXamlPath)
             {
-                return view;
+                return eXamlData;
             }
 
             MainAssembly = view.GetType().Assembly;
@@ -105,14 +135,14 @@ namespace Tizen.NUI.EXaml
                 reader.Close();
                 reader.Dispose();
 
-                LoadEXaml.Load(view, xaml);
+                LoadEXaml.Load(view, xaml, out eXamlData);
             }
             else
             {
-                throw new Exception($"Can't find examl file {eXamlPath}");
+                throw new Exception($"Can't find examl file {likelyResourcePath}");
             }
 
-            return view;
+            return eXamlData;
         }
 
         /// Used for TCT and TC coverage, will never be opened.

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -46,7 +46,7 @@ namespace Tizen.NUI.Binding
 
                     if (newValue is BindableObject targetBindableObject)
                     {
-                        targetBindableObject.IsCreateByXaml = true;
+                        targetBindableObject.IsBinded = true;
                     }
                 }
             }),
@@ -256,7 +256,7 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetValue(BindableProperty property, object value)
         {
-            if (true == isCreateByXaml)
+            if (true == IsBinded)
             {
                 SetValue(property, value, false, true);
             }
@@ -578,7 +578,7 @@ namespace Tizen.NUI.Binding
             if (fromStyle && !CanBeSetFromStyle(targetProperty))
                 return;
 
-            IsCreateByXaml = true;
+            IsBinded = true;
 
             var context = GetOrCreateContext(targetProperty);
             if (fromStyle)
@@ -751,6 +751,12 @@ namespace Tizen.NUI.Binding
                 binding.Apply(BindingContext, this, context.Property, fromBindingContextChanged: fromBindingContextChanged);
             }
         }
+
+        internal bool IsBinded
+        {
+            get;
+            set;
+        } = false;
 
         static void BindingContextPropertyBindingChanging(BindableObject bindable, BindingBase oldBindingBase, BindingBase newBindingBase)
         {

--- a/src/Tizen.NUI/src/public/XamlBinding/Binding.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Binding.cs
@@ -116,7 +116,7 @@ namespace Tizen.NUI.Binding
 
                 if (source is BindableObject bindableObject)
                 {
-                    bindableObject.IsCreateByXaml = true;
+                    bindableObject.IsBinded = true;
                 }
             }
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
To fix https://code.sec.samsung.net/jira/browse/GRE-2306.

Provide method so that user can dispose all xaml object.

After this is released, the patch https://github.com/nui-dali/Tizen.NUI.XamlBuild/pull/27 could be merged.

Sample:

C#
```
    public partial class CustomExtension
    {
        public CustomExtension()
        {
            InitializeComponent();
        }

        protected override void Dispose(bool disposing)
        {
            ExitXaml(); //This is generated by XamlBuild.
            base.Dispose(disposing);
        }
    }
```

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
