### PR TITLE
[NUI] Add brokenImageUrl

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
@@ -51,6 +51,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_SetBrokenImageUrl")]
+            public static extern void SetBrokenImageUrl(global::System.Runtime.InteropServices.HandleRef jarg1,uint jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetBrokenImageUrl")]
+            public static extern string GetBrokenImageUrl(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -175,6 +175,43 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// The Type of BrokenImage
+        /// </summary>
+        internal enum BrokenImageType
+        {
+            Small = 0,
+            Normal = 1,
+            Large = 2
+        }
+
+        /// <summary>
+        /// Sets the broken image url.
+        /// The broken image is the image to show when image loading is failed.
+        /// When the broken image and type are set in the Application,
+        /// the proper brokenImage is set automatically considering the size of view and the size of the brokenImage.
+        /// This Api is used from theme manager.
+        /// </summary>
+        /// <param name="type"> The type for brokenImage </param>
+        /// <param name="url"> The url for brokenImage </param>
+        internal void SetBrokenImageUrl(BrokenImageType type, string url)
+        {
+            Interop.StyleManager.SetBrokenImageUrl(SwigCPtr, (uint)type, url);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Gets the broken image url
+        /// </summary>
+        /// <param name="type"> The type for brokenImage</param>
+        /// <returns> the url for brokenImage </returns>
+        internal string GetBrokenImageUrl(BrokenImageType type)
+        {
+            string ret = Interop.StyleManager.GetBrokenImageUrl(SwigCPtr, (uint)type);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         internal StyleManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Theme/Theme.cs
+++ b/src/Tizen.NUI/src/public/Theme/Theme.cs
@@ -108,6 +108,24 @@ namespace Tizen.NUI
         public string Version { get; set; } = null;
 
         /// <summary>
+        /// The url of small broken image
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string SmallBrokenImageUrl { get; set; } = null;
+
+        /// <summary>
+        /// The url of broken image
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string BrokenImageUrl { get; set; } = null;
+
+        /// <summary>
+        /// The url of large broken image
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string LargeBrokenImageUrl { get; set; } = null;
+
+        /// <summary>
         /// For Xaml use only.
         /// The bulit-in theme id that will be used as base of this.
         /// View styles with same key are merged.
@@ -289,7 +307,10 @@ namespace Tizen.NUI
             var result = new Theme()
             {
                 Id = this.Id,
-                Resources = Resources
+                Resources = Resources,
+                SmallBrokenImageUrl = this.SmallBrokenImageUrl,
+                BrokenImageUrl = this.BrokenImageUrl,
+                LargeBrokenImageUrl = this.LargeBrokenImageUrl
             };
 
             foreach (var item in this)
@@ -322,6 +343,12 @@ namespace Tizen.NUI
 
             if (Version == null) Version = theme.Version;
 
+            SmallBrokenImageUrl = theme.SmallBrokenImageUrl;
+
+            BrokenImageUrl = theme.BrokenImageUrl;
+
+            LargeBrokenImageUrl = theme.LargeBrokenImageUrl;
+
             foreach (var item in theme)
             {
                 if (item.Value == null)
@@ -353,6 +380,13 @@ namespace Tizen.NUI
             {
                 Version = theme.Version;
             }
+
+            SmallBrokenImageUrl = theme.SmallBrokenImageUrl;
+
+            BrokenImageUrl = theme.BrokenImageUrl;
+
+            LargeBrokenImageUrl = theme.LargeBrokenImageUrl;
+
 
             foreach (var item in theme)
             {

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -161,6 +161,10 @@ namespace Tizen.NUI
                 newTheme.Id = "NONAME";
             }
 
+            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Small, newTheme.SmallBrokenImageUrl ?? "");
+            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Normal, newTheme.BrokenImageUrl ?? "");
+            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Large, newTheme.LargeBrokenImageUrl ?? "");
+
             userTheme = newTheme;
             UpdateThemeForInitialize();
             UpdateThemeForUpdate();


### PR DESCRIPTION
Add brokenImageUrl for setting broken image
users can use three Types BrokenImage from ThemeManger
the broken images are automatically changed internally considering the size of broken image and view.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
