### PR TITLE
[NUI] Fix comments of BorderlineColor

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -466,7 +466,6 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The color for the borderline of the View.
-        /// This color is affected by View Opacity.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Color BorderlineColor

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -532,7 +532,6 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The color for the borderline of the View.
         /// It is Color.Black by default.
-        /// This color is affected by View Opacity.
         /// </summary>
         /// <remarks>
         /// <para>


### PR DESCRIPTION
Currently the borderline color affected by View Opacity
But by check internally, we check it is just kind of bugs.
So during ACR, we don't tell it this is one of feature.

Bugfix will done in DALi side internally.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
