### PR TITLE
[NUI] fix Item measure specification to be largable as much as they need

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/ItemsLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/ItemsLayouter.cs
@@ -332,15 +332,15 @@ namespace Tizen.NUI.Components
             if (child.Layout == null) return;
 
             //FIXME: This measure can be restricted size of child to be less than parent size.
-            // but in some multiple-line TextLabel can be long enough to over the it's parent size.
-
+            // but our parent can be not calculated yet, also some child can be bigger than it's parent size,
+            // so we use implicit value 9999 as restricted specification.
             MeasureSpecification childWidthMeasureSpec = LayoutGroup.GetChildMeasureSpecification(
-                        new MeasureSpecification(new LayoutLength(parent.Size.Width - parent.Padding.Start - parent.Padding.End - child.Margin.Start - child.Margin.End), MeasureSpecification.ModeType.Exactly),
+                        new MeasureSpecification(new LayoutLength(9999), MeasureSpecification.ModeType.Exactly),
                         new LayoutLength(0),
                         new LayoutLength(child.WidthSpecification));
 
             MeasureSpecification childHeightMeasureSpec = LayoutGroup.GetChildMeasureSpecification(
-                        new MeasureSpecification(new LayoutLength(parent.Size.Height - parent.Padding.Top - parent.Padding.Bottom - child.Margin.Top - child.Margin.Bottom), MeasureSpecification.ModeType.Exactly),
+                        new MeasureSpecification(new LayoutLength(9999), MeasureSpecification.ModeType.Exactly),
                         new LayoutLength(0),
                         new LayoutLength(child.HeightSpecification));
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
