### PR TITLE
[NUI] Fix svace issue

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -19,6 +19,7 @@ using global::System;
 using global::System.Runtime.InteropServices;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Tizen.NUI.BaseComponents
 {
@@ -935,11 +936,11 @@ namespace Tizen.NUI.BaseComponents
             string[] parts = pair.Split(',');
             if (parts.Length == 1)
             {
-                return new LottieFrameInfo(Int32.Parse(parts[0].Trim()));
+                return new LottieFrameInfo(Int32.Parse(parts[0].Trim(), CultureInfo.InvariantCulture));
             }
             else if (parts.Length == 2)
             {
-                return new LottieFrameInfo(Int32.Parse(parts[0].Trim()), Int32.Parse(parts[1].Trim()));
+                return new LottieFrameInfo(Int32.Parse(parts[0].Trim(), CultureInfo.InvariantCulture), Int32.Parse(parts[1].Trim(), CultureInfo.InvariantCulture));
             }
 
             Tizen.Log.Error("NUI", $"Can not convert string {pair} to LottieFrameInfo");

--- a/src/Tizen.NUI/src/public/Common/Color.cs
+++ b/src/Tizen.NUI/src/public/Common/Color.cs
@@ -18,6 +18,7 @@
 using System;
 using Tizen.NUI.Binding;
 using System.ComponentModel;
+using System.Globalization;
 
 namespace Tizen.NUI
 {
@@ -1029,7 +1030,7 @@ namespace Tizen.NUI
                         R = Math.Min(1.0f, ((float)Convert.ToInt32(components[0], 10)) / 255.0f);
                         G = Math.Min(1.0f, ((float)Convert.ToInt32(components[1], 10)) / 255.0f);
                         B = Math.Min(1.0f, ((float)Convert.ToInt32(components[2], 10)) / 255.0f);
-                        A = Math.Min(1.0f, float.Parse(components[3]));
+                        A = Math.Min(1.0f, float.Parse(components[3], CultureInfo.InvariantCulture));
                     }
                 }
             }


### PR DESCRIPTION
-Checker: API.CSHARP.CULTURE

WID:1125388 Method float.Parse(string) is culture specific.
Its usage can cause unexpected behaviour.
It is recommended to add IFormatProvider argument into invocation.

Signed-off-by: huiyu.eun <huiyu.eun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
