### PR TITLE
[NUI] Fix View.DisConnectFromSignals() to return when the native object has no body

### DIFF
--- a/src/Tizen.NUI/Tizen.NUI.csproj
+++ b/src/Tizen.NUI/Tizen.NUI.csproj
@@ -6,6 +6,10 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>NUI_DEBUG_OFF;</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <TizenPreloadFile Include="Tizen.NUI.preload" Sequence="30" />
   </ItemGroup>

--- a/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
+++ b/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
@@ -227,7 +227,7 @@ namespace Tizen.NUI
             [CallerFilePath] string file = null
         )
         {
-            Tizen.Log.Debug("NUI", $"{msg} (at line {lineNum} of {caller} in {file})\n");
+            Tizen.Log.Error("NUI", $"{msg} (at line {lineNum} of {caller} in {file})\n");
         }
 
         public static void Error(string msg,

--- a/src/Tizen.NUI/src/internal/Common/Registry.cs
+++ b/src/Tizen.NUI/src/internal/Common/Registry.cs
@@ -63,6 +63,7 @@ namespace Tizen.NUI
                 NUILog.Debug("refCptr is already exist! OR something wrong!");
             }
 
+            NUILog.Debug($"[Registry] Register! type:{baseHandle.GetType()} count:{Instance._controlMap.Count} copyNativeHandle:{baseHandle.GetBaseHandleCPtrHandleRef.Handle.ToString("X8")}");
             return;
         }
 
@@ -81,6 +82,7 @@ namespace Tizen.NUI
                 NUILog.Debug("something wrong when removing refCptr!");
             }
 
+            NUILog.Debug($"[Registry] Unregister! type:{baseHandle.GetType()} count:{Instance._controlMap.Count} copyNativeHandle:{baseHandle.GetBaseHandleCPtrHandleRef.Handle.ToString("X8")}");
             return;
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1119,6 +1119,20 @@ namespace Tizen.NUI.BaseComponents
                 return;
             }
 
+#if NUI_DEBUG_ON
+            NUILog.Debug($"[Dispose] View.Dispose({type}) START");
+            NUILog.Debug($"[Dispose] type:{GetType()} copyNativeHandle:{GetBaseHandleCPtrHandleRef.Handle.ToString("X8")}");
+            if(HasBody())
+            {
+                NUILog.Debug($"[Dispose] ID:{Interop.Actor.GetId(GetBaseHandleCPtrHandleRef)} Name:{Interop.Actor.GetName(GetBaseHandleCPtrHandleRef)}");
+            }
+            else
+            {
+                NUILog.Debug($"has no native body!");
+            }
+#endif
+
+
             //_mergedStyle = null;
 
             if (type == DisposeTypes.Explicit)
@@ -1156,6 +1170,9 @@ namespace Tizen.NUI.BaseComponents
             {
                 view.InternalParent = null;
             }
+
+            NUILog.Debug($"[Dispose] View.Dispose({type}) END");
+            NUILog.Debug($"=============================");
 
             base.Dispose(type);
         }
@@ -1200,8 +1217,19 @@ namespace Tizen.NUI.BaseComponents
 
         private void DisConnectFromSignals()
         {
+            if (HasBody() == false)
+            {
+                NUILog.Debug($"[Dispose] DisConnectFromSignals() No native body! No need to Disconnect Signals!");
+                return;
+            }
+            NUILog.Debug($"[Dispose] DisConnectFromSignals START");
+            NUILog.Debug($"[Dispose] View.DisConnectFromSignals() type:{GetType()} copyNativeHandle:{GetBaseHandleCPtrHandleRef.Handle.ToString("X8")}");
+            NUILog.Debug($"[Dispose] ID:{Interop.Actor.GetId(GetBaseHandleCPtrHandleRef)} Name:{Interop.Actor.GetName(GetBaseHandleCPtrHandleRef)}");
+
             if (onRelayoutEventCallback != null)
             {
+                NUILog.Debug($"[Dispose] onRelayoutEventCallback");
+
                 using ViewSignal signal = new ViewSignal(Interop.ActorSignal.ActorOnRelayoutSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(onRelayoutEventCallback);
                 onRelayoutEventCallback = null;
@@ -1209,6 +1237,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (offWindowEventCallback != null)
             {
+                NUILog.Debug($"[Dispose] offWindowEventCallback");
+
                 using ViewSignal signal = new ViewSignal(Interop.ActorSignal.ActorOffSceneSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(offWindowEventCallback);
                 offWindowEventCallback = null;
@@ -1216,6 +1246,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (onWindowEventCallback != null)
             {
+                NUILog.Debug($"[Dispose] onWindowEventCallback");
+
                 using ViewSignal signal = new ViewSignal(Interop.ActorSignal.ActorOnSceneSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(onWindowEventCallback);
                 onWindowEventCallback = null;
@@ -1223,6 +1255,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (wheelEventCallback != null)
             {
+                NUILog.Debug($"[Dispose] wheelEventCallback");
+
                 using WheelSignal signal = new WheelSignal(Interop.ActorSignal.ActorWheelEventSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(wheelEventCallback);
                 wheelEventCallback = null;
@@ -1230,12 +1264,16 @@ namespace Tizen.NUI.BaseComponents
 
             if (WindowWheelEventHandler != null)
             {
+                NUILog.Debug($"[Dispose] WindowWheelEventHandler");
+
                 NUIApplication.GetDefaultWindow().WheelEvent -= OnWindowWheelEvent;
                 WindowWheelEventHandler = null;
             }
 
             if (hoverEventCallback != null)
             {
+                NUILog.Debug($"[Dispose] hoverEventCallback");
+
                 using HoverSignal signal = new HoverSignal(Interop.ActorSignal.ActorHoveredSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(hoverEventCallback);
                 hoverEventCallback = null;
@@ -1243,6 +1281,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (interceptTouchDataCallback != null)
             {
+                NUILog.Debug($"[Dispose] interceptTouchDataCallback");
+
                 using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorInterceptTouchSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(interceptTouchDataCallback);
                 interceptTouchDataCallback = null;
@@ -1250,6 +1290,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (touchDataCallback != null)
             {
+                NUILog.Debug($"[Dispose] touchDataCallback");
+
                 using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorTouchSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(touchDataCallback);
                 touchDataCallback = null;
@@ -1257,6 +1299,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (ResourcesLoadedCallback != null)
             {
+                NUILog.Debug($"[Dispose] ResourcesLoadedCallback");
+
                 using ViewSignal signal = new ViewSignal(Interop.View.ResourceReadySignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(ResourcesLoadedCallback);
                 ResourcesLoadedCallback = null;
@@ -1264,6 +1308,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (keyCallback != null)
             {
+                NUILog.Debug($"[Dispose] keyCallback");
+
                 using ControlKeySignal signal = new ControlKeySignal(Interop.ViewSignal.KeyEventSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(keyCallback);
                 keyCallback = null;
@@ -1271,6 +1317,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (keyInputFocusLostCallback != null)
             {
+                NUILog.Debug($"[Dispose] keyInputFocusLostCallback");
+
                 using KeyInputFocusSignal signal = new KeyInputFocusSignal(Interop.ViewSignal.KeyInputFocusLostSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(keyInputFocusLostCallback);
                 keyInputFocusLostCallback = null;
@@ -1278,6 +1326,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (keyInputFocusGainedCallback != null)
             {
+                NUILog.Debug($"[Dispose] keyInputFocusGainedCallback");
+
                 using KeyInputFocusSignal signal = new KeyInputFocusSignal(Interop.ViewSignal.KeyInputFocusGainedSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(keyInputFocusGainedCallback);
                 keyInputFocusGainedCallback = null;
@@ -1285,6 +1335,8 @@ namespace Tizen.NUI.BaseComponents
 
             if (backgroundResourceLoadedCallback != null)
             {
+                NUILog.Debug($"[Dispose] backgroundResourceLoadedCallback");
+
                 using ViewSignal signal = new ViewSignal(Interop.View.ResourceReadySignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(backgroundResourceLoadedCallback);
                 backgroundResourceLoadedCallback = null;
@@ -1292,10 +1344,13 @@ namespace Tizen.NUI.BaseComponents
 
             if (onWindowSendEventCallback != null)
             {
+                NUILog.Debug($"[Dispose] onWindowSendEventCallback");
+
                 using ViewSignal signal = new ViewSignal(Interop.ActorSignal.ActorOnSceneSignal(GetBaseHandleCPtrHandleRef), false);
                 signal?.Disconnect(onWindowSendEventCallback);
                 onWindowSendEventCallback = null;
             }
+            NUILog.Debug($"[Dispose] DisConnectFromSignals END");
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -50,6 +50,10 @@ namespace Tizen.NUI
         //A Flag to check who called Dispose(). (By User or DisposeQueue)
         private bool isDisposeQueued = false;
 
+#if NUI_DEBUG_ON
+        private static int debuggingCount = 0;
+#endif
+
         /// <summary>
         /// Create an instance of BaseHandle.
         /// </summary>
@@ -74,6 +78,8 @@ namespace Tizen.NUI
             //to catch derived classes dali native exceptions
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
+            NUILog.Debug($"[Dispose] BaseHandle.contructor with cMemeryOwn:{cMemoryOwn} START");
+
             registerMe = swigCMemOwn = cMemoryOwn;
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
             // using copy constructor to create another native handle so Registry.Unregister works fine.
@@ -82,14 +88,27 @@ namespace Tizen.NUI
 
             if (registerMe)
             {
-
                 // Register this instance of BaseHandle in the registry.
                 Registry.Register(this);
             }
+
+#if NUI_DEBUG_ON
+            NUILog.Debug($"[Dispose] type:{GetType()} copyNativeHandle:{swigCPtrCopy.Handle.ToString("X8")}");
+
+            debuggingCount++;
+            if (this is BaseComponents.View view)
+            {
+                NUILog.Debug($"[Dispose] ID:{view.ID} Name:{view.Name} debuggingCount:{debuggingCount}");
+            }
+            NUILog.Debug($"[Dispose] BaseHandle.contructor with cMemeryOwn END");
+            NUILog.Debug($"=============================");
+#endif
         }
 
         internal BaseHandle(global::System.IntPtr cPtr)
         {
+            NUILog.Debug($"[Dispose] BaseHandle.contructor START");
+
             registerMe = swigCMemOwn = true;
 
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
@@ -103,6 +122,19 @@ namespace Tizen.NUI
                 // Register this instance of BaseHandle in the registry.
                 Registry.Register(this);
             }
+
+#if NUI_DEBUG_ON
+            NUILog.Debug($"[Dispose] type:{GetType()} copyNativeHandle:{swigCPtrCopy.Handle.ToString("X8")}");
+
+            debuggingCount++;
+            if (this is BaseComponents.View view)
+            {
+                NUILog.Debug($"[Dispose] ID:{view.ID} Name:{view.Name} debuggingCount:{debuggingCount}");
+            }
+            NUILog.Debug($"[Dispose] BaseHandle.contructor END");
+            NUILog.Debug($"=============================");
+#endif
+
         }
 
         /// <summary>
@@ -494,6 +526,8 @@ namespace Tizen.NUI
                 return;
             }
 
+            NUILog.Debug($"[Dispose] BaseHandle.Dispose({type}) START");
+
             if (type == DisposeTypes.Explicit)
             {
                 //Called by User
@@ -511,6 +545,11 @@ namespace Tizen.NUI
             {
                 Registry.Unregister(this);
             }
+
+#if NUI_DEBUG_ON
+            debuggingCount--;
+            NUILog.Debug($"[Dispose] swigCMemOwn:{swigCMemOwn} debuggingCount:{debuggingCount} type:{GetType()} copyNativeHandle:{swigCPtrCopy.Handle.ToString("X8")}");
+#endif
 
             if (SwigCPtr.Handle != IntPtr.Zero)
             {
@@ -534,6 +573,9 @@ namespace Tizen.NUI
             {
                 Application.Current.XamlResourceChanged -= OnResourcesChanged;
             }
+            
+            NUILog.Debug($"[Dispose] BaseHandle.Dispose({type}) END");
+            NUILog.Debug($"=============================");
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
- Fix View.DisConnectFromSignals() to return when the native object has no body
- Add debugging log which comes only when the NUI_DEBUG_ON is defined

### API Changes ###
none