### PR TITLE
[NUI] Make Text selection APIs public

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1324,8 +1324,11 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// The Selected Text property (read-only).
+        /// The portion of the text that has been selected by the user.
         /// </summary>
+        /// <remarks>
+        /// Empty string when nothing is selected.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public string SelectedText
         {
@@ -1378,6 +1381,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The start index for selection.
         /// </summary>
+        /// <remarks>
+        /// When there is no selection, the index is current cursor position.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public int SelectedTextStart
         {
@@ -1392,6 +1398,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The end index for selection.
         /// </summary>
+        /// <remarks>
+        /// When there is no selection, the index is current cursor position.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public int SelectedTextEnd
         {
@@ -1978,10 +1987,13 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// Select text from start to end index. <br />
-        /// The index is valid when 0 or positive. <br />
+        /// The index is valid when 0 or positive.
         /// </summary>
         /// <param name="start">The start index for selection.</param>
         /// <param name="end">The end index for selection.</param>
+        /// <remarks>
+        /// If the end index exceeds the maximum value, it is set to the length of the text.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public void SelectText(int start, int end)
         {
@@ -1995,7 +2007,8 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Clear selection of the text.
+        /// Clear selection of the text. <br />
+        /// Valid when selection is activate.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public void SelectNone()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1326,7 +1326,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The Selected Text property (read-only).
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public string SelectedText
         {
             get
@@ -1378,9 +1378,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The start index for selection.
         /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done, Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public int SelectedTextStart
         {
             get
@@ -1394,9 +1392,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The end index for selection.
         /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done, Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public int SelectedTextEnd
         {
             get
@@ -1973,7 +1969,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Select the whole text.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public void SelectWholeText()
         {
             Interop.TextEditor.SelectWholeText(SwigCPtr);
@@ -1986,7 +1982,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="start">The start index for selection.</param>
         /// <param name="end">The end index for selection.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public void SelectText(int start, int end)
         {
             if (start < 0)
@@ -2001,7 +1997,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Clear selection of the text.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public void SelectNone()
         {
             _ = Interop.TextEditor.SelectNone(SwigCPtr);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1576,9 +1576,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The Selected Text property.
         /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done, Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public string SelectedText
         {
             get
@@ -1592,9 +1590,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The start index for selection.
         /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done, Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public int SelectedTextStart
         {
             get
@@ -1608,9 +1604,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The end index for selection.
         /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done, Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public int SelectedTextEnd
         {
             get
@@ -2059,9 +2053,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Select the whole text.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        /// This will be released at Tizen.NET API Level 5.5, so currently this would be used as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public void SelectWholeText()
         {
             Interop.TextField.SelectWholeText(SwigCPtr);
@@ -2074,7 +2066,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="start">The start index for selection.</param>
         /// <param name="end">The end index for selection.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public void SelectText(int start, int end)
         {
             if (start < 0)
@@ -2089,9 +2081,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Clear selection of the text.
         /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        /// This will be public opened in tizen_6.0 after ACR done, Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public void SelectNone()
         {
             _ = Interop.TextField.SelectNone(SwigCPtr);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1574,8 +1574,11 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// The Selected Text property.
+        /// The portion of the text that has been selected by the user.
         /// </summary>
+        /// <remarks>
+        /// Empty string when nothing is selected.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public string SelectedText
         {
@@ -1590,6 +1593,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The start index for selection.
         /// </summary>
+        /// <remarks>
+        /// When there is no selection, the index is current cursor position.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public int SelectedTextStart
         {
@@ -1604,6 +1610,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The end index for selection.
         /// </summary>
+        /// <remarks>
+        /// When there is no selection, the index is current cursor position.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public int SelectedTextEnd
         {
@@ -2062,10 +2071,13 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// Select text from start to end index. <br />
-        /// The index is valid when 0 or positive. <br />
+        /// The index is valid when 0 or positive.
         /// </summary>
         /// <param name="start">The start index for selection.</param>
         /// <param name="end">The end index for selection.</param>
+        /// <remarks>
+        /// If the end index exceeds the maximum value, it is set to the length of the text.
+        /// </remarks>
         /// <since_tizen> 9 </since_tizen>
         public void SelectText(int start, int end)
         {
@@ -2079,7 +2091,8 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Clear selection of the text.
+        /// Clear selection of the text. <br />
+        /// Valid when selection is activate.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public void SelectNone()


### PR DESCRIPTION
Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: https://code.sec.samsung.net/jira/browse/TCSACR-461

- src/Tizen.NUI/src/public/BaseComponents/TextField.cs
  - string SelectedText {get;}
  - int SelectedTextStart {get;}
  - int SelectedTextEnd {get;}
  - void SelectWholeText()
  - void SelectText(int start, int end)
  - void SelectNone()

- src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
  - string SelectedText {get;}
  - int SelectedTextStart {get;}
  - int SelectedTextEnd {get;}
  - void SelectWholeText()
  - void SelectText(int start, int end)
  - void SelectNone()