### PR TITLE
[NUI] Fix testhub NUI.Components coredump issue

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -559,6 +559,16 @@ namespace Tizen.NUI.BaseComponents
                 return;
             }
 
+            if (disposing == false)
+            {
+                if (SwigCPtr.Handle == IntPtr.Zero || SwigCMemOwn == false)
+                {
+                    // at this case, implicit nor explicit dispose is not required. No native object is made.
+                    disposed = true;
+                    return;
+                }
+            }
+
             if (disposing)
             {
                 Unparent();


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix testhub NUI.Components coredump issue
- there was no fail but coredumps are remained after finishing NUI.Components test.
- native crash occured when empty native object handle is accessed and the TouchEvent signal is tried to be gotten.
- https://code.sec.samsung.net/jira/browse/TSDF-2266


### API Changes ###
none