### PR TITLE
[NUI] Call RemoveWidget when WidgetView is disposed

### DIFF
--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -826,6 +826,9 @@ namespace Tizen.NUI
                 return;
             }
 
+            //Remove Widget from WidgetViewManager
+            WidgetViewManager.Instance.RemoveWidget(this);
+
             //Release your own unmanaged resources here.
             //You should not access any managed member here except static instance.
             //because the execution order of Finalizes is non-deterministic.


### PR DESCRIPTION
when WidgetView is disposed, RemoveWidget must be called.
so i added this patch

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
