### PR TITLE
[NUI] Fix View to catch Relayout by default

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -122,6 +122,9 @@ namespace Tizen.NUI.BaseComponents
             onWindowSendEventCallback = SendViewAddedEventToWindow;
             this.OnWindowSignal().Connect(onWindowSendEventCallback);
 
+            onRelayoutEventCallback = OnRelayout;
+            this.OnRelayoutSignal().Connect(onRelayoutEventCallback);
+
             if (!shown)
             {
                 SetVisible(false);


### PR DESCRIPTION
Previously, View's OnRelayout could be called only if app added Relayout
event callback.

Dali's actor size is calculated after NUI Layout layouts views.
In some special cases, NUI Layout is required to layout views again
based on the Dali's actor size calculation.

To resolve the special cases, layouting is required to be triggered in
View's OnRelayout.
To achieve the above, OnRelayout should be called regardless of app's
Relayout event callback.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
