### PR TITLE
[NUI] Fix comments of CornerRadiusPolicy and Borderline

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -421,6 +421,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The radius for the rounded corners of the View.
         /// The values in Vector4 are used in clockwise order from top-left to bottom-left : Vector4(top-left-corner, top-right-corner, bottom-right-corner, bottom-left-corner).
+        /// Each radius will clamp internally to the half of smaller of the view's width or height.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public Vector4 CornerRadius
@@ -430,7 +431,7 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Whether the CornerRadius property value is relative (percentage [0.0f to 1.0f] of the view size) or absolute (in world units).
+        /// Whether the CornerRadius property value is relative (percentage [0.0f to 0.5f] of the view size) or absolute (in world units).
         /// It is absolute by default.
         /// When the policy is relative, the corner radius is relative to the smaller of the view's width and height.
         /// </summary>
@@ -453,6 +454,7 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The color for the borderline of the View.
+        /// This color is affected by View Opacity.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Color BorderlineColor

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -465,6 +465,7 @@ namespace Tizen.NUI.BaseComponents
         /// The radius for the rounded corners of the View.
         /// This will rounds background and shadow edges.
         /// The values in Vector4 are used in clockwise order from top-left to bottom-left : Vector4(top-left-corner, top-right-corner, bottom-right-corner, bottom-left-corner).
+        /// Each radius will clamp internally to the half of smaller of the view's width or height.
         /// Note that, an image background (or shadow) may not have rounded corners if it uses a Border property.
         /// </summary>
         /// <remarks>
@@ -490,7 +491,7 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Whether the CornerRadius property value is relative (percentage [0.0f to 1.0f] of the view size) or absolute (in world units).
+        /// Whether the CornerRadius property value is relative (percentage [0.0f to 0.5f] of the view size) or absolute (in world units).
         /// It is absolute by default.
         /// When the policy is relative, the corner radius is relative to the smaller of the view's width and height.
         /// </summary>
@@ -503,12 +504,14 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The width for the borderline of the View.
-        /// This will draw borderline at background.
         /// Note that, an image background may not have borderline if it uses a Border property.
         /// </summary>
         /// <remarks>
         /// <para>
         /// Animatable - This property can be animated using <c>Animation</c> class.
+        /// <code>
+        /// animation.AnimateTo(view, "BorderlineWidth", 100.0f);
+        /// </code>
         /// </para>
         /// </remarks>
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -529,10 +532,14 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The color for the borderline of the View.
         /// It is Color.Black by default.
+        /// This color is affected by View Opacity.
         /// </summary>
         /// <remarks>
         /// <para>
         /// Animatable - This property can be animated using <c>Animation</c> class.
+        /// <code>
+        /// animation.AnimateTo(view, "BorderlineColor", new Color(r, g, b, a));
+        /// </code>
         /// </para>
         /// </remarks>
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -561,6 +568,9 @@ namespace Tizen.NUI.BaseComponents
         /// <remarks>
         /// <para>
         /// Animatable - This property can be animated using <c>Animation</c> class.
+        /// <code>
+        /// animation.AnimateTo(view, "BorderlineOffset", -1.0f);
+        /// </code>
         /// </para>
         /// </remarks>
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
@@ -53,7 +53,7 @@ namespace Tizen.NUI
         internal Vector4 CornerRadius { get; set; }
 
         /// <summary>
-        /// Whether the CornerRadius value is relative (percentage [0.0f to 1.0f] of the view size) or absolute (in world units).
+        /// Whether the CornerRadius value is relative (percentage [0.0f to 0.5f] of the view size) or absolute (in world units).
         /// </summary>
         internal VisualTransformPolicyType CornerRadiusPolicy { get; set; } = VisualTransformPolicyType.Absolute;
 


### PR DESCRIPTION
When CornerRadiusPolicy is Relative, the maximum value is 0.5f.
If value is bigger than 0.5f, it will be clamped internally.
But we cannot notificate that informations only by documents.
Now fix it.

And more, We add some more informations about borderline color;
It will be affected by view opacity

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
