### PR TITLE
[NUI] Move ChangeLayoutSiblingOrder from LayoutGroup to LayoutItem

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1219,8 +1219,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetValue(SiblingOrderProperty, value);
 
-                LayoutGroup layout = Layout as LayoutGroup;
-                layout?.ChangeLayoutSiblingOrder(value);
+                Layout?.ChangeLayoutSiblingOrder(value);
 
                 NotifyPropertyChanged();
             }

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -138,33 +138,6 @@ namespace Tizen.NUI
             RequestLayout();
         }
 
-
-        /// <summary>
-        /// Sets the sibling order of the layout item so the layout can be defined within the same parent.
-        /// </summary>
-        /// <param name="order">the sibling order of the layout item</param>
-        /// <since_tizen> 6 </since_tizen>
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void ChangeLayoutSiblingOrder(int order)
-        {
-            if (Owner != null)
-            {
-                var ownerParent = Owner.GetParent() as View;
-                if (ownerParent != null)
-                {
-                    var parent = ownerParent.Layout as LayoutGroup;
-
-                    if (parent != null && parent.LayoutChildren.Count > order)
-                    {
-                        parent.LayoutChildren.Remove(this);
-                        parent.LayoutChildren.Insert(order, this);
-                    }
-                }
-            }
-            RequestLayout();
-        }
-
         /// <summary>
         /// Sets the order of the child layout in the layout group.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -165,6 +165,22 @@ namespace Tizen.NUI
             RequestLayout();
         }
 
+        /// <summary>
+        /// Sets the order of the child layout in the layout group.
+        /// </summary>
+        /// <param name="child">the child layout in the layout group</param>
+        /// <param name="order">the order of the child layout in the layout group</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ChangeLayoutChildOrder(LayoutItem child, int order)
+        {
+            if ((child != null) && (LayoutChildren.Count > order))
+            {
+                LayoutChildren.Remove(child);
+                LayoutChildren.Insert(order, child);
+                RequestLayout();
+            }
+        }
+
         // Attaches to View ChildAdded signal so called when a View is added to a view.
         private void AddChildToLayoutGroup(View child)
         {

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -628,5 +628,24 @@ namespace Tizen.NUI
             Dispose(true);
             global::System.GC.SuppressFinalize(this);
         }
+
+        /// <summary>
+        /// Sets the sibling order of the layout item so the layout can be defined within the same parent.
+        /// </summary>
+        /// <param name="order">the sibling order of the layout item</param>
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ChangeLayoutSiblingOrder(int order)
+        {
+            if (Owner != null)
+            {
+                var ownerParent = Owner.GetParent() as View;
+                if (ownerParent != null)
+                {
+                    var parent = ownerParent.Layout as LayoutGroup;
+                    parent?.ChangeLayoutChildOrder(this, order);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Previously, ChangeLayoutSiblingOrder was provided by LayoutGroup.
So, any layout class inherited from LayoutItem could not use it.

Now, ChangeLayoutSiblingOrder is moved from LayoutGroup to LayoutItem.
So, all layout classes inherited from LayoutItem can use it.

This PR has been made to resolve the following issue.
https://github.sec.samsung.net/dotnet/NUIBackend/issues/87

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
