### PR TITLE
[NUI] Open BorderlineWidth / Color / Offset APIs

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -457,7 +457,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The width for the borderline of the View.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public float? BorderlineWidth
         {
             get => (float?)GetValue(BorderlineWidthProperty);
@@ -467,7 +467,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The color for the borderline of the View.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public Color BorderlineColor
         {
             get => (Color)GetValue(BorderlineColorProperty);
@@ -476,12 +476,12 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The Relative offset for the borderline of the View.
-        /// recommand [-1.0f to 1.0f] range.
-        /// If -1.0f, borderline draw inside of View.
-        /// If 1.0f, borderline draw outside of View.
-        /// If 0.0f, borderline draw half at inside and half at outside.
+        /// Recommended range : [-1.0f to 1.0f].
+        /// If -1.0f, draw borderline inside of the View.
+        /// If 1.0f, draw borderline outside of the View.
+        /// If 0.0f, draw borderline half inside and half outside.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public float? BorderlineOffset
         {
             get => (float?)GetValue(BorderlineOffsetProperty);

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -505,7 +505,6 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The width for the borderline of the View.
-        /// Note that, an image background may not have borderline if it uses a Border property.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -514,9 +513,9 @@ namespace Tizen.NUI.BaseComponents
         /// animation.AnimateTo(view, "BorderlineWidth", 100.0f);
         /// </code>
         /// </para>
+        /// Note that, an image background may not have borderline if it uses the Border property.
         /// </remarks>
-        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public float BorderlineWidth
         {
             get
@@ -542,8 +541,7 @@ namespace Tizen.NUI.BaseComponents
         /// </code>
         /// </para>
         /// </remarks>
-        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public Color BorderlineColor
         {
             get
@@ -559,10 +557,10 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The Relative offset for the borderline of the View.
-        /// recommand [-1.0f to 1.0f] range.
-        /// If -1.0f, borderline draw inside of View.
-        /// If 1.0f, borderline draw outside of View.
-        /// If 0.0f, borderline draw half at inside and half at outside.
+        /// Recommended range : [-1.0f to 1.0f].
+        /// If -1.0f, draw borderline inside of the View.
+        /// If 1.0f, draw borderline outside of the View.
+        /// If 0.0f, draw borderline half inside and half outside.
         /// It is 0.0f by default.
         /// </summary>
         /// <remarks>
@@ -573,8 +571,7 @@ namespace Tizen.NUI.BaseComponents
         /// </code>
         /// </para>
         /// </remarks>
-        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public float BorderlineOffset
         {
             get


### PR DESCRIPTION
Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
Add borderline properies for view
 - BorderlineWidth (float, default = 0.0f)
   : Width of the borderline
 - BorderlineColor (Vector4, default = Color.Black)
   : Color of the borderline
 - BorderlineOffset (float, default = 0.0f)
   : Relative position offset from 'Real' borderline of visual.
     == 0.0f then half is inside, and half is outside of visual.
     == -1.0f then all borderline will be rendered inside of visual.
     == 1.0f then all borderline will be rendered outside of visual.

These three properties are animatable

If it is ImageView, this property allow to ImageView.Property.IMAGE and View.Property.BACKGROUND.
Otherwise, allow to View.Property.BACKGROUND.
### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: https://code.sec.samsung.net/jira/browse/TCSACR-458

src/Tizen.NUI/src/public/BaseComponents/View.cs
View
    [Add] float BorderlineWidth { get; set; }
    [Add] Color BorderlineColor { get; set; }
    [Add] float BorderlineOffet { get; set; }

src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
ViewStyle
    [Add] float? BorderlineWidth { get; set; }
    [Add] Color BorderlineColor { get; set; }
    [Add] float? BorderlineOffset { get; set; }