### PR TITLE
[NUI] Add Window.NativeHandle, VideoView.NativeHandle

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -383,6 +383,31 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Get native player handle.
+        /// <example>
+        /// How to get native player handle
+        /// <code>
+        /// VideoView videoView = new VideoView();
+        /// videoView.ResourceUrl = "some xxx video path";
+        /// var handle = videoView.NativeHandle;
+        /// if(handle?.IsInvalid == false)
+        /// {
+        ///     IntPtr nativeHandle = handle.DangerousGetHandle();
+        ///     // do something with nativeHandle
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public SafeHandle NativeHandle
+        {
+            get
+            {
+                return new NUI.SafeNativePlayerHandle(this);
+            }
+        }
+
         internal VideoViewSignal FinishedSignal()
         {
             VideoViewSignal ret = new VideoViewSignal(Interop.VideoView.FinishedSignal(SwigCPtr), false);
@@ -481,6 +506,7 @@ namespace Tizen.NUI.BaseComponents
     /// Contains and encapsulates Native Player handle.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("Deprecated in API9, will be removed in API11. Please use VideoView.NativeHandle instead!")]
     public class SafeNativePlayerHandle : SafeHandle
     {
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoViewHandle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoViewHandle.cs
@@ -1,0 +1,62 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Contains and encapsulates Native Player handle.
+    /// </summary>
+    internal class SafeNativePlayerHandle : SafeHandle
+    {
+        /// <summary>
+        /// Constructor, Native player handle is set to handle.
+        /// </summary>
+        internal SafeNativePlayerHandle(VideoView videoView) : base(global::System.IntPtr.Zero, false)
+        {
+            if (videoView != null)
+            {
+                SetHandle(videoView.GetNativePlayerHandle());
+            }
+        }
+
+        /// <summary>
+        /// Null check if the handle is valid or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool IsInvalid
+        {
+            get
+            {
+                return handle == global::System.IntPtr.Zero;
+            }
+        }
+        /// <summary>
+        /// Release handle itself.
+        /// </summary>
+        /// <returns>true when released successfully.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override bool ReleaseHandle()
+        {
+            SetHandle(global::System.IntPtr.Zero);
+            return true;
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         static public Window Get(View view)
         {
-            if(view == null)
+            if (view == null)
             {
                 NUILog.Error("if there is no view, it can not get a window");
                 return null;
@@ -1727,5 +1727,28 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// Get Native Window handle.
+        /// <example>
+        /// How to get Native Window handle
+        /// <code>
+        /// Window window = NUIApplication.GetDefaultWindow();
+        /// var handle = window.NativeHandle;
+        /// if(handle?.IsInvalid == false)
+        /// {
+        ///     IntPtr nativeHandle = handle.DangerousGetHandle();
+        ///     // do something with nativeHandle
+        /// }
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public SafeHandle NativeHandle
+        {
+            get
+            {
+                return new NUI.SafeNativeWindowHandle(this);
+            }
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -902,6 +902,7 @@ namespace Tizen.NUI
         /// Contains and encapsulates Native Window handle.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated in API9, will be removed in API11. Please use Window.NativeHandle instead!")]
         public class SafeNativeWindowHandle : SafeHandle
         {
             /// <summary>

--- a/src/Tizen.NUI/src/public/Window/WindowHandle.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowHandle.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Contains and encapsulates Native Window handle.
+    /// </summary>
+    internal class SafeNativeWindowHandle : SafeHandle
+    {
+        /// <summary>
+        ///Constructor, Native window handle is set to handle.
+        /// </summary>
+        internal SafeNativeWindowHandle(Window currentWindow) : base(IntPtr.Zero, false)
+        {
+            SetHandle(currentWindow != null ? currentWindow.GetNativeWindowHandler() : IntPtr.Zero);
+        }
+        /// <summary>
+        /// Null check if the handle is valid or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool IsInvalid
+        {
+            get
+            {
+                return this.handle == IntPtr.Zero;
+            }
+        }
+        /// <summary>
+        /// Release handle itself.
+        /// </summary>
+        /// <returns>true when released successfully.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override bool ReleaseHandle()
+        {
+            SetHandle(global::System.IntPtr.Zero);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
[NUI] Add Window.NativeHandle
The old way of using SafeNativeWindowHandle is not intuitive and is hard to understand. so we replace SafeNativeWindowHandle into Window.NativeHandle and add VideoView.NativeHandle which is very similar to Window.NativeHandle in getting native handle.

### API Changes ###
https://code.sec.samsung.net/jira/browse/TCSACR-456