### PR TITLE
[NUI] fix crash with double enter in TextEditor with TextLabel

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -203,10 +203,16 @@ namespace Tizen.NUI
         /// <since_tizen> 6 </since_tizen>
         public void Measure(MeasureSpecification widthMeasureSpec, MeasureSpecification heightMeasureSpec)
         {
-            OnMeasure(widthMeasureSpec, heightMeasureSpec);
-            OnMeasureIndependentChildren(widthMeasureSpec, heightMeasureSpec);
-            flags = flags | LayoutFlags.LayoutRequired;
-            flags &= ~LayoutFlags.ForceLayout;
+            bool needsLayout = NeedsLayout(widthMeasureSpec.Size.AsDecimal(), heightMeasureSpec.Size.AsDecimal(), widthMeasureSpec.Mode, heightMeasureSpec.Mode);
+
+            needsLayout = needsLayout || ((flags & LayoutFlags.ForceLayout) == LayoutFlags.ForceLayout);
+            if (needsLayout)
+            {
+                OnMeasure(widthMeasureSpec, heightMeasureSpec);
+                OnMeasureIndependentChildren(widthMeasureSpec, heightMeasureSpec);
+                flags = flags | LayoutFlags.LayoutRequired;
+                flags &= ~LayoutFlags.ForceLayout;
+            }
 
             oldWidthMeasureSpec = widthMeasureSpec;
             oldHeightMeasureSpec = heightMeasureSpec;

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -205,17 +205,15 @@ namespace Tizen.NUI
         {
             bool needsLayout = NeedsLayout(widthMeasureSpec.Size.AsDecimal(), heightMeasureSpec.Size.AsDecimal(), widthMeasureSpec.Mode, heightMeasureSpec.Mode);
 
-            needsLayout = needsLayout || ((flags & LayoutFlags.ForceLayout) == LayoutFlags.ForceLayout);
             if (needsLayout)
             {
                 OnMeasure(widthMeasureSpec, heightMeasureSpec);
                 OnMeasureIndependentChildren(widthMeasureSpec, heightMeasureSpec);
                 flags = flags | LayoutFlags.LayoutRequired;
                 flags &= ~LayoutFlags.ForceLayout;
+                oldWidthMeasureSpec = widthMeasureSpec;
+                oldHeightMeasureSpec = heightMeasureSpec;
             }
-
-            oldWidthMeasureSpec = widthMeasureSpec;
-            oldHeightMeasureSpec = heightMeasureSpec;
         }
 
         internal bool NeedsLayout(float widthSize, float heightSize, MeasureSpecification.ModeType widthMode, MeasureSpecification.ModeType heightMode)


### PR DESCRIPTION
### Description of Change ###
after optimizing layout in this pull request : https://github.com/Samsung/TizenFX/pull/2841
a crash started to appear when entering double enter in TextEditor while its TextChanged event set text to a TextLabel, and these controls are inside parent with layout (example View with LinearLayout).
the crash happens because an extra calls to OnMeasure (compared to before the above optimization pull request), which seems to call GetNaturalSize which is not stable, and in this case it cause a crash.
these extra calls happens because we have moved the condition that check if layout is needed to the LayoutController, and the Measure function in LayoutItem does not check if layout is needed anymore.
so If Measure function of LayoutItem is called from anywhere other than the LayoutController (in this case MeasureChildWithMargins function from inside LayoutGroup is calling it), the code inside it will be executed regardless the layout is needed or not.

so if my above assumption is correct, we can add a condition to check if layout needed in Measure function to make sure we only call its code when needed from all code paths (this pull request do this).
or search for every place that call Measure function and add this condition.

example code : https://github.com/wonrst/NUI-Test/blob/main/text-handle-pos/handle.cs 

please let me know what do you think ? 