### PR TITLE
[NUI] Fix ContentPage to calculate AppBar and Content size correctly

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -183,7 +183,7 @@ namespace Tizen.NUI.Components
                         appBarSizeH = Size2D.Height - Padding.Top - Padding.Bottom - appBar.Margin.Top - appBar.Margin.Bottom;
                     }
 
-                    appBar.Size2D = new Size2D(appBarSizeW, appBarSizeH);
+                    appBar.SetSize(new Size2D(appBarSizeW, appBarSizeH));
                 }
             }
 
@@ -209,7 +209,7 @@ namespace Tizen.NUI.Components
                         contentSizeH = Size2D.Height - Padding.Top - Padding.Bottom - content.Margin.Top - content.Margin.Bottom - (appBar?.Size2D.Height ?? 0);
                     }
 
-                    content.Size2D = new Size2D(contentSizeW, contentSizeH);
+                    content.SetSize(new Size2D(contentSizeW, contentSizeH));
                 }
             }
         }


### PR DESCRIPTION
Previously, the size of AppBar and Content was set by setting Size2D
property.
This caused AppBar and Content to change their
Width/HeightSpecification.
Consequently, the size of AppBar and Content was not recalculated when
window size was changed.

Now, the size of AppBar and Content is set by SetSize() method.
Since SetSize() method does not change Width/HeightSpecification, the
size of AppBar and Content is recalculated correctly when window size is
changed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
