### PR TITLE
[NUI] Add SelectText to TextField, TextEditor

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -235,6 +235,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectWholeText")]
             public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectText")]
+            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_get")]
             public static extern int SelectedTextGet();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -236,7 +236,7 @@ namespace Tizen.NUI
             public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SelectText")]
-            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef textEditorRef, uint start, uint end);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SELECTED_TEXT_get")]
             public static extern int SelectedTextGet();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -247,6 +247,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectWholeText")]
             public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectText")]
+            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_GRAB_HANDLE_get")]
             public static extern int EnableGrabHandleGet();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -248,7 +248,7 @@ namespace Tizen.NUI
             public static extern void SelectWholeText(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SelectText")]
-            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
+            public static extern void SelectText(global::System.Runtime.InteropServices.HandleRef textFieldRef, uint start, uint end);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_ENABLE_GRAB_HANDLE_get")]
             public static extern int EnableGrabHandleGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1547,6 +1547,18 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Select text from start to end index.
+        /// </summary>
+        /// <param name="start">The start index for selection.</param>
+        /// <param name="end">The end index for selection.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SelectText(uint start, uint end)
+        {
+            Interop.TextEditor.SelectText(SwigCPtr, start, end);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Clear selection of the text.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1617,6 +1617,18 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Select text from start to end index.
+        /// </summary>
+        /// <param name="start">The start index for selection.</param>
+        /// <param name="end">The end index for selection.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SelectText(uint start, uint end)
+        {
+            Interop.TextField.SelectText(SwigCPtr, start, end);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Clear selection of the text.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>


### PR DESCRIPTION
Select text from start to end index.
This API works in the same way as SelectWholeText().
When this is called, a SelectText event is added to the event queue.
So this can guarantee the behavior even if called before the text is rendered.

// example
textField.SelectText(2, 10);

Relative patches:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/261509/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/261951/

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>