### PR TITLE
[NUI] Remove unused conditional expression in LayoutGroup

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -180,13 +180,9 @@ namespace Tizen.NUI
             // If child already has a Layout then don't change it.
             if (null == child.Layout)
             {
-                // Only wrap View with a Layout if a child a pure View or Layout explicitly set on this Layout
-                if ((true == Owner.LayoutSet || GetType() == typeof(View)))
-                {
-                    // If child of this layout is a pure View then assign it a LayoutGroup
-                    // If the child is derived from a View then it may be a legacy or existing container hence will do layouting itself.
-                    child.Layout = child.CreateDefaultLayout();
-                }
+                // If child view does not have Layout, then default layout is automatically set to the child view.
+                // The Layout is automatically added to this LayoutGroup when child view sets Layout.
+                child.Layout = child.CreateDefaultLayout();
             }
             else
             {


### PR DESCRIPTION
Since AddChildToLayoutGroup is called only if view's Layout is set, the
conditional expression is meaningless.

Owner.LayoutSet is always true, so this is unnecessary code.

GetType() is always Tizen.NUI.LayoutGroup, so the intended code might be
child.GetType() == typeof(View).

The intended code is incorrect, because any class, derived from View, is
also required to set default Layout if it does not set Layout.

If the class, derived from View, uses its own Layout instead of the
default Layout, then the class already sets its own Layout, so
child.Layout cannot be null.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
