### PR TITLE
[NUI] Fix MatchParent child position with LinearLayout Center Alignment

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -339,6 +339,14 @@ namespace Tizen.NUI
             float remainingWidth = widthSize - totalLength;
             float totalWeightLength = 0.0f;
 
+            // Up to now, only WrapContent children's sizes are added to the totalLength.
+            // Since the totalLength is used in OnLayout as the sum of all children's sizes,
+            // the layout size is assigned to the totalLength if MatchParent child exists.
+            if (childrenMatchParentCount > 0)
+            {
+                totalLength = widthSize;
+            }
+
             // 2ND PHASE:
             //
             // We measure all children whose width specification policy is MatchParent without weight.
@@ -571,6 +579,14 @@ namespace Tizen.NUI
 
             float remainingHeight = heightSize - totalLength;
             float totalWeightLength = 0.0f;
+
+            // Up to now, only WrapContent children's sizes are added to the totalLength.
+            // Since the totalLength is used in OnLayout as the sum of all children's sizes,
+            // the layout size is assigned to the totalLength if MatchParent child exists.
+            if (childrenMatchParentCount > 0)
+            {
+                totalLength = heightSize;
+            }
 
             // 2ND PHASE:
             //


### PR DESCRIPTION
Previously, LinearLayout calculated MatchParent children's positions
incorrectly when the LinearAlignment was Center.
Because the MatchParent children's sizes were not added to the sum of
all children's sizes.

Now, the MatchParent children's sizes are added to the sum of all
children's sizes and it leads that MatchParent children's positions are
calculated correctly when the LinearAlignment is Center.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
