### PR TITLE
[NUI] Fix to update Scrollbar when ScrollableBase size changes

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -645,10 +645,13 @@ namespace Tizen.NUI.Components
                 WidthSpecification = ScrollingDirection == Direction.Vertical ? LayoutParamPolicies.MatchParent : LayoutParamPolicies.WrapContent,
                 HeightSpecification = ScrollingDirection == Direction.Vertical ? LayoutParamPolicies.WrapContent : LayoutParamPolicies.MatchParent,
             };
+            // Check if children's sizes change to update Scrollbar
             ContentContainer.Relayout += OnScrollingChildRelayout;
             propertyNotification = ContentContainer.AddPropertyNotification("position", PropertyCondition.Step(mScrollingEventThreshold));
             propertyNotification.Notified += OnPropertyChanged;
             base.Add(ContentContainer);
+            // Check if ScrollableBase's size changes to update Scrollbar
+            base.Relayout += OnScrollingChildRelayout;
 
             Scrollbar = new Scrollbar();
 


### PR DESCRIPTION
Previously, if ScrollableBase size changed, Scrollbar was not updated.
So some children was not displayed when ScrollableBase size changed.

Now, when ScrollableBase size changes, Scrollbar is updated in the
ScrollableBase's Relayout callback.
So all children are displayed correctly when ScrollableBase size changes.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
