### PR TITLE
[NUI] Ignore ResizePolicy when View size is calculated by Layout

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1856,6 +1856,9 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
+                // Store ResizePolicy to restore it when Layout is unset.
+                widthResizePolicy = value;
+
                 SetValue(WidthResizePolicyProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1873,6 +1876,9 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
+                // Store ResizePolicy to restore it when Layout is unset.
+                heightResizePolicy = value;
+
                 SetValue(HeightResizePolicyProperty, value);
                 NotifyPropertyChanged();
             }
@@ -2549,6 +2555,13 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
+                // ResizePolicy is restored when Layout is unset and it is considered when View size is calculated.
+                // SetValue(LayoutProperty, value) sets InternalLayout only if layout is not null.
+                if (value == null)
+                {
+                    RestoreResizePolicy();
+                }
+
                 SetValue(LayoutProperty, value);
             }
         }


### PR DESCRIPTION
View size is calculated based on Width/HeightSpecification if View's
Layout is set.

However, if View's ResizePolicy is not UseNaturalSize (default value),
then View's ResizePolicy also affects View size calculation in DALi
although View's Layout is set.

To ignore ResizePolicy when View size is calculated by View's Layout,
ResizePolicy is set with FIXED when View's Layout is set.

ResizePolicy is stored when Layout is set and it is ignored when View
size is calculated.
ResizePolicy is restored when Layout is unset and it is considered when
View size is calculated.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
