### PR TITLE
[NUI] Fix the build error when referencing to NUI.XamlBuild of which version is higher than 1.0.11

### DIFF
--- a/test/NUITizenGallery/NUITizenGallery.csproj
+++ b/test/NUITizenGallery/NUITizenGallery.csproj
@@ -413,7 +413,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Tizen.NUI.XamlBuild" Version="1.0.11" />
+        <PackageReference Include="Tizen.NUI.XamlBuild" Version="1.0.27" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/NUITizenGallery/README.md
+++ b/test/NUITizenGallery/README.md
@@ -18,5 +18,6 @@
 ![](./.pic/csproj-file.png)
 
 ### Start debugging
+- Open VS Code by the command, **"$ code NUITizenGallery.code-workspace"** in /TizenFX/test/NUITizenGallery/ folder.
 - Do run and debug by clicking "play button" as shown below
 ![](./.pic/run.png)


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix the build error when referencing to NUI.XamlBuild of which version is higher than 1.0.11

### API Changes ###
none