### PR TITLE
[NUI] VectorGraphics.Shape: Temporary add enums

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Shape.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/Shape.cs
@@ -46,6 +46,65 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         }
 
         /// <summary>
+        /// Enumeration for The fill rule of shape.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("please use VectorGraphics.FillRuleType")]
+        public enum FillRuleType
+        {
+            /// <summary>
+            /// Draw a horizontal line from the point to a location outside the shape. Determine whether the direction of the line at each intersection point is up or down. The winding number is determined by summing the direction of each intersection. If the number is non zero, the point is inside the shape.
+            /// </summary>
+            Winding = 0,
+            /// <summary>
+            /// Draw a horizontal line from the point to a location outside the shape, and count the number of intersections. If the number of intersections is an odd number, the point is inside the shape.
+            /// </summary>
+            EvenOdd
+        }
+
+        /// <summary>
+        /// Enumeration for The cap style to be used for stroking the path.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("please use VectorGraphics.StrokeCapType")]
+        public enum StrokeCapType
+        {
+            /// <summary>
+            /// The end of lines is rendered as a square around the last point.
+            /// </summary>
+            Square = 0,
+            /// <summary>
+            /// The end of lines is rendered as a half-circle around the last point.
+            /// </summary>
+            Round,
+            /// <summary>
+            /// The end of lines is rendered as a full stop on the last point itself.
+            /// </summary>
+            Butt
+        }
+
+        /// <summary>
+        /// numeration for The join style to be used for stroking the path.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("please use VectorGraphics.StrokeJoinType")]
+        public enum StrokeJoinType
+        {
+            /// <summary>
+            /// Used to render beveled line joins. The outer corner of the joined lines is filled by enclosing the triangular region of the corner with a straight line between the outer corners of each stroke.
+            /// </summary>
+            Bevel = 0,
+            /// <summary>
+            /// Used to render rounded line joins. Circular arcs are used to join two lines smoothly.
+            /// </summary>
+            Round,
+            /// <summary>
+            /// Used to render mitered line joins. The intersection of the strokes is clipped at a line perpendicular to the bisector of the angle between the strokes, at the distance from the intersection of the segments equal to the product of the miter limit value and the border radius.  This prevents long spikes being created.
+            /// </summary>
+            Miter
+        }
+
+        /// <summary>
         /// The color to use for filling the path.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSample.cs
@@ -93,7 +93,7 @@ namespace Tizen.NUI.Samples
             {
                 StrokeColor = new Color(0.0f, 0.5f, 0.0f, 0.5f),
                 StrokeWidth = 10.0f,
-                StrokeJoin = StrokeJoinType.Round,
+                StrokeJoin = Shape.StrokeJoinType.Round,
             };
             arcShape.AddArc(0.0f, 0.0f, 80.0f, 0.0f, 0.0f, true);
             arcShape.Translate(100.0f, 300.0f);
@@ -104,8 +104,8 @@ namespace Tizen.NUI.Samples
                 FillColor = new Color(0.0f, 0.5f, 0.0f, 0.5f),
                 StrokeColor = new Color(0.5f, 0.0f, 0.5f, 0.5f),
                 StrokeWidth = 30.0f,
-                FillRule = FillRuleType.EvenOdd,
-                StrokeJoin = StrokeJoinType.Round,
+                FillRule = Shape.FillRuleType.EvenOdd,
+                StrokeJoin = Shape.StrokeJoinType.Round,
             };
 
             shape.Scale(0.5f);
@@ -159,7 +159,7 @@ namespace Tizen.NUI.Samples
                 FillColor = new Color(0.0f, 1.0f, 1.0f, 1.0f),
                 StrokeColor = new Color(0.5f, 1.0f, 0.5f, 1.0f),
                 StrokeWidth = 30.0f,
-                StrokeCap = StrokeCapType.Round,
+                StrokeCap = Shape.StrokeCapType.Round,
                 FillGradient = starFillLinearGradient,
                 StrokeGradient = starStrokeLinearGradient,
             };


### PR DESCRIPTION
### Description of Change ###

TCT has not been passed yet. So we add a temporary enum for the current submit.
After verifying the TCT, this patch reverts.

TCT: https://review.tizen.org/gerrit/#/c/test/tct/csharp/api/+/263178/


<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: no

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
