### PR TITLE
[NUI] Make Page.Appear/Disappear events public

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -20,33 +20,33 @@ using System.ComponentModel;
 namespace Tizen.NUI.Components
 {
     /// <summary>
-    /// PageAppearingEventArgs is a class to record page appearing event arguments which will be sent to user.
+    /// PageAppearingEventArgs is a class to record <see cref="Page.Appearing"/> event arguments which will be sent to user.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    /// <since_tizen> 9 </since_tizen>
     public class PageAppearingEventArgs : EventArgs
     {
     }
 
     /// <summary>
-    /// PageDisappearingEventArgs is a class to record page disappearing event arguments which will be sent to user.
+    /// PageDisappearingEventArgs is a class to record <see cref="Page.Disappearing"/> event arguments which will be sent to user.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    /// <since_tizen> 9 </since_tizen>
     public class PageDisappearingEventArgs : EventArgs
     {
     }
 
     /// <summary>
-    /// PageAppearedEventArgs is a class to record page appeared event arguments which will be sent to user.
+    /// PageAppearedEventArgs is a class to record <see cref="Page.Appeared"/> event arguments which will be sent to user.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    /// <since_tizen> 9 </since_tizen>
     public class PageAppearedEventArgs : EventArgs
     {
     }
 
     /// <summary>
-    /// PageDisappearedEventArgs is a class to record page disappeared event arguments which will be sent to user.
+    /// PageDisappearedEventArgs is a class to record <see cref="Page.Disappeared"/> event arguments which will be sent to user.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    /// <since_tizen> 9 </since_tizen>
     public class PageDisappearedEventArgs : EventArgs
     {
     }
@@ -127,27 +127,27 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// An event for the page appearing signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// Appearing event is invoked right before the page appears.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public event EventHandler<PageAppearingEventArgs> Appearing;
 
         /// <summary>
-        /// An event for the page disappearing signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// Disappearing event is invoked right before the page disappears.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public event EventHandler<PageDisappearingEventArgs> Disappearing;
 
         /// <summary>
-        /// An event for the page appeared signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// Appeared event is invoked right after the page appears.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public event EventHandler<PageAppearedEventArgs> Appeared;
 
         /// <summary>
-        /// An event for the page disappeared signal which can be used to subscribe or unsubscribe the event handler provided by the user.
+        /// Disappeared event is invoked right after the page disappears.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <since_tizen> 9 </since_tizen>
         public event EventHandler<PageDisappearedEventArgs> Disappeared;
 
         internal void InvokeAppearing()


### PR DESCRIPTION
This is ACR patch to make Appearing, Disappearing, Appeared, Disappeared
events of Page public.
Also PageAppearingEventArgs, PageDisppearingEventArgs,
PageAppearedEventArgs, PageDisppearedEventArgs classes are added
publicly.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
