### PR TITLE
[NUI] Add struct Placeholder, HiddenInput to Text Components

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -237,7 +237,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetFontStyle(FontStyle fontStyle)
         {
-            SetProperty(TextEditor.Property.FontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
+            SetValue(FontStyleProperty, TextUtils.GetFontStyleMap(fontStyle));
         }
 
         /// <summary>
@@ -250,9 +250,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetFontStyle()
         {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.FontStyle).Get(map);
-            return TextUtils.GetFontStyleStruct(map);
+            return TextUtils.GetFontStyleStruct((PropertyMap)GetValue(FontStyleProperty));
         }
 
         /// <summary>
@@ -734,8 +732,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetInputFontStyle(FontStyle fontStyle)
         {
-            SetProperty(TextEditor.Property.InputFontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
-            NotifyPropertyChanged();
+            SetValue(InputFontStyleProperty, TextUtils.GetFontStyleMap(fontStyle));
         }
 
         /// <summary>
@@ -748,9 +745,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetInputFontStyle()
         {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.InputFontStyle).Get(map);
-            return TextUtils.GetFontStyleStruct(map);
+            return TextUtils.GetFontStyleStruct((PropertyMap)GetValue(InputFontStyleProperty));
         }
 
         /// <summary>
@@ -848,7 +843,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetUnderline(Underline underline)
         {
-            SetProperty(TextEditor.Property.UNDERLINE, new PropertyValue(TextUtils.GetUnderlineMap(underline)));
+            SetValue(UnderlineProperty, TextUtils.GetUnderlineMap(underline));
         }
 
         /// <summary>
@@ -861,9 +856,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Underline GetUnderline()
         {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.UNDERLINE).Get(map);
-            return TextUtils.GetUnderlineStruct(map);
+            return TextUtils.GetUnderlineStruct((PropertyMap)GetValue(UnderlineProperty));
         }
 
         /// <summary>
@@ -926,7 +919,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetShadow(Tizen.NUI.Text.Shadow shadow)
         {
-            SetProperty(TextEditor.Property.SHADOW, new PropertyValue(TextUtils.GetShadowMap(shadow)));
+            SetValue(ShadowProperty, TextUtils.GetShadowMap(shadow));
         }
 
         /// <summary>
@@ -939,9 +932,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Tizen.NUI.Text.Shadow GetShadow()
         {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.SHADOW).Get(map);
-            return TextUtils.GetShadowStruct(map);
+            return TextUtils.GetShadowStruct((PropertyMap)GetValue(ShadowProperty));
         }
 
         /// <summary>
@@ -1037,7 +1028,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetOutline(Outline outline)
         {
-            SetProperty(TextEditor.Property.OUTLINE, new PropertyValue(TextUtils.GetOutlineMap(outline)));
+            SetValue(OutlineProperty, TextUtils.GetOutlineMap(outline));
         }
 
         /// <summary>
@@ -1050,9 +1041,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Outline GetOutline()
         {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.OUTLINE).Get(map);
-            return TextUtils.GetOutlineStruct(map);
+            return TextUtils.GetOutlineStruct((PropertyMap)GetValue(OutlineProperty));
         }
 
         /// <summary>
@@ -1610,7 +1599,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPlaceholder(Placeholder placeholder)
         {
-            SetProperty(TextEditor.Property.PLACEHOLDER, new PropertyValue(TextUtils.GetPlaceholderMap(placeholder)));
+            SetValue(PlaceholderProperty, TextUtils.GetPlaceholderMap(placeholder));
         }
 
         /// <summary>
@@ -1623,9 +1612,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Placeholder GetPlaceholder()
         {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.PLACEHOLDER).Get(map);
-            return TextUtils.GetPlaceholderStruct(map);
+            return TextUtils.GetPlaceholderStruct((PropertyMap)GetValue(PlaceholderProperty));
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1497,6 +1497,7 @@ namespace Tizen.NUI.BaseComponents
         /// </code>
         /// </example>
         /// <since_tizen> 3 </since_tizen>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721: Property names should not match get methods")]
         public Tizen.NUI.PropertyMap Placeholder
         {
             get
@@ -1577,6 +1578,54 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(PlaceholderProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Set Placeholder to TextEditor. <br />
+        /// </summary>
+        /// <param name="placeholder">The Placeholder</param>
+        /// <remarks>
+        /// SetPlaceholder specifies the attributes of the placeholder property through <see cref="Tizen.NUI.Text.Placeholder"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetPlaceholder method.
+        /// <code>
+        /// var placeholder = new Tizen.NUI.Text.Placeholder();
+        /// placeholder.Text = "placeholder text";
+        /// placeholder.TextFocused = "placeholder textFocused";
+        /// placeholder.Color = new Color("#45B39D");
+        /// placeholder.FontFamily = "BreezeSans";
+        /// placeholder.FontStyle = new Tizen.NUI.Text.FontStyle()
+        /// {
+        ///     Width = FontWidthType.Expanded,
+        ///     Weight = FontWeightType.ExtraLight,
+        ///     Slant = FontSlantType.Italic,
+        /// };
+        /// placeholder.PointSize = 25.0f;
+        /// //placeholder.PixelSize = 50.0f;
+        /// placeholder.Ellipsis = true;
+        /// editor.SetPlaceholder(placeholder);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetPlaceholder(Placeholder placeholder)
+        {
+            SetProperty(TextEditor.Property.PLACEHOLDER, new PropertyValue(TextUtils.GetPlaceholderMap(placeholder)));
+        }
+
+        /// <summary>
+        /// Get Placeholder from TextEditor. <br />
+        /// </summary>
+        /// <returns>The Placeholder</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Placeholder"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Placeholder GetPlaceholder()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextEditor.Property.PLACEHOLDER).Get(map);
+            return TextUtils.GetPlaceholderStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -508,6 +508,49 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set SelectionHandleImage to TextEditor. <br />
+        /// </summary>
+        /// <param name="selectionHandleImage">The SelectionHandleImage</param>
+        /// <remarks>
+        /// SetSelectionHandleImage specifies the display image used for the selection handle through <see cref="Tizen.NUI.Text.SelectionHandleImage"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetSelectionHandleImage method.
+        /// <code>
+        /// var selectionHandleImage = new Tizen.NUI.Text.SelectionHandleImage();
+        /// selectionHandleImage.LeftImageUrl = "handle_downleft.png";
+        /// selectionHandleImage.RightImageUrl = "handle_downright.png";
+        /// editor.SetSelectionHandleImage(selectionHandleImage);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSelectionHandleImage(SelectionHandleImage selectionHandleImage)
+        {
+            if (!String.IsNullOrEmpty(selectionHandleImage.LeftImageUrl))
+            {
+                SetValue(SelectionHandleImageLeftProperty, TextUtils.GetFileNameMap(selectionHandleImage.LeftImageUrl));
+            }
+
+            if (!String.IsNullOrEmpty(selectionHandleImage.RightImageUrl))
+            {
+                SetValue(SelectionHandleImageRightProperty, TextUtils.GetFileNameMap(selectionHandleImage.RightImageUrl));
+            }
+        }
+
+        /// <summary>
+        /// Get SelectionHandleImage from TextEditor. <br />
+        /// </summary>
+        /// <returns>The SelectionHandleImage</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.SelectionHandleImage"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SelectionHandleImage GetSelectionHandleImage()
+        {
+            return TextUtils.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleImageLeftProperty), (PropertyMap)GetValue(SelectionHandleImageRightProperty));
+        }
+
+        /// <summary>
         /// The SelectionHandlePressedImageLeft property.
         /// The selectionHandlePressedImageLeft map contains the following key :<br />
         /// <list type="table">
@@ -550,6 +593,49 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set SelectionHandlePressedImage to TextEditor. <br />
+        /// </summary>
+        /// <param name="selectionHandlePressedImage">The SelectionHandleImage</param>
+        /// <remarks>
+        /// SetSelectionHandlePressedImage specifies the display image used for the selection handle through <see cref="Tizen.NUI.Text.SelectionHandleImage"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetSelectionHandlePressedImage method.
+        /// <code>
+        /// var selectionHandlePressedImage = new Tizen.NUI.Text.SelectionHandleImage();
+        /// selectionHandlePressedImage.LeftImageUrl = "handle_pressed_downleft.png";
+        /// selectionHandlePressedImage.RightImageUrl = "handle_pressed_downright.png";
+        /// editor.SetSelectionHandlePressedImage(selectionHandlePressedImage);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSelectionHandlePressedImage(SelectionHandleImage selectionHandlePressedImage)
+        {
+            if (!String.IsNullOrEmpty(selectionHandlePressedImage.LeftImageUrl))
+            {
+                SetValue(SelectionHandlePressedImageLeftProperty, TextUtils.GetFileNameMap(selectionHandlePressedImage.LeftImageUrl));
+            }
+
+            if (!String.IsNullOrEmpty(selectionHandlePressedImage.RightImageUrl))
+            {
+                SetValue(SelectionHandlePressedImageRightProperty, TextUtils.GetFileNameMap(selectionHandlePressedImage.RightImageUrl));
+            }
+        }
+
+        /// <summary>
+        /// Get SelectionHandlePressedImage from TextEditor. <br />
+        /// </summary>
+        /// <returns>The SelectionHandlePressedImage</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.SelectionHandleImage"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SelectionHandleImage GetSelectionHandlePressedImage()
+        {
+            return TextUtils.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandlePressedImageLeftProperty), (PropertyMap)GetValue(SelectionHandlePressedImageRightProperty));
+        }
+
+        /// <summary>
         /// The SelectionHandleMarkerImageLeft property.
         /// The selectionHandleMarkerImageLeft map contains the following key :<br />
         /// <list type="table">
@@ -589,6 +675,49 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(SelectionHandleMarkerImageRightProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Set SelectionHandleMarkerImage to TextEditor. <br />
+        /// </summary>
+        /// <param name="selectionHandleMarkerImage">The SelectionHandleImage</param>
+        /// <remarks>
+        /// SetSelectionHandleMarkerImage specifies the display image used for the selection handle through <see cref="Tizen.NUI.Text.SelectionHandleImage"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetSelectionHandleMarkerImage method.
+        /// <code>
+        /// var selectionHandleMarkerImage = new Tizen.NUI.Text.SelectionHandleImage();
+        /// selectionHandleMarkerImage.LeftImageUrl = "handle_pressed_downleft.png";
+        /// selectionHandleMarkerImage.RightImageUrl = "handle_pressed_downright.png";
+        /// editor.SetSelectionHandleMarkerImage(selectionHandleMarkerImage);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSelectionHandleMarkerImage(SelectionHandleImage selectionHandleMarkerImage)
+        {
+            if (!String.IsNullOrEmpty(selectionHandleMarkerImage.LeftImageUrl))
+            {
+                SetValue(SelectionHandleMarkerImageLeftProperty, TextUtils.GetFileNameMap(selectionHandleMarkerImage.LeftImageUrl));
+            }
+
+            if (!String.IsNullOrEmpty(selectionHandleMarkerImage.RightImageUrl))
+            {
+                SetValue(SelectionHandleMarkerImageRightProperty, TextUtils.GetFileNameMap(selectionHandleMarkerImage.RightImageUrl));
+            }
+        }
+
+        /// <summary>
+        /// Get SelectionHandleMarkerImage from TextEditor. <br />
+        /// </summary>
+        /// <returns>The SelectionHandleMarkerImage</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.SelectionHandleImage"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SelectionHandleImage GetSelectionHandleMarkerImage()
+        {
+            return TextUtils.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleMarkerImageLeftProperty), (PropertyMap)GetValue(SelectionHandleMarkerImageRightProperty));
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -327,8 +327,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetFontStyle(FontStyle fontStyle)
         {
-            SetProperty(TextField.Property.FontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
-            NotifyPropertyChanged();
+            SetValue(FontStyleProperty, TextUtils.GetFontStyleMap(fontStyle));
         }
 
         /// <summary>
@@ -341,9 +340,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetFontStyle()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.FontStyle).Get(map);
-            return TextUtils.GetFontStyleStruct(map);
+            return TextUtils.GetFontStyleStruct((PropertyMap)GetValue(FontStyleProperty));
         }
 
         /// <summary>
@@ -1006,8 +1003,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetInputFontStyle(FontStyle fontStyle)
         {
-            SetProperty(TextField.Property.InputFontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
-            NotifyPropertyChanged();
+            SetValue(InputFontStyleProperty, TextUtils.GetFontStyleMap(fontStyle));
         }
 
         /// <summary>
@@ -1020,9 +1016,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetInputFontStyle()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.InputFontStyle).Get(map);
-            return TextUtils.GetFontStyleStruct(map);
+            return TextUtils.GetFontStyleStruct((PropertyMap)GetValue(InputFontStyleProperty));
         }
 
         /// <summary>
@@ -1086,7 +1080,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetUnderline(Underline underline)
         {
-            SetProperty(TextField.Property.UNDERLINE, new PropertyValue(TextUtils.GetUnderlineMap(underline)));
+            SetValue(UnderlineProperty, TextUtils.GetUnderlineMap(underline));
         }
 
         /// <summary>
@@ -1099,9 +1093,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Underline GetUnderline()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.UNDERLINE).Get(map);
-            return TextUtils.GetUnderlineStruct(map);
+            return TextUtils.GetUnderlineStruct((PropertyMap)GetValue(UnderlineProperty));
         }
 
         /// <summary>
@@ -1164,7 +1156,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetShadow(Tizen.NUI.Text.Shadow shadow)
         {
-            SetProperty(TextField.Property.SHADOW, new PropertyValue(TextUtils.GetShadowMap(shadow)));
+            SetValue(ShadowProperty, TextUtils.GetShadowMap(shadow));
         }
 
         /// <summary>
@@ -1177,9 +1169,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Tizen.NUI.Text.Shadow GetShadow()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.SHADOW).Get(map);
-            return TextUtils.GetShadowStruct(map);
+            return TextUtils.GetShadowStruct((PropertyMap)GetValue(ShadowProperty));
         }
 
         /// <summary>
@@ -1275,7 +1265,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetOutline(Outline outline)
         {
-            SetProperty(TextField.Property.OUTLINE, new PropertyValue(TextUtils.GetOutlineMap(outline)));
+            SetValue(OutlineProperty, TextUtils.GetOutlineMap(outline));
         }
 
         /// <summary>
@@ -1288,9 +1278,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Outline GetOutline()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.OUTLINE).Get(map);
-            return TextUtils.GetOutlineStruct(map);
+            return TextUtils.GetOutlineStruct((PropertyMap)GetValue(OutlineProperty));
         }
 
         /// <summary>
@@ -1368,8 +1356,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetHiddenInput(HiddenInput hiddenInput)
         {
-            SetProperty(TextField.Property.HiddenInputSettings, new PropertyValue(TextUtils.GetHiddenInputMap(hiddenInput)));
-            NotifyPropertyChanged();
+            SetValue(HiddenInputSettingsProperty, TextUtils.GetHiddenInputMap(hiddenInput));
         }
 
         /// <summary>
@@ -1382,9 +1369,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HiddenInput GetHiddenInput()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.HiddenInputSettings).Get(map);
-            return TextUtils.GetHiddenInputStruct(map);
+            return TextUtils.GetHiddenInputStruct((PropertyMap)GetValue(HiddenInputSettingsProperty));
         }
 
         /// <summary>
@@ -1797,7 +1782,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPlaceholder(Placeholder placeholder)
         {
-            SetProperty(TextField.Property.PLACEHOLDER, new PropertyValue(TextUtils.GetPlaceholderMap(placeholder)));
+            SetValue(PlaceholderProperty, TextUtils.GetPlaceholderMap(placeholder));
         }
 
         /// <summary>
@@ -1810,9 +1795,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Placeholder GetPlaceholder()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.PLACEHOLDER).Get(map);
-            return TextUtils.GetPlaceholderStruct(map);
+            return TextUtils.GetPlaceholderStruct((PropertyMap)GetValue(PlaceholderProperty));
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1644,6 +1644,7 @@ namespace Tizen.NUI.BaseComponents
         /// </code>
         /// </example>
         /// <since_tizen> 3 </since_tizen>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721: Property names should not match get methods")]
         public Tizen.NUI.PropertyMap Placeholder
         {
             get
@@ -1724,6 +1725,54 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(PlaceholderProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Set Placeholder to TextField. <br />
+        /// </summary>
+        /// <param name="placeholder">The Placeholder</param>
+        /// <remarks>
+        /// SetPlaceholder specifies the attributes of the placeholder property through <see cref="Tizen.NUI.Text.Placeholder"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetPlaceholder method.
+        /// <code>
+        /// var placeholder = new Tizen.NUI.Text.Placeholder();
+        /// placeholder.Text = "placeholder text";
+        /// placeholder.TextFocused = "placeholder textFocused";
+        /// placeholder.Color = new Color("#45B39D");
+        /// placeholder.FontFamily = "BreezeSans";
+        /// placeholder.FontStyle = new Tizen.NUI.Text.FontStyle()
+        /// {
+        ///     Width = FontWidthType.Expanded,
+        ///     Weight = FontWeightType.ExtraLight,
+        ///     Slant = FontSlantType.Italic,
+        /// };
+        /// placeholder.PointSize = 25.0f;
+        /// //placeholder.PixelSize = 50.0f;
+        /// placeholder.Ellipsis = true;
+        /// field.SetPlaceholder(placeholder);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetPlaceholder(Placeholder placeholder)
+        {
+            SetProperty(TextField.Property.PLACEHOLDER, new PropertyValue(TextUtils.GetPlaceholderMap(placeholder)));
+        }
+
+        /// <summary>
+        /// Get Placeholder from TextField. <br />
+        /// </summary>
+        /// <returns>The Placeholder</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Placeholder"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Placeholder GetPlaceholder()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextField.Property.PLACEHOLDER).Get(map);
+            return TextUtils.GetPlaceholderStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -748,6 +748,49 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set SelectionHandleImage to TextField. <br />
+        /// </summary>
+        /// <param name="selectionHandleImage">The SelectionHandleImage</param>
+        /// <remarks>
+        /// SetSelectionHandleImage specifies the display image used for the selection handle through <see cref="Tizen.NUI.Text.SelectionHandleImage"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetSelectionHandleImage method.
+        /// <code>
+        /// var selectionHandleImage = new Tizen.NUI.Text.SelectionHandleImage();
+        /// selectionHandleImage.LeftImageUrl = "handle_downleft.png";
+        /// selectionHandleImage.RightImageUrl = "handle_downright.png";
+        /// field.SetSelectionHandleImage(selectionHandleImage);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSelectionHandleImage(SelectionHandleImage selectionHandleImage)
+        {
+            if (!String.IsNullOrEmpty(selectionHandleImage.LeftImageUrl))
+            {
+                SetValue(SelectionHandleImageLeftProperty, TextUtils.GetFileNameMap(selectionHandleImage.LeftImageUrl));
+            }
+
+            if (!String.IsNullOrEmpty(selectionHandleImage.RightImageUrl))
+            {
+                SetValue(SelectionHandleImageRightProperty, TextUtils.GetFileNameMap(selectionHandleImage.RightImageUrl));
+            }
+        }
+
+        /// <summary>
+        /// Get SelectionHandleImage from TextField. <br />
+        /// </summary>
+        /// <returns>The SelectionHandleImage</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.SelectionHandleImage"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SelectionHandleImage GetSelectionHandleImage()
+        {
+            return TextUtils.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleImageLeftProperty), (PropertyMap)GetValue(SelectionHandleImageRightProperty));
+        }
+
+        /// <summary>
         /// The SelectionHandlePressedImageLeft property.
         /// The selectionHandlePressedImageLeft map contains the following key :<br />
         /// <list type="table">
@@ -790,6 +833,49 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set SelectionHandlePressedImage to TextField. <br />
+        /// </summary>
+        /// <param name="selectionHandlePressedImage">The SelectionHandleImage</param>
+        /// <remarks>
+        /// SetSelectionHandlePressedImage specifies the display image used for the selection handle through <see cref="Tizen.NUI.Text.SelectionHandleImage"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetSelectionHandlePressedImage method.
+        /// <code>
+        /// var selectionHandlePressedImage = new Tizen.NUI.Text.SelectionHandleImage();
+        /// selectionHandlePressedImage.LeftImageUrl = "handle_pressed_downleft.png";
+        /// selectionHandlePressedImage.RightImageUrl = "handle_pressed_downright.png";
+        /// field.SetSelectionHandlePressedImage(selectionHandlePressedImage);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSelectionHandlePressedImage(SelectionHandleImage selectionHandlePressedImage)
+        {
+            if (!String.IsNullOrEmpty(selectionHandlePressedImage.LeftImageUrl))
+            {
+                SetValue(SelectionHandlePressedImageLeftProperty, TextUtils.GetFileNameMap(selectionHandlePressedImage.LeftImageUrl));
+            }
+
+            if (!String.IsNullOrEmpty(selectionHandlePressedImage.RightImageUrl))
+            {
+                SetValue(SelectionHandlePressedImageRightProperty, TextUtils.GetFileNameMap(selectionHandlePressedImage.RightImageUrl));
+            }
+        }
+
+        /// <summary>
+        /// Get SelectionHandlePressedImage from TextField. <br />
+        /// </summary>
+        /// <returns>The SelectionHandlePressedImage</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.SelectionHandleImage"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SelectionHandleImage GetSelectionHandlePressedImage()
+        {
+            return TextUtils.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandlePressedImageLeftProperty), (PropertyMap)GetValue(SelectionHandlePressedImageRightProperty));
+        }
+
+        /// <summary>
         /// The SelectionHandleMarkerImageLeft property.
         /// The selectionHandleMarkerImageLeft map contains the following key :<br />
         /// <list type="table">
@@ -829,6 +915,49 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(SelectionHandleMarkerImageRightProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Set SelectionHandleMarkerImage to TextField. <br />
+        /// </summary>
+        /// <param name="selectionHandleMarkerImage">The SelectionHandleImage</param>
+        /// <remarks>
+        /// SetSelectionHandleMarkerImage specifies the display image used for the selection handle through <see cref="Tizen.NUI.Text.SelectionHandleImage"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetSelectionHandleMarkerImage method.
+        /// <code>
+        /// var selectionHandleMarkerImage = new Tizen.NUI.Text.SelectionHandleImage();
+        /// selectionHandleMarkerImage.LeftImageUrl = "handle_pressed_downleft.png";
+        /// selectionHandleMarkerImage.RightImageUrl = "handle_pressed_downright.png";
+        /// field.SetSelectionHandleMarkerImage(selectionHandleMarkerImage);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSelectionHandleMarkerImage(SelectionHandleImage selectionHandleMarkerImage)
+        {
+            if (!String.IsNullOrEmpty(selectionHandleMarkerImage.LeftImageUrl))
+            {
+                SetValue(SelectionHandleMarkerImageLeftProperty, TextUtils.GetFileNameMap(selectionHandleMarkerImage.LeftImageUrl));
+            }
+
+            if (!String.IsNullOrEmpty(selectionHandleMarkerImage.RightImageUrl))
+            {
+                SetValue(SelectionHandleMarkerImageRightProperty, TextUtils.GetFileNameMap(selectionHandleMarkerImage.RightImageUrl));
+            }
+        }
+
+        /// <summary>
+        /// Get SelectionHandleMarkerImage from TextField. <br />
+        /// </summary>
+        /// <returns>The SelectionHandleMarkerImage</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.SelectionHandleImage"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SelectionHandleImage GetSelectionHandleMarkerImage()
+        {
+            return TextUtils.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleMarkerImageLeftProperty), (PropertyMap)GetValue(SelectionHandleMarkerImageRightProperty));
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1348,6 +1348,46 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set HiddenInput to TextField. <br />
+        /// </summary>
+        /// <param name="hiddenInput">The HiddenInput</param>
+        /// <remarks>
+        /// SetHiddenInput specifies the requested font style through <see cref="Tizen.NUI.Text.HiddenInput"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetHiddenInput method.
+        /// <code>
+        /// var hiddenInput = new Tizen.NUI.Text.HiddenInput();
+        /// hiddenInput.Mode = HiddenInputModeType.ShowLastCharacter;
+        /// hiddenInput.SubstituteCharacter = '★';
+        /// hiddenInput.SubstituteCount = 0;
+        /// hiddenInput.ShowLastCharacterDuration = 1000;
+        /// field.SetHiddenInput(hiddenInput);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetHiddenInput(HiddenInput hiddenInput)
+        {
+            SetProperty(TextField.Property.HiddenInputSettings, new PropertyValue(TextUtils.GetHiddenInputMap(hiddenInput)));
+            NotifyPropertyChanged();
+        }
+
+        /// <summary>
+        /// Get HiddenInput from TextField. <br />
+        /// </summary>
+        /// <returns>The HiddenInput</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.HiddenInput"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public HiddenInput GetHiddenInput()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextField.Property.HiddenInputSettings).Get(map);
+            return TextUtils.GetHiddenInputStruct(map);
+        }
+
+        /// <summary>
         /// The PixelSize property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -302,7 +302,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetFontStyle(FontStyle fontStyle)
         {
-            SetProperty(TextLabel.Property.FontStyle, new PropertyValue(TextUtils.GetFontStyleMap(fontStyle)));
+            SetValue(FontStyleProperty, TextUtils.GetFontStyleMap(fontStyle));
         }
 
         /// <summary>
@@ -315,9 +315,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetFontStyle()
         {
-            var map = new PropertyMap();
-            GetProperty(TextLabel.Property.FontStyle).Get(map);
-            return TextUtils.GetFontStyleStruct(map);
+            return TextUtils.GetFontStyleStruct((PropertyMap)GetValue(FontStyleProperty));
         }
 
         /// <summary>
@@ -723,7 +721,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetUnderline(Underline underline)
         {
-            SetProperty(TextLabel.Property.UNDERLINE, new PropertyValue(TextUtils.GetUnderlineMap(underline)));
+            SetValue(UnderlineProperty, TextUtils.GetUnderlineMap(underline));
         }
 
         /// <summary>
@@ -736,9 +734,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Underline GetUnderline()
         {
-            var map = new PropertyMap();
-            GetProperty(TextLabel.Property.UNDERLINE).Get(map);
-            return TextUtils.GetUnderlineStruct(map);
+            return TextUtils.GetUnderlineStruct((PropertyMap)GetValue(UnderlineProperty));
         }
 
         /// <summary>
@@ -786,7 +782,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetShadow(Tizen.NUI.Text.Shadow shadow)
         {
-            SetProperty(TextLabel.Property.SHADOW, new PropertyValue(TextUtils.GetShadowMap(shadow)));
+            SetValue(ShadowProperty, TextUtils.GetShadowMap(shadow));
         }
 
         /// <summary>
@@ -799,9 +795,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Tizen.NUI.Text.Shadow GetShadow()
         {
-            var map = new PropertyMap();
-            GetProperty(TextLabel.Property.SHADOW).Get(map);
-            return TextUtils.GetShadowStruct(map);
+            return TextUtils.GetShadowStruct((PropertyMap)GetValue(ShadowProperty));
         }
 
         /// <summary>
@@ -883,7 +877,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetOutline(Outline outline)
         {
-            SetProperty(TextLabel.Property.OUTLINE, new PropertyValue(TextUtils.GetOutlineMap(outline)));
+            SetValue(OutlineProperty, TextUtils.GetOutlineMap(outline));
         }
 
         /// <summary>
@@ -896,9 +890,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Outline GetOutline()
         {
-            var map = new PropertyMap();
-            GetProperty(TextLabel.Property.OUTLINE).Get(map);
-            return TextUtils.GetOutlineStruct(map);
+            return TextUtils.GetOutlineStruct((PropertyMap)GetValue(OutlineProperty));
         }
 
         /// <summary>
@@ -1125,7 +1117,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetTextFit(TextFit textFit)
         {
-            SetProperty(TextLabel.Property.TextFit, new PropertyValue(TextUtils.GetTextFitMap(textFit)));
+            SetValue(TextFitProperty, TextUtils.GetTextFitMap(textFit));
         }
 
         /// <summary>
@@ -1140,9 +1132,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public TextFit GetTextFit()
         {
-            var map = new PropertyMap();
-            GetProperty(TextLabel.Property.TextFit).Get(map);
-            return TextUtils.GetTextFitStruct(map);
+            return TextUtils.GetTextFitStruct((PropertyMap)GetValue(TextFitProperty));
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -1682,6 +1682,75 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// This method converts a HiddenInput struct to a PropertyMap and returns it.
+        /// The returned map can be used for set HiddenInputSettings PropertyMap in the SetHiddenInput method.
+        /// <param name="hiddenInput">The HiddenInput struct value.</param>
+        /// <returns> A PropertyMap for HiddenInput property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PropertyMap GetHiddenInputMap(HiddenInput hiddenInput)
+        {
+            var map = new PropertyMap();
+
+            map.Add(0, new PropertyValue((int)hiddenInput.Mode));
+
+            if (hiddenInput.SubstituteCharacter != null)
+                map.Add(1, new PropertyValue(Convert.ToInt32(hiddenInput.SubstituteCharacter)));
+
+            if (hiddenInput.SubstituteCount != null)
+                map.Add(2, new PropertyValue((int)hiddenInput.SubstituteCount));
+
+            if (hiddenInput.ShowLastCharacterDuration != null)
+                map.Add(3, new PropertyValue((int)hiddenInput.ShowLastCharacterDuration));
+
+            return map;
+        }
+
+        /// <summary>
+        /// This method converts a HiddenInputSettings map to a struct and returns it.
+        /// The returned struct can be returned to the user as a HiddenInput in the GetHiddenInput method.
+        /// <param name="map">The HiddenInput PropertyMap.</param>
+        /// <returns> A HiddenInput struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static HiddenInput GetHiddenInputStruct(PropertyMap map)
+        {
+            PropertyValue value = null;
+
+            var hiddenInput = new HiddenInput();
+
+            value = map.Find(0);
+            if (value != null)
+            {
+                value.Get(out int mode);
+                hiddenInput.Mode = (HiddenInputModeType)mode;
+            }
+
+            value = map.Find(1);
+            if (value != null)
+            {
+                value.Get(out int substituteCharacter);
+                hiddenInput.SubstituteCharacter = Convert.ToChar(substituteCharacter);
+            }
+
+            value = map.Find(2);
+            if (value != null)
+            {
+                value.Get(out int substituteCount);
+                hiddenInput.SubstituteCount = substituteCount;
+            }
+
+            value = map.Find(3);
+            if (value != null)
+            {
+                value.Get(out int showLastCharacterDuration);
+                hiddenInput.ShowLastCharacterDuration = showLastCharacterDuration;
+            }
+
+            return hiddenInput;
+        }
+
+        /// <summary>
         /// Copy the previously selected text into the clipboard and return the copied value.
         /// </summary>
         /// <param name="textEditor">The textEditor control from which the text is copied.</param>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -1592,6 +1592,96 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// This method converts a Placeholder struct to a PropertyMap and returns it.
+        /// The returned map can be used for set Placeholder PropertyMap in the SetPlaceholder method.
+        /// <param name="placeholder">The Placeholder struct value.</param>
+        /// <returns> A PropertyMap for Placeholder property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PropertyMap GetPlaceholderMap(Placeholder placeholder)
+        {
+            var map = new PropertyMap();
+
+            if (placeholder.Text != null)
+                map.Add("text", new PropertyValue(placeholder.Text));
+
+            if (placeholder.TextFocused != null)
+                map.Add("textFocused", new PropertyValue(placeholder.TextFocused));
+
+            if (placeholder.Color != null)
+                map.Add("color", new PropertyValue(placeholder.Color));
+
+            if (placeholder.FontFamily != null)
+                map.Add("fontFamily", new PropertyValue(placeholder.FontFamily));
+
+            if (placeholder.FontStyle != null)
+                map.Add("fontStyle", new PropertyValue(GetFontStyleMap((FontStyle)placeholder.FontStyle)));
+
+            if (placeholder.PointSize != null && placeholder.PixelSize != null)
+                map.Add("pointSize", new PropertyValue((float)placeholder.PointSize));
+
+            else if (placeholder.PointSize != null)
+                map.Add("pointSize", new PropertyValue((float)placeholder.PointSize));
+
+            else if (placeholder.PixelSize != null)
+                map.Add("pixelSize", new PropertyValue((float)placeholder.PixelSize));
+            
+            map.Add("ellipsis", new PropertyValue(placeholder.Ellipsis));
+
+            return map;
+        }
+
+        /// <summary>
+        /// This method converts a Placeholder map to a struct and returns it.
+        /// The returned struct can be returned to the user as a Placeholder in the GetPlaceholder method.
+        /// <param name="map">The Placeholder PropertyMap.</param>
+        /// <returns> A Placeholder struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Placeholder GetPlaceholderStruct(PropertyMap map)
+        {
+            string text = "";
+            string textFocused = "";
+            Color color = new Color();
+            string fontFamily = null;
+            var fontStyle = new PropertyMap();
+            PropertyValue pointSizeValue = null;
+            PropertyValue pixelSizeValue = null;
+            bool ellipsis = false;
+
+            map.Find(0)?.Get(out text);
+            map.Find(1)?.Get(out textFocused);
+            map.Find(2).Get(color);
+            map.Find(3)?.Get(out fontFamily);
+            map.Find(4).Get(fontStyle);
+            pointSizeValue = map.Find(5);
+            pixelSizeValue = map.Find(6);
+            map.Find(7)?.Get(out ellipsis);
+
+            var placeholder = new Placeholder();
+            placeholder.Text = text;
+            placeholder.TextFocused = textFocused;
+            placeholder.Color = color;
+            placeholder.FontFamily = fontFamily;
+            placeholder.Ellipsis = ellipsis;
+            placeholder.FontStyle = GetFontStyleStruct(fontStyle);
+
+            if (pointSizeValue != null)
+            {
+                pointSizeValue.Get(out float pointSize);
+                placeholder.PointSize = pointSize;
+            }
+
+            if (pixelSizeValue != null)
+            {
+                pixelSizeValue.Get(out float pixelSize);
+                placeholder.PixelSize = pixelSize;
+            }
+
+            return placeholder;
+        }
+
+        /// <summary>
         /// Copy the previously selected text into the clipboard and return the copied value.
         /// </summary>
         /// <param name="textEditor">The textEditor control from which the text is copied.</param>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -1751,6 +1751,42 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// This method converts a fileName string to a PropertyMap and returns it.
+        /// The returned map can be used for set SelectionHandleImageLeft, SelectionHandleImageRight PropertyMap in the SetSelectionHandleImage method.
+        /// <param name="fileName">The file path string value for SelectionHandleImage.</param>
+        /// <returns> A PropertyMap for SelectionHandleImageLeft, SelectionHandleImageRight properties. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PropertyMap GetFileNameMap(string fileName)
+        {
+            return new PropertyMap().Add("filename", new PropertyValue(fileName));
+        }
+
+        /// <summary>
+        /// This method converts a SelectionHandleImageLeft, SelectionHandleImageRight map to a struct and returns it.
+        /// The returned struct can be returned to the user as a SelectionHandleImage in the GetSelectionHandleImage method.
+        /// <param name="leftImageMap">The SelectionHandleImageLeft PropertyMap.</param>
+        /// <param name="rightImageMap">The SelectionHandleImageRight PropertyMap.</param>
+        /// <returns> A SelectionHandleImage struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static SelectionHandleImage GetSelectionHandleImageStruct(PropertyMap leftImageMap, PropertyMap rightImageMap)
+        {
+            string leftImageUrl = null;
+            string rightImageUrl = null;
+
+            var selectionHandleImage = new SelectionHandleImage();
+
+            leftImageMap.Find(0, "filename")?.Get(out leftImageUrl);
+            rightImageMap.Find(0, "filename")?.Get(out rightImageUrl);
+
+            selectionHandleImage.LeftImageUrl = leftImageUrl;
+            selectionHandleImage.RightImageUrl = rightImageUrl;
+
+            return selectionHandleImage;
+        }
+
+        /// <summary>
         /// Copy the previously selected text into the clipboard and return the copied value.
         /// </summary>
         /// <param name="textEditor">The textEditor control from which the text is copied.</param>

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -2279,5 +2279,40 @@ namespace Tizen.NUI
             [EditorBrowsable(EditorBrowsableState.Never)]
             public bool Ellipsis { get; set; }
         }
+
+        /// <summary>
+        /// A struct to pass data of HiddenInputSettings PropertyMap. <br />
+        /// </summary>
+        /// <remarks>
+        /// The HiddenInput struct is used as an argument to SetHiddenInput and GetHiddenInput methods. <br />
+        /// See <see cref="Tizen.NUI.BaseComponents.TextField.SetHiddenInput"/> and <see cref="Tizen.NUI.BaseComponents.TextField.GetHiddenInput"/>. <br />
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public struct HiddenInput
+        {
+            /// <summary>
+            /// The mode for input text display. <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public HiddenInputModeType Mode { get; set; }
+
+            /// <summary>
+            /// All input characters are substituted by this character (if null, the default value is '*'). <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public char? SubstituteCharacter { get; set; }
+
+            /// <summary>
+            /// Length of text to show or hide, available when HideCount/ShowCount mode is used (if null, the default value is 0). <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public int? SubstituteCount { get; set; }
+
+            /// <summary>
+            /// Hide last character after this duration, available when ShowLastCharacter mode (if null, the default value is 1000). <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public int? ShowLastCharacterDuration { get; set; }
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -2216,5 +2216,68 @@ namespace Tizen.NUI
             [EditorBrowsable(EditorBrowsableState.Never)]
             public FontSizeType FontSizeType { get; set; }
         }
+
+        /// <summary>
+        /// A struct to pass data of Placeholder PropertyMap. <br />
+        /// </summary>
+        /// <remarks>
+        /// The Placeholder struct is used as an argument to SetPlaceholder and GetPlaceholder methods. <br />
+        /// See <see cref="Tizen.NUI.BaseComponents.TextField.SetPlaceholder"/>, <see cref="Tizen.NUI.BaseComponents.TextField.SetPlaceholder"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.SetPlaceholder"/> and <see cref="Tizen.NUI.BaseComponents.TextEditor.SetPlaceholder"/>. <br />
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public struct Placeholder
+        {
+            /// <summary>
+            /// The text to display when the TextField is empty and inactive.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public string Text { get; set; }
+
+            /// <summary>
+            /// The text to display when the placeholder has focus.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public string TextFocused { get; set; }
+
+            /// <summary>
+            /// The color of the placeholder text.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public Color Color { get; set; }
+
+            /// <summary>
+            /// The FontFamily of the placeholder text.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public string FontFamily { get; set; }
+
+            /// <summary>
+            /// The FontStyle of the placeholder text (if null, the text control FontStyle is used).
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public FontStyle? FontStyle { get; set; }
+
+            /// <summary>
+            /// The PointSize of the placeholder text. <br />
+            /// Not required if PixelSize provided. <br />
+            /// If both provided or neither provided then the text control point size is used. <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public float? PointSize { get; set; }
+
+            /// <summary>
+            /// The PiexSize of the placeholder text.
+            /// Not required if PointSize provided. <br />
+            /// If both provided or neither provided then the text control point size is used. <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public float? PixelSize { get; set; }
+
+            /// <summary>
+            /// The ellipsis of the placeholder text (the default value is false).
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool Ellipsis { get; set; }
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -2314,5 +2314,35 @@ namespace Tizen.NUI
             [EditorBrowsable(EditorBrowsableState.Never)]
             public int? ShowLastCharacterDuration { get; set; }
         }
+
+        /// <summary>
+        /// A struct to pass data of SelectionHandleImageLeft, SelectionHandleImageRight, SelectionHandlePressedImageLeft, SelectionHandlePressedImageRight, SelectionHandleMarkerImageLeft and SelectionHandleMarkerImageRight PropertyMap. <br />
+        /// </summary>
+        /// <remarks>
+        /// The SelectionHandleImage struct is used as an argument to SetSelectionHandleImage, GetSelectionHandleImage methods, SetSelectionHandlePressedImage, GetSelectionHandlePressedImage, SetSelectionHandleMarkerImage and GetSelectionHandleMarkerImage. <br />
+        /// See <see cref="Tizen.NUI.BaseComponents.TextField.SetSelectionHandleImage"/>, <see cref="Tizen.NUI.BaseComponents.TextField.GetSelectionHandleImage"/>, <see cref="Tizen.NUI.BaseComponents.TextField.SetSelectionHandlePressedImage"/>, <see cref="Tizen.NUI.BaseComponents.TextField.GetSelectionHandlePressedImage"/>, <see cref="Tizen.NUI.BaseComponents.TextField.SetSelectionHandleMarkerImage"/>, <see cref="Tizen.NUI.BaseComponents.TextField.GetSelectionHandleMarkerImage"/>, <br />
+        /// <see cref="Tizen.NUI.BaseComponents.TextEditor.SetSelectionHandleImage"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.GetSelectionHandleImage"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.SetSelectionHandlePressedImage"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.GetSelectionHandlePressedImage"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.SetSelectionHandleMarkerImage"/> and <see cref="Tizen.NUI.BaseComponents.TextEditor.GetSelectionHandleMarkerImage"/>. <br />
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public struct SelectionHandleImage
+        {
+            /// <summary>
+            /// The image path to display for the left selection handle. <br />
+            /// It means the handle in the bottom-left. <br />
+            /// If the handle needs to be displayed in the top-left, this image will be vertically flipped. <br />
+            /// If null or empty string, it doesn't change the property. <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public string LeftImageUrl { get; set; }
+
+            /// <summary>
+            /// The image path to display for the right selection handle. <br />
+            /// It means the handle in the bottom-right. <br />
+            /// If the handle needs to be displayed in the top-right, this image will be vertically flipped. <br />
+            /// If null or empty string, it doesn't change the property. <br />
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public string RightImageUrl { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Add a Placeholder struct to pass data of DALi Placeholder PropertyMap.
The Placeholder struct can be used as an argument to
SetPlaceholder and GetPlaceholder methods.

// example
var placeholder = new Tizen.NUI.Text.Placeholder();
placeholder.Text = "placeholder text";
placeholder.TextFocused = "placeholder textFocused";
placeholder.Color = new Color("#45B39D");
placeholder.FontFamily = "BreezeSans";
placeholder.FontStyle = new Tizen.NUI.Text.FontStyle()
{
    Width = FontWidthType.Expanded,
    Weight = FontWeightType.ExtraLight,
    Slant = FontSlantType.Italic,
};
placeholder.PointSize = 25.0f;
//placeholder.PixelSize = 50.0f;
placeholder.Ellipsis = true;

field.SetPlaceholder(placeholder);

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>