### PR TITLE
[NUI] Add SetFontStyle, GetFontStyle to Text Components

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -218,6 +218,44 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set FontStyle to TextEditor. <br />
+        /// </summary>
+        /// <param name="fontStyle">The FontStyle</param>
+        /// <remarks>
+        /// SetFontStyle specifies the requested font style through <see cref="Tizen.NUI.Text.FontStyle"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetFontStyle method.
+        /// <code>
+        /// var fontStyle = new Tizen.NUI.Text.FontStyle();
+        /// fontStyle.Width = FontWidthType.Expanded;
+        /// fontStyle.Weight = FontWeightType.Bold;
+        /// fontStyle.Slant = FontSlantType.Italic;
+        /// editor.SetFontStyle(fontStyle);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetFontStyle(FontStyle fontStyle)
+        {
+            SetProperty(TextEditor.Property.FontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
+        }
+
+        /// <summary>
+        /// Get FontStyle from TextEditor. <br />
+        /// </summary>
+        /// <returns>The FontStyle</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.FontStyle"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontStyle GetFontStyle()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextEditor.Property.FontStyle).Get(map);
+            return TextUtils.GetFontStyleStruct(map);
+        }
+
+        /// <summary>
         /// The PointSize property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
@@ -673,6 +711,45 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(InputFontStyleProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Set InputFontStyle to TextEditor. <br />
+        /// </summary>
+        /// <param name="fontStyle">The FontStyle</param>
+        /// <remarks>
+        /// SetInputFontStyle specifies the requested font style for new input text through <see cref="Tizen.NUI.Text.FontStyle"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetInputFontStyle method.
+        /// <code>
+        /// var fontStyle = new Tizen.NUI.Text.FontStyle();
+        /// fontStyle.Width = FontWidthType.Expanded;
+        /// fontStyle.Weight = FontWeightType.Bold;
+        /// fontStyle.Slant = FontSlantType.Italic;
+        /// editor.SetInputFontStyle(fontStyle);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetInputFontStyle(FontStyle fontStyle)
+        {
+            SetProperty(TextEditor.Property.InputFontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
+            NotifyPropertyChanged();
+        }
+
+        /// <summary>
+        /// Get InputFontStyle from TextEditor. <br />
+        /// </summary>
+        /// <returns>The FontStyle</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.FontStyle"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontStyle GetInputFontStyle()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextEditor.Property.InputFontStyle).Get(map);
+            return TextUtils.GetFontStyleStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -17,7 +17,6 @@
 
 extern alias TizenSystemSettings;
 using TizenSystemSettings.Tizen.System;
-using System.Text.RegularExpressions;
 
 using System;
 using System.Globalization;
@@ -1323,12 +1322,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetInputFilter(InputFilter inputFilter)
         {
-            var map = new PropertyMap();
-            var accepted = inputFilter.Accepted != null ? new PropertyValue(inputFilter.Accepted.ToString()) : new PropertyValue("");
-            var rejected = inputFilter.Rejected != null ? new PropertyValue(inputFilter.Rejected.ToString()) : new PropertyValue("");
-            map.Add(0, accepted);
-            map.Add(1, rejected);
-            SetProperty(TextEditor.Property.InputFilter, new PropertyValue(map));
+            SetProperty(TextEditor.Property.InputFilter, new PropertyValue(TextUtils.GetInputFilterMap(inputFilter)));
         }
 
         /// <summary>
@@ -1343,16 +1337,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var map = new PropertyMap();
             GetProperty(TextEditor.Property.InputFilter).Get(map);
-            string accepted = "";
-            string rejected = "";
-            map.Find(0)?.Get(out accepted);
-            map.Find(1)?.Get(out rejected);
-
-            var inputFilter = new InputFilter();
-            inputFilter.Accepted = new Regex(accepted);
-            inputFilter.Rejected = new Regex(rejected);
-
-            return inputFilter;
+            return TextUtils.GetInputFilterStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -16,7 +16,6 @@
  */
 extern alias TizenSystemSettings;
 using TizenSystemSettings.Tizen.System;
-using System.Text.RegularExpressions;
 
 using System;
 using System.Globalization;
@@ -1470,12 +1469,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetInputFilter(InputFilter inputFilter)
         {
-            var map = new PropertyMap();
-            var accepted = inputFilter.Accepted != null ? new PropertyValue(inputFilter.Accepted.ToString()) : new PropertyValue("");
-            var rejected = inputFilter.Rejected != null ? new PropertyValue(inputFilter.Rejected.ToString()) : new PropertyValue("");
-            map.Add(0, accepted);
-            map.Add(1, rejected);
-            SetProperty(TextField.Property.InputFilter, new PropertyValue(map));
+            SetProperty(TextField.Property.InputFilter, new PropertyValue(TextUtils.GetInputFilterMap(inputFilter)));
         }
 
         /// <summary>
@@ -1490,16 +1484,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var map = new PropertyMap();
             GetProperty(TextField.Property.InputFilter).Get(map);
-            string accepted = "";
-            string rejected = "";
-            map.Find(0)?.Get(out accepted);
-            map.Find(1)?.Get(out rejected);
-
-            var inputFilter = new InputFilter();
-            inputFilter.Accepted = new Regex(accepted);
-            inputFilter.Rejected = new Regex(rejected);
-
-            return inputFilter;
+            return TextUtils.GetInputFilterStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -308,6 +308,45 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set FontStyle to TextField. <br />
+        /// </summary>
+        /// <param name="fontStyle">The FontStyle</param>
+        /// <remarks>
+        /// SetFontStyle specifies the requested font style through <see cref="Tizen.NUI.Text.FontStyle"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetFontStyle method.
+        /// <code>
+        /// var fontStyle = new Tizen.NUI.Text.FontStyle();
+        /// fontStyle.Width = FontWidthType.Expanded;
+        /// fontStyle.Weight = FontWeightType.Bold;
+        /// fontStyle.Slant = FontSlantType.Italic;
+        /// field.SetFontStyle(fontStyle);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetFontStyle(FontStyle fontStyle)
+        {
+            SetProperty(TextField.Property.FontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
+            NotifyPropertyChanged();
+        }
+
+        /// <summary>
+        /// Get FontStyle from TextField. <br />
+        /// </summary>
+        /// <returns>The FontStyle</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.FontStyle"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontStyle GetFontStyle()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextField.Property.FontStyle).Get(map);
+            return TextUtils.GetFontStyleStruct(map);
+        }
+
+        /// <summary>
         /// The PointSize property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
@@ -944,6 +983,45 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(InputFontStyleProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Set InputFontStyle to TextField. <br />
+        /// </summary>
+        /// <param name="fontStyle">The FontStyle</param>
+        /// <remarks>
+        /// SetInputFontStyle specifies the requested font style for new input text through <see cref="Tizen.NUI.Text.FontStyle"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetInputFontStyle method.
+        /// <code>
+        /// var fontStyle = new Tizen.NUI.Text.FontStyle();
+        /// fontStyle.Width = FontWidthType.Expanded;
+        /// fontStyle.Weight = FontWeightType.Bold;
+        /// fontStyle.Slant = FontSlantType.Italic;
+        /// field.SetInputFontStyle(fontStyle);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetInputFontStyle(FontStyle fontStyle)
+        {
+            SetProperty(TextField.Property.InputFontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
+            NotifyPropertyChanged();
+        }
+
+        /// <summary>
+        /// Get InputFontStyle from TextField. <br />
+        /// </summary>
+        /// <returns>The FontStyle</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.FontStyle"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontStyle GetInputFontStyle()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextField.Property.InputFontStyle).Get(map);
+            return TextUtils.GetFontStyleStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -21,6 +21,7 @@ using TizenSystemSettings.Tizen.System;
 using System;
 using System.Globalization;
 using System.ComponentModel;
+using Tizen.NUI.Text;
 
 namespace Tizen.NUI.BaseComponents
 {
@@ -278,6 +279,44 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(FontStyleProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Set FontStyle to TextLabel. <br />
+        /// </summary>
+        /// <param name="fontStyle">The FontStyle</param>
+        /// <remarks>
+        /// SetFontStyle specifies the requested font style through <see cref="Tizen.NUI.Text.FontStyle"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetFontStyle method.
+        /// <code>
+        /// var fontStyle = new Tizen.NUI.Text.FontStyle();
+        /// fontStyle.Width = FontWidthType.Expanded;
+        /// fontStyle.Weight = FontWeightType.Bold;
+        /// fontStyle.Slant = FontSlantType.Italic;
+        /// label.SetFontStyle(fontStyle);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetFontStyle(FontStyle fontStyle)
+        {
+            SetProperty(TextLabel.Property.FontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
+        }
+
+        /// <summary>
+        /// Get FontStyle from TextLabel. <br />
+        /// </summary>
+        /// <returns>The FontStyle</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.FontStyle"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontStyle GetFontStyle()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextLabel.Property.FontStyle).Get(map);
+            return TextUtils.GetFontStyleStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -19,6 +19,7 @@ extern alias TizenSystemSettings;
 using TizenSystemSettings.Tizen.System;
 using System;
 using System.ComponentModel;
+using System.Text.RegularExpressions;
 using Tizen.NUI.Text;
 
 namespace Tizen.NUI.BaseComponents
@@ -1467,6 +1468,46 @@ namespace Tizen.NUI.BaseComponents
             fontStyle.Slant = GetFontSlantType(slant);
 
             return fontStyle;
+        }
+
+        /// <summary>
+        /// This method converts a InputFilter struct to a PropertyMap and returns it.
+        /// The returned map can be used for set InputFilter PropertyMap in the SetInputFilter method.
+        /// <param name="inputFilter">The InputFilter struct value.</param>
+        /// <returns> A PropertyMap for InputFilter property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PropertyMap GetInputFilterMap(InputFilter inputFilter)
+        {
+            var map = new PropertyMap();
+            var accepted = inputFilter.Accepted != null ? new PropertyValue(inputFilter.Accepted.ToString()) : new PropertyValue("");
+            var rejected = inputFilter.Rejected != null ? new PropertyValue(inputFilter.Rejected.ToString()) : new PropertyValue("");
+            map.Add(0, accepted);
+            map.Add(1, rejected);
+
+            return map;
+        }
+
+        /// <summary>
+        /// This method converts a InputFilter map to a struct and returns it.
+        /// The returned struct can be returned to the user as a InputFilter in the GetInputFilter method.
+        /// <param name="map">The InputFilter PropertyMap.</param>
+        /// <returns> A InputFilter struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static InputFilter GetInputFilterStruct(PropertyMap map)
+        {
+            string accepted = "";
+            string rejected = "";
+            map.Find(0)?.Get(out accepted);
+            map.Find(1)?.Get(out rejected);
+
+            var inputFilter = new InputFilter();
+            inputFilter.Accepted = new Regex(accepted);
+            inputFilter.Rejected = new Regex(rejected);
+
+            return inputFilter;
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -19,6 +19,7 @@ extern alias TizenSystemSettings;
 using TizenSystemSettings.Tizen.System;
 using System;
 using System.ComponentModel;
+using Tizen.NUI.Text;
 
 namespace Tizen.NUI.BaseComponents
 {
@@ -1151,6 +1152,321 @@ namespace Tizen.NUI.BaseComponents
             }
 
             return ret;
+        }
+
+        /// <summary>
+        /// It returns a string value according to FontWidthType.
+        /// The returned value can be used for FontStyle PropertyMap.
+        /// <param name="fontWidthType">The FontWidthType enum value.</param>
+        /// <returns> A string value for FontStyle.Width property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static string GetFontWidthString(FontWidthType fontWidthType)
+        {
+            string value = "none";
+
+            switch (fontWidthType)
+            {
+                default:
+                case FontWidthType.None:
+                    value = "none";
+                    break;
+                case FontWidthType.UltraCondensed:
+                    value = "ultraCondensed";
+                    break;
+                case FontWidthType.ExtraCondensed:
+                    value = "extraCondensed";
+                    break;
+                case FontWidthType.Condensed:
+                    value = "condensed";
+                    break;
+                case FontWidthType.SemiCondensed:
+                    value = "semiCondensed";
+                    break;
+                case FontWidthType.Normal:
+                    value = "normal";
+                    break;
+                case FontWidthType.SemiExpanded:
+                    value = "semiExpanded";
+                    break;
+                case FontWidthType.Expanded:
+                    value = "expanded";
+                    break;
+                case FontWidthType.ExtraExpanded:
+                    value = "extraExpanded";
+                    break;
+                case FontWidthType.UltraExpanded:
+                    value = "ultraExpanded";
+                    break;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// It returns a string value according to FontWeightType.
+        /// The returned value can be used for FontStyle PropertyMap.
+        /// <param name="fontWeightType">The FontWeightType enum value.</param>
+        /// <returns> A string value for FontStyle.Weight property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static string GetFontWeightString(FontWeightType fontWeightType)
+        {
+            string value = "none";
+
+            switch (fontWeightType)
+            {
+                default:
+                case FontWeightType.None:
+                    value = "none";
+                    break;
+                case FontWeightType.Thin:
+                    value = "thin";
+                    break;
+                case FontWeightType.UltraLight:
+                    value = "ultraLight";
+                    break;
+                case FontWeightType.Light:
+                    value = "light";
+                    break;
+                case FontWeightType.DemiLight:
+                    value = "demiLight";
+                    break;
+                case FontWeightType.Book:
+                    value = "book";
+                    break;
+                case FontWeightType.Normal:
+                    value = "normal";
+                    break;
+                case FontWeightType.Medium:
+                    value = "medium";
+                    break;
+                case FontWeightType.DemiBold:
+                    value = "demiBold";
+                    break;
+                case FontWeightType.Bold:
+                    value = "bold";
+                    break;
+                case FontWeightType.UltraBold:
+                    value = "ultraBold";
+                    break;
+                case FontWeightType.Black:
+                    value = "black";
+                    break;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// It returns a string value according to FontSlantType.
+        /// The returned value can be used for FontStyle PropertyMap.
+        /// <param name="fontSlantType">The FontSlantType enum value.</param>
+        /// <returns> A string value for FontStyle.Slant property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static string GetFontSlantString(FontSlantType fontSlantType)
+        {
+            string value = "none";
+
+            switch (fontSlantType)
+            {
+                default:
+                case FontSlantType.None:
+                    value = "none";
+                    break;
+                case FontSlantType.Normal:
+                    value = "normal";
+                    break;
+                case FontSlantType.Italic:
+                    value = "italic";
+                    break;
+                case FontSlantType.Oblique:
+                    value = "oblique";
+                    break;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// It returns a FontWidthType value according to fontWidthString.
+        /// The returned value can be used for FontStyle PropertyMap.
+        /// <param name="fontWidthString">The FontWidth string value.</param>
+        /// <returns> A FontWidthType value for FontStyle.Width property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static FontWidthType GetFontWidthType(string fontWidthString)
+        {
+            FontWidthType value = FontWidthType.None;
+
+            switch (fontWidthString)
+            {
+                default:
+                case "none":
+                    value = FontWidthType.None;
+                    break;
+                case "ultraCondensed":
+                    value = FontWidthType.UltraCondensed;
+                    break;
+                case "extraCondensed":
+                    value = FontWidthType.ExtraCondensed;
+                    break;
+                case "condensed":
+                    value = FontWidthType.Condensed;
+                    break;
+                case "semiCondensed":
+                    value = FontWidthType.SemiCondensed;
+                    break;
+                case "normal":
+                    value = FontWidthType.Normal;
+                    break;
+                case "semiExpanded":
+                    value = FontWidthType.SemiExpanded;
+                    break;
+                case "expanded":
+                    value = FontWidthType.Expanded;
+                    break;
+                case "extraExpanded":
+                    value = FontWidthType.ExtraExpanded;
+                    break;
+                case "ultraExpanded":
+                    value = FontWidthType.UltraExpanded;
+                    break;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// It returns a FontWeightType value according to fontWeightString.
+        /// The returned value can be used for FontStyle PropertyMap.
+        /// <param name="fontWeightString">The FontWeight string value.</param>
+        /// <returns> A FontWeightType value for FontStyle.Weight property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static FontWeightType GetFontWeightType(string fontWeightString)
+        {
+            FontWeightType value = FontWeightType.None;
+
+            switch (fontWeightString)
+            {
+                default:
+                case "none":
+                    value = FontWeightType.None;
+                    break;
+                case "thin":
+                    value = FontWeightType.Thin;
+                    break;
+                case "ultraLight":
+                    value = FontWeightType.UltraLight;
+                    break;
+                case "light":
+                    value = FontWeightType.Light;
+                    break;
+                case "demiLight":
+                    value = FontWeightType.DemiLight;
+                    break;
+                case "book":
+                    value = FontWeightType.Book;
+                    break;
+                case "normal":
+                    value = FontWeightType.Normal;
+                    break;
+                case "medium":
+                    value = FontWeightType.Medium;
+                    break;
+                case "demiBold":
+                    value = FontWeightType.DemiBold;
+                    break;
+                case "bold":
+                    value = FontWeightType.Bold;
+                    break;
+                case "ultraBold":
+                    value = FontWeightType.UltraBold;
+                    break;
+                case "black":
+                    value = FontWeightType.Black;
+                    break;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// It returns a FontSlantType value according to fontSlantString.
+        /// The returned value can be used for FontStyle PropertyMap.
+        /// <param name="fontSlantString">The FontSlant string value.</param>
+        /// <returns> A FontSlantType value for FontStyle.Slant property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static FontSlantType GetFontSlantType(string fontSlantString)
+        {
+            FontSlantType value = FontSlantType.None;
+
+            switch (fontSlantString)
+            {
+                default:
+                case "none":
+                    value = FontSlantType.None;
+                    break;
+                case "normal":
+                    value = FontSlantType.Normal;
+                    break;
+                case "italic":
+                    value = FontSlantType.Italic;
+                    break;
+                case "oblique":
+                    value = FontSlantType.Oblique;
+                    break;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// This method converts a FontStyle struct to a PropertyMap and returns it.
+        /// The returned map can be used for set FontStyle PropertyMap in the SetFontStyle method.
+        /// <param name="fontStyle">The FontStyle struct value.</param>
+        /// <returns> A PropertyMap for FontStyle property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PropertyMap GetFontStyleMap(FontStyle fontStyle)
+        {
+            var map = new PropertyMap();
+            var width = new PropertyValue(GetFontWidthString(fontStyle.Width));
+            var weight = new PropertyValue(GetFontWeightString(fontStyle.Weight));
+            var slant = new PropertyValue(GetFontSlantString(fontStyle.Slant));
+
+            map.Add("width", width);
+            map.Add("weight", weight);
+            map.Add("slant", slant);
+
+            return map;
+        }
+
+        /// <summary>
+        /// This method converts a FontStyle map to a struct and returns it.
+        /// The returned struct can be returned to the user as a FontStyle in the GetFontStyle method.
+        /// <param name="map">The FontStyle PropertyMap.</param>
+        /// <returns> A FontStyle struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static FontStyle GetFontStyleStruct(PropertyMap map)
+        {
+            string width = "none";
+            string weight = "none";
+            string slant = "none";
+            map.Find(0, "width")?.Get(out width);
+            map.Find(0, "weight")?.Get(out weight);
+            map.Find(0, "slant")?.Get(out slant);
+
+            var fontStyle = new FontStyle();
+            fontStyle.Width = GetFontWidthType(width);
+            fontStyle.Weight = GetFontWeightType(weight);
+            fontStyle.Slant = GetFontSlantType(slant);
+
+            return fontStyle;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -2035,5 +2035,34 @@ namespace Tizen.NUI
             [EditorBrowsable(EditorBrowsableState.Never)]
             public Regex Rejected { get; set; }
         }
+
+        /// <summary>
+        /// A struct to pass data of FontStyle PropertyMap. <br />
+        /// </summary>
+        /// <remarks>
+        /// The FontStyle struct is used as an argument to SetFontStyle and GetFontStyle methods. <br />
+        /// See <see cref="Tizen.NUI.BaseComponents.TextLabel.SetFontStyle"/>, <see cref="Tizen.NUI.BaseComponents.TextLabel.GetFontStyle"/>, <see cref="Tizen.NUI.BaseComponents.TextField.SetFontStyle"/>, <see cref="Tizen.NUI.BaseComponents.TextField.GetFontStyle"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.SetFontStyle"/> and <see cref="Tizen.NUI.BaseComponents.TextEditor.GetFontStyle"/>. <br />
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public struct FontStyle
+        {
+            /// <summary>
+            /// The Width defines occupied by each glyph.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public FontWidthType Width { get; set; }
+
+            /// <summary>
+            /// The Weight defines the thickness or darkness of the glyphs.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public FontWeightType Weight { get; set; }
+
+            /// <summary>
+            /// The Slant defines whether to use italics.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public FontSlantType Slant { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->

Add a FontStyle struct to pass data of DALi FontStyle PropertyMap.
The FontStyle struct can be used as an argument to
SetFontStyle, GetFontStyle, SetInputFontStyle and GetInputFontStyle methods.

If a placeholder struct is added later, it can be used as a property of the placeholder.

// example
var fontStyle = new Tizen.NUI.Text.FontStyle();
fontStyle.Width = FontWidthType.Expanded;
fontStyle.Weight = FontWeightType.Bold;
fontStyle.Slant = FontSlantType.Italic;
textLabel.SetFontStyle(fontStyle);