### PR TITLE
[NUI] Remove duplicate getCPtr from BaseHandle subclasses

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -382,11 +382,6 @@ namespace Tizen.NUI
             s_current = this;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Application obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void Dispose(DisposeTypes type)
         {
             if (disposed)

--- a/src/Tizen.NUI/src/internal/Application/ComponentApplication.cs
+++ b/src/Tizen.NUI/src/internal/Application/ComponentApplication.cs
@@ -29,11 +29,6 @@ namespace Tizen.NUI
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ComponentApplication obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.swigCPtr;
-        }
-
         protected override void Dispose(DisposeTypes type)
         {
             if (disposed)

--- a/src/Tizen.NUI/src/internal/Application/WatchApplication.cs
+++ b/src/Tizen.NUI/src/internal/Application/WatchApplication.cs
@@ -26,11 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WatchApplication obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Watch.DeleteWatchApplication(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/AsyncImageLoader.cs
+++ b/src/Tizen.NUI/src/internal/Common/AsyncImageLoader.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AsyncImageLoader obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.AsyncImageLoader.DeleteAsyncImageLoader(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/CustomActor.cs
+++ b/src/Tizen.NUI/src/internal/Common/CustomActor.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(CustomActor obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.CustomActorImpl.DeleteCustomActor(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
@@ -28,11 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FrameBuffer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.FrameBuffer.DeleteFrameBuffer(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/LinearConstrainer.cs
+++ b/src/Tizen.NUI/src/internal/Common/LinearConstrainer.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(LinearConstrainer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.LinearConstrainer.DeleteLinearConstrainer(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
+++ b/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
@@ -26,11 +26,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ObjectRegistry obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.ObjectRegistry.DeleteObjectRegistry(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/PathConstrainer.cs
+++ b/src/Tizen.NUI/src/internal/Common/PathConstrainer.cs
@@ -23,11 +23,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PathConstrainer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.PathConstrainer.DeletePathConstrainer(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTask.cs
@@ -28,11 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RenderTask obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.RenderTask.DeleteRenderTask(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Common/RenderTaskList.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTaskList.cs
@@ -28,11 +28,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RenderTaskList obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/internal/Transition/FadeTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/FadeTransitionItem.cs
@@ -43,11 +43,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FadeTransitionItem obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal FadeTransitionItem(FadeTransitionItem handle) : this(Interop.FadeTransitionItem.NewFadeTransitionItem(FadeTransitionItem.getCPtr(handle)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Transition/ScaleTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/ScaleTransitionItem.cs
@@ -54,11 +54,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ScaleTransitionItem obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal ScaleTransitionItem(ScaleTransitionItem handle) : this(Interop.ScaleTransitionItem.NewScaleTransitionItem(ScaleTransitionItem.getCPtr(handle)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Transition/SlideTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/SlideTransitionItem.cs
@@ -43,11 +43,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(SlideTransitionItem obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal SlideTransitionItem(SlideTransitionItem handle) : this(Interop.SlideTransitionItem.NewSlideTransitionItem(SlideTransitionItem.getCPtr(handle)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Transition/TransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionItem.cs
@@ -42,11 +42,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TransitionItem obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal TransitionItem(TransitionItem handle) : this(Interop.TransitionItem.NewTransitionItem(TransitionItem.getCPtr(handle)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Transition/TransitionItemBase.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionItemBase.cs
@@ -118,11 +118,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TransitionItemBase obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal TransitionItemBase(TransitionItemBase handle) : this(Interop.TransitionItemBase.NewTransitionItemBase(TransitionItemBase.getCPtr(handle)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
@@ -142,11 +142,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TransitionSet obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal TransitionSet(TransitionSet handle) : this(Interop.TransitionSet.NewTransitionSet(TransitionSet.getCPtr(handle)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Widget/WidgetApplication.cs
+++ b/src/Tizen.NUI/src/internal/Widget/WidgetApplication.cs
@@ -30,11 +30,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WidgetApplication obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.WidgetApplication.DeleteWidgetApplication(swigCPtr);

--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
@@ -37,11 +37,6 @@ namespace Tizen.NUI.Accessibility
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AccessibilityManager obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Animation/Animatable.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animatable.cs
@@ -214,11 +214,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Animatable obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal uint GetPropertyCount()
         {
             uint ret = Interop.HandleInternal.HandleGetPropertyCount(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -1079,11 +1079,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Animation obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal object ConvertTo(object value, Type toType)
         {
             Func<object> getConverter = () =>

--- a/src/Tizen.NUI/src/public/Animation/KeyFrames.cs
+++ b/src/Tizen.NUI/src/public/Animation/KeyFrames.cs
@@ -103,11 +103,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(KeyFrames obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Animation/Path.cs
+++ b/src/Tizen.NUI/src/public/Animation/Path.cs
@@ -171,11 +171,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Path obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Animation/TransitionData.cs
+++ b/src/Tizen.NUI/src/public/Animation/TransitionData.cs
@@ -85,11 +85,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TransitionData obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -519,11 +519,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Layer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetAnchorPoint(Vector3 anchorPoint)

--- a/src/Tizen.NUI/src/public/Common/PropertyBuffer.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyBuffer.cs
@@ -68,11 +68,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyBuffer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/PropertyCondition.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyCondition.cs
@@ -144,11 +144,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyCondition obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
@@ -239,11 +239,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PropertyNotification obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -175,11 +175,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(StyleManager obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal StyleManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Common/TypeInfo.cs
+++ b/src/Tizen.NUI/src/public/Common/TypeInfo.cs
@@ -111,11 +111,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TypeInfo obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Common/TypeRegistry.cs
+++ b/src/Tizen.NUI/src/public/Common/TypeRegistry.cs
@@ -31,11 +31,6 @@ namespace Tizen.NUI
         {
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TypeRegistry obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Events/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Events/Gesture.cs
@@ -188,11 +188,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Gesture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Gesture GetGestureFromPtr(global::System.IntPtr cPtr)
         {
             Gesture ret = new Gesture(cPtr, false);

--- a/src/Tizen.NUI/src/public/Events/GestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/GestureDetector.cs
@@ -131,11 +131,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(GestureDetector obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Events/Hover.cs
+++ b/src/Tizen.NUI/src/public/Events/Hover.cs
@@ -153,11 +153,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Hover obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Hover GetHoverFromPtr(global::System.IntPtr cPtr)
         {
             Hover ret = new Hover(cPtr, false);

--- a/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
@@ -126,11 +126,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(LongPressGesture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static LongPressGesture GetLongPressGestureFromPtr(global::System.IntPtr cPtr)
         {
             LongPressGesture ret = new LongPressGesture(cPtr, false);

--- a/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
@@ -195,11 +195,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(LongPressGestureDetector obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Events/PanGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGesture.cs
@@ -319,11 +319,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PanGesture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static PanGesture GetPanGestureFromPtr(global::System.IntPtr cPtr)
         {
             PanGesture ret = new PanGesture(cPtr, false);

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -492,11 +492,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PanGestureDetector obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal new static PanGestureDetector DownCast(BaseHandle handle)
         {
             PanGestureDetector ret = Registry.GetManagedBaseHandleFromNativePtr(handle) as PanGestureDetector;

--- a/src/Tizen.NUI/src/public/Events/PinchGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGesture.cs
@@ -154,11 +154,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PinchGesture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static PinchGesture GetPinchGestureFromPtr(global::System.IntPtr cPtr)
         {
             PinchGesture ret = new PinchGesture(cPtr, false);

--- a/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
@@ -103,11 +103,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PinchGestureDetector obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal PinchGestureDetector Assign(PinchGestureDetector rhs)
         {
             PinchGestureDetector ret = new PinchGestureDetector(Interop.PinchGesture.PinchGestureDetectorAssign(SwigCPtr, PinchGestureDetector.getCPtr(rhs)), false);

--- a/src/Tizen.NUI/src/public/Events/RotationGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGesture.cs
@@ -129,11 +129,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RotationGesture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static RotationGesture GetRotationGestureFromPtr(global::System.IntPtr cPtr)
         {
             RotationGesture ret = new RotationGesture(cPtr, false);

--- a/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
@@ -103,11 +103,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(RotationGestureDetector obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal RotationGestureDetector Assign(RotationGestureDetector rhs)
         {
             RotationGestureDetector ret = new RotationGestureDetector(Interop.RotationGesture.RotationGestureDetectorAssign(SwigCPtr, RotationGestureDetector.getCPtr(rhs)), false);

--- a/src/Tizen.NUI/src/public/Events/TapGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGesture.cs
@@ -173,11 +173,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TapGesture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Gets the TapGesture from the pointer.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
@@ -160,11 +160,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TapGestureDetector obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static TapGestureDetector GetTapGestureDetectorFromPtr(global::System.IntPtr cPtr)
         {
             TapGestureDetector ret = new TapGestureDetector(cPtr, false);

--- a/src/Tizen.NUI/src/public/Events/Touch.cs
+++ b/src/Tizen.NUI/src/public/Events/Touch.cs
@@ -209,11 +209,6 @@ namespace Tizen.NUI
             return (MouseButton)ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Touch obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Touch GetTouchFromPtr(global::System.IntPtr cPtr)
         {
             Touch ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Touch;

--- a/src/Tizen.NUI/src/public/Events/Wheel.cs
+++ b/src/Tizen.NUI/src/public/Events/Wheel.cs
@@ -246,11 +246,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Wheel obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Wheel GetWheelFromPtr(global::System.IntPtr cPtr)
         {
             Wheel ret = new Wheel(cPtr, false);

--- a/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
@@ -283,11 +283,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PixelBuffer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal PixelBuffer Assign(PixelBuffer rhs)
         {
             PixelBuffer ret = new PixelBuffer(Interop.PixelBuffer.Assign(SwigCPtr, PixelBuffer.getCPtr(rhs)), false);

--- a/src/Tizen.NUI/src/public/Images/PixelData.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelData.cs
@@ -148,11 +148,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(PixelData obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Input/AutofillContainer.cs
+++ b/src/Tizen.NUI/src/public/Input/AutofillContainer.cs
@@ -109,12 +109,6 @@ namespace Tizen.NUI
         {
         }
 
-
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(AutofillContainer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal AutofillContainer(AutofillContainer autofillContainer) : this(Interop.AutofillContainer.NewAutofillContainer(AutofillContainer.getCPtr(autofillContainer)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/public/Input/Key.cs
+++ b/src/Tizen.NUI/src/public/Input/Key.cs
@@ -316,11 +316,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Key obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static Key GetKeyFromPtr(global::System.IntPtr cPtr)
         {
             Key ret = new Key(cPtr, false);

--- a/src/Tizen.NUI/src/public/Rendering/Geometry.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Geometry.cs
@@ -167,11 +167,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Geometry obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Rendering/Renderer.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Renderer.cs
@@ -659,11 +659,6 @@ namespace Tizen.NUI
             return CurrentShader;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Renderer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal Renderer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Rendering/Sampler.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Sampler.cs
@@ -71,11 +71,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Sampler obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal Sampler(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Rendering/Shader.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Shader.cs
@@ -71,11 +71,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Shader obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal Shader(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Rendering/Texture.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Texture.cs
@@ -123,11 +123,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Texture obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Rendering/TextureSet.cs
+++ b/src/Tizen.NUI/src/public/Rendering/TextureSet.cs
@@ -116,11 +116,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TextureSet obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Rendering/VertexBuffer.cs
+++ b/src/Tizen.NUI/src/public/Rendering/VertexBuffer.cs
@@ -85,11 +85,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VertexBuffer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -209,11 +209,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(FontClient obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static FontClient Get()
         {
             FontClient ret = new FontClient(Interop.FontClient.Get(), true);

--- a/src/Tizen.NUI/src/public/Utility/ScrollViewEffect.cs
+++ b/src/Tizen.NUI/src/public/Utility/ScrollViewEffect.cs
@@ -35,11 +35,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(ScrollViewEffect obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal ScrollViewEffect(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.ScrollView.ScrollViewEffectUpcast(cPtr), cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
+++ b/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
@@ -220,11 +220,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(TTSPlayer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal StateChangedSignalType StateChangedSignal()
         {
             StateChangedSignalType ret = new StateChangedSignalType(Interop.TtsPlayer.StateChangedSignal(SwigCPtr), false);

--- a/src/Tizen.NUI/src/public/Utility/Timer.cs
+++ b/src/Tizen.NUI/src/public/Utility/Timer.cs
@@ -212,11 +212,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Timer obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         /// <summary>
         /// Sets a new interval on the timer and starts the timer.<br />
         /// Cancels the previous timer.<br />

--- a/src/Tizen.NUI/src/public/Visuals/VisualBase.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualBase.cs
@@ -143,11 +143,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(VisualBase obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal void SetName(string name)
         {
             Interop.VisualBase.SetName(SwigCPtr, name);

--- a/src/Tizen.NUI/src/public/Widget/Widget.cs
+++ b/src/Tizen.NUI/src/public/Widget/Widget.cs
@@ -82,11 +82,6 @@ namespace Tizen.NUI
             widgetImpl.SetContentInfo(contentInfo);
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Widget obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal System.IntPtr GetIntPtr()
         {
             return SwigCPtr.Handle;

--- a/src/Tizen.NUI/src/public/Widget/WidgetViewManager.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetViewManager.cs
@@ -95,11 +95,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(WidgetViewManager obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static WidgetViewManager DownCast(BaseHandle handle)
         {
             WidgetViewManager ret = new WidgetViewManager(Interop.WidgetViewManager.DownCast(BaseHandle.getCPtr(handle)), true);

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1171,11 +1171,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static global::System.Runtime.InteropServices.HandleRef getCPtr(Window obj)
-        {
-            return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
-        }
-
         internal static bool IsInstalled()
         {
             bool ret = Interop.Stage.IsInstalled();


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
