### PR TITLE
[NUI] Fix svace issue of dereferencing possible null handle in TextUtils

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -1651,9 +1651,9 @@ namespace Tizen.NUI.BaseComponents
 
             map.Find(0)?.Get(out text);
             map.Find(1)?.Get(out textFocused);
-            map.Find(2).Get(color);
+            map.Find(2)?.Get(color);
             map.Find(3)?.Get(out fontFamily);
-            map.Find(4).Get(fontStyle);
+            map.Find(4)?.Get(fontStyle);
             pointSizeValue = map.Find(5);
             pixelSizeValue = map.Find(6);
             map.Find(7)?.Get(out ellipsis);


### PR DESCRIPTION
Since PropertyMap.Find can return null, Find().Get() should be replaced with
Find()?.Get().

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
