### PR TITLE
[NUI] Add attached bindable property CheckBoxGroup.IsGroupHolder

### DIFF
--- a/src/Tizen.NUI.Components/Controls/CheckBoxGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/CheckBoxGroup.cs
@@ -14,8 +14,12 @@
  * limitations under the License.
  *
  */
+
+using System;
 using System.ComponentModel;
 using System.Collections.Generic;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
 
 namespace Tizen.NUI.Components
 {
@@ -34,6 +38,14 @@ namespace Tizen.NUI.Components
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class CheckBoxGroup : SelectGroup
     {
+        /// <summary>
+        /// IsGroupHolderProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IsGroupHolderProperty = BindableProperty.CreateAttached("IsGroupHolder", typeof(bool), typeof(View), false, propertyChanged: OnIsGroupHolderChanged);
+
+        private static readonly BindableProperty CheckBoxGroupProperty = BindableProperty.CreateAttached("CheckBoxGroup", typeof(CheckBoxGroup), typeof(View), null, propertyChanged: OnCheckBoxGroupChanged);
+
         static CheckBoxGroup() { }
 
         /// <summary>
@@ -45,6 +57,28 @@ namespace Tizen.NUI.Components
         public CheckBoxGroup() : base()
         {
         }
+
+        /// <summary>
+        /// Gets a CheckBoxGroup.IsGroupHolder property of a view.
+        /// </summary>
+        /// <param name="view">The group holder.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool GetIsGroupHolder(View view) => (bool)view.GetValue(IsGroupHolderProperty);
+
+        /// <summary>
+        /// Sets a CheckBoxGroup.IsGroupHolder property for a view.
+        /// </summary>
+        /// <param name="view">The group holder.</param>
+        /// <param name="value">The value to set.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetIsGroupHolder(View view, bool value) => view.SetValue(IsGroupHolderProperty, value, false, true);
+
+        /// <summary>
+        /// Gets a attached CheckBoxGroup for a view.
+        /// </summary>
+        /// <param name="view">The group holder.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static CheckBoxGroup GetCheckBoxGroup(View view) => view.GetValue(CheckBoxGroupProperty) as CheckBoxGroup;
 
         /// <summary>
         /// Add CheckBox to the end of CheckBoxGroup.
@@ -162,6 +196,57 @@ namespace Tizen.NUI.Components
             foreach (CheckBox cb in ItemGroup)
             {
                 cb.IsSelected = state;
+            }
+        }
+
+        private static void OnIsGroupHolderChanged(Binding.BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = bindable as View;
+
+            if (view == null) return;
+
+            if (!(bool)newValue)
+            {
+                view.SetValue(CheckBoxGroupProperty, null, false, true);
+                return;
+            }
+
+            if (view.GetValue(CheckBoxGroupProperty) == null)
+            {
+                view.SetValue(CheckBoxGroupProperty, new CheckBoxGroup(), false, true);
+            }
+        }
+
+        private static void OnCheckBoxGroupChanged(Binding.BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = bindable as View;
+
+            if (view == null) return;
+
+            if (oldValue is CheckBoxGroup oldGroup)
+            {
+                view.ChildAdded -= oldGroup.OnChildChanged;
+                view.ChildRemoved -= oldGroup.OnChildChanged;
+                oldGroup.RemoveAll();
+            }
+
+            if (newValue is CheckBoxGroup newGroup)
+            {
+                view.ChildAdded += newGroup.OnChildChanged;
+                view.ChildRemoved += newGroup.OnChildChanged;
+                newGroup.OnChildChanged(view, null);
+            }
+        }
+
+        private void OnChildChanged(object sender, EventArgs args)
+        {
+            if (sender is View view)
+            {
+                RemoveAll();
+                foreach (var child in view.Children)
+                {
+                    if (child is CheckBox checkBox) Add(checkBox);
+                }
             }
         }
     }

--- a/src/Tizen.NUI.Components/Controls/RadioButtonGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/RadioButtonGroup.cs
@@ -179,14 +179,5 @@ namespace Tizen.NUI.Components
                         Add(radioButton);
             }
         }
-
-        private void RemoveAll()
-        {
-            var copied = ItemGroup.ToArray();
-            foreach (var button in copied)
-            {
-                Remove(button as RadioButton);
-            }
-        }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/SelectGroup.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectGroup.cs
@@ -168,6 +168,20 @@ namespace Tizen.NUI.Components
             SelectedChanged?.Invoke(this, new EventArgs());
         }
 
+        /// <summary>
+        /// Remove all existing items in the group.
+        /// </summary>
+        private protected void RemoveAll()
+        {
+            foreach (var item in ItemGroup)
+            {
+                item.SelectedChanged -= GroupSelectionHandler;
+                item.ResetItemGroup();
+            }
+
+            ItemGroup.Clear();
+        }
+
         private void GroupSelectionHandler(object sender, SelectedChangedEventArgs args)
         {
             if (isSelectionChanging)


### PR DESCRIPTION
Add attached bindable property CheckBoxGroup.IsGroupHolder to the View.

In NUI, the parent View that holds checkboxes does not related with CheckBoxGroup.
Which means user must create CheckBoxGroup manually and then add all checkbox to the group.

```
var check1 = new CheckBox();
var check2 = new CheckBox();
var check3 = new CheckBox();

parent.Add(check1);
parent.Add(check2);
parent.Add(check3);

var group = new CheckBoxGroup();
group.Add(check1);
group.Add(check2);
group.Add(check3);
```

In this structure, user can not make a group in XAML code.
This patch introduce attached property to the View for the CheckBoxGroup:
```
<View CheckBoxGroup.IsGroupHolder="True">
  <CheckBox Text="Check1"/>
  <CheckBox Text="Check2"/>
  <CheckBox Text="Check3"/>
</View>
```

And then the user can access check box group from the View using GetCheckBoxGroup(view).

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
