### PR TITLE
[NUI] Add Strikethrough Property

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -337,6 +337,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_PasteText")]
             public static extern void PasteText(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_STRIKETHROUGH_get")]
+            public static extern int StrikethroughGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextEditor_Property_INPUT_STRIKETHROUGH_get")]
+            public static extern int InputStrikethroughGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -306,6 +306,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_PasteText")]
             public static extern void PasteText(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_STRIKETHROUGH_get")]
+            public static extern int StrikethroughGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextField_Property_INPUT_STRIKETHROUGH_get")]
+            public static extern int InputStrikethroughGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -169,6 +169,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabelSignal")]
             public static extern void DeleteTextLabelSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_STRIKETHROUGH_get")]
+            public static extern int StrikethroughGet();
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
@@ -176,6 +176,12 @@ namespace Tizen.NUI.BaseComponents
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputUnderline = (string)newValue,
             defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputUnderline);
 
+        /// <summary> The bindable property of InputStrikethrough. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly BindableProperty InputStrikethroughProperty = BindableProperty.Create(nameof(InputStrikethrough), typeof(string), typeof(TextEditorStyle), String.Empty,
+            propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputStrikethrough = (string)newValue,
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputStrikethrough);
+
         /// <summary> The bindable property of InputShadow. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(InputShadow), typeof(string), typeof(TextEditorStyle), String.Empty,
@@ -276,6 +282,7 @@ namespace Tizen.NUI.BaseComponents
         private string inputFontFamily;
         private float? inputPointSize;
         private string inputUnderline;
+        private string inputStrikethrough;
         private string inputShadow;
         private string emboss;
         private string inputEmboss;
@@ -505,6 +512,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (string)GetValue(InputUnderlineProperty);
             set => SetValue(InputUnderlineProperty, value);
+        }
+
+        /// <summary>
+        /// The InputStrikethrough property.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string InputStrikethrough
+        {
+            get => (string)GetValue(InputStrikethroughProperty);
+            set => SetValue(InputStrikethroughProperty, value);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
@@ -387,6 +387,19 @@ namespace Tizen.NUI.BaseComponents
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputUnderline;
         });
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty InputStrikethroughProperty = BindableProperty.Create(nameof(InputStrikethrough), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textFieldStyle = (TextFieldStyle)bindable;
+            textFieldStyle.inputStrikethrough = (string)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textFieldStyle = (TextFieldStyle)bindable;
+            return textFieldStyle.inputStrikethrough;
+        });
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(InputShadow), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
@@ -535,6 +548,7 @@ namespace Tizen.NUI.BaseComponents
         private Vector4 placeholderTextColor;
         private Vector4 primaryCursorColor;
         private PropertyMap fontStyle;
+        private string inputStrikethrough;
 
         static TextFieldStyle() { }
 
@@ -749,6 +763,13 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (string)GetValue(InputUnderlineProperty);
             set => SetValue(InputUnderlineProperty, value);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string InputStrikethrough
+        {
+            get => (string)GetValue(InputStrikethroughProperty);
+            set => SetValue(InputStrikethroughProperty, value);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -926,7 +926,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetStrikethrough(Strikethrough strikethrough)
         {
-            SetProperty(TextEditor.Property.Strikethroug, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+            SetProperty(TextEditor.Property.Strikethrough, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
         }
 
         /// <summary>
@@ -940,7 +940,7 @@ namespace Tizen.NUI.BaseComponents
         public Strikethrough GetStrikethrough()
         {
             var map = new PropertyMap();
-            GetProperty(TextEditor.Property.Strikethroug).Get(map);
+            GetProperty(TextEditor.Property.Strikethrough).Get(map);
             return TextUtils.GetStrikethroughStruct(map);
         }
 
@@ -2195,7 +2195,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EllipsisPosition = Interop.TextEditor.EllipsisPositionGet();
             internal static readonly int MinLineSize = Interop.TextEditor.MinLineSizeGet();
             internal static readonly int InputFilter = Interop.TextEditor.InputFilterGet();
-            internal static readonly int Strikethroug = Interop.TextEditor.StrikethroughGet();
+            internal static readonly int Strikethrough = Interop.TextEditor.StrikethroughGet();
             internal static readonly int InputStrikethrough = Interop.TextEditor.InputStrikethroughGet();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -885,63 +885,22 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The Strikethrough property.
-        /// The Strikethrough map contains the following keys :<br />
-        /// <list type="table">
-        /// <item><term>enable (bool)</term><description>Whether the strikethrough is enabled (the default value is false)</description></item>
-        /// <item><term>color (Color)</term><description>The color of the strikethrough (If not provided then the color of the text is used)</description></item>
-        /// <item><term>height (float)</term><description>The height in pixels of the strikethrough (the default value is 1.f)</description></item>
-        /// </list>
         /// </summary>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PropertyMap Strikethrough
+        public Strikethrough Strikethrough
         {
             get
             {
-                return (PropertyMap)GetValue(StrikethroughProperty);
+                return (Strikethrough)GetValue(StrikethroughProperty);
             }
             set
             {
                 SetValue(StrikethroughProperty, value);
                 NotifyPropertyChanged();
             }
-        }
-
-        /// <summary>
-        /// Set Strikethrough to TextEditor. <br />
-        /// </summary>
-        /// <param name="strikethrough">The Strikethrough</param>
-        /// <remarks>
-        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
-        /// </remarks>
-        /// <example>
-        /// The following example demonstrates how to use the SetStrikethrough method.
-        /// <code>
-        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
-        /// strikethrough.Enable = true;
-        /// strikethrough.Color = new Color("#3498DB");
-        /// strikethrough.Height = 2.0f;
-        /// editor.SetStrikethrough(strikethrough);
-        /// </code>
-        /// </example>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetStrikethrough(Strikethrough strikethrough)
-        {
-            SetProperty(TextEditor.Property.Strikethrough, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
-        }
-
-        /// <summary>
-        /// Get Strikethrough from TextEditor. <br />
-        /// </summary>
-        /// <returns>The Strikethrough</returns>
-        /// <remarks>
-        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Strikethrough GetStrikethrough()
-        {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.Strikethrough).Get(map);
-            return TextUtils.GetStrikethroughStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -926,7 +926,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetStrikethrough(Strikethrough strikethrough)
         {
-            SetProperty(TextEditor.Property.STRIKETHROUGH, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+            SetProperty(TextEditor.Property.Strikethroug, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
         }
 
         /// <summary>
@@ -940,7 +940,7 @@ namespace Tizen.NUI.BaseComponents
         public Strikethrough GetStrikethrough()
         {
             var map = new PropertyMap();
-            GetProperty(TextEditor.Property.STRIKETHROUGH).Get(map);
+            GetProperty(TextEditor.Property.Strikethroug).Get(map);
             return TextUtils.GetStrikethroughStruct(map);
         }
 
@@ -2195,7 +2195,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EllipsisPosition = Interop.TextEditor.EllipsisPositionGet();
             internal static readonly int MinLineSize = Interop.TextEditor.MinLineSizeGet();
             internal static readonly int InputFilter = Interop.TextEditor.InputFilterGet();
-            internal static readonly int STRIKETHROUGH = Interop.TextEditor.StrikethroughGet();
+            internal static readonly int Strikethroug = Interop.TextEditor.StrikethroughGet();
             internal static readonly int InputStrikethrough = Interop.TextEditor.InputStrikethroughGet();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -884,6 +884,84 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The Strikethrough property.
+        /// The Strikethrough map contains the following keys :<br />
+        /// <list type="table">
+        /// <item><term>enable (bool)</term><description>Whether the strikethrough is enabled (the default value is false)</description></item>
+        /// <item><term>color (Color)</term><description>The color of the strikethrough (If not provided then the color of the text is used)</description></item>
+        /// <item><term>height (float)</term><description>The height in pixels of the strikethrough (the default value is 1.f)</description></item>
+        /// </list>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PropertyMap Strikethrough
+        {
+            get
+            {
+                return (PropertyMap)GetValue(StrikethroughProperty);
+            }
+            set
+            {
+                SetValue(StrikethroughProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Set Strikethrough to TextEditor. <br />
+        /// </summary>
+        /// <param name="strikethrough">The Strikethrough</param>
+        /// <remarks>
+        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetStrikethrough method.
+        /// <code>
+        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
+        /// strikethrough.Enable = true;
+        /// strikethrough.Color = new Color("#3498DB");
+        /// strikethrough.Height = 2.0f;
+        /// editor.SetStrikethrough(strikethrough);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetStrikethrough(Strikethrough strikethrough)
+        {
+            SetProperty(TextEditor.Property.STRIKETHROUGH, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+        }
+
+        /// <summary>
+        /// Get Strikethrough from TextEditor. <br />
+        /// </summary>
+        /// <returns>The Strikethrough</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Strikethrough GetStrikethrough()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextEditor.Property.STRIKETHROUGH).Get(map);
+            return TextUtils.GetStrikethroughStruct(map);
+        }
+
+        /// <summary>
+        /// The InputStrikethrough property.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string InputStrikethrough
+        {
+            get
+            {
+                return (string)GetValue(InputStrikethroughProperty);
+            }
+            set
+            {
+                SetValue(InputStrikethroughProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The Shadow property.
         /// The shadow map contains the following keys :<br />
         /// <list type="table">
@@ -2117,6 +2195,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EllipsisPosition = Interop.TextEditor.EllipsisPositionGet();
             internal static readonly int MinLineSize = Interop.TextEditor.MinLineSizeGet();
             internal static readonly int InputFilter = Interop.TextEditor.InputFilterGet();
+            internal static readonly int STRIKETHROUGH = Interop.TextEditor.StrikethroughGet();
+            internal static readonly int InputStrikethrough = Interop.TextEditor.InputStrikethroughGet();
         }
 
         internal class InputStyle
@@ -2132,7 +2212,8 @@ namespace Tizen.NUI.BaseComponents
                 Underline = 0x0020,
                 Shadow = 0x0040,
                 Emboss = 0x0080,
-                Outline = 0x0100
+                Outline = 0x0100,
+                Strikethrough = 0x0200
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -591,6 +591,42 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputUnderline).Get(out temp);
             return temp;
         }));
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty StrikethroughProperty = BindableProperty.Create(nameof(Strikethrough), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.STRIKETHROUGH, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            PropertyMap temp = new PropertyMap();
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.STRIKETHROUGH).Get(temp);
+            return temp;
+        }));
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty InputStrikethroughProperty = BindableProperty.Create(nameof(InputStrikethrough), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputStrikethrough, new Tizen.NUI.PropertyValue((string)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            string temp;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputStrikethrough).Get(out temp);
+            return temp;
+        }));
+
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowProperty = BindableProperty.Create(nameof(Shadow), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -598,7 +598,7 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethrough, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethrough, new Tizen.NUI.PropertyValue(TextUtils.GetStrikethroughMap((Tizen.NUI.Text.Strikethrough)newValue)));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
@@ -606,7 +606,7 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethrough).Get(temp);
-            return temp;
+            return TextUtils.GetStrikethroughStruct(temp);
         }));
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -598,14 +598,14 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethroug, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethrough, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textEditor = (TextEditor)bindable;
             PropertyMap temp = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethroug).Get(temp);
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethrough).Get(temp);
             return temp;
         }));
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -598,14 +598,14 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.STRIKETHROUGH, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethroug, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textEditor = (TextEditor)bindable;
             PropertyMap temp = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.STRIKETHROUGH).Get(temp);
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.Strikethroug).Get(temp);
             return temp;
         }));
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1123,63 +1123,22 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The Strikethrough property.
-        /// The Strikethrough map contains the following keys :<br />
-        /// <list type="table">
-        /// <item><term>enable (bool)</term><description>Whether the strikethrough is enabled (the default value is false)</description></item>
-        /// <item><term>color (Color)</term><description>The color of the strikethrough (If not provided then the color of the text is used)</description></item>
-        /// <item><term>height (float)</term><description>The height in pixels of the strikethrough (the default value is 1.f)</description></item>
-        /// </list>
         /// </summary>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PropertyMap Strikethrough
+        public Strikethrough Strikethrough
         {
             get
             {
-                return (PropertyMap)GetValue(StrikethroughProperty);
+                return (Strikethrough)GetValue(StrikethroughProperty);
             }
             set
             {
                 SetValue(StrikethroughProperty, value);
                 NotifyPropertyChanged();
             }
-        }
-
-        /// <summary>
-        /// Set Strikethrough to TextField. <br />
-        /// </summary>
-        /// <param name="strikethrough">The Strikethrough</param>
-        /// <remarks>
-        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
-        /// </remarks>
-        /// <example>
-        /// The following example demonstrates how to use the SetStrikethrough method.
-        /// <code>
-        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
-        /// strikethrough.Enable = true;
-        /// strikethrough.Color = new Color("#3498DB");
-        /// strikethrough.Height = 2.0f;
-        /// field.SetStrikethrough(strikethrough);
-        /// </code>
-        /// </example>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetStrikethrough(Strikethrough strikethrough)
-        {
-            SetProperty(TextField.Property.Strikethrough, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
-        }
-
-        /// <summary>
-        /// Get Strikethrough from TextField. <br />
-        /// </summary>
-        /// <returns>The Strikethrough</returns>
-        /// <remarks>
-        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Strikethrough GetStrikethrough()
-        {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.Strikethrough).Get(map);
-            return TextUtils.GetStrikethroughStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1164,7 +1164,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetStrikethrough(Strikethrough strikethrough)
         {
-            SetProperty(TextField.Property.STRIKETHROUGH, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+            SetProperty(TextField.Property.Strikethroug, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
         }
 
         /// <summary>
@@ -1178,7 +1178,7 @@ namespace Tizen.NUI.BaseComponents
         public Strikethrough GetStrikethrough()
         {
             var map = new PropertyMap();
-            GetProperty(TextField.Property.STRIKETHROUGH).Get(map);
+            GetProperty(TextField.Property.Strikethroug).Get(map);
             return TextUtils.GetStrikethroughStruct(map);
         }
 
@@ -2201,7 +2201,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int GrabHandleColor = Interop.TextField.GrabHandleColorGet();
             internal static readonly int EllipsisPosition = Interop.TextField.EllipsisPositionGet();
             internal static readonly int InputFilter = Interop.TextField.InputFilterGet();
-            internal static readonly int STRIKETHROUGH = Interop.TextField.StrikethroughGet();
+            internal static readonly int Strikethroug = Interop.TextField.StrikethroughGet();
             internal static readonly int InputStrikethrough = Interop.TextField.InputStrikethroughGet();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1164,7 +1164,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetStrikethrough(Strikethrough strikethrough)
         {
-            SetProperty(TextField.Property.Strikethroug, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+            SetProperty(TextField.Property.Strikethrough, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
         }
 
         /// <summary>
@@ -1178,7 +1178,7 @@ namespace Tizen.NUI.BaseComponents
         public Strikethrough GetStrikethrough()
         {
             var map = new PropertyMap();
-            GetProperty(TextField.Property.Strikethroug).Get(map);
+            GetProperty(TextField.Property.Strikethrough).Get(map);
             return TextUtils.GetStrikethroughStruct(map);
         }
 
@@ -2201,7 +2201,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int GrabHandleColor = Interop.TextField.GrabHandleColorGet();
             internal static readonly int EllipsisPosition = Interop.TextField.EllipsisPositionGet();
             internal static readonly int InputFilter = Interop.TextField.InputFilterGet();
-            internal static readonly int Strikethroug = Interop.TextField.StrikethroughGet();
+            internal static readonly int Strikethrough = Interop.TextField.StrikethroughGet();
             internal static readonly int InputStrikethrough = Interop.TextField.InputStrikethroughGet();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1122,6 +1122,84 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The Strikethrough property.
+        /// The Strikethrough map contains the following keys :<br />
+        /// <list type="table">
+        /// <item><term>enable (bool)</term><description>Whether the strikethrough is enabled (the default value is false)</description></item>
+        /// <item><term>color (Color)</term><description>The color of the strikethrough (If not provided then the color of the text is used)</description></item>
+        /// <item><term>height (float)</term><description>The height in pixels of the strikethrough (the default value is 1.f)</description></item>
+        /// </list>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PropertyMap Strikethrough
+        {
+            get
+            {
+                return (PropertyMap)GetValue(StrikethroughProperty);
+            }
+            set
+            {
+                SetValue(StrikethroughProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Set Strikethrough to TextField. <br />
+        /// </summary>
+        /// <param name="strikethrough">The Strikethrough</param>
+        /// <remarks>
+        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetStrikethrough method.
+        /// <code>
+        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
+        /// strikethrough.Enable = true;
+        /// strikethrough.Color = new Color("#3498DB");
+        /// strikethrough.Height = 2.0f;
+        /// field.SetStrikethrough(strikethrough);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetStrikethrough(Strikethrough strikethrough)
+        {
+            SetProperty(TextField.Property.STRIKETHROUGH, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+        }
+
+        /// <summary>
+        /// Get Strikethrough from TextField. <br />
+        /// </summary>
+        /// <returns>The Strikethrough</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Strikethrough GetStrikethrough()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextField.Property.STRIKETHROUGH).Get(map);
+            return TextUtils.GetStrikethroughStruct(map);
+        }
+
+        /// <summary>
+        /// The InputStrikethrough property.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string InputStrikethrough
+        {
+            get
+            {
+                return (string)GetValue(InputStrikethroughProperty);
+            }
+            set
+            {
+                SetValue(InputStrikethroughProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The Shadow property.
         /// The shadow map contains the following keys :<br />
         /// <list type="table">
@@ -2123,6 +2201,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int GrabHandleColor = Interop.TextField.GrabHandleColorGet();
             internal static readonly int EllipsisPosition = Interop.TextField.EllipsisPositionGet();
             internal static readonly int InputFilter = Interop.TextField.InputFilterGet();
+            internal static readonly int STRIKETHROUGH = Interop.TextField.StrikethroughGet();
+            internal static readonly int InputStrikethrough = Interop.TextField.InputStrikethroughGet();
         }
 
         internal class InputStyle
@@ -2137,7 +2217,8 @@ namespace Tizen.NUI.BaseComponents
                 Underline = 0x0010,
                 Shadow = 0x0020,
                 Emboss = 0x0040,
-                Outline = 0x0080
+                Outline = 0x0080,
+                Strikethrough = 0x0200
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -772,7 +772,7 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethrough, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethrough, new Tizen.NUI.PropertyValue(TextUtils.GetStrikethroughMap((Tizen.NUI.Text.Strikethrough)newValue)));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
@@ -780,7 +780,7 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethrough).Get(temp);
-            return temp;
+            return TextUtils.GetStrikethroughStruct(temp);
         }));
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -765,6 +765,41 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputUnderline).Get(out temp);
             return temp;
         }));
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty StrikethroughProperty = BindableProperty.Create(nameof(TextField.Strikethrough), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textField = (TextField)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.STRIKETHROUGH, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textField = (TextField)bindable;
+            PropertyMap temp = new PropertyMap();
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.STRIKETHROUGH).Get(temp);
+            return temp;
+        }));
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty InputStrikethroughProperty = BindableProperty.Create(nameof(TextField.InputStrikethrough), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textField = (TextField)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputStrikethrough, new Tizen.NUI.PropertyValue((string)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textField = (TextField)bindable;
+            string temp;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputStrikethrough).Get(out temp);
+            return temp;
+        }));
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowProperty = BindableProperty.Create(nameof(TextField.Shadow), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -772,14 +772,14 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.STRIKETHROUGH, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethroug, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textField = (TextField)bindable;
             PropertyMap temp = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.STRIKETHROUGH).Get(temp);
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethroug).Get(temp);
             return temp;
         }));
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -772,14 +772,14 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethroug, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethrough, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textField = (TextField)bindable;
             PropertyMap temp = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethroug).Get(temp);
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.Strikethrough).Get(temp);
             return temp;
         }));
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -742,66 +742,23 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// The Strikethrough property.<br />
-        /// The default strikethrough parameters.<br />
-        /// The strikethrough map contains the following keys :<br />
-        /// <list type="table">
-        /// <item><term>enable (bool)</term><description>Whether the strikethrough is enabled (the default value is false)</description></item>
-        /// <item><term>color (Color)</term><description>The color of the strikethrough (If not provided then the color of the text is used)</description></item>
-        /// <item><term>height (float)</term><description>The height in pixels of the strikethrough (the default value is 1.f)</description></item>
-        /// </list>
+        /// The Strikethrough property.
         /// </summary>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721: Property names should not match get methods")]
-        public PropertyMap Strikethrough
+        public Strikethrough Strikethrough
         {
             get
             {
-                return (PropertyMap)GetValue(StrikethroughProperty);
+                return (Strikethrough)GetValue(StrikethroughProperty);
             }
             set
             {
                 SetValue(StrikethroughProperty, value);
                 NotifyPropertyChanged();
             }
-        }
-
-        /// <summary>
-        /// Set Strikethrough to TextLabel. <br />
-        /// </summary>
-        /// <param name="strikethrough">The Strikethrough</param>
-        /// <remarks>
-        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
-        /// </remarks>
-        /// <example>
-        /// The following example demonstrates how to use the SetStrikethrough method.
-        /// <code>
-        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
-        /// strikethrough.Enable = true;
-        /// strikethrough.Color = new Color("#3498DB");
-        /// strikethrough.Height = 2.0f;
-        /// label.SetStrikethrough(strikethrough);
-        /// </code>
-        /// </example>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetStrikethrough(Strikethrough strikethrough)
-        {
-            SetProperty(TextLabel.Property.Strikethrough, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
-        }
-
-        /// <summary>
-        /// Get Strikethrough from TextLabel. <br />
-        /// </summary>
-        /// <returns>The Strikethrough</returns>
-        /// <remarks>
-        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Strikethrough GetStrikethrough()
-        {
-            var map = new PropertyMap();
-            GetProperty(TextLabel.Property.Strikethrough).Get(map);
-            return TextUtils.GetStrikethroughStruct(map);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -742,6 +742,69 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The Strikethrough property.<br />
+        /// The default strikethrough parameters.<br />
+        /// The strikethrough map contains the following keys :<br />
+        /// <list type="table">
+        /// <item><term>enable (bool)</term><description>Whether the strikethrough is enabled (the default value is false)</description></item>
+        /// <item><term>color (Color)</term><description>The color of the strikethrough (If not provided then the color of the text is used)</description></item>
+        /// <item><term>height (float)</term><description>The height in pixels of the strikethrough (the default value is 1.f)</description></item>
+        /// </list>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1721: Property names should not match get methods")]
+        public PropertyMap Strikethrough
+        {
+            get
+            {
+                return (PropertyMap)GetValue(StrikethroughProperty);
+            }
+            set
+            {
+                SetValue(StrikethroughProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Set Strikethrough to TextLabel. <br />
+        /// </summary>
+        /// <param name="strikethrough">The Strikethrough</param>
+        /// <remarks>
+        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetStrikethrough method.
+        /// <code>
+        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
+        /// strikethrough.Enable = true;
+        /// strikethrough.Color = new Color("#3498DB");
+        /// strikethrough.Height = 2.0f;
+        /// label.SetStrikethrough(strikethrough);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetStrikethrough(Strikethrough strikethrough)
+        {
+            SetProperty(TextLabel.Property.STRIKETHROUGH, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+        }
+
+        /// <summary>
+        /// Get Strikethrough from TextLabel. <br />
+        /// </summary>
+        /// <returns>The Strikethrough</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Strikethrough GetStrikethrough()
+        {
+            var map = new PropertyMap();
+            GetProperty(TextLabel.Property.STRIKETHROUGH).Get(map);
+            return TextUtils.GetStrikethroughStruct(map);
+        }
+
+        /// <summary>
         /// The Shadow property.<br />
         /// The default shadow parameters.<br />
         /// The shadow map contains the following keys :<br />
@@ -1375,6 +1438,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int MinLineSize = Interop.TextLabel.MinLineSizeGet();
             internal static readonly int FontSizeScale = Interop.TextLabel.FontSizeScaleGet();
             internal static readonly int EllipsisPosition = Interop.TextLabel.EllipsisPositionGet();
+            internal static readonly int STRIKETHROUGH = Interop.TextLabel.StrikethroughGet();
         }
 
         private void OnShadowColorChanged(float x, float y, float z, float w)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -786,7 +786,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetStrikethrough(Strikethrough strikethrough)
         {
-            SetProperty(TextLabel.Property.STRIKETHROUGH, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+            SetProperty(TextLabel.Property.Strikethroug, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
         }
 
         /// <summary>
@@ -800,7 +800,7 @@ namespace Tizen.NUI.BaseComponents
         public Strikethrough GetStrikethrough()
         {
             var map = new PropertyMap();
-            GetProperty(TextLabel.Property.STRIKETHROUGH).Get(map);
+            GetProperty(TextLabel.Property.Strikethroug).Get(map);
             return TextUtils.GetStrikethroughStruct(map);
         }
 
@@ -1438,7 +1438,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int MinLineSize = Interop.TextLabel.MinLineSizeGet();
             internal static readonly int FontSizeScale = Interop.TextLabel.FontSizeScaleGet();
             internal static readonly int EllipsisPosition = Interop.TextLabel.EllipsisPositionGet();
-            internal static readonly int STRIKETHROUGH = Interop.TextLabel.StrikethroughGet();
+            internal static readonly int Strikethroug = Interop.TextLabel.StrikethroughGet();
         }
 
         private void OnShadowColorChanged(float x, float y, float z, float w)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -786,7 +786,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetStrikethrough(Strikethrough strikethrough)
         {
-            SetProperty(TextLabel.Property.Strikethroug, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
+            SetProperty(TextLabel.Property.Strikethrough, new PropertyValue(TextUtils.GetStrikethroughMap(strikethrough)));
         }
 
         /// <summary>
@@ -800,7 +800,7 @@ namespace Tizen.NUI.BaseComponents
         public Strikethrough GetStrikethrough()
         {
             var map = new PropertyMap();
-            GetProperty(TextLabel.Property.Strikethroug).Get(map);
+            GetProperty(TextLabel.Property.Strikethrough).Get(map);
             return TextUtils.GetStrikethroughStruct(map);
         }
 
@@ -1438,7 +1438,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int MinLineSize = Interop.TextLabel.MinLineSizeGet();
             internal static readonly int FontSizeScale = Interop.TextLabel.FontSizeScaleGet();
             internal static readonly int EllipsisPosition = Interop.TextLabel.EllipsisPositionGet();
-            internal static readonly int Strikethroug = Interop.TextLabel.StrikethroughGet();
+            internal static readonly int Strikethrough = Interop.TextLabel.StrikethroughGet();
         }
 
         private void OnShadowColorChanged(float x, float y, float z, float w)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -345,6 +345,24 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.UNDERLINE).Get(temp);
             return temp;
         }));
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty StrikethroughProperty = BindableProperty.Create(nameof(Strikethrough), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.STRIKETHROUGH, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            PropertyMap temp = new PropertyMap();
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.STRIKETHROUGH).Get(temp);
+            return temp;
+        }));
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowProperty = BindableProperty.Create(nameof(Shadow), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -352,14 +352,14 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.STRIKETHROUGH, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethroug, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.STRIKETHROUGH).Get(temp);
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethroug).Get(temp);
             return temp;
         }));
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -352,14 +352,14 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethroug, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethrough, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethroug).Get(temp);
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethrough).Get(temp);
             return temp;
         }));
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -352,7 +352,7 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethrough, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethrough, new Tizen.NUI.PropertyValue(TextUtils.GetStrikethroughMap((Tizen.NUI.Text.Strikethrough)newValue)));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
@@ -360,7 +360,7 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.Strikethrough).Get(temp);
-            return temp;
+            return TextUtils.GetStrikethroughStruct(temp);
         }));
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -1413,6 +1413,50 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// This method converts a Strikethrough struct to a PropertyMap and returns it.
+        /// The returned map can be used for set Strikethrough PropertyMap in the SetStrikethrough method.
+        /// <param name="strikethrough">The Strikethrough struct value.</param>
+        /// <returns> A PropertyMap for Strikethrough property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PropertyMap GetStrikethroughMap(Strikethrough strikethrough)
+        {
+            var map = new PropertyMap();
+
+            map.Add("enable", new PropertyValue(strikethrough.Enable));
+
+            if (strikethrough.Color != null)
+                map.Add("color", new PropertyValue(strikethrough.Color));
+
+            if (strikethrough.Height != null)
+                map.Add("height", new PropertyValue((float)strikethrough.Height));
+
+            return map;
+        }
+
+        /// <summary>
+        /// This method converts a Strikethrough map to a struct and returns it.
+        /// The returned struct can be returned to the user as a Strikethrough in the GetStrikethrough method.
+        /// <param name="map">The Strikethrough PropertyMap.</param>
+        /// <returns> A Strikethrough struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Strikethrough GetStrikethroughStruct(PropertyMap map)
+        {
+            Color color = new Color();
+            map.Find(0, "enable").Get(out bool enable);
+            map.Find(0, "color").Get(color);
+            map.Find(0, "height").Get(out float height);
+
+            var strikethrough = new Strikethrough();
+            strikethrough.Enable = enable;
+            strikethrough.Color = color;
+            strikethrough.Height = height;
+
+            return strikethrough;
+        }
+
+        /// <summary>
         /// This method converts a Shadow struct to a PropertyMap and returns it.
         /// The returned map can be used for set Shadow PropertyMap in the SetShadow method.
         /// <param name="shadow">The Shadow struct value.</param>

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -2121,6 +2121,35 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// A struct to pass data of Strikethrough PropertyMap. <br />
+        /// </summary>
+        /// <remarks>
+        /// The Strikethrough struct is used as an argument to SetStrikethrough and GetStrikethrough methods. <br />
+        /// See <see cref="Tizen.NUI.BaseComponents.TextLabel.SetStrikethrough"/>, <see cref="Tizen.NUI.BaseComponents.TextLabel.GetStrikethrough"/>, <see cref="Tizen.NUI.BaseComponents.TextField.SetUnderline"/>, <see cref="Tizen.NUI.BaseComponents.TextField.GetStrikethrough"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.SetStrikethrough"/> and <see cref="Tizen.NUI.BaseComponents.TextEditor.GetStrikethrough"/>. <br />
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public struct Strikethrough
+        {
+            /// <summary>
+            /// Whether the strikethrough is enabled (the default value is false).
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool Enable { get; set; }
+
+            /// <summary>
+            /// The color of the strikethrough (if not provided then the color of the text is used).
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public Color Color { get; set; }
+
+            /// <summary>
+            /// The height in pixels of the strikethrough (if null, the default value is 1.0f).
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public float? Height { get; set; }
+        }
+
+        /// <summary>
         /// A struct to pass data of Shadow PropertyMap. <br />
         /// </summary>
         /// <remarks>
@@ -2139,7 +2168,7 @@ namespace Tizen.NUI
             /// <summary>
             /// The offset in pixels of the shadow (if null, the default value is 0, 0). <br />
             /// If not provided then the shadow is not enabled. <br />
-            ///  
+            ///
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             public Vector2 Offset { get; set; }


### PR DESCRIPTION
### Description of Change ###
Add Strikethrough property to NUI
Strikethrough is a typographical presentation of words with a horizontal line through their center

The strikethrough map contains the following keys:

- enable (bool): Whether the strikethrough is enabled (the default value is false)
- color (Color): The color of the strikethrough (If not provided then the color of the text is used)
- height (float): The height in pixels of the strikethrough (the default value is 1.f)

 
**Added**: 

- public Map Strikethrough { get; set; } // Property to TextLabel, TextEditor & TextField
- public Map InputStrikethrough { get; set; } // Property to  TextEditor & TextField

**Related patches on DALi**:

- Add Strikethrough Property : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/263388
- Extending Style - Adding Strikethrough :  https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/258031


