### PR TITLE
Revert "[NUI] Roll back to fix build error of TCT code"

### DIFF
--- a/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
@@ -189,18 +189,6 @@ namespace Tizen.NUI.Xaml
             }
         }
 
-        [Obsolete("Use the XamlFileProvider to provide xaml files. We will remove this when Cycle 8 hits Stable.")]
-        public static object Create(string xaml, bool doNotThrow = false)
-        {
-            object inflatedView = null;
-            using (var textreader = new StringReader(xaml))
-            using (var reader = XmlReader.Create(textreader))
-            {
-                inflatedView = Create(reader, doNotThrow);
-            }
-            return inflatedView;
-        }
-
         public static object Create(XmlReader reader, bool doNotThrow = false)
         {
             object inflatedView = null;

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObjectExtensions.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObjectExtensions.cs
@@ -38,22 +38,5 @@ namespace Tizen.NUI.Binding
             var binding = new Binding(path, mode, converter, stringFormat: stringFormat);
             self.SetBinding(targetProperty, binding);
         }
-
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [ObsoleteAttribute(" ", false)]
-        public static void SetBinding<TSource>(this BindableObject self, BindableProperty targetProperty, Expression<Func<TSource, object>> sourceProperty, BindingMode mode = BindingMode.Default,
-                                               IValueConverter converter = null, string stringFormat = null)
-        {
-            if (self == null)
-                throw new ArgumentNullException(nameof(self));
-            if (targetProperty == null)
-                throw new ArgumentNullException(nameof(targetProperty));
-            if (sourceProperty == null)
-                throw new ArgumentNullException(nameof(sourceProperty));
-
-            Binding binding = Binding.Create(sourceProperty, mode, converter, stringFormat: stringFormat);
-            self.SetBinding(targetProperty, binding);
-        }
     }
 }

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableProperty.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableProperty.cs
@@ -319,29 +319,6 @@ namespace Tizen.NUI.Binding
         internal ValidateValueDelegate ValidateValue { get; private set; }
 
         /// <summary>
-        /// Deprecated. Do not use.
-        /// </summary>
-        /// <typeparam name="TDeclarer">The type of the declaring object.</typeparam>
-        /// <typeparam name="TPropertyType">The type of the property.</typeparam>
-        /// <param name="getter">An expression identifying the getter for the property using this BindableProperty as backing store.</param>
-        /// <param name="defaultValue">The default value for the property.</param>
-        /// <param name="defaultBindingMode">The BindingMode to use on SetBinding() if no BindingMode is given. This parameter is optional. Default is BindingMode.OneWay.</param>
-        /// <param name="validateValue">A delegate to be run when a value is set. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanged">A delegate to be run when the value has changed. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
-        /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
-        /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
-        /// <returns>A newly created BindableProperty.</returns>
-        [Obsolete("Create<> (generic) is obsolete as of version 2.1.0 and is no longer supported.")]
-        public static BindableProperty Create<TDeclarer, TPropertyType>(Expression<Func<TDeclarer, TPropertyType>> getter, TPropertyType defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
-                                                                        ValidateValueDelegate<TPropertyType> validateValue = null, BindingPropertyChangedDelegate<TPropertyType> propertyChanged = null,
-                                                                        BindingPropertyChangingDelegate<TPropertyType> propertyChanging = null, CoerceValueDelegate<TPropertyType> coerceValue = null,
-                                                                        CreateDefaultValueDelegate<TDeclarer, TPropertyType> defaultValueCreator = null) where TDeclarer : BindableObject
-        {
-            return Create(getter, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, defaultValueCreator: defaultValueCreator);
-        }
-
-        /// <summary>
         /// Creates a new instance of the BindableProperty class.
         /// </summary>
         /// <param name="propertyName">The name of the BindableProperty.</param>
@@ -364,29 +341,6 @@ namespace Tizen.NUI.Binding
         }
 
         /// <summary>
-        /// Deprecated. Do not use.
-        /// </summary>
-        /// <typeparam name="TDeclarer">The type of the declaring object.</typeparam>
-        /// <typeparam name="TPropertyType">The type of the property.</typeparam>
-        /// <param name="staticgetter">An expression identifying a static method returning the value of the property using this BindableProperty as backing store.</param>
-        /// <param name="defaultValue">The default value for the property.</param>
-        /// <param name="defaultBindingMode">The BindingMode to use on SetBinding() if no BindingMode is given. This parameter is optional. Default is BindingMode.OneWay.</param>
-        /// <param name="validateValue">A delegate to be run when a value is set. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanged">A delegate to be run when the value has changed. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
-        /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
-        /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
-        [Obsolete("CreateAttached<> (generic) is obsolete as of version 2.1.0 and is no longer supported.")]
-        public static BindableProperty CreateAttached<TDeclarer, TPropertyType>(Expression<Func<BindableObject, TPropertyType>> staticgetter, TPropertyType defaultValue,
-                                                                                BindingMode defaultBindingMode = BindingMode.OneWay, ValidateValueDelegate<TPropertyType> validateValue = null, BindingPropertyChangedDelegate<TPropertyType> propertyChanged = null,
-                                                                                BindingPropertyChangingDelegate<TPropertyType> propertyChanging = null, CoerceValueDelegate<TPropertyType> coerceValue = null,
-                                                                                CreateDefaultValueDelegate<BindableObject, TPropertyType> defaultValueCreator = null)
-        {
-            return CreateAttached<TDeclarer, TPropertyType>(staticgetter, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null,
-                defaultValueCreator: defaultValueCreator);
-        }
-
-        /// <summary>
         /// Creates a new instance of the BindableProperty class for an attached property.
         /// </summary>
         /// <param name="propertyName">The name of the BindableProperty.</param>
@@ -405,32 +359,6 @@ namespace Tizen.NUI.Binding
                                                       CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null)
         {
             return CreateAttached(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, false, defaultValueCreator);
-        }
-
-        /// <summary>
-        /// Deprecated. Do not use.
-        /// </summary>
-        /// <typeparam name="TDeclarer">The type of the declaring object.</typeparam>
-        /// <typeparam name="TPropertyType">The type of the property.</typeparam>
-        /// <param name="staticgetter">An expression identifying a static method returning the value of the property using this BindableProperty as backing store.</param>
-        /// <param name="defaultValue">The default value for the property.</param>
-        /// <param name="defaultBindingMode">The BindingMode to use on SetBinding() if no BindingMode is given. This parameter is optional. Default is BindingMode.OneWay.</param>
-        /// <param name="validateValue">A delegate to be run when a value is set. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanged">A delegate to be run when the value has changed. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
-        /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
-        /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
-        /// <returns>A newly created attached read-only BindablePropertyKey.</returns>
-        [Obsolete("CreateAttachedReadOnly<> (generic) is obsolete as of version 2.1.0 and is no longer supported.")]
-        public static BindablePropertyKey CreateAttachedReadOnly<TDeclarer, TPropertyType>(Expression<Func<BindableObject, TPropertyType>> staticgetter, TPropertyType defaultValue,
-                                                                                           BindingMode defaultBindingMode = BindingMode.OneWayToSource, ValidateValueDelegate<TPropertyType> validateValue = null,
-                                                                                           BindingPropertyChangedDelegate<TPropertyType> propertyChanged = null, BindingPropertyChangingDelegate<TPropertyType> propertyChanging = null,
-                                                                                           CoerceValueDelegate<TPropertyType> coerceValue = null, CreateDefaultValueDelegate<BindableObject, TPropertyType> defaultValueCreator = null)
-
-        {
-            return
-                new BindablePropertyKey(CreateAttached<TDeclarer, TPropertyType>(staticgetter, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, true,
-                    defaultValueCreator));
         }
 
         /// <summary>
@@ -457,29 +385,6 @@ namespace Tizen.NUI.Binding
         }
 
         /// <summary>
-        /// Deprecated. Do not use.
-        /// </summary>
-        /// <typeparam name="TDeclarer">The type of the declaring object.</typeparam>
-        /// <typeparam name="TPropertyType">The type of the property.</typeparam>
-        /// <param name="getter">An expression identifying the getter for the property using this BindableProperty as backing store.</param>
-        /// <param name="defaultValue">The default value for the property.</param>
-        /// <param name="defaultBindingMode">The BindingMode to use on SetBinding() if no BindingMode is given. This parameter is optional. Default is BindingMode.OneWay.</param>
-        /// <param name="validateValue">A delegate to be run when a value is set. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanged">A delegate to be run when the value has changed. This parameter is optional. Default is null.</param>
-        /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
-        /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
-        /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
-        /// <returns>A newly created BindablePropertyKey.</returns>
-        [Obsolete("CreateReadOnly<> (generic) is obsolete as of version 2.1.0 and is no longer supported.")]
-        public static BindablePropertyKey CreateReadOnly<TDeclarer, TPropertyType>(Expression<Func<TDeclarer, TPropertyType>> getter, TPropertyType defaultValue,
-                                                                                   BindingMode defaultBindingMode = BindingMode.OneWayToSource, ValidateValueDelegate<TPropertyType> validateValue = null,
-                                                                                   BindingPropertyChangedDelegate<TPropertyType> propertyChanged = null, BindingPropertyChangingDelegate<TPropertyType> propertyChanging = null,
-                                                                                   CoerceValueDelegate<TPropertyType> coerceValue = null, CreateDefaultValueDelegate<TDeclarer, TPropertyType> defaultValueCreator = null) where TDeclarer : BindableObject
-        {
-            return new BindablePropertyKey(Create(getter, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, true, defaultValueCreator));
-        }
-
-        /// <summary>
         /// Creates a new instance of the BindablePropertyKey class.
         /// </summary>
         /// <param name="propertyName">The name of the BindableProperty.</param>
@@ -501,99 +406,12 @@ namespace Tizen.NUI.Binding
                 new BindablePropertyKey(new BindableProperty(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue,
                     isReadOnly: true, defaultValueCreator: defaultValueCreator));
         }
-
-        [Obsolete("Create<> (generic) is obsolete as of version 2.1.0 and is no longer supported.")]
-        internal static BindableProperty Create<TDeclarer, TPropertyType>(Expression<Func<TDeclarer, TPropertyType>> getter, TPropertyType defaultValue, BindingMode defaultBindingMode,
-                                                                          ValidateValueDelegate<TPropertyType> validateValue, BindingPropertyChangedDelegate<TPropertyType> propertyChanged, BindingPropertyChangingDelegate<TPropertyType> propertyChanging,
-                                                                          CoerceValueDelegate<TPropertyType> coerceValue, BindablePropertyBindingChanging bindingChanging, bool isReadOnly = false,
-                                                                          CreateDefaultValueDelegate<TDeclarer, TPropertyType> defaultValueCreator = null) where TDeclarer : BindableObject
-        {
-            if (getter == null)
-                throw new ArgumentNullException(nameof(getter));
-
-            Expression expr = getter.Body;
-
-            var unary = expr as UnaryExpression;
-            if (unary != null)
-                expr = unary.Operand;
-
-            var member = expr as MemberExpression;
-            if (member == null)
-                throw new ArgumentException("getter must be a MemberExpression", nameof(getter));
-
-            var property = (PropertyInfo)member.Member;
-
-            ValidateValueDelegate untypedValidateValue = null;
-            BindingPropertyChangedDelegate untypedBindingPropertyChanged = null;
-            BindingPropertyChangingDelegate untypedBindingPropertyChanging = null;
-            CoerceValueDelegate untypedCoerceValue = null;
-            CreateDefaultValueDelegate untypedDefaultValueCreator = null;
-            if (validateValue != null)
-                untypedValidateValue = (bindable, value) => validateValue(bindable, (TPropertyType)value);
-            if (propertyChanged != null)
-                untypedBindingPropertyChanged = (bindable, oldValue, newValue) => propertyChanged(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
-            if (propertyChanging != null)
-                untypedBindingPropertyChanging = (bindable, oldValue, newValue) => propertyChanging(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
-            if (coerceValue != null)
-                untypedCoerceValue = (bindable, value) => coerceValue(bindable, (TPropertyType)value);
-            if (defaultValueCreator != null)
-                untypedDefaultValueCreator = o => defaultValueCreator((TDeclarer)o);
-
-            return new BindableProperty(property.Name, property.PropertyType, typeof(TDeclarer), defaultValue, defaultBindingMode, untypedValidateValue, untypedBindingPropertyChanged,
-                untypedBindingPropertyChanging, untypedCoerceValue, bindingChanging, isReadOnly, untypedDefaultValueCreator);
-        }
-
         internal static BindableProperty Create(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode, ValidateValueDelegate validateValue,
                                                 BindingPropertyChangedDelegate propertyChanged, BindingPropertyChangingDelegate propertyChanging, CoerceValueDelegate coerceValue, BindablePropertyBindingChanging bindingChanging,
                                                 CreateDefaultValueDelegate defaultValueCreator = null)
         {
             return new BindableProperty(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, bindingChanging,
                 defaultValueCreator: defaultValueCreator);
-        }
-
-        [Obsolete("CreateAttached<> (generic) is obsolete as of version 2.1.0 and is no longer supported.")]
-        internal static BindableProperty CreateAttached<TDeclarer, TPropertyType>(Expression<Func<BindableObject, TPropertyType>> staticgetter, TPropertyType defaultValue, BindingMode defaultBindingMode,
-                                                                                  ValidateValueDelegate<TPropertyType> validateValue, BindingPropertyChangedDelegate<TPropertyType> propertyChanged, BindingPropertyChangingDelegate<TPropertyType> propertyChanging,
-                                                                                  CoerceValueDelegate<TPropertyType> coerceValue, BindablePropertyBindingChanging bindingChanging, bool isReadOnly = false,
-                                                                                  CreateDefaultValueDelegate<BindableObject, TPropertyType> defaultValueCreator = null)
-        {
-            if (staticgetter == null)
-                throw new ArgumentNullException(nameof(staticgetter));
-
-            Expression expr = staticgetter.Body;
-
-            var unary = expr as UnaryExpression;
-            if (unary != null)
-                expr = unary.Operand;
-
-            var methodcall = expr as MethodCallExpression;
-            if (methodcall == null)
-                throw new ArgumentException("staticgetter must be a MethodCallExpression", nameof(staticgetter));
-
-            MethodInfo method = methodcall.Method;
-            if (!method.Name.StartsWith("Get", StringComparison.Ordinal))
-                throw new ArgumentException("staticgetter name must start with Get", nameof(staticgetter));
-
-            string propertyname = method.Name.Substring(3);
-
-            ValidateValueDelegate untypedValidateValue = null;
-            BindingPropertyChangedDelegate untypedBindingPropertyChanged = null;
-            BindingPropertyChangingDelegate untypedBindingPropertyChanging = null;
-            CoerceValueDelegate untypedCoerceValue = null;
-            CreateDefaultValueDelegate untypedDefaultValueCreator = null;
-            if (validateValue != null)
-                untypedValidateValue = (bindable, value) => validateValue(bindable, (TPropertyType)value);
-            if (propertyChanged != null)
-                untypedBindingPropertyChanged = (bindable, oldValue, newValue) => propertyChanged(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
-            if (propertyChanging != null)
-                untypedBindingPropertyChanging = (bindable, oldValue, newValue) => propertyChanging(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
-            if (coerceValue != null)
-                untypedCoerceValue = (bindable, value) => coerceValue(bindable, (TPropertyType)value);
-            if (defaultValueCreator != null)
-                untypedDefaultValueCreator = o => defaultValueCreator(o);
-
-            return new BindableProperty(propertyname, method.ReturnType, typeof(TDeclarer), defaultValue, defaultBindingMode, untypedValidateValue, untypedBindingPropertyChanged, untypedBindingPropertyChanging,
-                untypedCoerceValue, bindingChanging, isReadOnly, untypedDefaultValueCreator);
         }
 
         internal static BindableProperty CreateAttached(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode, ValidateValueDelegate validateValue,

--- a/src/Tizen.NUI/src/public/XamlBinding/Binding.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Binding.cs
@@ -133,18 +133,6 @@ namespace Tizen.NUI.Binding
             }
         }
 
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [ObsoleteAttribute(" ", false)]
-        public static Binding Create<TSource>(Expression<Func<TSource, object>> propertyGetter, BindingMode mode = BindingMode.Default, IValueConverter converter = null, object converterParameter = null,
-                                              string stringFormat = null)
-        {
-            if (propertyGetter == null)
-                throw new ArgumentNullException(nameof(propertyGetter));
-
-            return new Binding(GetBindingPath(propertyGetter), mode, converter, converterParameter, stringFormat);
-        }
-
         internal override void Apply(bool fromTarget)
         {
             base.Apply(fromTarget);
@@ -202,95 +190,6 @@ namespace Tizen.NUI.Binding
 
             if (expression != null)
                 expression.Unapply();
-        }
-
-        [Obsolete]
-        static string GetBindingPath<TSource>(Expression<Func<TSource, object>> propertyGetter)
-        {
-            Expression expr = propertyGetter.Body;
-
-            var unary = expr as UnaryExpression;
-            if (unary != null)
-                expr = unary.Operand;
-
-            var builder = new StringBuilder();
-
-            var indexed = false;
-
-            var member = expr as MemberExpression;
-            if (member == null)
-            {
-                var methodCall = expr as MethodCallExpression;
-                if (methodCall != null)
-                {
-                    if (methodCall.Arguments.Count == 0)
-                        throw new ArgumentException("Method calls are not allowed in binding expression");
-
-                    var arguments = new List<string>(methodCall.Arguments.Count);
-                    foreach (Expression arg in methodCall.Arguments)
-                    {
-                        if (arg.NodeType != ExpressionType.Constant)
-                            throw new ArgumentException("Only constants can be used as indexer arguments");
-
-                        object value = ((ConstantExpression)arg).Value;
-                        arguments.Add(value != null ? value.ToString() : "null");
-                    }
-
-                    Type declarerType = methodCall.Method.DeclaringType;
-                    DefaultMemberAttribute defaultMember = declarerType.GetTypeInfo().GetCustomAttributes(typeof(DefaultMemberAttribute), true).OfType<DefaultMemberAttribute>().FirstOrDefault();
-                    string indexerName = defaultMember != null ? defaultMember.MemberName : "Item";
-
-                    MethodInfo getterInfo =
-                        declarerType.GetProperties().Where(pi => (pi.GetMethod != null) && pi.Name == indexerName && pi.CanRead && pi.GetMethod.IsPublic && !pi.GetMethod.IsStatic).Select(pi => pi.GetMethod).FirstOrDefault();
-                    if (getterInfo != null)
-                    {
-                        if (getterInfo == methodCall.Method)
-                        {
-                            indexed = true;
-                            builder.Append("[");
-
-                            var first = true;
-                            foreach (string argument in arguments)
-                            {
-                                if (!first)
-                                    builder.Append(",");
-
-                                builder.Append(argument);
-                                first = false;
-                            }
-
-                            builder.Append("]");
-
-                            member = methodCall.Object as MemberExpression;
-                        }
-                        else
-                            throw new ArgumentException("Method calls are not allowed in binding expressions");
-                    }
-                    else
-                        throw new ArgumentException("Public indexer not found");
-                }
-                else
-                    throw new ArgumentException("Invalid expression type");
-            }
-
-            while (member != null)
-            {
-                var property = (PropertyInfo)member.Member;
-                if (builder.Length != 0)
-                {
-                    if (!indexed)
-                        builder.Insert(0, ".");
-                    else
-                        indexed = false;
-                }
-
-                builder.Insert(0, property.Name);
-
-                //				member = member.Expression as MemberExpression ?? (member.Expression as UnaryExpression)?.Operand as MemberExpression;
-                member = member.Expression as MemberExpression ?? (member.Expression is UnaryExpression ? (member.Expression as UnaryExpression).Operand as MemberExpression : null);
-            }
-
-            return builder.ToString();
         }
     }
 }


### PR DESCRIPTION
This reverts commit 57b9a87490bfd7fccdc92370ef0dee8834c5e4c4.

### Description of Change ###
<!-- Describe your changes here. -->
1. Remove obsolete apis of XAML.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
