### PR TITLE
[NUI] Fix to follow coding rule

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -15,10 +15,7 @@
  *
  */
 
-using Tizen.NUI.BaseComponents;
 using System.Runtime.InteropServices;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System;
 using System.ComponentModel;
 
@@ -36,16 +33,7 @@ namespace Tizen.NUI
     /// </summary>
     internal sealed class ProcessorController : Disposable
     {
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-        internal delegate void ProcessorCallback();
-
-        private ProcessorCallback callback = null;
-
-        public event EventHandler ProcessorOnceEvent;
-
-        public event EventHandler ProcessorEvent;
-
-        public event EventHandler LayoutProcessorEvent;
+        private static ProcessorController instance = null;
 
         private ProcessorController() : this(Interop.ProcessorController.New(), true)
         {
@@ -53,17 +41,24 @@ namespace Tizen.NUI
 
         internal ProcessorController(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
-            callback = new ProcessorCallback(Process);
-            Interop.ProcessorController.SetCallback(SwigCPtr, callback);
+            processorCallback = new ProcessorEventHandler(Process);
+            Interop.ProcessorController.SetCallback(SwigCPtr, processorCallback);
         }
 
-        private static ProcessorController instance = null;
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        internal delegate void ProcessorEventHandler();
+
+        private ProcessorEventHandler processorCallback = null;
+
+        public event EventHandler ProcessorOnceEvent;
+        public event EventHandler ProcessorEvent;
+        public event EventHandler LayoutProcessorEvent;
 
         public static ProcessorController Instance
         {
             get
             {
-                if(instance == null)
+                if (instance == null)
                 {
                     instance = new ProcessorController();
                 }
@@ -85,7 +80,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(DisposeTypes type)
         {
-            Interop.ProcessorController.RemoveCallback(SwigCPtr, callback);
+            Interop.ProcessorController.RemoveCallback(SwigCPtr, processorCallback);
             ProcessorOnceEvent = null;
             ProcessorEvent = null;
             LayoutProcessorEvent = null;

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
@@ -29,10 +29,10 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr DeleteProcessorController(global::System.Runtime.InteropServices.HandleRef processorController);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_SetCallback")]
-            public static extern void SetCallback(global::System.Runtime.InteropServices.HandleRef processorController, Tizen.NUI.ProcessorController.ProcessorCallback processorCallback);
+            public static extern void SetCallback(global::System.Runtime.InteropServices.HandleRef processorController, Tizen.NUI.ProcessorController.ProcessorEventHandler processorCallback);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_RemoveCallback")]
-            public static extern void RemoveCallback(global::System.Runtime.InteropServices.HandleRef processorController, Tizen.NUI.ProcessorController.ProcessorCallback processorCallback);
+            public static extern void RemoveCallback(global::System.Runtime.InteropServices.HandleRef processorController, Tizen.NUI.ProcessorController.ProcessorEventHandler processorCallback);
         }
     }
 }


### PR DESCRIPTION
- Follow C# Coding rule
 1) reposition the type of class
 2) delete unusued using state
 3) follow event naming rule

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
