### PR TITLE
[NUI] Fix GridLayout to calculate child's size proportional to span

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
@@ -126,7 +126,7 @@ namespace Tizen.NUI
                     Node node = edgeList[i];
                     // update expanded size.
                     if (node.Stretch.HasFlag(StretchFlags.Expand))
-                        node.ExpandedSize = curExpandedSize / totalExpand;
+                        node.ExpandedSize = curExpandedSize * (node.End - node.Start) / totalExpand;
                 }
 
                 // re-init locations based on updated expanded size.


### PR DESCRIPTION
Previously, child's size was not proportional to its span.
e.g. width of span 1 was the same with width of span 2.

Now, child's size is proportional to its span.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
