### PR TITLE
[NUI] Fix typo in FittingMode

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -685,7 +685,7 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        internal VisualFittingModeType CovertFittingModetoVisualFittingMode(FittingModeType value)
+        internal VisualFittingModeType ConvertFittingModetoVisualFittingMode(FittingModeType value)
         {
             switch (value)
             {
@@ -700,7 +700,7 @@ namespace Tizen.NUI.BaseComponents
                 case FittingModeType.FitHeight:
                     return VisualFittingModeType.FitHeight;
                 case FittingModeType.FitWidth:
-                    return VisualFittingModeType.FitHeight;
+                    return VisualFittingModeType.FitWidth;
                 default:
                     return VisualFittingModeType.Fill;
             }
@@ -773,7 +773,7 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                VisualFittingModeType ret = CovertFittingModetoVisualFittingMode(value);
+                VisualFittingModeType ret = ConvertFittingModetoVisualFittingMode(value);
                 PropertyValue setValue = new PropertyValue((int)ret);
                 if(_fittingMode != ret)
                 {

--- a/src/Tizen.NUI/src/public/Utility/GraphicsTypeExtensions.cs
+++ b/src/Tizen.NUI/src/public/Utility/GraphicsTypeExtensions.cs
@@ -3,7 +3,7 @@
 namespace Tizen.NUI
 {
     /// <summary>
-    /// The GraphicTypeExtensions class is graphics type coverter for pixel based object.
+    /// The GraphicTypeExtensions class is graphics type converter for pixel based object.
     /// Density independent pixel(dp) unit is our basic target type and you can get converted value by ToDp(),
     /// and you can get original pixel by ToDp().
     /// One dp is a virtual pixel unit that's roughly equal to one pixel on a medium-density(160dpi) screen.


### PR DESCRIPTION
FittingModeType.FitWidth does not work because of typo.
i fix it.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
