### PR TITLE
[NUI] Remove redundant DALi object reference check code

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -1035,7 +1035,7 @@ namespace Tizen.NUI
         {
             // register all Views with the type registry, so that can be created / styled via JSON
             //ViewRegistryHelper.Initialize(); //moved to Application side.
-            if (instance)
+            if (instance != null)
             {
                 return instance;
             }
@@ -1050,7 +1050,7 @@ namespace Tizen.NUI
 
         public static Application NewApplication(string stylesheet, NUIApplication.WindowMode windowMode, Rectangle positionSize)
         {
-            if (instance)
+            if (instance != null)
             {
                 return instance;
             }
@@ -1064,7 +1064,7 @@ namespace Tizen.NUI
 
         public static Application NewApplication(string[] args, string stylesheet, NUIApplication.WindowMode windowMode)
         {
-            if (instance)
+            if (instance != null)
             {
                 return instance;
             }
@@ -1078,7 +1078,7 @@ namespace Tizen.NUI
 
         public static Application NewApplication(string[] args, string stylesheet, NUIApplication.WindowMode windowMode, Rectangle positionSize)
         {
-            if (instance)
+            if (instance != null)
             {
                 return instance;
             }
@@ -1092,7 +1092,7 @@ namespace Tizen.NUI
 
         public static Application NewApplication(string stylesheet, NUIApplication.WindowMode windowMode, WindowType type)
         {
-            if (instance)
+            if (instance != null)
             {
                 return instance;
             }
@@ -1303,7 +1303,7 @@ namespace Tizen.NUI
             {
                 Window currWin = Registry.GetManagedBaseHandleFromNativePtr(Interop.Application.GetWindowsFromList(i)) as Window;
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                if (currWin)
+                if (currWin != null)
                 {
                     WindowList.Add(currWin);
                 }

--- a/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
@@ -603,7 +603,7 @@ namespace Tizen.NUI
         {
             View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
 
-            if (view)
+            if (view != null)
             {
                 OnChildAdd(view);
             }
@@ -613,7 +613,7 @@ namespace Tizen.NUI
         {
             View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
 
-            if (view)
+            if (view != null)
             {
                 OnChildRemove(view);
             }
@@ -657,7 +657,7 @@ namespace Tizen.NUI
         private float SwigDirectorCalculateChildSize(global::System.IntPtr child, int dimension)
         {
             View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
+            if (view != null)
             {
                 return CalculateChildSize(view, (DimensionType)dimension);
             }
@@ -702,7 +702,7 @@ namespace Tizen.NUI
         private void SwigDirectorOnStyleChange(global::System.IntPtr styleManager, int change)
         {
             StyleManager stManager = Registry.GetManagedBaseHandleFromNativePtr(styleManager) as StyleManager;
-            if (stManager)
+            if (stManager != null)
             {
                 OnStyleChange(stManager, (StyleChangeType)change);
             }

--- a/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
@@ -363,7 +363,7 @@ namespace Tizen.NUI
         private void DirectorOnChildAdd(global::System.IntPtr child)
         {
             View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
+            if (view != null)
             {
                 OnChildAdd?.Invoke(view);
             }
@@ -372,7 +372,7 @@ namespace Tizen.NUI
         private void DirectorOnChildRemove(global::System.IntPtr child)
         {
             View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
+            if (view != null)
             {
                 OnChildRemove?.Invoke(view);
             }
@@ -431,7 +431,7 @@ namespace Tizen.NUI
         private float DirectorCalculateChildSize(global::System.IntPtr child, int dimension)
         {
             View view = Registry.GetManagedBaseHandleFromNativePtr(child) as View;
-            if (view)
+            if (view != null)
             {
                 return CalculateChildSize?.Invoke(view, (DimensionType)dimension) ?? 0.0f;
             }

--- a/src/Tizen.NUI/src/internal/FrameBroker/DefaultFrameBroker.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/DefaultFrameBroker.cs
@@ -88,7 +88,7 @@ namespace Tizen.NUI
                     providerImage.PivotPoint = transition.DefaultImageStyle.PivotPoint;
                     providerImage.PositionUsesPivotPoint = true;
                     providerImage.AddRenderer(GetRenderer(frame));
-                    if (mainView)
+                    if (mainView != null)
                     {
                         mainView.Add(providerImage);
                         providerImage.LowerToBottom();

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -236,11 +236,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 4 </since_tizen>
         public override Container GetParent()
         {
-            if (InternalParent)
-            {
-                return this.InternalParent as Container;
-            }
-            return null;
+            return InternalParent as Container;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Input/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/Input/FocusManager.cs
@@ -522,7 +522,7 @@ namespace Tizen.NUI
             }
             else
             {
-                if (e.ProposedView) return proposed;
+                if (e.ProposedView != null) return proposed;
                 else return current;
             }
         }

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -449,7 +449,7 @@ namespace Tizen.NUI
 
                     View owner = Owner;
 
-                    if (owner)
+                    if (owner != null)
                     {
                         // Margin and Padding only supported when child anchor point is TOP_LEFT.
                         if (owner.PivotPoint == PivotPoint.TopLeft || (owner.PositionUsesPivotPoint == false))


### PR DESCRIPTION
Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
