### PR TITLE
[Tizen.Applications.RPCPort] Change internal TimeStamp's type to IntPtr

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
@@ -30,8 +30,8 @@ internal static partial class Interop
         [StructLayout(LayoutKind.Sequential)]
         internal struct TimeStamp
         {
-            public nint sec;
-            public nint nsec;
+            public IntPtr sec;
+            public IntPtr nsec;
         }
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications.Common.csproj
+++ b/src/Tizen.Applications.Common/Tizen.Applications.Common.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
@@ -141,7 +141,7 @@ namespace Tizen.Applications.RPCPort
             if (r != Interop.LibRPCPort.ErrorCode.None)
                 throw new InvalidIOException();
 
-            return new TimeStamp(time.sec, time.nsec);
+            return new TimeStamp(time.sec.ToInt64(), time.nsec.ToInt64());
         }
     };
 


### PR DESCRIPTION
Signed-off-by: ChangGyu Choi <uppletaste@gmail.com>

### Description of Change ###
<!-- Describe your changes here. -->
nint is not supported by current version.
This patch Changes TimeStamp's member attribute type
to IntPtr.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - Non ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
