### PR TITLE
[Build] Fix common.props to drop ref assemblies

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -6,6 +6,7 @@
     <GenerateDependencyFile>False</GenerateDependencyFile>
     <Deterministic>True</Deterministic>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
+    <ProduceReferenceAssemblyInOutDir>True</ProduceReferenceAssemblyInOutDir>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Set `ProduceReferenceAssemblyInOutDir` to true as default.
