### PR TITLE
[NUI] Remove duplicate getCPtr from Disposable/View subclasses

### DIFF
--- a/src/Tizen.NUI.Wearable/src/public/WatchView.cs
+++ b/src/Tizen.NUI.Wearable/src/public/WatchView.cs
@@ -89,11 +89,6 @@ namespace Tizen.NUI.Wearable
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WatchView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal WatchView Assign(WatchView handle)
         {
             WatchView ret = new WatchView(Interop.WatchView.Assign(SwigCPtr, WatchView.getCPtr(handle)), false);

--- a/src/Tizen.NUI/src/internal/Common/Alignment.cs
+++ b/src/Tizen.NUI/src/internal/Common/Alignment.cs
@@ -25,11 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Alignment obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Alignment.DeleteAlignment(swigCPtr);
@@ -40,11 +35,6 @@ namespace Tizen.NUI
 
             internal Padding(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
             {
-            }
-
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Padding obj)
-            {
-                return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
             }
 
             protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Common/AngleAxis.cs
+++ b/src/Tizen.NUI/src/internal/Common/AngleAxis.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AngleAxis obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.AngleAxis.DeleteAngleAxis(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/AngleThresholdPair.cs
+++ b/src/Tizen.NUI/src/internal/Common/AngleThresholdPair.cs
@@ -24,11 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AngleThresholdPair obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.AngleThresholdPair.DeleteAngleThresholdPair(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/Any.cs
+++ b/src/Tizen.NUI/src/internal/Common/Any.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Any obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Any.DeleteAny(swigCPtr);
@@ -75,11 +70,6 @@ namespace Tizen.NUI
 
             internal AnyContainerBase(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
             {
-            }
-
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AnyContainerBase obj)
-            {
-                return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
             }
 
             protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Common/CustomActorImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/CustomActorImpl.cs
@@ -25,11 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CustomActorImpl obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             throw new global::System.MethodAccessException("C++ destructor does not have public access");

--- a/src/Tizen.NUI/src/internal/Common/CustomAlgorithmInterface.cs
+++ b/src/Tizen.NUI/src/internal/Common/CustomAlgorithmInterface.cs
@@ -26,11 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CustomAlgorithmInterface obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.CustomAlgorithmInterface.DeleteCustomAlgorithmInterface(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/Disposable.cs
+++ b/src/Tizen.NUI/src/internal/Common/Disposable.cs
@@ -78,6 +78,11 @@ namespace Tizen.NUI
             GC.SuppressFinalize(this);
         }
 
+        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Disposable obj)
+        {
+            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
+        }
+
         /// <summary>
         /// Hidden API (Inhouse API).
         /// Dispose. 

--- a/src/Tizen.NUI/src/internal/Common/FontDescription.cs
+++ b/src/Tizen.NUI/src/internal/Common/FontDescription.cs
@@ -24,11 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FontDescription obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.FontClient.DeleteFontDescription(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/FontMetrics.cs
+++ b/src/Tizen.NUI/src/internal/Common/FontMetrics.cs
@@ -22,11 +22,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FontMetrics obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.FontClient.DeleteFontMetrics(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/GlyphInfo.cs
+++ b/src/Tizen.NUI/src/internal/Common/GlyphInfo.cs
@@ -22,11 +22,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(GlyphInfo obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.GlytphInfo.DeleteGlyphInfo(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/InputMethodOptions.cs
+++ b/src/Tizen.NUI/src/internal/Common/InputMethodOptions.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(InputMethodOptions obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.InputMethodOptions.DeleteInputMethodOptions(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/Matrix.cs
+++ b/src/Tizen.NUI/src/internal/Common/Matrix.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Matrix obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Matrix.DeleteMatrix(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/Matrix3.cs
+++ b/src/Tizen.NUI/src/internal/Common/Matrix3.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Matrix3 obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Matrix.DeleteMatrix3(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/Model3dView.cs
+++ b/src/Tizen.NUI/src/internal/Common/Model3dView.cs
@@ -25,11 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Model3dView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Model3DView.DeleteModel3dView(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/NativeImageInterface.cs
+++ b/src/Tizen.NUI/src/internal/Common/NativeImageInterface.cs
@@ -26,11 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(NativeImageInterface obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             throw new global::System.MethodAccessException("C++ destructor does not have public access");

--- a/src/Tizen.NUI/src/internal/Common/RefObject.cs
+++ b/src/Tizen.NUI/src/internal/Common/RefObject.cs
@@ -28,11 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RefObject obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Common/Ruler.cs
+++ b/src/Tizen.NUI/src/internal/Common/Ruler.cs
@@ -27,11 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Ruler obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Common/RulerDomain.cs
+++ b/src/Tizen.NUI/src/internal/Common/RulerDomain.cs
@@ -28,11 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RulerDomain obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Common/RulerPtr.cs
+++ b/src/Tizen.NUI/src/internal/Common/RulerPtr.cs
@@ -27,11 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RulerPtr obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Common/SlotObserver.cs
+++ b/src/Tizen.NUI/src/internal/Common/SlotObserver.cs
@@ -26,11 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SlotObserver obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             delete_SlotObserver(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/StringValuePair.cs
+++ b/src/Tizen.NUI/src/internal/Common/StringValuePair.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(StringValuePair obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.StringValuePair.DeleteStringValuePair(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/TouchPoint.cs
+++ b/src/Tizen.NUI/src/internal/Common/TouchPoint.cs
@@ -24,11 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TouchPoint obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.TouchPoint.DeleteTouchPoint(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/TouchPointContainer.cs
+++ b/src/Tizen.NUI/src/internal/Common/TouchPointContainer.cs
@@ -27,11 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static HandleRef getCPtr(TouchPointContainer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(HandleRef swigCPtr)
         {
             Interop.TouchPointContainer.DeleteTouchPointContainer(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/TypeRegistration.cs
+++ b/src/Tizen.NUI/src/internal/Common/TypeRegistration.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TypeRegistration obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.TypeRegistration.DeleteTypeRegistration(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/Uint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Common/Uint16Pair.cs
@@ -35,11 +35,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Uint16Pair obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Uint16Pair.DeleteUint16Pair(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/VectorUint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorUint16Pair.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VectorUint16Pair obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.VectorUint16Pair.DeleteVectorUint16Pair(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/VectorUnsignedChar.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorUnsignedChar.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VectorUnsignedChar obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.VectorUnsignedChar.DeleteVectorUnsignedChar(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
@@ -28,11 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ViewImpl obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             throw new global::System.MethodAccessException("C++ destructor does not have public access");

--- a/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
@@ -134,11 +134,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ViewWrapperImpl obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
         }

--- a/src/Tizen.NUI/src/internal/Utility/Camera.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Camera.cs
@@ -29,11 +29,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Camera obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.CameraActor.DeleteCameraActor(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Utility/ConnectionTrackerInterface.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ConnectionTrackerInterface.cs
@@ -26,11 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ConnectionTrackerInterface obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Dispose
         /// </summary>

--- a/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
@@ -54,11 +54,6 @@ namespace Tizen.NUI
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(GaussianBlurView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.GaussianBlurView.DeleteGaussianBlurView(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Utility/Item.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Item.cs
@@ -30,11 +30,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Item obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Utility/ItemCollection.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemCollection.cs
@@ -30,11 +30,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ItemCollection obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Utility/ItemFactory.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemFactory.cs
@@ -29,11 +29,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ItemFactory obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Utility/ItemIdCollection.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemIdCollection.cs
@@ -29,11 +29,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ItemIdCollection obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Utility/ItemLayout.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemLayout.cs
@@ -29,11 +29,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ItemLayout obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Utility/ItemRange.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemRange.cs
@@ -29,11 +29,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ItemRange obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Utility/PageFactory.cs
+++ b/src/Tizen.NUI/src/internal/Utility/PageFactory.cs
@@ -24,11 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PageFactory obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.PageFactory.DeletePageFactory(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Utility/PageTurnLandscapeView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/PageTurnLandscapeView.cs
@@ -25,11 +25,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PageTurnLandscapeView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.PageTurnLandScapeView.DeletePageTurnLandscapeView(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Utility/PageTurnPortraitView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/PageTurnPortraitView.cs
@@ -24,11 +24,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PageTurnPortraitView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.PageTurnPortraitView.DeletePageTurnPortraitView(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Utility/PageTurnView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/PageTurnView.cs
@@ -27,11 +27,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PageTurnView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.PageTurnView.DeletePageTurnView(swigCPtr);

--- a/src/Tizen.NUI/src/internal/WebView/WebContextMenuItem.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebContextMenuItem.cs
@@ -234,10 +234,5 @@ namespace Tizen.NUI
                 return new WebContextMenu(result, true);
             }
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebContextMenuItem obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/WebView/WebSecurityOrigin.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebSecurityOrigin.cs
@@ -53,10 +53,5 @@ namespace Tizen.NUI
                 return Interop.WebSecurityOrigin.GetProtocol(SwigCPtr);
             }
         }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebSecurityOrigin obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
     }
 }

--- a/src/Tizen.NUI/src/internal/Widget/WidgetImpl.cs
+++ b/src/Tizen.NUI/src/internal/Widget/WidgetImpl.cs
@@ -30,11 +30,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WidgetImpl obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             //throw new global::System.MethodAccessException("C++ destructor does not have public access");

--- a/src/Tizen.NUI/src/public/Animation/AlphaFunction.cs
+++ b/src/Tizen.NUI/src/public/Animation/AlphaFunction.cs
@@ -229,11 +229,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AlphaFunction obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static string BuiltinToPropertyKey(BuiltinFunctions? alphaFunction)
         {
             string propertyKey = null;

--- a/src/Tizen.NUI/src/public/Application/WatchTime.cs
+++ b/src/Tizen.NUI/src/public/Application/WatchTime.cs
@@ -189,11 +189,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WatchTime obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static WatchTime GetWatchTimeFromPtr(global::System.IntPtr cPtr)
         {
             WatchTime ret = new WatchTime(cPtr, false);

--- a/src/Tizen.NUI/src/public/BaseComponents/CameraView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CameraView.cs
@@ -53,11 +53,6 @@ namespace Tizen.NUI.BaseComponents
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CameraView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Called when the camera view needs to be updated if the camera setting is changed.
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -582,11 +582,6 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TableView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
@@ -798,11 +793,6 @@ namespace Tizen.NUI.BaseComponents
                     if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
                     return ret;
                 }
-            }
-
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CellPosition obj)
-            {
-                return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
             }
 
             /// This will not be public opened.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -2059,11 +2059,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TextEditor obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t InputStyleChangedSignal()
         {
             SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextEditor_Dali__Toolkit__TextEditor__InputStyle__MaskF_t(Interop.TextEditor.InputStyleChangedSignal(SwigCPtr));

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -2098,11 +2098,6 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TextField obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t InputStyleChangedSignal()
         {
             SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t ret = new SWIGTYPE_p_Dali__SignalT_void_fDali__Toolkit__TextField_Dali__Toolkit__TextField__InputStyle__MaskF_t(Interop.TextField.InputStyleChangedSignal(SwigCPtr));

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -1253,11 +1253,6 @@ namespace Tizen.NUI.BaseComponents
             base.Dispose(type);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TextLabel obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -34,11 +34,6 @@ namespace Tizen.NUI.BaseComponents
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RendererParameters obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Dispose
         /// </summary>
@@ -675,11 +670,6 @@ namespace Tizen.NUI.BaseComponents
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(EmbeddedItemInfo obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Dispose
         /// </summary>
@@ -849,11 +839,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal ShadowParameters(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
-        }
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ShadowParameters obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -390,11 +390,6 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VideoView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Dispose.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Common/Color.cs
+++ b/src/Tizen.NUI/src/public/Common/Color.cs
@@ -1413,11 +1413,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Color(this);
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Color obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Color GetColorFromPtr(global::System.IntPtr cPtr)
         {
             Color ret = new Color(cPtr, false);

--- a/src/Tizen.NUI/src/public/Common/Degree.cs
+++ b/src/Tizen.NUI/src/public/Common/Degree.cs
@@ -79,11 +79,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Degree obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/Extents.cs
+++ b/src/Tizen.NUI/src/public/Common/Extents.cs
@@ -286,11 +286,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Extents(this);
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Extents obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal Extents Assign(SWIGTYPE_p_uint16_t array)
         {
             Extents ret = new Extents(Interop.Extents.AssignUint16(SwigCPtr, SWIGTYPE_p_uint16_t.getCPtr(array)), false);

--- a/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
@@ -39,11 +39,6 @@ namespace Tizen.NUI
             DirectorConnect();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FrameUpdateCallbackInterface obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         private void DirectorConnect()
         {
             Delegate0 = new DelegateFrameUpdateCallbackInterface(DirectorOnUpdate);

--- a/src/Tizen.NUI/src/public/Common/Position.cs
+++ b/src/Tizen.NUI/src/public/Common/Position.cs
@@ -878,11 +878,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Position(X, Y, Z);
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Position obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Position GetPositionFromPtr(global::System.IntPtr cPtr)
         {
             Position ret = new Position(cPtr, false);

--- a/src/Tizen.NUI/src/public/Common/Position2D.cs
+++ b/src/Tizen.NUI/src/public/Common/Position2D.cs
@@ -384,11 +384,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Position2D obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/Property.cs
+++ b/src/Tizen.NUI/src/public/Common/Property.cs
@@ -148,11 +148,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Property obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Property.DeleteProperty(swigCPtr);

--- a/src/Tizen.NUI/src/public/Common/PropertyArray.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyArray.cs
@@ -189,11 +189,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyArray obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/PropertyKey.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyKey.cs
@@ -205,11 +205,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyKey obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/PropertyMap.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyMap.cs
@@ -293,11 +293,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyMap obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal void SetValue(int key, PropertyValue value)
         {
             Interop.PropertyMap.SetValueIntKey(SwigCPtr, key, PropertyValue.getCPtr(value));

--- a/src/Tizen.NUI/src/public/Common/PropertyValue.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyValue.cs
@@ -621,11 +621,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyValue obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal bool Get(Matrix3 matrixValue)
         {
             bool ret = Interop.PropertyValue.GetMatrix3(SwigCPtr, Matrix3.getCPtr(matrixValue));

--- a/src/Tizen.NUI/src/public/Common/Radian.cs
+++ b/src/Tizen.NUI/src/public/Common/Radian.cs
@@ -90,11 +90,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Radian obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/Rectangle.cs
+++ b/src/Tizen.NUI/src/public/Common/Rectangle.cs
@@ -511,11 +511,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Rectangle(this);
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Rectangle obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/RelativeVector2.cs
+++ b/src/Tizen.NUI/src/public/Common/RelativeVector2.cs
@@ -134,11 +134,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RelativeVector2 obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// The addition operator.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Common/RelativeVector3.cs
+++ b/src/Tizen.NUI/src/public/Common/RelativeVector3.cs
@@ -332,11 +332,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RelativeVector3 obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal RelativeVector3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Common/RelativeVector4.cs
+++ b/src/Tizen.NUI/src/public/Common/RelativeVector4.cs
@@ -388,11 +388,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RelativeVector4 obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal RelativeVector4(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Common/Rotation.cs
+++ b/src/Tizen.NUI/src/public/Common/Rotation.cs
@@ -408,11 +408,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Rotation obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal Rotation(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Common/Size.cs
+++ b/src/Tizen.NUI/src/public/Common/Size.cs
@@ -397,11 +397,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Size obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal Size(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Common/Size2D.cs
+++ b/src/Tizen.NUI/src/public/Common/Size2D.cs
@@ -337,11 +337,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Size2D(Width, Height);
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Size2D obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Gets the size from the pointer.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Common/TimePeriod.cs
+++ b/src/Tizen.NUI/src/public/Common/TimePeriod.cs
@@ -31,11 +31,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TimePeriod obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.TimePeriod.DeleteTimePeriod(swigCPtr);

--- a/src/Tizen.NUI/src/public/Common/Vector2.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector2.cs
@@ -510,11 +510,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Vector2 obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal SWIGTYPE_p_float AsFloat()
         {
             global::System.IntPtr cPtr = Interop.Vector2.AsFloat(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Common/Vector3.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector3.cs
@@ -707,11 +707,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Vector3(X, Y, Z);
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Vector3 obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Vector3 GetVector3FromPtr(global::System.IntPtr cPtr)
         {
             Vector3 ret = new Vector3(cPtr, false);

--- a/src/Tizen.NUI/src/public/Common/Vector4.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector4.cs
@@ -751,11 +751,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Vector4(X, Y, Z, W);
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Vector4 obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Vector4 GetVector4FromPtr(global::System.IntPtr cPtr)
         {
             Vector4 ret = new Vector4(cPtr, false);

--- a/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
@@ -98,11 +98,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(NativeImageQueue obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Checks if the buffer can be got from the queue.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
@@ -65,11 +65,6 @@ namespace Tizen.NUI
             Bits32,
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(NativeImageSource obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IntPtr AcquireBuffer(ref int width, ref int height, ref int stride)
         {

--- a/src/Tizen.NUI/src/public/Layouting/PaddingType.cs
+++ b/src/Tizen.NUI/src/public/Layouting/PaddingType.cs
@@ -295,11 +295,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PaddingType obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Layouting/RelayoutContainer.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelayoutContainer.cs
@@ -38,11 +38,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RelayoutContainer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal RelayoutContainer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Utility/CubeTransitionEffect.cs
+++ b/src/Tizen.NUI/src/public/Utility/CubeTransitionEffect.cs
@@ -46,11 +46,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CubeTransitionEffect obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal CubeTransitionEffect(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -464,11 +464,6 @@ namespace Tizen.NUI
                 }
             }
 
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(GlyphBufferData obj)
-            {
-                return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-            }
-
             /// This will not be public opened.
             [EditorBrowsable(EditorBrowsableState.Never)]
             protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Utility/ScrollViewEvent.cs
+++ b/src/Tizen.NUI/src/public/Utility/ScrollViewEvent.cs
@@ -184,11 +184,6 @@ namespace Tizen.NUI
                 return ret;
             }
 
-            internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SnapEvent obj)
-            {
-                return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-            }
-
             /// <summary>
             /// Dispose
             /// </summary>

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -1950,11 +1950,6 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WebView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal WebView Assign(WebView webView)
         {
             WebView ret = new WebView(Interop.WebView.Assign(SwigCPtr, WebView.getCPtr(webView)), false);

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -579,11 +579,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WidgetView obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal WidgetView Assign(WidgetView handle)
         {
             WidgetView ret = new WidgetView(Interop.WidgetView.Assign(SwigCPtr, WidgetView.getCPtr(handle)), false);


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
