### PR TITLE
[NUI] Fix to measure GridLayout's children sizes correctly

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
@@ -293,9 +293,20 @@ namespace Tizen.NUI
 
             for (int i = 0; i < edgeList.Length; i++)
             {
-                float newLocation = locations[edgeList[i].Start] + edgeList[i].Edge + edgeList[i].ExpandedSize;
-                if (edgeList[i].Edge + edgeList[i].ExpandedSize > 0)
-                    newLocation += space;
+                float newLocation = locations[edgeList[i].Start];
+                // view's size is set to be the bigger one between its measured size and its expanded size.
+                if (edgeList[i].Edge > edgeList[i].ExpandedSize)
+                {
+                    newLocation += edgeList[i].Edge;
+                    if (edgeList[i].Edge > 0)
+                        newLocation += space;
+                }
+                else
+                {
+                    newLocation += edgeList[i].ExpandedSize;
+                    if (edgeList[i].ExpandedSize > 0)
+                        newLocation += space;
+                }
 
                 if (locations[edgeList[i].End] < newLocation)
                 {


### PR DESCRIPTION
Previously, if child's measured size is 0, then GridLayout does not
update the child's measured size when the child's size is set by using
GridLayout APIs.
e.g.
SetHorizontalStretch(child, GridLayout.StretchFlags.ExpandAndFill);

Moreover, if child has its own size and ExpandAndFill is set, then
child's size is set to be its own size (its measured size) plus its
expanded size.
e.g.
parent size is 100.
child1's measured size is 50 and ExpandAndFill.
child2's measured size is 0 and ExpandAndFill.
Then, child1's size is 50 + 25 = 75 and child2's size is 25.

To resolve the above, GridLayout updates child's measured size in
OnLayout() and child's size is set to be the bigger one between its
measured size and its expanded size.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
