### PR TITLE
[NUI] CanvasView: Add ClipPath and Mask feature for Drawable

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Drawable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Drawable.cs
@@ -45,6 +45,14 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_GetBoundingBox")]
             public static extern global::System.IntPtr GetBoundingBox(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetClipPath")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool SetClipPath(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Drawable_SetMask")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool SetMask(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
@@ -36,6 +36,22 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         }
 
         /// <summary>
+        /// Enumeration indicating the type used in the masking of two objects - the mask drawable and the own drawable.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum MaskType
+        {
+            /// <summary>
+            /// The pixels of the own drawable and the mask drawable are alpha blended. As a result, only the part of the own drawable, which intersects with the mask drawable is visible.
+            /// </summary>
+            Alpha = 0,
+            /// <summary>
+            /// The pixels of the own drawable and the complement to the mask drawable's pixels are alpha blended. As a result, only the part of the own which is not covered by the mask is visible.
+            /// </summary>
+            AlphaInverse
+        }
+
+        /// <summary>
         /// The transparency level [0 ~ 1.0], 0 means totally transparent, while 1 means opaque.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
@@ -82,6 +98,43 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
                 global::System.IntPtr cPtr = Interop.Drawable.GetBoundingBox(BaseHandle.getCPtr(this));
                 return Vector4.GetVector4FromPtr(cPtr);
             }
+        }
+
+        /// <summary>
+        /// The intersection with clip drawable is determined and only the resulting pixels from own drawable are rendered.
+        /// </summary>
+        /// <param name="clip">The clip drawable object.</param>
+        /// <returns>True when it's successful. False otherwise.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when drawable is null. </exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ClipPath(Drawable clip)
+        {
+            if (clip == null)
+            {
+                throw new ArgumentNullException(nameof(clip));
+            }
+            bool ret = Interop.Drawable.SetClipPath(View.getCPtr(this), BaseHandle.getCPtr(clip));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// The pixels of mask drawable and own drawable are blended according to MaskType.
+        /// </summary>
+        /// <param name="mask">The mask drawable object.</param>
+        /// <param name="type">The masking type.</param>
+        /// <returns>True when it's successful. False otherwise.</returns>
+        /// <exception cref="ArgumentNullException"> Thrown when drawable is null. </exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Mask(Drawable mask, MaskType type)
+        {
+            if (mask == null)
+            {
+                throw new ArgumentNullException(nameof(mask));
+            }
+            bool ret = Interop.Drawable.SetMask(View.getCPtr(this), BaseHandle.getCPtr(mask), (int)type);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
@@ -104,10 +104,10 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// The intersection with clip drawable is determined and only the resulting pixels from own drawable are rendered.
         /// </summary>
         /// <param name="clip">The clip drawable object.</param>
-        /// <returns>True when it's successful. False otherwise.</returns>
+        /// <exception cref="Exception"> Drawable clpping failed. </exception>
         /// <exception cref="ArgumentNullException"> Thrown when drawable is null. </exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ClipPath(Drawable clip)
+        public void ClipPath(Drawable clip)
         {
             if (clip == null)
             {
@@ -115,7 +115,10 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
             }
             bool ret = Interop.Drawable.SetClipPath(View.getCPtr(this), BaseHandle.getCPtr(clip));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            if (!ret)
+            {
+                throw new Exception("Drawable clipping failed or clip drawable is already added other drawable or canvas.");
+            }
         }
 
         /// <summary>
@@ -123,10 +126,10 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// </summary>
         /// <param name="mask">The mask drawable object.</param>
         /// <param name="type">The masking type.</param>
-        /// <returns>True when it's successful. False otherwise.</returns>
+        /// <exception cref="Exception"> Drawable masking failed. </exception>
         /// <exception cref="ArgumentNullException"> Thrown when drawable is null. </exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Mask(Drawable mask, MaskType type)
+        public void Mask(Drawable mask, MaskType type)
         {
             if (mask == null)
             {
@@ -134,7 +137,10 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
             }
             bool ret = Interop.Drawable.SetMask(View.getCPtr(this), BaseHandle.getCPtr(mask), (int)type);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            if (!ret)
+            {
+                throw new Exception("Drawable masking failed or mask drawable is already added other drawable or canvas.");
+            }
         }
 
         /// <summary>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSamsple.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSamsple.cs
@@ -54,6 +54,13 @@ namespace Tizen.NUI.Samples
             roundedRectShape.Rotate(45.0f);
             roundedRectShape.AddRect(-50.0f, -50.0f, 100.0f, 100.0f, 0.0f, 0.0f);
 
+            Shape circleMask = new Shape()
+            {
+                FillColor = new Color(1.0f, 1.0f, 1.0f, 1.0f),
+            };
+            circleMask.AddRect(-50.0f, -50.0f, 100.0f, 100.0f, 0.0f, 0.0f);
+            circleMask.Translate(350.0f, 100.0f);
+
             circleShape = new Shape()
             {
                 Opacity = 0.5f,
@@ -64,6 +71,8 @@ namespace Tizen.NUI.Samples
             };
             circleShape.AddCircle(0.0f, 0.0f, 150.0f, 100.0f);
             circleShape.Transform(new float[] { 0.6f, 0.0f, 350.0f, 0.0f, 0.6f, 100.0f, 0.0f, 0.0f, 1.0f });
+
+            circleShape.Mask(circleMask, Drawable.MaskType.Alpha);
 
             arcShape = new Shape()
             {
@@ -94,6 +103,13 @@ namespace Tizen.NUI.Samples
 
             canvasView.AddDrawable(shape);
 
+            Shape starClipper = new Shape()
+            {
+                FillColor = new Color(1.0f, 1.0f, 1.0f, 1.0f),
+            };
+            starClipper.AddCircle(0.0f, 0.0f, 160.0f, 160.0f);
+            starClipper.Translate(250.0f, 550.0f);
+
             starShape = new Shape()
             {
                 Opacity = 0.5f,
@@ -116,8 +132,9 @@ namespace Tizen.NUI.Samples
             starShape.AddLineTo(-54.0f, -56.0f);
             starShape.Close();
 
-            canvasView.AddDrawable(starShape);
+            starShape.ClipPath(starClipper);
 
+            canvasView.AddDrawable(starShape);
 
             group1 = new DrawableGroup();
             group1.AddDrawable(roundedRectShape);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Shape and DrawableGroup, which inherit drawable class,
can clipping and masking using ClipPath and Mask methods.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:no

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
Dependency patch
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/261672/