### PR TITLE
[Tizen.Applications.RPCPort] Add RPCPort ParcelHeader internal APIs

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
@@ -17,11 +17,21 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Tizen.Internals;
+
 internal static partial class Interop
 {
     internal static partial class Libc
     {
         [DllImport(Libraries.Libc, EntryPoint = "free", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Free(IntPtr ptr);
+
+        [NativeStruct("struct timespec", Include = "time.h")]
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct TimeStamp
+        {
+            public IntPtr sec;
+            public IntPtr nsec;
+        }
     }
 }

--- a/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.RPCPort.cs
@@ -145,6 +145,30 @@ internal static partial class Interop
             //int rpc_port_parcel_burst_write(rpc_port_parcel_h h, const unsigned char *buf, unsigned int size);
             [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_burst_write")]
             internal static extern ErrorCode Write(IntPtr parcelHandle, byte[] buf, int size);
+
+            //int rpc_port_parcel_get_header(rpc_port_parcel_h h, rpc_port_parcel_header_h *header);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_get_header")]
+            internal static extern ErrorCode GetHeader(IntPtr parcelHandle, out IntPtr ParcelHeaderHandle);
+
+            //int rpc_port_parcel_header_set_tag(rpc_port_parcel_header_h header, const char *tag);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_tag")]
+            internal static extern ErrorCode SetTag(IntPtr parcelHeaderHandle, string tag);
+
+            //int rpc_port_parcel_header_get_tag(rpc_port_parcel_header_h header, char **tag);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_tag")]
+            internal static extern ErrorCode GetTag(IntPtr parcelHeaderHandle, out string tag);
+
+            //int rpc_port_parcel_header_set_seq_num(rpc_port_parcel_header_h header, int seq_num);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_set_seq_num")]
+            internal static extern ErrorCode SetSeqNum(IntPtr parcelHeaderHandle, int seq_num);
+
+            //int rpc_port_parcel_header_get_seq_num(rpc_port_parcel_header_h header, int *seq_num);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_seq_num")]
+            internal static extern ErrorCode GetSeqNum(IntPtr parcelHeaderHandle, out int seq_num);
+
+            //int rpc_port_parcel_header_get_timestamp(rpc_port_parcel_header_h header, struct timespec *timestamp);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_parcel_header_get_timestamp")]
+            internal static extern ErrorCode GetTimeStamp(IntPtr parcelHeaderHandle, ref Libc.TimeStamp time);
         }
 
         internal static partial class Proxy
@@ -266,6 +290,10 @@ internal static partial class Interop
             //int rpc_port_unset_private_sharing(rpc_port_h port);
             [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_unset_private_sharing")]
             internal static extern ErrorCode UnsetPrivateSharing(IntPtr handle);
+
+            //int rpc_port_disconnect(rpc_port_h h);
+            [DllImport(Libraries.RpcPort, EntryPoint = "rpc_port_disconnect")]
+            internal static extern ErrorCode Disconnect(IntPtr handle);
         }
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
@@ -29,7 +29,7 @@ namespace Tizen.Applications.RPCPort
         /// <summary>
         /// Constructor with TimeStamp.
         /// </summary>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         internal TimeStamp(long second, long nanoSecond)
         {
             this.Second = second;
@@ -39,7 +39,7 @@ namespace Tizen.Applications.RPCPort
         /// <summary>
         /// The second of TimeStamp.
         /// </summary>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         public long Second
         {
             get;
@@ -49,7 +49,7 @@ namespace Tizen.Applications.RPCPort
         /// <summary>
         /// The nano second of TimeStamp.
         /// </summary>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         public long NanoSecond
         {
             get;
@@ -69,7 +69,7 @@ namespace Tizen.Applications.RPCPort
         /// <summary>
         /// Constructor with Header
         /// </summary>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         internal ParcelHeader()
         {
         }
@@ -79,7 +79,7 @@ namespace Tizen.Applications.RPCPort
         /// </summary>
         /// <param name="tag">The tag of Header</param>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         public void SetTag(string tag)
         {
             var r = Interop.LibRPCPort.Parcel.SetTag(_handle, tag);
@@ -92,7 +92,7 @@ namespace Tizen.Applications.RPCPort
         /// </summary>
         /// <returns>Tag</returns>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         public string GetTag()
         {
             var r = Interop.LibRPCPort.Parcel.GetTag(_handle, out string tag);
@@ -107,7 +107,7 @@ namespace Tizen.Applications.RPCPort
         /// </summary>
         /// <param name="sequenceNumber">The seqence number of Header</param>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         public void SetSequenceNumber(int sequenceNumber)
         {
             var r = Interop.LibRPCPort.Parcel.SetSeqNum(_handle, sequenceNumber);
@@ -120,7 +120,7 @@ namespace Tizen.Applications.RPCPort
         /// </summary>
         /// <returns>Sequence number</returns>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         public int GetSequenceNumber()
         {
             var r = Interop.LibRPCPort.Parcel.GetSeqNum(_handle, out int sequenceNumber);
@@ -135,7 +135,7 @@ namespace Tizen.Applications.RPCPort
         /// </summary>
         /// <returns>Time stamp</returns>
         /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
-        /// <since_tizen> 9 </since_tizen>
+        /// <since_tizen> 8 </since_tizen>
         public TimeStamp GetTimeStamp()
         {
             Interop.Libc.TimeStamp time = new Interop.Libc.TimeStamp();

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
@@ -15,9 +15,139 @@
  */
 
 using System;
+using System.ComponentModel;
 
 namespace Tizen.Applications.RPCPort
 {
+    /// <summary>
+    /// This structure represents the time stamp.(internal)
+    /// </summary>
+    /// <since_tizen> 8 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class TimeStamp
+    {
+        /// <summary>
+        /// Constructor with TimeStamp.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        internal TimeStamp(long second, long nanoSecond)
+        {
+            this.Second = second;
+            this.NanoSecond = nanoSecond;
+        }
+
+        /// <summary>
+        /// The second of TimeStamp.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public long Second
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The nano second of TimeStamp.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public long NanoSecond
+        {
+            get;
+            private set;
+        }
+    }
+
+    /// <summary>
+    /// The class is the header that has the Parcel's information.(internal)
+    /// </summary>
+    /// <since_tizen> 8 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ParcelHeader
+    {
+        internal IntPtr _handle;
+
+        /// <summary>
+        /// Constructor with Header
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        internal ParcelHeader()
+        {
+        }
+
+        /// <summary>
+        /// Sets tag of Header.
+        /// </summary>
+        /// <param name="tag">The tag of Header</param>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
+        /// <since_tizen> 9 </since_tizen>
+        public void SetTag(string tag)
+        {
+            var r = Interop.LibRPCPort.Parcel.SetTag(_handle, tag);
+            if (r != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
+
+        /// <summary>
+        /// Gets tag of Header.
+        /// </summary>
+        /// <returns>Tag</returns>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
+        /// <since_tizen> 9 </since_tizen>
+        public string GetTag()
+        {
+            var r = Interop.LibRPCPort.Parcel.GetTag(_handle, out string tag);
+            if (r != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+
+            return tag;
+        }
+
+        /// <summary>
+        /// Sets sequence number of Header.
+        /// </summary>
+        /// <param name="sequenceNumber">The seqence number of Header</param>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
+        /// <since_tizen> 9 </since_tizen>
+        public void SetSequenceNumber(int sequenceNumber)
+        {
+            var r = Interop.LibRPCPort.Parcel.SetSeqNum(_handle, sequenceNumber);
+            if (r != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+        }
+
+        /// <summary>
+        /// Gets sequence number of Header.
+        /// </summary>
+        /// <returns>Sequence number</returns>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
+        /// <since_tizen> 9 </since_tizen>
+        public int GetSequenceNumber()
+        {
+            var r = Interop.LibRPCPort.Parcel.GetSeqNum(_handle, out int sequenceNumber);
+            if (r != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+
+            return sequenceNumber;
+        }
+
+        /// <summary>
+        /// Gets time stamp of Header.
+        /// </summary>
+        /// <returns>Time stamp</returns>
+        /// <exception cref="InvalidIOException">Thrown when an internal IO error occurs.</exception>
+        /// <since_tizen> 9 </since_tizen>
+        public TimeStamp GetTimeStamp()
+        {
+            Interop.Libc.TimeStamp time = new Interop.Libc.TimeStamp();
+
+            var r = Interop.LibRPCPort.Parcel.GetTimeStamp(_handle, ref time);
+            if (r != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidIOException();
+
+            return new TimeStamp(time.sec.ToInt64(), time.nsec.ToInt64());
+        }
+    };
+
     /// <summary>
     /// The class that helps to perform marshalling and unmarshalling for RPC.
     /// </summary>
@@ -25,6 +155,7 @@ namespace Tizen.Applications.RPCPort
     public class Parcel : IDisposable
     {
         private IntPtr _handle;
+        private ParcelHeader _header;
 
         /// <summary>
         /// Constructor for this class.
@@ -300,6 +431,24 @@ namespace Tizen.Applications.RPCPort
             var ret = new byte[size];
             Interop.LibRPCPort.Parcel.Read(_handle, ret, size);
             return ret;
+        }
+
+        /// <summary>
+        /// Gets header of rpc port parcel.(internal)
+        /// </summary>
+        /// <returns>Parcel header</returns>
+        /// <since_tizen> 8 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ParcelHeader GetHeader()
+        {
+            if (_header == null) {
+                Interop.LibRPCPort.Parcel.GetHeader(_handle, out IntPtr handle);
+                _header = new ParcelHeader() {
+                    _handle = handle
+                };
+            }
+
+            return _header;
         }
 
         #region IDisposable Support

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Port.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -95,6 +96,19 @@ namespace Tizen.Applications.RPCPort
             Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Port.UnsetPrivateSharing(Handle);
             if (err != Interop.LibRPCPort.ErrorCode.None)
                 throw new InvalidIOException();
+        }
+
+        /// <summary>
+        /// Disconnects the port.(internal)
+        /// </summary>
+        /// <exception cref="System.InvalidOperationException">Thrown when an internal IO error occurrs.</exception>
+        /// <since_tizen> 8 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Disconnect()
+        {
+            Interop.LibRPCPort.ErrorCode err = Interop.LibRPCPort.Port.Disconnect(Handle);
+            if (err != Interop.LibRPCPort.ErrorCode.None)
+                throw new InvalidOperationException();
         }
     }
 }


### PR DESCRIPTION
Adds:
 class:
 - Tizen.Applications.RPCPort.Parcel.Header

 Operation:
 - Tizen.Applications.RPCPort.Disconnect()
 - Tizen.Applications.RPCPort.Parcel.GetHeader()
 - Tizen.Applications.RPCPort.Parcel.Header.SetTag()
 - Tizen.Applications.RPCPort.Parcel.Header.GetTag()
 - Tizen.Applications.RPCPort.Parcel.Header.SetSeqNum()
 - Tizen.Applications.RPCPort.Parcel.Header.GetSeqNum()
 - Tizen.Applications.RPCPort.Parcel.Header.GetTimeStamp()

Signed-off-by: ChangGyu Choi <uppletaste@gmail.com>

### Description of Change ###
Add internal APIs


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - Non ACR

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
