### PR TITLE
[NUI] Fix gridlayouter find wrong visible item

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -1290,6 +1290,7 @@ namespace Tizen.NUI.Components
                             {
                                 found.start = gInfo.StartIndex - adds;
                                 failed = false;
+                                break;
                             }
                             //can be step in spanSize...
                             for (int i = 1; i < gInfo.Count; i++)
@@ -1310,6 +1311,7 @@ namespace Tizen.NUI.Components
                                     break;
                                 }
                             }
+                            if (!failed) break;
                         }
                     }
                     //footer only shows?
@@ -1348,6 +1350,7 @@ namespace Tizen.NUI.Components
                             {
                                 found.end = gInfo.StartIndex + adds;
                                 failed = false;
+                                break;
                             }
                             //can be step in spanSize...
                             for (int i = 1; i < gInfo.Count; i++)
@@ -1367,12 +1370,13 @@ namespace Tizen.NUI.Components
                                     break;
                                 }
                             }
+                            if (!failed) break;
                         }
                     }
                     //footer only shows?
                     if (failed)
                     {
-                        found.start = MaxIndex;
+                        found.end = MaxIndex;
                     }
                 }
                 else


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
