### PR TITLE
[Applications.Common] Add exception handlings for setting CultureInfo

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -279,12 +279,28 @@ namespace Tizen.Applications
 
         private void ChangeCurrentCultureInfo(string locale)
         {
-            CultureInfo.CurrentCulture = ConvertCultureInfo(locale);
+            CultureInfo cultureInfo = ConvertCultureInfo(locale);
+            if (cultureInfo != null)
+            {
+                CultureInfo.CurrentCulture = cultureInfo;
+            }
+            else
+            {
+                Log.Error(LogTag, "CultureInfo is null. locale: " + locale);
+            }
         }
 
         private void ChangeCurrentUICultureInfo(string locale)
         {
-            CultureInfo.CurrentUICulture = ConvertCultureInfo(locale);
+            CultureInfo cultureInfo = ConvertCultureInfo(locale);
+            if (cultureInfo != null)
+            {
+                CultureInfo.CurrentUICulture = cultureInfo;
+            }
+            else
+            {
+                Log.Error(LogTag, "CultureInfo is null. locale: " + locale);
+            }
         }
 
         private bool ExistCultureInfo(string locale)
@@ -354,8 +370,14 @@ namespace Tizen.Applications
 
             if (fallbackCultureInfo == null)
             {
-                locale = "en";
-                fallbackCultureInfo = GetCultureInfo(locale);
+                try
+                {
+                    fallbackCultureInfo = new CultureInfo("en");
+                }
+                catch (CultureNotFoundException e)
+                {
+                    Log.Error(LogTag, "Failed to create CultureInfo. err = " + e.Message);
+                }
             }
 
             return fallbackCultureInfo;


### PR DESCRIPTION
Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->

If the CultureInfo is null when setting CurrentUICultureInfo, it throws ArgumentNullException.
The value of set_CurrentUICultureInfo(CultureInfo value) cannot be null.
This patch adds exception handlings for setting CultureInfo.

### Problem ###
log.cpp: stdErrRedirect(98) > System.ArgumentNullException: Value cannot be null. (Parameter 'value')
 at System.Globalization.CultureInfo.set_CurrentUICulture(CultureInfo value)
 at Tizen.Applications.CoreApplication.OnCreate() in /home/abuild/rpmbuild/BUILD/csapi-tizenfx-9.0.0.16756+nui22045/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs:line 146
 at Tizen.NUI.NUIApplication.OnCreate() in /home/abuild/rpmbuild/BUILD/csapi-tizenfx-9.0.0.16756+nui22045/src/Tizen.NUI/src/public/Application/NUIApplication.cs:line 446