### PR TITLE
[NUI] Delete dispose() in GetOriginalImageSize

### DIFF
--- a/src/Tizen.NUI/src/internal/images/ImageLoading.cs
+++ b/src/Tizen.NUI/src/internal/images/ImageLoading.cs
@@ -517,7 +517,6 @@ namespace Tizen.NUI
         {
             var val = new Uint16Pair(Interop.ImageLoading.GetOriginalImageSize(filename, orientationCorrection), true);
             Size2D ret = new Size2D(val.GetWidth(), val.GetHeight());
-            val.Dispose();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
Some applications call this function outside the main thread and this is a problem.
so i delete it temporary

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
