### PR TITLE
[NUI] Fix to measure RelativeLayout's children sizes correctly

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/RelativeLayout.cs
@@ -233,6 +233,10 @@ namespace Tizen.NUI
             return (ChildrenWidth, ChildrenHeight);
         }
 
+        private Geometry GetHorizontalSpace(View view) => GetHorizontalRelative(view, MeasuredWidth.Size.AsDecimal() - (Padding.Start + Padding.End)).spaceGeometry;
+
+        private Geometry GetVerticalSpace(View view) => GetVerticalRelative(view, MeasuredHeight.Size.AsDecimal() - (Padding.Top + Padding.Bottom)).spaceGeometry;
+
         private Geometry GetHorizontalLayout(View view) => GetHorizontalRelative(view, MeasuredWidth.Size.AsDecimal() - (Padding.Start + Padding.End)).viewGeometry;
 
         private Geometry GetVerticalLayout(View view) => GetVerticalRelative(view, MeasuredHeight.Size.AsDecimal() - (Padding.Top + Padding.Bottom)).viewGeometry;


### PR DESCRIPTION
Previously, TextLabel and TextField's Ellipsis were not displayed in
RelativeLayout, because TextLabel and TextField's size always covers the full
text string.

Now, if TextLabel and TextField support Ellipsis, then RelativeLayout sets the
exact space size to the TextLabel and TextField. So if the assigned size does
not cover the full text string, then Ellipsis is displayed.

Previously, redundant Meausre() was called again in OnMeasure().

Now, Measure() is called again only for FillHorizontal/Vertical cases to set the
filled size to the MeasuredWidth/Height to calculate grand children's size
correctly.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
