### PR TITLE
[NUI] Remove cached ImageUrl at EncodedImageBuffer

### DIFF
--- a/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
@@ -35,7 +35,6 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class EncodedImageBuffer : BaseHandle
     {
-        private ImageUrl mCachedImageUrl = null; // cached Generated Url.
         private VectorUnsignedChar mCachedBuffer = null; // cached encoded raw buffer
 
         /// <summary>
@@ -76,8 +75,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ImageUrl GenerateUrl()
         {
-            mCachedImageUrl ??= new ImageUrl(Interop.EncodedImageBuffer.GenerateUrl(this.SwigCPtr.Handle), true);
-            return mCachedImageUrl;
+            return new ImageUrl(Interop.EncodedImageBuffer.GenerateUrl(this.SwigCPtr.Handle), true);
         }
 
         /// <summary>
@@ -110,7 +108,6 @@ namespace Tizen.NUI
                 //Called by User
                 //Release your own managed resources here.
                 //You should release all of your own disposable objects here.
-                mCachedImageUrl?.Dispose();
                 mCachedBuffer?.Dispose();
             }
 


### PR DESCRIPTION
```
                var imageBuffer = new EncodedImageBuffer(stream);
                var imageUrl = imageBuffer.GenerateUrl(); ///< Get reference of mCachedImageUrl
                imageBuffer.Dispose(); ///< ...and imageUrl disposed!

                var img0 = new ImageView
                {
                    ResourceUrl = imageUrl.ToString()
                };

                Add(img0);
```

There was some problems when we get cached ImageUrl's reference.

Generated ImageUrl must not have any dependency with original encoded image buffer (in app side).
and ImageUrl is only for Engine-side class. (NUI should not control this class's reference)
So I just remove cached data of ImageUrl.
It will works fine.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
