### PR TITLE
[Sensor] Add orientation sensor type

### DIFF
--- a/src/Tizen.Sensor/Tizen.Sensor/SensorEnumerations.cs
+++ b/src/Tizen.Sensor/Tizen.Sensor/SensorEnumerations.cs
@@ -100,6 +100,14 @@ namespace Tizen.Sensor
         /// </summary>
         MagnetometerRotationVectorSensor = 20,
         /// <summary>
+        /// The Gyroscope-based orientation sensor.
+        /// </summary>
+        GyroscopeOrientationSensor = 100,
+        /// <summary>
+        /// Geomagnetic-based orientation sensor.
+        /// </summary>
+        MagnetometerOrientationSensor = 105,
+        /// <summary>
         /// Pedometer sensor.
         /// </summary>
         HRMBatch = 0x200,


### PR DESCRIPTION
- SENSOR_GYROSCOPE_ORIENTATION : based on gyroscope_rotation_vector
- SENSOR_GEOMAGNETIC_ORIENTATION : based on geomagnetic_rotration_vector

### Description of Change ###
To use 6-Axis orientation, add new sensor types.