### PR TITLE
[NUI] Fix ImageLayout to add children layouts

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1517,7 +1517,7 @@ namespace Tizen.NUI.BaseComponents
             PixelArea = new RelativeVector4(x, y, z, w);
         }
 
-        private class ImageLayout : LayoutItem
+        private class ImageLayout : LayoutGroup
         {
             /// <summary>
             /// Gets or sets the mode to adjust view size to preserve the aspect ratio of the image resource.
@@ -1602,6 +1602,18 @@ namespace Tizen.NUI.BaseComponents
                 if (heightSpecChanged)
                 {
                     heightMeasureSpec = new MeasureSpecification(new LayoutLength(newHeight), MeasureSpecification.ModeType.Exactly);
+                }
+
+                foreach (var childLayout in LayoutChildren)
+                {
+                    if (!childLayout.SetPositionByLayout)
+                    {
+                        continue;
+                    }
+
+                    // Measure children like AbsoluteLayout does.
+                    // Use the ImageLayout's calculated widthMeasureSpec and heightMeasureSpec for measuring children.
+                    MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
                 }
 
                 MeasuredSize.StateType childWidthState = MeasuredSize.StateType.MeasuredSizeOK;


### PR DESCRIPTION
Previously, ImageLayout inherited from LayoutItem so it could not add
children layouts.

Now, ImageLayout inherits from LayoutGroup so it can add children
layouts.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
