### PR TITLE
[NUI] Fix to call base.Initialize() of LinearLayouter and GridLayouter

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -118,6 +118,7 @@ namespace Tizen.NUI.Components
             if (pureCount == 0)
             {
                 isSourceEmpty = true;
+                base.Initialize(colView);
                 return;
             }
             isSourceEmpty = false;

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -113,6 +113,7 @@ namespace Tizen.NUI.Components
             if (count == (hasHeader? (hasFooter? 2 : 1) : 0))
             {
                 isSourceEmpty = true;
+                base.Initialize(view);
                 return;
             }
             isSourceEmpty = false;


### PR DESCRIPTION
Previously, base.Initialize() of LinearLayouter and GridLayouter was not
called if source was empty.
This caused Container to be null and caused null reference in
RequestLayout().

Now, it is guaranteed that base.Initialize() of LinearLayouter and
GridLayouter is called.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
