### PR TITLE
[NUI] Add CursorPositionChanged Event

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -177,6 +177,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_InputStyleChangedSignal")]
             public static extern global::System.IntPtr InputStyleChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CursorMovedSignal")]
+            public static extern global::System.IntPtr CursorMovedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_MaxLengthReachedSignal")]
             public static extern global::System.IntPtr MaxLengthReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -177,8 +177,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_InputStyleChangedSignal")]
             public static extern global::System.IntPtr InputStyleChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CursorMovedSignal")]
-            public static extern global::System.IntPtr CursorMovedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_CursorPositionChangedSignal")]
+            public static extern global::System.IntPtr CursorPositionChangedSignal(global::System.Runtime.InteropServices.HandleRef pTextEditor);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_MaxLengthReachedSignal")]
             public static extern global::System.IntPtr MaxLengthReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -189,6 +189,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_TextChangedSignal")]
             public static extern global::System.IntPtr TextChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CursorMovedSignal")]
+            public static extern global::System.IntPtr CursorMovedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_MaxLengthReachedSignal")]
             public static extern global::System.IntPtr MaxLengthReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -189,8 +189,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_TextChangedSignal")]
             public static extern global::System.IntPtr TextChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CursorMovedSignal")]
-            public static extern global::System.IntPtr CursorMovedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_CursorPositionChangedSignal")]
+            public static extern global::System.IntPtr CursorPositionChangedSignal(global::System.Runtime.InteropServices.HandleRef pTextField);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_MaxLengthReachedSignal")]
             public static extern global::System.IntPtr MaxLengthReachedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1742,6 +1742,11 @@ namespace Tizen.NUI.BaseComponents
                 {
                     this.MaxLengthReachedSignal().Disconnect(textEditorMaxLengthReachedCallbackDelegate);
                 }
+
+                if (textEditorCursorMovedCallbackDelegate != null)
+                {
+                    this.CursorMovedSignal().Disconnect(textEditorCursorMovedCallbackDelegate);
+                }
             }
 
             base.Dispose(type);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1743,9 +1743,9 @@ namespace Tizen.NUI.BaseComponents
                     this.MaxLengthReachedSignal().Disconnect(textEditorMaxLengthReachedCallbackDelegate);
                 }
 
-                if (textEditorCursorMovedCallbackDelegate != null)
+                if (textEditorCursorPositionChangedCallbackDelegate != null)
                 {
-                    this.CursorMovedSignal().Disconnect(textEditorCursorMovedCallbackDelegate);
+                    this.CursorPositionChangedSignal().Disconnect(textEditorCursorPositionChangedCallbackDelegate);
                 }
             }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -315,7 +315,7 @@ namespace Tizen.NUI.BaseComponents
                 CursorPositionChangedEventArgs e = new CursorPositionChangedEventArgs();
 
                 // Populate all members of "e" (CursorPositionChangedEventArgs) with real data
-                e.CursorPosition = oldPosition;
+                e.OldCursorPosition = oldPosition;
 
                 //here we send all data to user event handlers
                 textEditorCursorPositionChangedEventHandler?.Invoke(this, e);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -318,7 +318,7 @@ namespace Tizen.NUI.BaseComponents
                 e.CursorPosition = oldPosition;
 
                 //here we send all data to user event handlers
-                textEditorCursorPositionChangedEventHandler(this, e);
+                textEditorCursorPositionChangedEventHandler?.Invoke(this, e);
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -52,7 +52,7 @@ namespace Tizen.NUI.BaseComponents
         private delegate void ScrollStateChangedCallbackDelegate(IntPtr textEditor, ScrollState state);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void CursorPositionChangedCallbackDelegate(IntPtr textEditor, uint oldPosition, uint newPosition);
+        private delegate void CursorPositionChangedCallbackDelegate(IntPtr textEditor, uint oldPosition);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textEditor);
@@ -308,15 +308,14 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void OnCursorPositionChanged(IntPtr textEditor, uint oldPosition, uint newPosition)
+        private void OnCursorPositionChanged(IntPtr textEditor, uint oldPosition)
         {
             if (textEditorCursorPositionChangedEventHandler != null)
             {
                 CursorPositionChangedEventArgs e = new CursorPositionChangedEventArgs();
 
                 // Populate all members of "e" (CursorPositionChangedEventArgs) with real data
-                e.OldCursorPosition = oldPosition;
-                e.CursorPosition = newPosition;
+                e.CursorPosition = oldPosition;
 
                 //here we send all data to user event handlers
                 textEditorCursorPositionChangedEventHandler(this, e);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -33,6 +33,9 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<ScrollStateChangedEventArgs> textEditorScrollStateChangedEventHandler;
         private ScrollStateChangedCallbackDelegate textEditorScrollStateChangedCallbackDelegate;
 
+        private EventHandler<CursorMovedEventArgs> textEditorCursorMovedEventHandler;
+        private CursorMovedCallbackDelegate textEditorCursorMovedCallbackDelegate;
+
         private EventHandler<MaxLengthReachedEventArgs> textEditorMaxLengthReachedEventHandler;
         private MaxLengthReachedCallbackDelegate textEditorMaxLengthReachedCallbackDelegate;
 
@@ -47,6 +50,9 @@ namespace Tizen.NUI.BaseComponents
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void ScrollStateChangedCallbackDelegate(IntPtr textEditor, ScrollState state);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate void CursorMovedCallbackDelegate(IntPtr textEditor, uint oldPosition, uint newPosition);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textEditor);
@@ -106,6 +112,32 @@ namespace Tizen.NUI.BaseComponents
                 {
                     ScrollStateChangedSignal(this).Disconnect(textEditorScrollStateChangedCallbackDelegate);
                 }
+            }
+        }
+
+        /// <summary>
+        /// The CursorMoved event.
+        /// </summary>
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<CursorMovedEventArgs> CursorMoved
+        {
+            add
+            {
+                if (textEditorCursorMovedEventHandler == null)
+                {
+                    textEditorCursorMovedCallbackDelegate = (OnCursorMoved);
+                    CursorMovedSignal().Connect(textEditorCursorMovedCallbackDelegate);
+                }
+                textEditorCursorMovedEventHandler += value;
+            }
+            remove
+            {
+                if (textEditorCursorMovedEventHandler == null && CursorMovedSignal().Empty() == false)
+                {
+                    this.CursorMovedSignal().Disconnect(textEditorCursorMovedCallbackDelegate);
+                }
+                textEditorCursorMovedEventHandler -= value;
             }
         }
 
@@ -218,6 +250,13 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
+        internal TextEditorSignal CursorMovedSignal()
+        {
+            TextEditorSignal ret = new TextEditorSignal(Interop.TextEditor.CursorMovedSignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         internal TextEditorSignal MaxLengthReachedSignal()
         {
             TextEditorSignal ret = new TextEditorSignal(Interop.TextEditor.MaxLengthReachedSignal(SwigCPtr), false);
@@ -266,6 +305,22 @@ namespace Tizen.NUI.BaseComponents
                 }
                 //here we send all data to user event handlers
                 textEditorScrollStateChangedEventHandler(this, e);
+            }
+        }
+
+        private void OnCursorMoved(IntPtr textEditor, uint oldPosition, uint newPosition)
+        {
+            if (textEditorCursorMovedEventHandler != null)
+            {
+                CursorMovedEventArgs e = new CursorMovedEventArgs();
+
+                // Populate all members of "e" (CursorMovedEventArgs) with real data
+                e.TextEditor = Registry.GetManagedBaseHandleFromNativePtr(textEditor) as TextEditor;
+                e.OldCursorPosition = oldPosition;
+                e.NewCursorPosition = newPosition;
+
+                //here we send all data to user event handlers
+                textEditorCursorMovedEventHandler(this, e);
             }
         }
 
@@ -369,6 +424,27 @@ namespace Tizen.NUI.BaseComponents
                     scrollState = value;
                 }
             }
+        }
+
+        /// <summary>
+        /// The CursorMoved event arguments.
+        /// </summary>
+        public class CursorMovedEventArgs : EventArgs
+        {
+            /// <summary>
+            /// TextEditor.
+            /// </summary>
+            public TextEditor TextEditor { get; set;}
+
+            /// <summary>
+            /// cursor postion before the move.
+            /// </summary>
+            public uint OldCursorPosition { get; set;}
+
+            /// <summary>
+            /// cursor postion after the move.
+            /// </summary>
+            public uint NewCursorPosition { get; set;}
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -33,8 +33,8 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<ScrollStateChangedEventArgs> textEditorScrollStateChangedEventHandler;
         private ScrollStateChangedCallbackDelegate textEditorScrollStateChangedCallbackDelegate;
 
-        private EventHandler<CursorMovedEventArgs> textEditorCursorMovedEventHandler;
-        private CursorMovedCallbackDelegate textEditorCursorMovedCallbackDelegate;
+        private EventHandler<CursorPositionChangedEventArgs> textEditorCursorPositionChangedEventHandler;
+        private CursorPositionChangedCallbackDelegate textEditorCursorPositionChangedCallbackDelegate;
 
         private EventHandler<MaxLengthReachedEventArgs> textEditorMaxLengthReachedEventHandler;
         private MaxLengthReachedCallbackDelegate textEditorMaxLengthReachedCallbackDelegate;
@@ -52,7 +52,7 @@ namespace Tizen.NUI.BaseComponents
         private delegate void ScrollStateChangedCallbackDelegate(IntPtr textEditor, ScrollState state);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void CursorMovedCallbackDelegate(IntPtr textEditor, uint oldPosition, uint newPosition);
+        private delegate void CursorPositionChangedCallbackDelegate(IntPtr textEditor, uint oldPosition, uint newPosition);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textEditor);
@@ -116,28 +116,28 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// The CursorMoved event.
+        /// The CursorPositionChanged event.
         /// </summary>
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public event EventHandler<CursorMovedEventArgs> CursorMoved
+        public event EventHandler<CursorPositionChangedEventArgs> CursorPositionChanged
         {
             add
             {
-                if (textEditorCursorMovedEventHandler == null)
+                if (textEditorCursorPositionChangedEventHandler == null)
                 {
-                    textEditorCursorMovedCallbackDelegate = (OnCursorMoved);
-                    CursorMovedSignal().Connect(textEditorCursorMovedCallbackDelegate);
+                    textEditorCursorPositionChangedCallbackDelegate = (OnCursorPositionChanged);
+                    CursorPositionChangedSignal().Connect(textEditorCursorPositionChangedCallbackDelegate);
                 }
-                textEditorCursorMovedEventHandler += value;
+                textEditorCursorPositionChangedEventHandler += value;
             }
             remove
             {
-                if (textEditorCursorMovedEventHandler == null && CursorMovedSignal().Empty() == false)
+                if (textEditorCursorPositionChangedEventHandler == null && CursorPositionChangedSignal().Empty() == false)
                 {
-                    this.CursorMovedSignal().Disconnect(textEditorCursorMovedCallbackDelegate);
+                    this.CursorPositionChangedSignal().Disconnect(textEditorCursorPositionChangedCallbackDelegate);
                 }
-                textEditorCursorMovedEventHandler -= value;
+                textEditorCursorPositionChangedEventHandler -= value;
             }
         }
 
@@ -250,9 +250,9 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        internal TextEditorSignal CursorMovedSignal()
+        internal TextEditorSignal CursorPositionChangedSignal()
         {
-            TextEditorSignal ret = new TextEditorSignal(Interop.TextEditor.CursorMovedSignal(SwigCPtr), false);
+            TextEditorSignal ret = new TextEditorSignal(Interop.TextEditor.CursorPositionChangedSignal(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -308,19 +308,18 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void OnCursorMoved(IntPtr textEditor, uint oldPosition, uint newPosition)
+        private void OnCursorPositionChanged(IntPtr textEditor, uint oldPosition, uint newPosition)
         {
-            if (textEditorCursorMovedEventHandler != null)
+            if (textEditorCursorPositionChangedEventHandler != null)
             {
-                CursorMovedEventArgs e = new CursorMovedEventArgs();
+                CursorPositionChangedEventArgs e = new CursorPositionChangedEventArgs();
 
-                // Populate all members of "e" (CursorMovedEventArgs) with real data
-                e.TextEditor = Registry.GetManagedBaseHandleFromNativePtr(textEditor) as TextEditor;
+                // Populate all members of "e" (CursorPositionChangedEventArgs) with real data
                 e.OldCursorPosition = oldPosition;
-                e.NewCursorPosition = newPosition;
+                e.CursorPosition = newPosition;
 
                 //here we send all data to user event handlers
-                textEditorCursorMovedEventHandler(this, e);
+                textEditorCursorPositionChangedEventHandler(this, e);
             }
         }
 
@@ -424,27 +423,6 @@ namespace Tizen.NUI.BaseComponents
                     scrollState = value;
                 }
             }
-        }
-
-        /// <summary>
-        /// The CursorMoved event arguments.
-        /// </summary>
-        public class CursorMovedEventArgs : EventArgs
-        {
-            /// <summary>
-            /// TextEditor.
-            /// </summary>
-            public TextEditor TextEditor { get; set;}
-
-            /// <summary>
-            /// cursor postion before the move.
-            /// </summary>
-            public uint OldCursorPosition { get; set;}
-
-            /// <summary>
-            /// cursor postion after the move.
-            /// </summary>
-            public uint NewCursorPosition { get; set;}
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
@@ -58,6 +58,6 @@ namespace Tizen.NUI.BaseComponents
         /// cursor postion before the change.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint CursorPosition { get; set; }
+        public uint OldCursorPosition { get; set; }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
@@ -58,12 +58,12 @@ namespace Tizen.NUI.BaseComponents
         /// cursor postion before the change.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint OldCursorPosition { get; set;}
+        public uint OldCursorPosition { get; set; }
 
         /// <summary>
         /// cursor postion after the change.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint CursorPosition { get; set;}
+        public uint CursorPosition { get; set; }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
@@ -47,4 +47,23 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public InputFilterType Type { get; set; }
     }
+
+    /// <summary>
+    /// The CursorPositionChanged event arguments.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class CursorPositionChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// cursor postion before the change.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint OldCursorPosition { get; set;}
+
+        /// <summary>
+        /// cursor postion after the change.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint CursorPosition { get; set;}
+    }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
@@ -58,12 +58,6 @@ namespace Tizen.NUI.BaseComponents
         /// cursor postion before the change.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint OldCursorPosition { get; set; }
-
-        /// <summary>
-        /// cursor postion after the change.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public uint CursorPosition { get; set; }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1759,6 +1759,11 @@ namespace Tizen.NUI.BaseComponents
             //because the execution order of Finalizes is non-deterministic.
             if (this.HasBody())
             {
+                if (textFieldCursorMovedCallbackDelegate != null)
+                {
+                    this.CursorMovedSignal().Disconnect(textFieldCursorMovedCallbackDelegate);
+                }
+
                 if (textFieldMaxLengthReachedCallbackDelegate != null)
                 {
                     this.MaxLengthReachedSignal().Disconnect(textFieldMaxLengthReachedCallbackDelegate);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1759,9 +1759,9 @@ namespace Tizen.NUI.BaseComponents
             //because the execution order of Finalizes is non-deterministic.
             if (this.HasBody())
             {
-                if (textFieldCursorMovedCallbackDelegate != null)
+                if (textFieldCursorPositionChangedCallbackDelegate != null)
                 {
-                    this.CursorMovedSignal().Disconnect(textFieldCursorMovedCallbackDelegate);
+                    this.CursorPositionChangedSignal().Disconnect(textFieldCursorPositionChangedCallbackDelegate);
                 }
 
                 if (textFieldMaxLengthReachedCallbackDelegate != null)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
@@ -29,8 +29,8 @@ namespace Tizen.NUI.BaseComponents
     {
         private EventHandler<TextChangedEventArgs> textFieldTextChangedEventHandler;
         private TextChangedCallbackDelegate textFieldTextChangedCallbackDelegate;
-        private EventHandler<CursorMovedEventArgs> textFieldCursorMovedEventHandler;
-        private CursorMovedCallbackDelegate textFieldCursorMovedCallbackDelegate;
+        private EventHandler<CursorPositionChangedEventArgs> textFieldCursorPositionChangedEventHandler;
+        private CursorPositionChangedCallbackDelegate textFieldCursorPositionChangedCallbackDelegate;
         private EventHandler<MaxLengthReachedEventArgs> textFieldMaxLengthReachedEventHandler;
         private MaxLengthReachedCallbackDelegate textFieldMaxLengthReachedCallbackDelegate;
         private EventHandler<AnchorClickedEventArgs> textFieldAnchorClickedEventHandler;
@@ -42,7 +42,7 @@ namespace Tizen.NUI.BaseComponents
         private delegate void TextChangedCallbackDelegate(IntPtr textField);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void CursorMovedCallbackDelegate(IntPtr textField, uint oldPosition, uint newPosition);
+        private delegate void CursorPositionChangedCallbackDelegate(IntPtr textField, uint oldPosition, uint newPosition);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textField);
@@ -79,28 +79,28 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// The CursorMoved event.
+        /// The CursorPositionChanged event.
         /// </summary>
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public event EventHandler<CursorMovedEventArgs> CursorMoved
+        public event EventHandler<CursorPositionChangedEventArgs> CursorPositionChanged
         {
             add
             {
-                if (textFieldCursorMovedEventHandler == null)
+                if (textFieldCursorPositionChangedEventHandler == null)
                 {
-                    textFieldCursorMovedCallbackDelegate = (OnCursorMoved);
-                    CursorMovedSignal().Connect(textFieldCursorMovedCallbackDelegate);
+                    textFieldCursorPositionChangedCallbackDelegate = (OnCursorPositionChanged);
+                    CursorPositionChangedSignal().Connect(textFieldCursorPositionChangedCallbackDelegate);
                 }
-                textFieldCursorMovedEventHandler += value;
+                textFieldCursorPositionChangedEventHandler += value;
             }
             remove
             {
-                if (textFieldCursorMovedEventHandler == null && CursorMovedSignal().Empty() == false)
+                if (textFieldCursorPositionChangedEventHandler == null && CursorPositionChangedSignal().Empty() == false)
                 {
-                    this.CursorMovedSignal().Disconnect(textFieldCursorMovedCallbackDelegate);
+                    this.CursorPositionChangedSignal().Disconnect(textFieldCursorPositionChangedCallbackDelegate);
                 }
-                textFieldCursorMovedEventHandler -= value;
+                textFieldCursorPositionChangedEventHandler -= value;
             }
         }
 
@@ -205,9 +205,9 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        internal TextFieldSignal CursorMovedSignal()
+        internal TextFieldSignal CursorPositionChangedSignal()
         {
-            TextFieldSignal ret = new TextFieldSignal(Interop.TextField.CursorMovedSignal(SwigCPtr), false);
+            TextFieldSignal ret = new TextFieldSignal(Interop.TextField.CursorPositionChangedSignal(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -246,19 +246,18 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void OnCursorMoved(IntPtr textField, uint oldPosition, uint newPosition)
+        private void OnCursorPositionChanged(IntPtr textField, uint oldPosition, uint newPosition)
         {
-            if (textFieldCursorMovedEventHandler != null)
+            if (textFieldCursorPositionChangedEventHandler != null)
             {
-                CursorMovedEventArgs e = new CursorMovedEventArgs();
+                CursorPositionChangedEventArgs e = new CursorPositionChangedEventArgs();
 
-                // Populate all members of "e" (CursorMovedEventArgs) with real data
-                e.TextField = Registry.GetManagedBaseHandleFromNativePtr(textField) as TextField;
+                // Populate all members of "e" (CursorPositionChangedEventArgs) with real data
                 e.OldCursorPosition = oldPosition;
-                e.NewCursorPosition = newPosition;
+                e.CursorPosition = newPosition;
 
                 //here we send all data to user event handlers
-                textFieldCursorMovedEventHandler(this, e);
+                textFieldCursorPositionChangedEventHandler(this, e);
             }
         }
 
@@ -320,27 +319,6 @@ namespace Tizen.NUI.BaseComponents
                     textField = value;
                 }
             }
-        }
-
-        /// <summary>
-        /// The CursorMoved event arguments.
-        /// </summary>
-        public class CursorMovedEventArgs : EventArgs
-        {
-            /// <summary>
-            /// TextField.
-            /// </summary>
-            public TextField TextField { get; set;}
-
-            /// <summary>
-            /// cursor postion before the move.
-            /// </summary>
-            public uint OldCursorPosition { get; set;}
-
-            /// <summary>
-            /// cursor postion after the move.
-            /// </summary>
-            public uint NewCursorPosition { get; set;}
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
@@ -29,6 +29,8 @@ namespace Tizen.NUI.BaseComponents
     {
         private EventHandler<TextChangedEventArgs> textFieldTextChangedEventHandler;
         private TextChangedCallbackDelegate textFieldTextChangedCallbackDelegate;
+        private EventHandler<CursorMovedEventArgs> textFieldCursorMovedEventHandler;
+        private CursorMovedCallbackDelegate textFieldCursorMovedCallbackDelegate;
         private EventHandler<MaxLengthReachedEventArgs> textFieldMaxLengthReachedEventHandler;
         private MaxLengthReachedCallbackDelegate textFieldMaxLengthReachedCallbackDelegate;
         private EventHandler<AnchorClickedEventArgs> textFieldAnchorClickedEventHandler;
@@ -38,6 +40,9 @@ namespace Tizen.NUI.BaseComponents
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void TextChangedCallbackDelegate(IntPtr textField);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate void CursorMovedCallbackDelegate(IntPtr textField, uint oldPosition, uint newPosition);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textField);
@@ -70,6 +75,32 @@ namespace Tizen.NUI.BaseComponents
                 {
                     TextChangedSignal().Disconnect(textFieldTextChangedCallbackDelegate);
                 }
+            }
+        }
+
+        /// <summary>
+        /// The CursorMoved event.
+        /// </summary>
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<CursorMovedEventArgs> CursorMoved
+        {
+            add
+            {
+                if (textFieldCursorMovedEventHandler == null)
+                {
+                    textFieldCursorMovedCallbackDelegate = (OnCursorMoved);
+                    CursorMovedSignal().Connect(textFieldCursorMovedCallbackDelegate);
+                }
+                textFieldCursorMovedEventHandler += value;
+            }
+            remove
+            {
+                if (textFieldCursorMovedEventHandler == null && CursorMovedSignal().Empty() == false)
+                {
+                    this.CursorMovedSignal().Disconnect(textFieldCursorMovedCallbackDelegate);
+                }
+                textFieldCursorMovedEventHandler -= value;
             }
         }
 
@@ -174,6 +205,13 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
+        internal TextFieldSignal CursorMovedSignal()
+        {
+            TextFieldSignal ret = new TextFieldSignal(Interop.TextField.CursorMovedSignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         internal TextFieldSignal MaxLengthReachedSignal()
         {
             TextFieldSignal ret = new TextFieldSignal(Interop.TextField.MaxLengthReachedSignal(SwigCPtr), false);
@@ -205,6 +243,22 @@ namespace Tizen.NUI.BaseComponents
                 e.TextField = Registry.GetManagedBaseHandleFromNativePtr(textField) as TextField;
                 //here we send all data to user event handlers
                 textFieldTextChangedEventHandler(this, e);
+            }
+        }
+
+        private void OnCursorMoved(IntPtr textField, uint oldPosition, uint newPosition)
+        {
+            if (textFieldCursorMovedEventHandler != null)
+            {
+                CursorMovedEventArgs e = new CursorMovedEventArgs();
+
+                // Populate all members of "e" (CursorMovedEventArgs) with real data
+                e.TextField = Registry.GetManagedBaseHandleFromNativePtr(textField) as TextField;
+                e.OldCursorPosition = oldPosition;
+                e.NewCursorPosition = newPosition;
+
+                //here we send all data to user event handlers
+                textFieldCursorMovedEventHandler(this, e);
             }
         }
 
@@ -266,6 +320,27 @@ namespace Tizen.NUI.BaseComponents
                     textField = value;
                 }
             }
+        }
+
+        /// <summary>
+        /// The CursorMoved event arguments.
+        /// </summary>
+        public class CursorMovedEventArgs : EventArgs
+        {
+            /// <summary>
+            /// TextField.
+            /// </summary>
+            public TextField TextField { get; set;}
+
+            /// <summary>
+            /// cursor postion before the move.
+            /// </summary>
+            public uint OldCursorPosition { get; set;}
+
+            /// <summary>
+            /// cursor postion after the move.
+            /// </summary>
+            public uint NewCursorPosition { get; set;}
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
@@ -256,7 +256,7 @@ namespace Tizen.NUI.BaseComponents
                 e.CursorPosition = oldPosition;
 
                 //here we send all data to user event handlers
-                textFieldCursorPositionChangedEventHandler(this, e);
+                textFieldCursorPositionChangedEventHandler?.Invoke(this, e);
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
@@ -42,7 +42,7 @@ namespace Tizen.NUI.BaseComponents
         private delegate void TextChangedCallbackDelegate(IntPtr textField);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        private delegate void CursorPositionChangedCallbackDelegate(IntPtr textField, uint oldPosition, uint newPosition);
+        private delegate void CursorPositionChangedCallbackDelegate(IntPtr textField, uint oldPosition);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textField);
@@ -246,15 +246,14 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void OnCursorPositionChanged(IntPtr textField, uint oldPosition, uint newPosition)
+        private void OnCursorPositionChanged(IntPtr textField, uint oldPosition)
         {
             if (textFieldCursorPositionChangedEventHandler != null)
             {
                 CursorPositionChangedEventArgs e = new CursorPositionChangedEventArgs();
 
                 // Populate all members of "e" (CursorPositionChangedEventArgs) with real data
-                e.OldCursorPosition = oldPosition;
-                e.CursorPosition = newPosition;
+                e.CursorPosition = oldPosition;
 
                 //here we send all data to user event handlers
                 textFieldCursorPositionChangedEventHandler(this, e);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
@@ -253,7 +253,7 @@ namespace Tizen.NUI.BaseComponents
                 CursorPositionChangedEventArgs e = new CursorPositionChangedEventArgs();
 
                 // Populate all members of "e" (CursorPositionChangedEventArgs) with real data
-                e.CursorPosition = oldPosition;
+                e.OldCursorPosition = oldPosition;
 
                 //here we send all data to user event handlers
                 textFieldCursorPositionChangedEventHandler?.Invoke(this, e);


### PR DESCRIPTION
Add CursorPositionChanged event, 
which will be called every time the cursor moves.

editor.CursorCursorPositionChanged += (s, e) =>
{
    e.OldCursorPosition; //cursor position before the change
};

related patch : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/262362