### PR TITLE
[NUI] VectorGraphics: Move enums out of class

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Drawable.cs
@@ -35,21 +35,6 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         {
         }
 
-        /// <summary>
-        /// Enumeration indicating the type used in the masking of two objects - the mask drawable and the own drawable.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public enum MaskType
-        {
-            /// <summary>
-            /// The pixels of the own drawable and the mask drawable are alpha blended. As a result, only the part of the own drawable, which intersects with the mask drawable is visible.
-            /// </summary>
-            Alpha = 0,
-            /// <summary>
-            /// The pixels of the own drawable and the complement to the mask drawable's pixels are alpha blended. As a result, only the part of the own which is not covered by the mask is visible.
-            /// </summary>
-            AlphaInverse
-        }
 
         /// <summary>
         /// The transparency level [0 ~ 1.0], 0 means totally transparent, while 1 means opaque.

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Gradient.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Gradient.cs
@@ -43,26 +43,6 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         }
 
         /// <summary>
-        /// Enumeration specifying how to fill the area outside the gradient bounds.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public enum SpreadType
-        {
-            /// <summary>
-            /// The remaining area is filled with the closest stop color.
-            /// </summary>
-            Pad = 0,
-            /// <summary>
-            /// The gradient pattern is reflected outside the gradient area until the expected region is filled.
-            /// </summary>
-            Reflect,
-            /// <summary>
-            /// The gradient pattern is repeated continuously beyond the gradient area until the expected region is filled.
-            /// </summary>
-            Repeat
-        };
-
-        /// <summary>
         /// Specifying how to fill the area outside the gradient bounds.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Shape.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Shape.cs
@@ -48,6 +48,7 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// Enumeration for The fill rule of shape.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
+        [Obsolete("Please do not use this Shape.StrokeJoinType(Will be changed.).")]
         public enum FillRuleType
         {
             /// <summary>
@@ -64,6 +65,7 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// Enumeration for The cap style to be used for stroking the path.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
+        [Obsolete("Please do not use this Shape.StrokeCapType(Will be changed.).")]
         public enum StrokeCapType
         {
             /// <summary>
@@ -84,6 +86,7 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// numeration for The join style to be used for stroking the path.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
+        [Obsolete("Please do not use this Shape.StrokeJoinType(Will be changed.).")]
         public enum StrokeJoinType
         {
             /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Shape.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Shape.cs
@@ -48,7 +48,6 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// Enumeration for The fill rule of shape.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Please do not use this Shape.StrokeJoinType(Will be changed.).")]
         public enum FillRuleType
         {
             /// <summary>
@@ -65,7 +64,6 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// Enumeration for The cap style to be used for stroking the path.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Please do not use this Shape.StrokeCapType(Will be changed.).")]
         public enum StrokeCapType
         {
             /// <summary>
@@ -86,7 +84,6 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// numeration for The join style to be used for stroking the path.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        [Obsolete("Please do not use this Shape.StrokeJoinType(Will be changed.).")]
         public enum StrokeJoinType
         {
             /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/VectorGraphicsConstants.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/VectorGraphicsConstants.cs
@@ -1,0 +1,115 @@
+/*
+* Copyright(c) 2021 Samsung Electronics Co., Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Tizen.NUI.BaseComponents.VectorGraphics
+{
+    /// <summary>
+    /// Enumeration for The fill rule of shape.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum FillRuleType
+    {
+        /// <summary>
+        /// Draw a horizontal line from the point to a location outside the shape. Determine whether the direction of the line at each intersection point is up or down. The winding number is determined by summing the direction of each intersection. If the number is non zero, the point is inside the shape.
+        /// </summary>
+        Winding = 0,
+        /// <summary>
+        /// Draw a horizontal line from the point to a location outside the shape, and count the number of intersections. If the number of intersections is an odd number, the point is inside the shape.
+        /// </summary>
+        EvenOdd
+    }
+
+    /// <summary>
+    /// Enumeration for The cap style to be used for stroking the path.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum StrokeCapType
+    {
+        /// <summary>
+        /// The end of lines is rendered as a square around the last point.
+        /// </summary>
+        Square = 0,
+        /// <summary>
+        /// The end of lines is rendered as a half-circle around the last point.
+        /// </summary>
+        Round,
+        /// <summary>
+        /// The end of lines is rendered as a full stop on the last point itself.
+        /// </summary>
+        Butt
+    }
+
+    /// <summary>
+    /// numeration for The join style to be used for stroking the path.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum StrokeJoinType
+    {
+        /// <summary>
+        /// Used to render beveled line joins. The outer corner of the joined lines is filled by enclosing the triangular region of the corner with a straight line between the outer corners of each stroke.
+        /// </summary>
+        Bevel = 0,
+        /// <summary>
+        /// Used to render rounded line joins. Circular arcs are used to join two lines smoothly.
+        /// </summary>
+        Round,
+        /// <summary>
+        /// Used to render mitered line joins. The intersection of the strokes is clipped at a line perpendicular to the bisector of the angle between the strokes, at the distance from the intersection of the segments equal to the product of the miter limit value and the border radius.  This prevents long spikes being created.
+        /// </summary>
+        Miter
+    }
+
+    /// <summary>
+    /// Enumeration indicating the type used in the masking of two objects - the mask drawable and the own drawable.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum MaskType
+    {
+        /// <summary>
+        /// The pixels of the own drawable and the mask drawable are alpha blended. As a result, only the part of the own drawable, which intersects with the mask drawable is visible.
+        /// </summary>
+        Alpha = 0,
+        /// <summary>
+        /// The pixels of the own drawable and the complement to the mask drawable's pixels are alpha blended. As a result, only the part of the own which is not covered by the mask is visible.
+        /// </summary>
+        AlphaInverse
+    }
+
+    /// <summary>
+    /// Enumeration specifying how to fill the area outside the gradient bounds.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum SpreadType
+    {
+        /// <summary>
+        /// The remaining area is filled with the closest stop color.
+        /// </summary>
+        Pad = 0,
+        /// <summary>
+        /// The gradient pattern is reflected outside the gradient area until the expected region is filled.
+        /// </summary>
+        Reflect,
+        /// <summary>
+        /// The gradient pattern is repeated continuously beyond the gradient area until the expected region is filled.
+        /// </summary>
+        Repeat
+    };
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSamsple.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSamsple.cs
@@ -53,7 +53,7 @@ namespace Tizen.NUI.Samples
                     new ColorStop(0.5f, new Color(0.0f,1.0f,0.0f,1.0f)),
                     new ColorStop(1.0f, new Color(0.0f,0.0f,1.0f,1.0f))
                 }.AsReadOnly(),
-                Spread = Gradient.SpreadType.Reflect,
+                Spread = SpreadType.Reflect,
             };
             roundedRectFillRadialGradient.SetBounds(new Position2D(0, 0), 30);
 
@@ -87,7 +87,7 @@ namespace Tizen.NUI.Samples
             circleShape.AddCircle(0.0f, 0.0f, 150.0f, 100.0f);
             circleShape.Transform(new float[] { 0.6f, 0.0f, 350.0f, 0.0f, 0.6f, 100.0f, 0.0f, 0.0f, 1.0f });
 
-            circleShape.Mask(circleMask, Drawable.MaskType.Alpha);
+            circleShape.Mask(circleMask, MaskType.Alpha);
 
             arcShape = new Shape()
             {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Move enums to VectorGraphicsConstants.cs to avoid nested types.
And add a warning message to FillRuleType, StrokeCapType,
and StrokeJoinType enums of the Shape class that have become ACR.
https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/nested-types

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:no

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
