### PR TITLE
[NUI] Allow to set Size.Depth

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1351,11 +1351,11 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
                 Size size = (Size)newValue;
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SIZE, new Tizen.NUI.PropertyValue(size));
                 // Set Specification so when layouts measure this View it matches the value set here.
                 // All Views are currently Layouts.
                 view.WidthSpecification = (int)System.Math.Ceiling(size.Width);
                 view.HeightSpecification = (int)System.Math.Ceiling(size.Height);
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SIZE, new Tizen.NUI.PropertyValue(size));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DisposeTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DisposeTest.cs
@@ -1,15 +1,23 @@
-﻿
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using Tizen.NUI.BaseComponents;
 using System.Collections.Generic;
 
 namespace Tizen.NUI.Samples
 {
+    // Make custom view to ignore Layout features so we can use Depth information
+    public class Custom3DView : CustomView
+    {
+        // Default View Enabled SizeNegotiations, and It is Breakdown the depth values.
+        // So we need to create CustomView whitch CustomViewBehavior.DisableSizeNegotiation.
+        public Custom3DView() : base("Custom3DView", CustomViewBehaviour.DisableSizeNegotiation)
+        {
+        }
+    }
+
     // copied from https://github.com/hinohie/nui-demo/blob/geotest/Mesh/Mesh.cs
     public class DisposeTest : IExample
     {
-
         public struct Vec2
         {
             float x;
@@ -52,8 +60,7 @@ namespace Tizen.NUI.Samples
         "varying mediump vec3 vPosition;\n" +
         "void main()\n" +
         "{\n" +
-        //"    vec4 pos = vec4(aPosition, 1.0)*vec4(uSize,1.0);\n"+
-        "    vec4 pos = vec4(aPosition, 1.0)*vec4(uSize.xy, 400.0 ,1.0);\n" +
+        "    vec4 pos = vec4(aPosition, 1.0)*vec4(uSize,1.0);\n"+
         "    gl_Position = uMvpMatrix*pos;\n" +
         "    vPosition = aPosition;\n" +
         "    vNormal   = normalize(uNormalMatrix * aNormal);\n" +
@@ -66,8 +73,8 @@ namespace Tizen.NUI.Samples
         "varying mediump vec3 vNormal;\n" +
         "varying mediump vec2 vTexCoord;\n" +
         "varying mediump vec3 vPosition;\n" +
-        "mediump vec3 uLightDir = vec3(2.0, 0.5, 1.0);\n" +
-        "mediump vec3 uViewDir  = vec3(0.0, 0.0, 1.0);\n" +
+        "mediump vec3 uLightDir = vec3(2.0, 0.5, 1.0);\n" + // constant light dir
+        "mediump vec3 uViewDir  = vec3(0.0, 0.0, 1.0);\n" + // constant view dir.
         "mediump vec3 uAmbientColor = vec3(0.2, 0.2, 0.2);\n" +
         "mediump vec3 uDiffuseColor = vec3(0.8, 0.8, 0.8);\n" +
         "mediump vec3 uSpecularColor = vec3(0.5, 0.5, 0.5);\n" +
@@ -84,6 +91,7 @@ namespace Tizen.NUI.Samples
         "}\n";
 
         // Copy from dali-toolkit/internal/visuals/primitive/primitive-visual.cpp
+        // NOTE. I add one more slices for texture coordinate
         private global::System.IntPtr SphereVertexDataPtr()
         {
             TexturedQuadVertex[] vertices = new TexturedQuadVertex[SPHERE_VERTEX_NUMBER];
@@ -92,7 +100,6 @@ namespace Tizen.NUI.Samples
             const int stacks = SPHERE_STACKS;
             // Build start.
             {
-
                 int vertexIndex = 0; //Track progress through vertices.
                 float x;
                 float y;
@@ -107,7 +114,10 @@ namespace Tizen.NUI.Samples
                 //Middle stacks.
                 for (int i = 1; i < stacks; i++)
                 {
-                    for (int j = 0; j < slices; j++, vertexIndex++)
+                    //Note. This vertex method is not common.
+                    //We set one more vertexes for correct texture coordinate. at j == slices
+                    //j==0 and j==slices have equal position, normal, but there texcoord.x is different
+                    for (int j = 0; j <= slices; j++, vertexIndex++)
                     {
                         float cos_j = (float)Math.Cos(2.0f * (float)Math.PI * j / (float)slices);
                         float sin_j = (float)Math.Sin(2.0f * (float)Math.PI * j / (float)slices);
@@ -151,92 +161,66 @@ namespace Tizen.NUI.Samples
             {
                 int indiceIndex = 0; //Used to keep track of progress through indices.
                 int previousCycleBeginning = 1; //Stores the index of the vertex that started the cycle of the previous stack.
-                int currentCycleBeginning = 1 + slices;
+                int currentCycleBeginning = 1 + slices + 1;
 
                 //Top stack. Loop from index 1 to index slices, as not counting the very first vertex.
                 for (int i = 1; i <= slices; i++, indiceIndex += 3)
                 {
                     indices[indiceIndex] = 0;
-                    if (i == slices)
-                    {
-                        //End, so loop around.
-                        indices[indiceIndex + 1] = 1;
-                    }
-                    else
-                    {
-                        indices[indiceIndex + 1] = (ushort)(i + 1);
-                    }
+                    indices[indiceIndex + 1] = (ushort)(i + 1);
                     indices[indiceIndex + 2] = (ushort)i;
                 }
 
                 //Middle Stacks. Want to form triangles between the top and bottom stacks, so loop up to the number of stacks - 2.
-                for (int i = 0; i < stacks - 2; i++, previousCycleBeginning += slices, currentCycleBeginning += slices)
+                //Note. This index method is not common.
+                //We increase Beginning indexes slices+1 cause we add one more vertexes for correct texture coordinate.
+                for (int i = 0; i < stacks - 2; i++, previousCycleBeginning += slices + 1, currentCycleBeginning += slices + 1)
                 {
                     for (int j = 0; j < slices; j++, indiceIndex += 6)
                     {
-                        if (j == slices - 1)
-                        {
-                            //End, so loop around.
-                            indices[indiceIndex] = (ushort)(previousCycleBeginning + j);
-                            indices[indiceIndex + 1] = (ushort)previousCycleBeginning;
-                            indices[indiceIndex + 2] = (ushort)(currentCycleBeginning + j);
-                            indices[indiceIndex + 3] = (ushort)(currentCycleBeginning + j);
-                            indices[indiceIndex + 4] = (ushort)previousCycleBeginning;
-                            indices[indiceIndex + 5] = (ushort)currentCycleBeginning;
-                        }
-                        else
-                        {
-                            indices[indiceIndex] = (ushort)(previousCycleBeginning + j);
-                            indices[indiceIndex + 1] = (ushort)(previousCycleBeginning + 1 + j);
-                            indices[indiceIndex + 2] = (ushort)(currentCycleBeginning + j);
-                            indices[indiceIndex + 3] = (ushort)(currentCycleBeginning + j);
-                            indices[indiceIndex + 4] = (ushort)(previousCycleBeginning + 1 + j);
-                            indices[indiceIndex + 5] = (ushort)(currentCycleBeginning + 1 + j);
-                        }
+                        indices[indiceIndex] = (ushort)(previousCycleBeginning + j);
+                        indices[indiceIndex + 1] = (ushort)(previousCycleBeginning + 1 + j);
+                        indices[indiceIndex + 2] = (ushort)(currentCycleBeginning + j);
+                        indices[indiceIndex + 3] = (ushort)(currentCycleBeginning + j);
+                        indices[indiceIndex + 4] = (ushort)(previousCycleBeginning + 1 + j);
+                        indices[indiceIndex + 5] = (ushort)(currentCycleBeginning + 1 + j);
                     }
                 }
 
                 //Bottom stack. Loop around the last stack from the previous loop, and go up to the penultimate vertex.
                 for (int i = 0; i < slices; i++, indiceIndex += 3)
                 {
-                    indices[indiceIndex] = (ushort)(previousCycleBeginning + slices);
+                    indices[indiceIndex] = (ushort)(previousCycleBeginning + slices + 1);
                     indices[indiceIndex + 1] = (ushort)(previousCycleBeginning + i);
-                    if (i == slices - 1)
-                    {
-                        //End, so loop around.
-                        indices[indiceIndex + 2] = (ushort)previousCycleBeginning;
-                    }
-                    else
-                    {
-                        indices[indiceIndex + 2] = (ushort)(previousCycleBeginning + i + 1);
-                    }
+                    indices[indiceIndex + 2] = (ushort)(previousCycleBeginning + i + 1);
                 }
             }
             // Build done.
 
             return indices;
         }
-        const int NUMBER_OF_SPHERES_ROW = 3;
-        const int NUMBER_OF_SPHERES_COLUMN = 2;
-        const int NUMBER_OF_SPHERES = NUMBER_OF_SPHERES_ROW * NUMBER_OF_SPHERES_COLUMN;
-        const int SPHERE_SLICES = 150; // >= 3
-        const int SPHERE_STACKS = 90; // >= 1
-        const int SPHERE_VERTEX_NUMBER = SPHERE_SLICES * (SPHERE_STACKS - 1) + 2;
+        const int SPHERE_SLICES = 30; // >= 3
+        const int SPHERE_STACKS = 20; // >= 1
+        const int SPHERE_VERTEX_NUMBER = (SPHERE_SLICES + 1) * (SPHERE_STACKS - 1) + 2;
         const int SPHERE_INDEX_NUMBER = 6 * SPHERE_SLICES * (SPHERE_STACKS - 1);
 
 
-        private const int MaxObject = 5;
+        private const int AutoDisposedObjectCount = 10;
+        private const int ManualDisposedObjectCount = 10;
         private Window win;
         private View root;
         private Timer timer;
         private bool toggle = false;
         private string resource;
-        private List<View> views;
+        private List<Custom3DView> views;
+        private Animation rotateAnimation;
 
         public void Activate()
         {
             win = NUIApplication.GetDefaultWindow();
             resource = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
+            // Set layer behavior as Layer3D. without this, Rendering will be broken
+            win.GetDefaultLayer().Behavior = Layer.LayerBehavior.Layer3D;
             root = new View()
             {
                 Name = "root",
@@ -245,7 +229,8 @@ namespace Tizen.NUI.Samples
             };
             win.Add(root);
 
-            views = new List<View>();
+            views = new List<Custom3DView>();
+            rotateAnimation = new Animation(1500); //1.5s
 
             AddManyViews();
             toggle = true;
@@ -253,6 +238,7 @@ namespace Tizen.NUI.Samples
             timer = new Timer(3000); //3s
             timer.Tick += OnTimerTick;
             timer.Start();
+
         }
 
         private bool OnTimerTick(object source, Timer.TickEventArgs e)
@@ -293,13 +279,17 @@ namespace Tizen.NUI.Samples
         {
             Random rand = new Random();
 
-            for (int i = 0; i < MaxObject; i++)
+            for (int i = 0; i < AutoDisposedObjectCount; i++)
             {
                 int viewSize = 150;
-                var view = new View()
+                var view = new Custom3DView()
                 {
                     Size = new Size(viewSize, viewSize, viewSize),
-                    Position = new Position(rand.Next(10, 600), rand.Next(10, 600)),
+                    Position = new Position(
+                        rand.Next(10, win.WindowSize.Width - 10),
+                        rand.Next(10, win.WindowSize.Height - 10),
+                        rand.Next(-3 * viewSize, 3 * viewSize)
+                    ),
                 };
                 root.Add(view);
 
@@ -320,15 +310,21 @@ namespace Tizen.NUI.Samples
                 Renderer renderer = new Renderer(GenerateGeometry(), new Shader(VERTEX_SHADER, FRAGMENT_SHADER));
                 renderer.SetTextures(textureSet);
                 view.AddRenderer(renderer);
+
+                rotateAnimation.AnimateBy(view, "Orientation", new Rotation(new Radian(new Degree(360.0f)), Vector3.YAxis));
             }
-            
-            for (int i = 0; i < MaxObject; i++)
+
+            for (int i = 0; i < ManualDisposedObjectCount; i++)
             {
                 int viewSize = 150;
-                var view = new View()
+                var view = new Custom3DView()
                 {
                     Size = new Size(viewSize, viewSize, viewSize),
-                    Position = new Position(rand.Next(10, 600), rand.Next(10, 600)),
+                    Position = new Position(
+                        rand.Next(10, win.WindowSize.Width - 10),
+                        rand.Next(10, win.WindowSize.Height - 10),
+                        rand.Next(-3 * viewSize, 3 * viewSize)
+                    ),
                 };
                 root.Add(view);
                 views.Add(view);
@@ -350,8 +346,11 @@ namespace Tizen.NUI.Samples
                 Renderer renderer = new Renderer(GenerateGeometry(), new Shader(VERTEX_SHADER, FRAGMENT_SHADER));
                 renderer.SetTextures(textureSet);
                 view.AddRenderer(renderer);
-            }
 
+                rotateAnimation.AnimateBy(view, "Orientation", new Rotation(new Radian(new Degree(-360.0f)), Vector3.YAxis));
+            }
+            rotateAnimation.Looping = true;
+            rotateAnimation.Play();
         }
         private void RemoveAllViews()
         {
@@ -367,6 +366,7 @@ namespace Tizen.NUI.Samples
                 view.Dispose();
             }
             views.Clear();
+            rotateAnimation.Clear();
         }
 
         private void FullGC()
@@ -380,6 +380,7 @@ namespace Tizen.NUI.Samples
         {
             timer.Stop();
             RemoveAllViews();
+            rotateAnimation?.Dispose();
             root.Unparent();
             root.Dispose();
         }


### PR DESCRIPTION
Previous version set dali-side size first, and set Width/Height Specification.
But int Width/Height Specification setter, they also call Size2D property set.

Unfortunatly, Size2DProperty doesn't care about the depths of view.
So the Depth value is gone.

This patch re-ordering the function call to set dali-side size later
so Size.Depth will works well.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
