### PR TITLE
[NUI] Change the parameter of SelectText from uint to int

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1991,14 +1991,20 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Select text from start to end index.
+        /// Select text from start to end index. <br />
+        /// The index is valid when 0 or positive. <br />
         /// </summary>
         /// <param name="start">The start index for selection.</param>
         /// <param name="end">The end index for selection.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SelectText(uint start, uint end)
+        public void SelectText(int start, int end)
         {
-            Interop.TextEditor.SelectText(SwigCPtr, start, end);
+            if (start < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(start), "Value is less than zero");
+            if (end < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(end), "Value is less than zero");
+
+            Interop.TextEditor.SelectText(SwigCPtr, (uint)start, (uint)end);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -2079,14 +2079,20 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Select text from start to end index.
+        /// Select text from start to end index. <br />
+        /// The index is valid when 0 or positive. <br />
         /// </summary>
         /// <param name="start">The start index for selection.</param>
         /// <param name="end">The end index for selection.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SelectText(uint start, uint end)
+        public void SelectText(int start, int end)
         {
-            Interop.TextField.SelectText(SwigCPtr, start, end);
+            if (start < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(start), "Value is less than zero");
+            if (end < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(end), "Value is less than zero");
+
+            Interop.TextField.SelectText(SwigCPtr, (uint)start, (uint)end);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
SelectedTextStart and SelectedTextEnd properties are int.
Change the parameter of SelectText() to int for cosistency.