### PR TITLE
[NUI] Apply Padding and Margin in AbsoluteLayout

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -52,13 +52,14 @@ namespace Tizen.NUI
                     continue;
                 }
 
-                // Get size of child with no padding, no margin. we won't support margin, padding for AbsolutLayout.
-                MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
+                MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
 
                 // Determine the width and height needed by the children using their given position and size.
                 // Children could overlap so find the right most child.
-                float childRight = childLayout.MeasuredWidth.Size.AsDecimal() + childLayout.Owner.PositionX;
-                float childBottom = childLayout.MeasuredHeight.Size.AsDecimal() + childLayout.Owner.PositionY;
+                float childRight = childLayout.MeasuredWidth.Size.AsDecimal() + childLayout.Owner.PositionX +
+                                   Padding.Start + Padding.End + childLayout.Margin.Start + childLayout.Margin.End;
+                float childBottom = childLayout.MeasuredHeight.Size.AsDecimal() + childLayout.Owner.PositionY +
+                                    Padding.Top + Padding.Bottom + childLayout.Margin.Top + childLayout.Margin.Bottom;
 
                 if (maxWidth < childRight)
                     maxWidth = childRight;
@@ -103,10 +104,10 @@ namespace Tizen.NUI
                 LayoutLength childWidth = childLayout.MeasuredWidth.Size;
                 LayoutLength childHeight = childLayout.MeasuredHeight.Size;
 
-                LayoutLength childLeft = new LayoutLength(childLayout.Owner.PositionX);
-                LayoutLength childTop = new LayoutLength(childLayout.Owner.PositionY);
+                LayoutLength childLeft = new LayoutLength(childLayout.Owner.PositionX + Padding.Start + childLayout.Margin.Start);
+                LayoutLength childTop = new LayoutLength(childLayout.Owner.PositionY + Padding.Top + childLayout.Margin.Top);
 
-                childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight, true);
+                childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
             }
         }
     }


### PR DESCRIPTION
Previously, Padding and Margin was not applied in AbsoluteLayout.
So AbsoluteLayout's Padding and its children's Margin did not work.

Now, Padding and Margin are applied by AbsoluteLayout.
So AbsoluteLayout's children are positioned based on AbsoluteLayout's
Padding and children's Margin.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
