### PR TITLE
[NUI] Fix the Window.VisibilityChanged event's crash issue

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/KeyboardRepeatSettingsChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyboardRepeatSettingsChangedSignal.cs
@@ -70,7 +70,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        public KeyboardRepeatSettingsChangedSignal(Window window) : this(Interop.KeyboardRepeatSettingsChangedSignal.GetSignal(Window.getCPtr(window)), true)
+        public KeyboardRepeatSettingsChangedSignal(Window window) : this(Interop.KeyboardRepeatSettingsChangedSignal.GetSignal(Window.getCPtr(window)), false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/internal/Window/WindowEffectSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowEffectSignal.cs
@@ -70,7 +70,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        public WindowTransitionEffectSignal(Window window) : this(Interop.WindowTransitionEffectSignal.GetSignal(Window.getCPtr(window)), true)
+        public WindowTransitionEffectSignal(Window window) : this(Interop.WindowTransitionEffectSignal.GetSignal(Window.getCPtr(window)), false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/internal/Window/WindowVisibilityChangedEvent.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowVisibilityChangedEvent.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI
         {
         }
 
-        public WindowVisibilityChangedEvent(Window window) : this(Interop.WindowVisibilityChangedSignal.GetSignal(Window.getCPtr(window)), true)
+        public WindowVisibilityChangedEvent(Window window) : this(Interop.WindowVisibilityChangedSignal.GetSignal(Window.getCPtr(window)), false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples.sln
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI.Wearable", "..\..
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.System.Feedback", "..\..\src\Tizen.System.Feedback\Tizen.System.Feedback.csproj", "{D422D03E-7E32-4230-8306-B16DFE27E95A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Multimedia.Camera", "..\..\src\Tizen.Multimedia.Camera\Tizen.Multimedia.Camera.csproj", "{210C3F38-BD17-4583-816D-550C319FC6CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +95,10 @@ Global
 		{D422D03E-7E32-4230-8306-B16DFE27E95A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D422D03E-7E32-4230-8306-B16DFE27E95A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D422D03E-7E32-4230-8306-B16DFE27E95A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{210C3F38-BD17-4583-816D-550C319FC6CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{210C3F38-BD17-4583-816D-550C319FC6CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{210C3F38-BD17-4583-816D-550C319FC6CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{210C3F38-BD17-4583-816D-550C319FC6CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
@@ -60,9 +60,11 @@ namespace Tizen.NUI.Samples
                 log.Debug(tag, $"sender is Capture \n");
                 PixelBuffer pixelBuffer = capture.GetCapturedBuffer();
                 PixelData pixelData = PixelBuffer.Convert(pixelBuffer);
-                var imageUrl = pixelData.GenerateUrl();//capture.GetNativeImageSource().Url;
-                capturedImage = new ImageView(imageUrl.ToString());
-                log.Debug(tag, $"url={imageUrl.ToString()} \n");
+                //var imageUrl = pixelData.GenerateUrl();//capture.GetNativeImageSource().Url;
+                //capturedImage = new ImageView(imageUrl.ToString());
+                var url = pixelData.GenerateUrl();
+                capturedImage = new ImageView(url.ToString());
+                log.Debug(tag, $"url={url} \n");
 
                 capturedImage.Size = new Size(510, 510);
                 capturedImage.Position = new Position(10, 10);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowEventsTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowEventsTest.cs
@@ -1,0 +1,178 @@
+﻿
+using global::System;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Samples
+{
+    using log = Tizen.Log;
+
+    public class WindowEventsTest : IExample
+    {
+        const string tag = "NUITEST";
+
+        private Window childViewWindow;
+        private View parent1;
+        private View parent2;
+        private View child;
+
+        public void Activate()
+        {
+            parent1 = new View()
+            {
+                Size2D = new Size2D(500, 500),
+                Position = new Position(100, 100),
+                BackgroundColor = Color.Red,
+                Focusable = true,
+            };
+
+            parent2 = new View()
+            {
+                Size2D = new Size2D(500, 500),
+                Position = new Position(700, 100),
+                BackgroundColor = Color.Blue,
+                Focusable = true,
+            };
+
+            child = new View()
+            {
+                Size2D = new Size2D(250, 250),
+                BackgroundColor = Color.White,
+            };
+
+            child.AddedToWindow += OnChildAddedToWindow;
+            child.RemovedFromWindow += OnChildRemovedFromWindow;
+
+            Window.Instance.GetDefaultLayer().Add(parent1);
+            Window.Instance.GetDefaultLayer().Add(parent2);
+
+            parent1.LeftFocusableView = parent2;
+            parent2.RightFocusableView = parent1;
+
+            parent1.FocusGained += OnParentFocusGained;
+            parent2.FocusGained += OnParentFocusGained;
+
+            FocusManager.Instance.SetCurrentFocusView(parent1);
+            Window.Instance.BackgroundColor = new Color(1.0f, 0.92f, 0.80f, 1.0f);
+        }
+
+        private void OnParentFocusGained(object sender, EventArgs e)
+        {
+            child.Unparent();
+            (sender as View).Add(child);
+        }
+
+        private void OnChildRemovedFromWindow(object sender, EventArgs e)
+        {
+            UnsetChildViewWindow();
+        }
+
+        private void OnChildAddedToWindow(object sender, EventArgs e)
+        {
+            UnsetChildViewWindow();
+            SetChildViewWindow();
+        }
+
+        private void SetChildViewWindow()
+        {
+            childViewWindow = Window.Instance; // Window.Get(childView)?
+
+            if (childViewWindow != null)
+            {
+                childViewWindow.VisibilityChanged += OnChildViewWindowVisibilityChanged;
+                childViewWindow.Resized += OnChildViewWindowResized;
+
+                childViewWindow.FocusChanged += OnChildViewWindowFocusChanged;
+                childViewWindow.TouchEvent += OnChildViewWindowTouchEvent;
+                childViewWindow.WheelEvent += OnChildViewWindowWheelEvent;
+                childViewWindow.KeyEvent += OnChildViewWindowKeyEvent;
+                childViewWindow.TransitionEffect += OnChildViewWindowTransitionEffect;
+                childViewWindow.KeyboardRepeatSettingsChanged += OnChildViewWindowKeyboardRepeatSettingsChanged;
+                childViewWindow.ViewAdded += OnChildViewWindowViewAdded;
+            }
+        }
+
+        private void UnsetChildViewWindow()
+        {
+            if (childViewWindow != null)
+            {
+                childViewWindow.VisibilityChanged -= OnChildViewWindowVisibilityChanged;
+                childViewWindow.Resized -= OnChildViewWindowResized;
+
+                childViewWindow.FocusChanged -= OnChildViewWindowFocusChanged;
+                childViewWindow.TouchEvent -= OnChildViewWindowTouchEvent;
+                childViewWindow.WheelEvent -= OnChildViewWindowWheelEvent;
+                childViewWindow.KeyEvent -= OnChildViewWindowKeyEvent;
+                childViewWindow.TransitionEffect -= OnChildViewWindowTransitionEffect;
+                childViewWindow.KeyboardRepeatSettingsChanged -= OnChildViewWindowKeyboardRepeatSettingsChanged;
+                childViewWindow.ViewAdded -= OnChildViewWindowViewAdded;
+
+                childViewWindow = null;
+            }
+        }
+
+        private void OnChildViewWindowResized(object sender, Window.ResizedEventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowResized() called!");
+        }
+
+        private void OnChildViewWindowVisibilityChanged(object sender, Window.VisibilityChangedEventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowVisibilityChanged() called!");
+        }
+
+        private void OnChildViewWindowViewAdded(object sender, EventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowViewAdded() called!");
+        }
+
+        private void OnChildViewWindowKeyboardRepeatSettingsChanged(object sender, EventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowKeyboardRepeatSettingsChanged() called!");
+        }
+
+        private void OnChildViewWindowTransitionEffect(object sender, Window.TransitionEffectEventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowTransitionEffect() called!");
+        }
+
+        private void OnChildViewWindowKeyEvent(object sender, Window.KeyEventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowKeyEvent() called!");
+        }
+
+        private void OnChildViewWindowWheelEvent(object sender, Window.WheelEventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowWheelEvent() called!");
+        }
+
+        private void OnChildViewWindowTouchEvent(object sender, Window.TouchEventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowTouchEvent() called!");
+        }
+
+        private void OnChildViewWindowFocusChanged(object sender, Window.FocusChangedEventArgs e)
+        {
+            log.Fatal(tag, $"OnChildViewWindowFocusChanged() called!");
+        }
+
+        public void Deactivate()
+        {
+            if (child)
+            {
+                child.Unparent();
+                child.Dispose();
+            }
+
+            if (parent1)
+            {
+                parent1.Unparent();
+                parent1.Dispose();
+            }
+            if (parent2)
+            {
+                parent2.Unparent();
+                parent2.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix the Window.VisibilityChanged event's crash issue
- Because the signals which binds dali, contain signals as member variables, the cMemoryOwn should be false.
- Without this fix, the WindowEventsTest.cs gets crash when continously pushing left,right direction key.

### API Changes ###
none