### PR TITLE
[NUI] Add a comment about SENSITIVE.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1670,6 +1670,7 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// Gets or sets the status of whether the view should emit touch or hover signals.
+        /// If a View is made insensitive, then the View and its children are not hittable.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public bool Sensitive


### PR DESCRIPTION
 - If a View is insensitive, the children are also not hittable.
 - This patch adds that at the sensitive property comment.

Signed-off-by: seungho <sbsh.baek@samsung.com>