### PR TITLE
[Applications] Set CultureInfo using LCID instread of locale

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.BaseUtilsi18n.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.BaseUtilsi18n.cs
@@ -39,5 +39,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_variant")]
         internal static extern Int32 GetVariant(string localeID, [Out] StringBuilder variant, Int32 variantCapacity);
+
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_lcid")]
+        internal static extern UInt32 GetLCID(string localeID);
     }
 }

--- a/src/Tizen.Applications.Common/Interop/Interop.BaseUtilsi18n.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.BaseUtilsi18n.cs
@@ -27,20 +27,30 @@ internal static partial class Interop
     {
         [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_canonicalize")]
         internal static extern Int32 Canonicalize(string localeID, [Out] StringBuilder name, Int32 nameCapacity);
+        // int32_t i18n_ulocale_canonicalize(const char *locale_id, char *name, int32_t name_capacity);c
 
         [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_language")]
-        internal static extern Int32 GetLanguage(string localeID, [Out] StringBuilder language, Int32 languageCapacity, out int bufSizeLanguage);
+        internal static extern int GetLanguage(string localeID, [Out] StringBuilder language, Int32 languageCapacity, out int bufSizeLanguage);
+        // int i18n_ulocale_get_language(const char *locale_id, char *language, int32_t language_capacity, int32_t *buf_size_language);
 
         [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_script")]
         internal static extern Int32 GetScript(string localeID, [Out] StringBuilder script, Int32 scriptCapacity);
+        // int32_t i18n_ulocale_get_script(const char *locale_id, char *script, int32_t script_capacity);
 
         [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_country")]
         internal static extern Int32 GetCountry(string localeID, [Out] StringBuilder country, Int32 countryCapacity, out int err);
+        // int32_t i18n_ulocale_get_country(const char *locale_id, char *country, int32_t country_capacity, int *error);
 
         [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_variant")]
         internal static extern Int32 GetVariant(string localeID, [Out] StringBuilder variant, Int32 variantCapacity);
+        // int32_t i18n_ulocale_get_variant(const char *locale_id, char *variant, int32_t variant_capacity);
 
         [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_lcid")]
         internal static extern UInt32 GetLCID(string localeID);
+        // uint32_t i18n_ulocale_get_lcid(const char *locale_id);
+
+        [DllImport(Libraries.BaseUtilsi18n, EntryPoint = "i18n_ulocale_get_default")]
+        internal static extern int GetDefault(out IntPtr localeID);
+        // int i18n_ulocale_get_default(const char **locale);
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Timers;
 using Tizen.Applications.CoreBackend;
@@ -141,6 +142,10 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         protected virtual void OnCreate()
         {
+            string locale = ULocale.GetDefaultLocale();
+            ChangeCurrentUICultureInfo(locale);
+            ChangeCurrentCultureInfo(locale);
+
             Created?.Invoke(this, EventArgs.Empty);
         }
 
@@ -447,6 +452,22 @@ namespace Tizen.Applications
             // Get the LCID from ICU
             uint lcid = Interop.BaseUtilsi18n.GetLCID(locale);
             return (int)lcid;
+        }
+
+        internal static string GetDefaultLocale()
+        {
+            IntPtr stringPtr = IntPtr.Zero;
+            if (Interop.BaseUtilsi18n.GetDefault(out stringPtr) != 0)
+            {
+                return string.Empty;
+            }
+
+            if (stringPtr == IntPtr.Zero)
+            {
+                return string.Empty;
+            }
+
+            return Marshal.PtrToStringAnsi(stringPtr);
         }
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -287,11 +287,11 @@ namespace Tizen.Applications
             CultureInfo.CurrentUICulture = ConvertCultureInfo(locale);
         }
 
-        private bool ExistCultureInfo(CultureInfo cultureInfo)
+        private bool ExistCultureInfo(string locale)
         {
-            foreach (var info in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            foreach (var cultureInfo in CultureInfo.GetCultures(CultureTypes.AllCultures))
             {
-                if (info.Name == cultureInfo.Name)
+                if (cultureInfo.Name == locale)
                 {
                     return true;
                 }
@@ -302,23 +302,19 @@ namespace Tizen.Applications
 
         private CultureInfo GetCultureInfo(string locale)
         {
-            CultureInfo cultureInfo = null;
+            if (!ExistCultureInfo(locale))
+            {
+                return null;
+            }
 
             try
             {
-                cultureInfo = new CultureInfo(locale);
+                return new CultureInfo(locale);
             }
             catch (CultureNotFoundException)
             {
                 return null;
             }
-
-            if (!ExistCultureInfo(cultureInfo))
-            {
-                return null;
-            }
-
-            return cultureInfo;
         }
 
         private CultureInfo GetFallbackCultureInfo(ULocale uLocale)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The system locale of Tizen uses POSIX locale.
Currently, there is a problem when the system language is "uz_UZ@cryillic".  The CultureInfo is created that is 'uz-UZ-CYRILLIC'.  In this case, the CultureInfo should be created by "uz-Cyrl-UZ" locale.
For .NET applications, we should set CurrentCultureInfo and CurrentUICultureInfo properly.
After this patch is applied, we uses LCID instread of loclae of ULocale class to create CultureInfo.



