### PR TITLE
[NUI] Avoid creating BindablePropertyContext for the special cases

### DIFF
--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -188,6 +188,11 @@ namespace Tizen.NUI.Binding
             if (property == null)
                 throw new ArgumentNullException(nameof(property));
 
+            if (!IsBinded && property.DefaultValueCreator != null)
+            {
+                return property.DefaultValueCreator(this);
+            }
+
             BindablePropertyContext context = property.DefaultValueCreator != null ? GetOrCreateContext(property) : GetContext(property);
 
             if (context == null)


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
