### PR TITLE
[Applications] Fix wrong implementation of AttachWindowBelow method

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
@@ -676,7 +676,7 @@ namespace Tizen.Applications
         {
             Interop.ApplicationManager.ErrorCode err = Interop.ApplicationManager.ErrorCode.None;
 
-            err = Interop.ApplicationManager.AppManagerAttachWindow(parentAppId, childAppId);
+            err = Interop.ApplicationManager.AppManagerAttachWindowBelow(parentAppId, childAppId);
             if (err != Interop.ApplicationManager.ErrorCode.None)
             {
                 switch (err)


### PR DESCRIPTION
The AttachWindowBelow() method has to use AppManagerAttachWindowBelow().