### PR TITLE
[NUI] CanvasView: Add constructor that can be created without viewbox

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.CanvasView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.CanvasView.cs
@@ -24,6 +24,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_New__SWIG_0")]
             public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CanvasView_New__SWIG_1")]
+            public static extern global::System.IntPtr New();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CanvasView")]
             public static extern void DeleteCanvasView(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
@@ -34,6 +34,15 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// <summary>
         /// Creates an initialized CanvasView.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CanvasView() : this(Interop.CanvasView.New(), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Creates an initialized CanvasView.
+        /// </summary>
         /// <param name="viewBox">The size of viewbox.</param>
         /// <exception cref="ArgumentNullException"> Thrown when viewBox is null. </exception>
         /// <since_tizen> 9 </since_tizen>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Add a constructor so that it can be created without viewBox argument.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:no

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
Dependency patch
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/261876/
