### PR TITLE
[NUI][AT-SPI] Enabled and Disabled events for Accessibility

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -98,7 +98,7 @@ namespace Tizen.NUI.Components
                         instance.UpdateState();
                     }
 
-                    if (Accessibility.Accessibility.Enabled && instance.IsHighlighted)
+                    if (Accessibility.Accessibility.IsEnabled && instance.IsHighlighted)
                     {
                         instance.EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, newSelected);
                     }
@@ -374,7 +374,7 @@ namespace Tizen.NUI.Components
             {
                 TextLabel.Text = value;
 
-                if (Accessibility.Accessibility.Enabled && IsHighlighted && String.IsNullOrEmpty(AccessibilityName) && GetAccessibilityNameSignal().Empty())
+                if (Accessibility.Accessibility.IsEnabled && IsHighlighted && String.IsNullOrEmpty(AccessibilityName) && GetAccessibilityNameSignal().Empty())
                 {
                     EmitAccessibilityEvent(AccessibilityPropertyChangeEvent.Name);
                 }

--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -427,7 +427,7 @@ namespace Tizen.NUI.Components
 
                 SelectIn(indicatorList[selectedIndex]);
 
-                if (Accessibility.Accessibility.Enabled && IsHighlighted)
+                if (Accessibility.Accessibility.IsEnabled && IsHighlighted)
                 {
                     EmitAccessibilityEvent(AccessibilityPropertyChangeEvent.Value);
                 }

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -451,7 +451,7 @@ namespace Tizen.NUI.Components
             set
             {
                 SetValue(CurrentValueProperty, value);
-                if (Accessibility.Accessibility.Enabled && IsHighlighted)
+                if (Accessibility.Accessibility.IsEnabled && IsHighlighted)
                 {
                     EmitAccessibilityEvent(AccessibilityPropertyChangeEvent.Value);
                 }

--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -214,7 +214,7 @@ namespace Tizen.NUI.Components
         {
             if (info.PreviousState.Contains(ControlState.Selected) != info.CurrentState.Contains(ControlState.Selected))
             {
-                if (Accessibility.Accessibility.Enabled && IsHighlighted)
+                if (Accessibility.Accessibility.IsEnabled && IsHighlighted)
                 {
                     EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, info.CurrentState.Contains(ControlState.Selected));
                 }

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -176,7 +176,7 @@ namespace Tizen.NUI.Components
                 if (newValue != null)
                 {
                     instance.curValue = (float)newValue;
-                    if (Accessibility.Accessibility.Enabled && instance.IsHighlighted)
+                    if (Accessibility.Accessibility.IsEnabled && instance.IsHighlighted)
                     {
                         instance.EmitAccessibilityEvent(AccessibilityPropertyChangeEvent.Value);
                     }

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -365,7 +365,7 @@ namespace Tizen.NUI.Components
 
         private void OnSelect()
         {
-            if (Accessibility.Accessibility.Enabled && IsHighlighted)
+            if (Accessibility.Accessibility.IsEnabled && IsHighlighted)
             {
                 EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, IsSelected);
             }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
@@ -51,6 +51,12 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_IsEnabled")]
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool IsEnabled();
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate void EnabledDisabledSignalHandler();
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_RegisterEnabledDisabledSignalHandler")]
+            public static extern void RegisterEnabledDisabledSignalHandler(EnabledDisabledSignalHandler enabledSignalHandler, EnabledDisabledSignalHandler disabledSignalHandler);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Accessibility.cs
@@ -15,38 +15,41 @@
  *
  */
 
+using System;
+using System.Runtime.InteropServices;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
     {
         internal static partial class Accessibility
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_get_status")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GetStatus(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_get_status")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool GetStatus(HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_say")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool Say(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, bool jarg3, global::System.IntPtr jarg4);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_say")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool Say(HandleRef jarg1, string jarg2, bool jarg3, IntPtr jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_pause_resume")]
-            public static extern void PauseResume(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_pause_resume")]
+            public static extern void PauseResume(HandleRef jarg1, bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_stop_reading")]
-            public static extern void StopReading(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_stop_reading")]
+            public static extern void StopReading(HandleRef jarg1, bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_suppress_screen_reader")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool SuppressScreenReader(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_suppress_screen_reader")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool SuppressScreenReader(HandleRef jarg1, bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeEnableAutoInit")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeEnableAutoInit")]
             public static extern void BridgeEnableAutoInit();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeDisableAutoInit")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_BridgeDisableAutoInit")]
             public static extern void BridgeDisableAutoInit();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_IsEnabled")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "csharp_dali_accessibility_IsEnabled")]
+            [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool IsEnabled();
         }
     }

--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -67,7 +67,7 @@ namespace Tizen.NUI.Accessibility
         /// </remarks>
         /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static bool Enabled
+        public static bool IsEnabled
         {
             get
             {

--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -38,11 +38,29 @@ namespace Tizen.NUI.Accessibility
             dummy = new View();
             dummy.Name = "dali-atspi-singleton";
         }
+
+        static Accessibility()
+        {
+            enabledSignalHandler = () =>
+            {
+                Enabled?.Invoke(typeof(Accessibility), EventArgs.Empty);
+            };
+
+            disabledSignalHandler = () =>
+            {
+                Disabled?.Invoke(typeof(Accessibility), EventArgs.Empty);
+            };
+
+            Interop.Accessibility.RegisterEnabledDisabledSignalHandler(enabledSignalHandler, disabledSignalHandler);
+        }
+
         /// <summary>
         /// destructor. This is HiddenAPI. recommended not to use in public.
         /// </summary>
         ~Accessibility()
         {
+            Interop.Accessibility.RegisterEnabledDisabledSignalHandler(null, null);
+
             Tizen.Log.Debug("NUI", $"Accessibility is destroyed\n");
         }
         #endregion Constructor, Destructor, Dispose
@@ -285,6 +303,21 @@ namespace Tizen.NUI.Accessibility
             add => sayFinishedEventHandler += value;
             remove => sayFinishedEventHandler -= value;
         }
+
+        /// <summary>
+        /// Triggered whenever the value of IsEnabled would change from false to true
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static event EventHandler Enabled;
+
+        /// <summary>
+        /// Triggered whenever the value of IsEnabled would change from true to false
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static event EventHandler Disabled;
+
         #endregion Event, Enum, Struct, ETC
 
 
@@ -319,6 +352,10 @@ namespace Tizen.NUI.Accessibility
         private delegate void SayFinishedEventCallbackType(int result);
 
         private SayFinishedEventCallbackType callback = null;
+
+        private static Interop.Accessibility.EnabledDisabledSignalHandler enabledSignalHandler = null;
+
+        private static Interop.Accessibility.EnabledDisabledSignalHandler disabledSignalHandler = null;
 
         private void SayFinishedEventCallback(int result)
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -309,7 +309,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 RegisterDefaultLabel();
 
-                if (Accessibility.Accessibility.Enabled)
+                if (Accessibility.Accessibility.IsEnabled)
                 {
                     EmitAccessibilityStatesChangedEvent(AccessibilityStates.Showing, true);
                 }
@@ -333,7 +333,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 UnregisterDefaultLabel();
 
-                if (Accessibility.Accessibility.Enabled)
+                if (Accessibility.Accessibility.IsEnabled)
                 {
                     EmitAccessibilityStatesChangedEvent(AccessibilityStates.Showing, false);
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

These events are triggered whenever the value of `Accessibility.IsEnabled` is about to change. In particular, and by design, no event is delivered on application startup or shutdown. Users are encouraged to continue using `IsEnabled` to synchronously query the current accessibility state, and listen to these two events to detect and dynamically react to any later changes of this state if required.

Dependencies:
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/266049/ (merged)
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/266314/ (merged)


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
