### PR TITLE
[NUI] CanvasView: Change name DrawableGroup::Clear() to RemoveAllDrawables()

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.DrawableGroup.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DrawableGroup.cs
@@ -28,9 +28,9 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool AddDrawable(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_Clear")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DrawableGroup_RemoveAllDrawables")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static extern bool RemoveAllDrawables(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/DrawableGroup.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/DrawableGroup.cs
@@ -69,9 +69,9 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// </summary>
         /// <returns>True when it's successful. False otherwise.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Clear()
+        public bool RemoveAllDrawables()
         {
-            bool ret = Interop.DrawableGroup.Clear(BaseHandle.getCPtr(this));
+            bool ret = Interop.DrawableGroup.RemoveAllDrawables(BaseHandle.getCPtr(this));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             if (ret)
             {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Since the method name of the same concept in CanvasView is used as
'RemoveAllDrawables', change it to maintain the concept.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:No

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
Dependency patch
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/262039/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/262040/