### PR TITLE
Revert "Remove ReleaseFunction enum at PixelData (#3436)"

### DIFF
--- a/src/Tizen.NUI.Wearable/src/public/Title.cs
+++ b/src/Tizen.NUI.Wearable/src/public/Title.cs
@@ -270,7 +270,7 @@ namespace Tizen.NUI.Components
             pixelBuffer[6] = (byte)(0xFF * color2.Z);
             pixelBuffer[7] = (byte)(0xFF * color2.W);
 
-            PixelData pixelData = new PixelData(pixelBuffer, size, width, height, PixelFormat.RGBA8888);
+            PixelData pixelData = new PixelData(pixelBuffer, size, width, height, PixelFormat.RGBA8888, PixelData.ReleaseFunction.DeleteArray );
             Texture texture = new Texture(TextureType.TEXTURE_2D, PixelFormat.RGBA8888, width, height);
             texture.Upload(pixelData);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PixelData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PixelData.cs
@@ -25,7 +25,7 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PixelData_New")]
-            public static extern global::System.IntPtr New([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg1, uint jarg2, uint jarg3, uint jarg4, int jarg5);
+            public static extern global::System.IntPtr New([global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg1, uint jarg2, uint jarg3, uint jarg4, int jarg5, int jarg6);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PixelData__SWIG_0")]
             public static extern global::System.IntPtr NewPixelData();

--- a/src/Tizen.NUI/src/public/Images/PixelData.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelData.cs
@@ -45,10 +45,11 @@ namespace Tizen.NUI
         /// <param name="width">Buffer width in pixels.</param>
         /// <param name="height">Buffer height in pixels.</param>
         /// <param name="pixelFormat">The pixel format.</param>
+        /// <param name="releaseFunction">The function used to release the memory.</param>
         /// <since_tizen> 5 </since_tizen>
         /// This will be released at Tizen.NET API Level 5, so currently this would be used as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PixelData(byte[] buffer, uint bufferSize, uint width, uint height, PixelFormat pixelFormat) : this(Interop.PixelData.New(buffer, bufferSize, width, height, (int)pixelFormat), true)
+        public PixelData(byte[] buffer, uint bufferSize, uint width, uint height, PixelFormat pixelFormat, PixelData.ReleaseFunction releaseFunction) : this(Interop.PixelData.New(buffer, bufferSize, width, height, (int)pixelFormat, (int)releaseFunction), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
@@ -56,6 +57,25 @@ namespace Tizen.NUI
 
         internal PixelData(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
+        }
+
+        /// <summary>
+        /// Enumeration for function to release the pixel buffer.
+        /// </summary>
+        /// <since_tizen> 5 </since_tizen>
+        /// This will be released at Tizen.NET API Level 5, so currently this would be used as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum ReleaseFunction
+        {
+            /// <summary>
+            /// Use free function to release the pixel buffer.
+            /// </summary>
+            Free,
+
+            /// <summary>
+            /// Use delete[] operator to release the pixel buffer.
+            /// </summary>
+            DeleteArray
         }
 
         /// <summary>

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Images/TSPixelData.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Images/TSPixelData.cs
@@ -41,7 +41,7 @@ namespace Tizen.NUI.Devel.Tests
 
             byte[] buffer = new byte[1024];
 
-            var testingTarget = new PixelData(buffer, 1024, 100, 150, PixelFormat.L8);
+            var testingTarget = new PixelData(buffer, 1024, 100, 150, PixelFormat.L8, PixelData.ReleaseFunction.Free);
             Assert.IsNotNull(testingTarget, "Can't create success object PixelData");
             Assert.IsInstanceOf<PixelData>(testingTarget, "Should be an instance of PixelData type.");
 
@@ -63,7 +63,7 @@ namespace Tizen.NUI.Devel.Tests
 
             byte[] buffer = new byte[10];
 
-            using (PixelData pixelData = new PixelData(buffer, 10, 1, 2, PixelFormat.L8))
+            using (PixelData pixelData = new PixelData(buffer, 10, 1, 2, PixelFormat.L8, PixelData.ReleaseFunction.Free))
             {
                 var testingTarget = new PixelData(PixelData.getCPtr(pixelData).Handle, true);
                 Assert.IsNotNull(testingTarget, "Can't create success object PixelData");
@@ -89,7 +89,7 @@ namespace Tizen.NUI.Devel.Tests
 
             byte[] buffer = new byte[10];
 
-            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.L8);
+            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.L8, PixelData.ReleaseFunction.Free);
             Assert.IsNotNull(testingTarget, "Can't create success object PixelData");
             Assert.IsInstanceOf<PixelData>(testingTarget, "Should be an instance of PixelData type.");
 
@@ -114,7 +114,7 @@ namespace Tizen.NUI.Devel.Tests
 
             byte[] buffer = new byte[10];
 
-            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.L8);
+            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.L8, PixelData.ReleaseFunction.Free);
             Assert.IsNotNull(testingTarget, "Can't create success object PixelData");
             Assert.IsInstanceOf<PixelData>(testingTarget, "Should be an instance of PixelData type.");
 
@@ -139,7 +139,7 @@ namespace Tizen.NUI.Devel.Tests
 
             byte[] buffer = new byte[10];
 
-            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.L8);
+            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.L8, PixelData.ReleaseFunction.Free);
             Assert.IsNotNull(testingTarget, "Can't create success object PixelData");
             Assert.IsInstanceOf<PixelData>(testingTarget, "Should be an instance of PixelData type.");
 
@@ -164,7 +164,7 @@ namespace Tizen.NUI.Devel.Tests
 
             byte[] buffer = new byte[10];
 
-            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.BGR8888);
+            var testingTarget = new PixelData(buffer, 10, 1, 2, PixelFormat.BGR8888, PixelData.ReleaseFunction.Free);
             Assert.IsNotNull(testingTarget, "Can't create success object PixelData");
             Assert.IsInstanceOf<PixelData>(testingTarget, "Should be an instance of PixelData type.");
 


### PR DESCRIPTION
This reverts commit c2951987b9232e1fe24c8d2d98334fbb3ed03327.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: no

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
