### PR TITLE
[NUI] Add Popped event to Navigator

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -23,6 +23,19 @@ using Tizen.NUI.BaseComponents;
 namespace Tizen.NUI.Components
 {
     /// <summary>
+    /// PoppedEventArgs is a class to record popped event arguments which will be sent to user.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class PoppedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Page popped by Navigator.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Page Page { get; internal set; }
+    }
+
+    /// <summary>
     /// The Navigator is a class which navigates pages with stack methods such as Push and Pop.
     /// </summary>
     /// <remarks>
@@ -99,6 +112,13 @@ namespace Tizen.NUI.Components
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public event EventHandler<EventArgs> TransitionFinished;
+
+        /// <summary>
+        /// An event fired when Pop of a page has been finished.
+        /// Notice that Popped event handler should be removed when it is called not to call it duplicate.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<PoppedEventArgs> Popped;
 
         /// <summary>
         /// Returns the count of pages in Navigator.
@@ -200,6 +220,10 @@ namespace Tizen.NUI.Components
             if (navigationPages.Count == 1)
             {
                 Remove(topPage);
+
+                //Invoke Popped event
+                Popped?.Invoke(this, new PoppedEventArgs() { Page = topPage });
+
                 return topPage;
             }
             var newTopPage = navigationPages[navigationPages.Count - 2];
@@ -219,6 +243,9 @@ namespace Tizen.NUI.Components
                 //Invoke Page events
                 newTopPage.InvokeAppeared();
                 topPage.InvokeDisappeared();
+
+                //Invoke Popped event
+                Popped?.Invoke(this, new PoppedEventArgs() { Page = topPage });
             };
             transitionFinished = false;
 
@@ -319,6 +346,10 @@ namespace Tizen.NUI.Components
             if (navigationPages.Count == 1)
             {
                 Remove(curTop);
+
+                //Invoke Popped event
+                Popped?.Invoke(this, new PoppedEventArgs() { Page = curTop });
+
                 return curTop;
             }
 
@@ -344,6 +375,9 @@ namespace Tizen.NUI.Components
 
                     //Invoke Page events
                     curTop.InvokeDisappeared();
+
+                    //Invoke Popped event
+                    Popped?.Invoke(this, new PoppedEventArgs() { Page = curTop });
                 };
                 curAnimation.Play();
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/NavigatorSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/NavigatorSample.cs
@@ -9,6 +9,23 @@ namespace Tizen.NUI.Samples
         private ContentPage firstPage, secondPage;
         private Button firstButton, secondButton;
 
+        private void Popped(object sender, PoppedEventArgs args)
+        {
+            global::System.Console.WriteLine("Page is popped!");
+            args.page.Dispose();
+
+            if (args.page == firstPage)
+            {
+                firstPage = null;
+            }
+            else
+            {
+                secondPage = null;
+            }
+
+            navigator.Popped -= Popped;
+        }
+
         public void Activate()
         {
             Window window = NUIApplication.GetDefaultWindow();
@@ -38,6 +55,11 @@ namespace Tizen.NUI.Samples
 
             firstPage = new ContentPage()
             {
+                AppBar = new AppBar()
+                {
+                    AutoNavigationContent = false,
+                    Title = "FirstPage",
+                },
                 Content = firstButton,
             };
             firstPage.Appearing += (object sender, PageAppearingEventArgs e) =>
@@ -67,6 +89,10 @@ namespace Tizen.NUI.Samples
 
             secondPage = new ContentPage()
             {
+                AppBar = new AppBar()
+                {
+                    Title = "SecondPage",
+                },
                 Content = secondButton,
             };
             secondPage.Appearing += (object sender, PageAppearingEventArgs e) =>


### PR DESCRIPTION
Popped event is added to Navigator.
Popped event passes Page handle popped by Navigator.

By using Popped event, for example, user can dispose the popped page.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
