### PR TITLE
[NUI] Fix to support DimensionDependency in Layout

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -830,6 +830,8 @@ namespace Tizen.NUI.BaseComponents
             {
                 onRelayoutEventHandler(this, null);
             }
+
+            Layout?.RequestLayout();
         }
 
         // Callback for View TouchSignal

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -584,12 +584,34 @@ namespace Tizen.NUI
                         // the size of the owner view must be reset even the ExcludeLayouting is true.
                         if (Owner.HeightSpecification < 0 || Owner.WidthSpecification < 0)
                         {
-                            Owner.SetSize(right - left, bottom - top);
+                            if (Owner.WidthResizePolicy == ResizePolicyType.DimensionDependency && Owner.HeightResizePolicy != ResizePolicyType.DimensionDependency)
+                            {
+                                Owner.SetSize(Owner.SizeWidth, bottom - top);
+                            }
+                            else if (Owner.WidthResizePolicy != ResizePolicyType.DimensionDependency && Owner.HeightResizePolicy == ResizePolicyType.DimensionDependency)
+                            {
+                                Owner.SetSize(right - left, Owner.SizeHeight);
+                            }
+                            else if (Owner.WidthResizePolicy != ResizePolicyType.DimensionDependency && Owner.HeightResizePolicy != ResizePolicyType.DimensionDependency)
+                            {
+                                Owner.SetSize(right - left, bottom - top);
+                            }
                         }
                     }
                     else
                     {
-                        Owner.SetSize(right - left, bottom - top);
+                        if (Owner.WidthResizePolicy == ResizePolicyType.DimensionDependency && Owner.HeightResizePolicy != ResizePolicyType.DimensionDependency)
+                        {
+                            Owner.SetSize(Owner.SizeWidth, bottom - top);
+                        }
+                        else if (Owner.WidthResizePolicy != ResizePolicyType.DimensionDependency && Owner.HeightResizePolicy == ResizePolicyType.DimensionDependency)
+                        {
+                            Owner.SetSize(right - left, Owner.SizeHeight);
+                        }
+                        else if (Owner.WidthResizePolicy != ResizePolicyType.DimensionDependency && Owner.HeightResizePolicy != ResizePolicyType.DimensionDependency)
+                        {
+                            Owner.SetSize(right - left, bottom - top);
+                        }
                         Owner.SetPosition(left, top);
                     }
                 }


### PR DESCRIPTION
Previously, View with DimensionDependency could not be calculated
correctly by Layout.
Because the View's ResizePolicy is changed from DimensionDependency to
Fixed when Layout sets the View's Size.

Now, to support View with DimensionDependency, Layout does not change
width or height with DimensionDependency.
Instead, Layout calculates Views when a View is resized to use the size
calculated from DimensionDependency in Dali.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
