### PR TITLE
[NUI] Fix setvalue and xamlstyle issues

### DIFF
--- a/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
@@ -32,7 +32,7 @@ namespace Tizen.NUI
     {
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty GaussianBlurViewProperty = BindableProperty.Create(nameof(BlurStrength), typeof(float), typeof(GaussianBlurView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty BlurStrengthProperty = BindableProperty.Create(nameof(BlurStrength), typeof(float), typeof(GaussianBlurView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
         {
             var gaussianBlurView = (GaussianBlurView)bindable;
             if (newValue != null)
@@ -144,11 +144,11 @@ namespace Tizen.NUI
         {
             get
             {
-                return (float)GetValue(GaussianBlurViewProperty);
+                return (float)GetValue(BlurStrengthProperty);
             }
             set
             {
-                SetValue(GaussianBlurViewProperty, value);
+                SetValue(BlurStrengthProperty, value);
                 NotifyPropertyChanged();
             }
         }

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -267,16 +267,22 @@ namespace Tizen.NUI.Binding
                     throw new ArgumentNullException(nameof(property));
                 }
 
+                object oldvalue = null;
                 if (null == property.DefaultValueCreator)
                 {
                     BindablePropertyContext context = GetOrCreateContext(property);
                     if (null != context)
                     {
+                        oldvalue = context.Value;
                         context.Value = value;
                     }
                 }
+                else
+                {
+                    oldvalue = property.DefaultValueCreator.Invoke(this);
+                }
 
-                property.PropertyChanged?.Invoke(this, null, value);
+                property.PropertyChanged?.Invoke(this, oldvalue, value);
 
                 OnPropertyChanged(property.PropertyName);
                 OnPropertyChangedWithData(property);

--- a/src/Tizen.NUI/src/public/XamlBinding/BindablePropertyConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindablePropertyConverter.cs
@@ -22,6 +22,7 @@ using System.Reflection;
 using System.Xml;
 using Tizen.NUI.Binding.Internals;
 using Tizen.NUI.Xaml;
+using Tizen.NUI.StyleSheets;
 
 namespace Tizen.NUI.Binding
 {
@@ -65,6 +66,9 @@ namespace Tizen.NUI.Binding
                     var triggerBase = parent as TriggerBase;
                     if (triggerBase != null)
                         type = triggerBase.TargetType;
+                    var xamlStyle = parent as IStyle;
+                    if (xamlStyle != null)
+                        type = xamlStyle.TargetType;
                 }
                 else if (parentValuesProvider.TargetObject is Trigger)
                     type = (parentValuesProvider.TargetObject as Trigger).TargetType;
@@ -96,13 +100,13 @@ namespace Tizen.NUI.Binding
                 return null;
             if (value.Contains(":"))
             {
-                Console.WriteLine(null, "Can't resolve properties with xml namespace prefix.");
+                Console.WriteLine("Can't resolve properties with xml namespace prefix.");
                 return null;
             }
             string[] parts = value.Split('.');
             if (parts.Length != 2)
             {
-                Console.WriteLine(null, $"Can't resolve {value}. Accepted syntax is Type.PropertyName.");
+                Console.WriteLine($"Can't resolve {value}. Accepted syntax is Type.PropertyName.");
                 return null;
             }
             Type type = Type.GetType("Tizen.NUI." + parts[0]);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Fix SetValue to use default value not null as old value.
2. Make XamlStyle to use Setter directly.

```
<XamlStyle x:Key="baseStyle" TargetType="View">
       <Setter Property="SizeWidth" Value="100" />
       <Setter Property="SizeHeight" Value="10" />
 </XamlStyle>
```

3. Change GaussianBlurViewProperty to BlurStrengthProperty.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
