### PR TITLE
[NUI] Fix GridLayout to fill expanded size correctly

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -449,6 +449,7 @@ namespace Tizen.NUI
                     // because the grand children's Measure() is called with the mode type AtMost.
                     int widthSpecification = child.LayoutItem.Owner.WidthSpecification;
                     int heightSpecification = child.LayoutItem.Owner.HeightSpecification;
+                    Size2D origSize = new Size2D(child.LayoutItem.Owner.Size2D.Width, child.LayoutItem.Owner.Size2D.Height);
 
                     if (needMeasuredWidth)
                     {
@@ -470,6 +471,14 @@ namespace Tizen.NUI
                     if (needMeasuredHeight)
                     {
                         child.LayoutItem.Owner.HeightSpecification = heightSpecification;
+                    }
+
+                    // If the both Width/HeightSpecification are set with values bigger than 0,
+                    // then the child's Size2D is changed with the values of Width/HeightSpecification.
+                    // The Size2D changes, caused by setting Width/HeightSpecification, should be reverted.
+                    if (needMeasuredWidth && needMeasuredHeight && (widthSpecification > 0) && (heightSpecification > 0))
+                    {
+                        child.LayoutItem.Owner.SetSize(origSize.Width, origSize.Height);
                     }
                 }
 


### PR DESCRIPTION
Previously, child did not fill to the expanded size if the child had
positive Width/HeightSpecification.

e.g. Let child's WidthSpecification = 100
     Let child's HeightSpecification = 100
     Let child's expanded size (row and col's size) be (200, 200)
     Let child's Stretch mode be ExpandAndFill.
     (child should fill to the expanded size)
     Then, child's size became (100, 100) instead of fill to (200, 200)

Changing child's Width/HeightSpecification to assign
MeasuredWidth/Height could cause child's size changed.
Moreover, the changed size was not recalculated to the expanded size.

Now, child's size change is reverted so the child's size is not changed.
But the way of fixing this bug should be modified in a better way later.

e.g. Assigning MeasuredWidth/Height without changing
     Width/HeightSpecification.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
