### PR TITLE
[NUI] Change SelectionChangedEventArgs to TextSelectionChangedEventArgs

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -42,7 +42,7 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<AnchorClickedEventArgs> textEditorAnchorClickedEventHandler;
         private AnchorClickedCallbackDelegate textEditorAnchorClickedCallbackDelegate;
 
-        private EventHandler<SelectionChangedEventArgs> textEditorSelectionChangedEventHandler;
+        private EventHandler<TextSelectionChangedEventArgs> textEditorSelectionChangedEventHandler;
         private SelectionChangedCallbackDelegate textEditorSelectionChangedCallbackDelegate;
 
         private EventHandler<InputFilteredEventArgs> textEditorInputFilteredEventHandler;
@@ -203,7 +203,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public event EventHandler<SelectionChangedEventArgs> SelectionChanged
+        public event EventHandler<TextSelectionChangedEventArgs> SelectionChanged
         {
             add
             {
@@ -390,9 +390,9 @@ namespace Tizen.NUI.BaseComponents
         {
             if (textEditorSelectionChangedEventHandler != null)
             {
-                SelectionChangedEventArgs e = new SelectionChangedEventArgs();
+                TextSelectionChangedEventArgs e = new TextSelectionChangedEventArgs();
 
-                // Populate all members of "e" (SelectionChangedEventArgs) with real data
+                // Populate all members of "e" (TextSelectionChangedEventArgs) with real data
                 e.OldSelectionStart = oldStart;
                 e.OldSelectionEnd = oldEnd;
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI.BaseComponents
     /// </summary>
     /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class SelectionChangedEventArgs : EventArgs
+    public class TextSelectionChangedEventArgs : EventArgs
     {
         /// <summary>
         /// selection start before the change.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
@@ -36,7 +36,7 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<AnchorClickedEventArgs> textFieldAnchorClickedEventHandler;
         private AnchorClickedCallbackDelegate textFieldAnchorClickedCallbackDelegate;
 
-        private EventHandler<SelectionChangedEventArgs> textFieldSelectionChangedEventHandler;
+        private EventHandler<TextSelectionChangedEventArgs> textFieldSelectionChangedEventHandler;
         private SelectionChangedCallbackDelegate textFieldSelectionChangedCallbackDelegate;
 
         private EventHandler<InputFilteredEventArgs> textFieldInputFilteredEventHandler;
@@ -166,7 +166,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public event EventHandler<SelectionChangedEventArgs> SelectionChanged
+        public event EventHandler<TextSelectionChangedEventArgs> SelectionChanged
         {
             add
             {
@@ -329,9 +329,9 @@ namespace Tizen.NUI.BaseComponents
         {
             if (textFieldSelectionChangedEventHandler != null)
             {
-                SelectionChangedEventArgs e = new SelectionChangedEventArgs();
+                TextSelectionChangedEventArgs e = new TextSelectionChangedEventArgs();
 
-                // Populate all members of "e" (SelectionChangedEventArgs) with real data
+                // Populate all members of "e" (TextSelectionChangedEventArgs) with real data
                 e.OldSelectionStart = oldStart;
                 e.OldSelectionEnd = oldEnd;
 


### PR DESCRIPTION
There is an ambiguous reference problem,
because the newly added SelectionChangedEventArgs for Text
has the same name as the existing SelectionChangedEventArgs.

The SelectionChangedEventArgs for Text is not yet an opened API,
so temporarily renaming it to fix the issue.

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>
