### PR TITLE
[NUI] Make use some ImageView interop method again

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
@@ -100,6 +100,27 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ImageView")]
             public static extern void delete_ImageView(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_IMAGE_get")]
+            public static extern int ImageView_Property_IMAGE_get();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PRE_MULTIPLIED_ALPHA_get")]
+            public static extern int ImageView_Property_PRE_MULTIPLIED_ALPHA_get();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_PIXEL_AREA_get")]
+            public static extern int ImageView_Property_PIXEL_AREA_get();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_RELOAD_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_RELOAD_get();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_PLAY_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_PLAY_get();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_PAUSE_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_PAUSE_get();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ImageVisual_Actions_STOP_get")]
+            public static extern int ImageView_IMAGE_VISUAL_ACTION_STOP_get();
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Seungho Baek <sbsh.baek@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
