### PR TITLE
[NUI] sync from master to DevelNUI

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
@@ -676,7 +676,7 @@ namespace Tizen.Applications
         {
             Interop.ApplicationManager.ErrorCode err = Interop.ApplicationManager.ErrorCode.None;
 
-            err = Interop.ApplicationManager.AppManagerAttachWindow(parentAppId, childAppId);
+            err = Interop.ApplicationManager.AppManagerAttachWindowBelow(parentAppId, childAppId);
             if (err != Interop.ApplicationManager.ErrorCode.None)
             {
                 switch (err)


### PR DESCRIPTION
[Applications] Fix wrong implementation of AttachWindowBelow method (#3384)

The AttachWindowBelow() method has to use AppManagerAttachWindowBelow().

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
