### PR TITLE
[NUI] Make Unparent() in Dispose() be executed early

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -554,7 +554,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(bool disposing)
         {
-            base.Dispose(disposing);
+            if (disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Unparent();
+            }
 
             if (accessibilityDelegate != null)
             {
@@ -562,6 +570,8 @@ namespace Tizen.NUI.BaseComponents
                 Marshal.FreeHGlobal(accessibilityDelegatePtr);
                 accessibilityDelegate = null;
             }
+
+            base.Dispose(disposing);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1230,8 +1230,6 @@ namespace Tizen.NUI.BaseComponents
                     heightConstraint.Remove();
                     heightConstraint.Dispose();
                 }
-
-                Unparent();
             }
 
             //Release your own unmanaged resources here.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -236,7 +236,11 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 4 </since_tizen>
         public override Container GetParent()
         {
-            return this.InternalParent as Container;
+            if (InternalParent)
+            {
+                return this.InternalParent as Container;
+            }
+            return null;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -109,6 +109,7 @@ namespace Tizen.NUI
         /// Dispose.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        // following this guide: https://docs.microsoft.com/ko-kr/dotnet/fundamentals/code-analysis/quality-rules/ca1063?view=vs-2019 (CA1063)
         ~BaseHandle() => Dispose(false);
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
[NUI] Make Unparent() in Dispose() be executed early
- Unparent() needs to be excuted in explicit dispose() which is also same as disposing = true.
- Also it should be called prior to before the derived class of View deletes the native handle, otherwise when doing Unparent(), the child itself has empty body (native object has been deleted already).

### API Changes ###
none