### PR TITLE
[NUI] Add Horizontal/VerticalAlignment to LinearLayout

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using Tizen.NUI.BaseComponents;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,6 +27,8 @@ namespace Tizen.NUI
     /// </summary>
     public class LinearLayout : LayoutGroup
     {
+        private Alignment linearAlignment = Alignment.Top;
+
         /// <summary>
         /// [Draft] Enumeration for the direction in which the content is laid out
         /// </summary>
@@ -134,7 +137,63 @@ namespace Tizen.NUI
         /// [Draft] Get/Set the alignment in the layout
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
-        public LinearLayout.Alignment LinearAlignment { get; set; } = Alignment.Top;
+        public LinearLayout.Alignment LinearAlignment
+        {
+            get
+            {
+                return linearAlignment;
+            }
+
+            set
+            {
+                if (linearAlignment == value)
+                {
+                    return;
+                }
+
+                linearAlignment = value;
+
+                switch (linearAlignment)
+                {
+                    case Alignment.Begin:
+                        HorizontalAlignment = HorizontalAlignment.Begin;
+                        break;
+                    case Alignment.End:
+                        HorizontalAlignment = HorizontalAlignment.End;
+                        break;
+                    case Alignment.CenterHorizontal:
+                        HorizontalAlignment = HorizontalAlignment.Center;
+                        break;
+                    case Alignment.Top:
+                        VerticalAlignment = VerticalAlignment.Top;
+                        break;
+                    case Alignment.Bottom:
+                        VerticalAlignment = VerticalAlignment.Bottom;
+                        break;
+                    case Alignment.CenterVertical:
+                        VerticalAlignment = VerticalAlignment.Center;
+                        break;
+                    case Alignment.Center:
+                        HorizontalAlignment = HorizontalAlignment.Center;
+                        VerticalAlignment = VerticalAlignment.Center;
+                        break;
+                    default:
+                        break;
+                }
+            }
+         }
+
+        /// <summary>
+        /// Get/Set the horizontal alignment in the layout
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public HorizontalAlignment HorizontalAlignment { get; set; } = HorizontalAlignment.Begin;
+
+        /// <summary>
+        /// Get/Set the vertical alignment in the layout
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VerticalAlignment VerticalAlignment { get; set; } = VerticalAlignment.Top;
 
         private float totalLength = 0.0f;
         private Size2D cellPadding = new Size2D(0, 0);
@@ -725,9 +784,9 @@ namespace Tizen.NUI
             List<LayoutItem> LinearChildren = IterateLayoutChildren().ToList();
             int count = LinearChildren.Count;
 
-            switch (LinearAlignment)
+            switch (HorizontalAlignment)
             {
-                case Alignment.End:
+                case HorizontalAlignment.End:
                     // totalLength contains the padding already
                     // In case of RTL map END alignment to the left edge
                     if (isLayoutRtl)
@@ -739,12 +798,11 @@ namespace Tizen.NUI
                         childLeft = new LayoutLength(Padding.Start + right.AsDecimal() - left.AsDecimal() - totalLength);
                     }
                     break;
-                case Alignment.CenterHorizontal: // FALL THROUGH
-                case Alignment.Center:
+                case HorizontalAlignment.Center:
                     // totalLength contains the padding already
                     childLeft = new LayoutLength(Padding.Start + (right.AsDecimal() - left.AsDecimal() - totalLength) / 2.0f);
                     break;
-                case Alignment.Begin: // FALL THROUGH (default)
+                case HorizontalAlignment.Begin: // FALL THROUGH (default)
                 default:
                     // totalLength contains the padding already
                     // In case of RTL map BEGIN alignment to the right edge
@@ -779,16 +837,15 @@ namespace Tizen.NUI
                 LayoutLength childHeight = childLayout.MeasuredHeight.Size;
                 Extents childMargin = childLayout.Margin;
 
-                switch (LinearAlignment)
+                switch (VerticalAlignment)
                 {
-                    case Alignment.Bottom:
+                    case VerticalAlignment.Bottom:
                         childTop = new LayoutLength(height - Padding.Bottom - childHeight - childMargin.Bottom);
                         break;
-                    case Alignment.CenterVertical:
-                    case Alignment.Center: // FALLTHROUGH
+                    case VerticalAlignment.Center:
                         childTop = new LayoutLength(Padding.Top + ((childSpace - childHeight).AsDecimal() / 2.0f) + childMargin.Top - childMargin.Bottom);
                         break;
-                    case Alignment.Top: // FALLTHROUGH default
+                    case VerticalAlignment.Top: // FALLTHROUGH default
                     default:
                         childTop = new LayoutLength(Padding.Top + childMargin.Top);
                         break;
@@ -813,18 +870,17 @@ namespace Tizen.NUI
             List<LayoutItem> LinearChildren = IterateLayoutChildren().ToList();
             int count = LinearChildren.Count;
 
-            switch (LinearAlignment)
+            switch (VerticalAlignment)
             {
-                case Alignment.Bottom:
+                case VerticalAlignment.Bottom:
                     // totalLength contains the padding already
                     childTop = new LayoutLength(Padding.Top + bottom.AsDecimal() - top.AsDecimal() - totalLength);
                     break;
-                case Alignment.CenterVertical: // FALL THROUGH
-                case Alignment.Center:
+                case VerticalAlignment.Center:
                     // totalLength contains the padding already
                     childTop = new LayoutLength(Padding.Top + (bottom.AsDecimal() - top.AsDecimal() - totalLength) / 2.0f);
                     break;
-                case Alignment.Top:  // FALL THROUGH (default)
+                case VerticalAlignment.Top:  // FALL THROUGH (default)
                 default:
                     // totalLength contains the padding already
                     childTop = new LayoutLength(Padding.Top);
@@ -840,21 +896,20 @@ namespace Tizen.NUI
                 Extents childMargin = childLayout.Margin;
 
                 childTop += childMargin.Top;
-                switch (LinearAlignment)
+                switch (HorizontalAlignment)
                 {
-                    case Alignment.Begin:
+                    case HorizontalAlignment.Begin:
                     default:
                         {
                             childLeft = new LayoutLength(Padding.Start + childMargin.Start);
                             break;
                         }
-                    case Alignment.End:
+                    case HorizontalAlignment.End:
                         {
                             childLeft = new LayoutLength(width - Padding.End - childWidth - childMargin.End);
                             break;
                         }
-                    case Alignment.CenterHorizontal:
-                    case Alignment.Center: // FALL THROUGH
+                    case HorizontalAlignment.Center:
                         {
                             childLeft = new LayoutLength(Padding.Start + ((childSpace - childWidth).AsDecimal() / 2.0f) + childMargin.Start - childMargin.End);
                             break;

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -55,46 +55,46 @@ namespace Tizen.NUI
     }
 
     /// <summary>
-    /// Enumeration for the text horizontal aligning.
+    /// Enumeration for the horizontal alignment of objects such as texts and layout items.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     public enum HorizontalAlignment
     {
         /// <summary>
-        /// Texts place at the begin of horizontal direction.
+        /// Objects are placed at the beginning of the horizontal direction.
         /// </summary>
         [Description("BEGIN")]
         Begin,
         /// <summary>
-        /// Texts place at the center of horizontal direction.
+        /// Objects are placed at the center of the horizontal direction.
         /// </summary>
         [Description("CENTER")]
         Center,
         /// <summary>
-        /// Texts place at the end of horizontal direction.
+        /// Objects are placed at the end of the horizontal direction.
         /// </summary>
         [Description("END")]
         End
     }
 
     /// <summary>
-    /// Enumeration for the text horizontal aligning.
+    /// Enumeration for the vertical alignment of objects such as texts and layout items.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     public enum VerticalAlignment
     {
         /// <summary>
-        /// Texts place at the top of vertical direction.
+        /// Objects are placed at the top of the vertical direction.
         /// </summary>
         [Description("TOP")]
         Top,
         /// <summary>
-        /// Texts place at the center of vertical direction.
+        /// Objects are placed at the center of the vertical direction.
         /// </summary>
         [Description("CENTER")]
         Center,
         /// <summary>
-        /// Texts place at the bottom of vertical direction.
+        /// Objects are placed at the bottom of the vertical direction.
         /// </summary>
         [Description("BOTTOM")]
         Bottom


### PR DESCRIPTION
Previously, LinearAlignment of LinearLayout could not support the
combination of horizontal and vertical alignments.
e.g. could not support CenterHorizontal with Bottom

Now, HorizontalAlignment and VerticalAlignment have been added to
support the combination of horizontal and vertical alignments.

To use the enum types Tizen.NUI.Horizontal/VerticalAlignment for
LinearLayout.Horizontal/VerticalAlignment, the documentation of
Tizen.NUI.Horizontal/VerticalAlignment has been updated.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
