### PR TITLE
[NUI] Fix Weight and size calculation in LinearLayout

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -345,10 +345,9 @@ namespace Tizen.NUI
                 float childMarginHeight = childMargin.Top + childMargin.Bottom;
                 bool useRemainingWidth = (childDesiredWidth == 0) && (childWeight > 0);
 
-                totalWeight += childWeight;
-
                 if ((childDesiredWidth == LayoutParamPolicies.MatchParent) || (useRemainingWidth))
                 {
+                    totalWeight += childWeight;
                     childrenMatchParentCount++;
                 }
 
@@ -487,19 +486,19 @@ namespace Tizen.NUI
                 if (needToMeasure == true)
                 {
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
+                }
 
-                    if (childWeight > 0)
+                if ((childWeight > 0) && ((childDesiredWidth == LayoutParamPolicies.MatchParent) || (childDesiredWidth == 0)))
+                {
+                    float childMeasuredWidth = childLayout.MeasuredWidth.Size.AsDecimal();
+
+                    if (childMeasuredWidth < 0)
                     {
-                        float childMeasuredWidth = childLayout.MeasuredWidth.Size.AsDecimal();
-
-                        if (childMeasuredWidth < 0)
-                        {
-                            totalWeightLength = Math.Max(totalWeightLength, totalWeightLength + childMargin.Start + childMargin.End);
-                        }
-                        else
-                        {
-                            totalWeightLength = Math.Max(totalWeightLength, totalWeightLength + childMeasuredWidth + childMargin.Start + childMargin.End);
-                        }
+                        totalWeightLength = Math.Max(totalWeightLength, totalWeightLength + childMargin.Start + childMargin.End);
+                    }
+                    else
+                    {
+                        totalWeightLength = Math.Max(totalWeightLength, totalWeightLength + childMeasuredWidth + childMargin.Start + childMargin.End);
                     }
                 }
             } // 2ND PHASE foreach
@@ -598,10 +597,9 @@ namespace Tizen.NUI
                 float childMarginHeight = childMargin.Top + childMargin.Bottom;
                 bool useRemainingHeight = (childDesiredHeight == 0) && (childWeight > 0);
 
-                totalWeight += childWeight;
-
                 if ((childDesiredHeight == LayoutParamPolicies.MatchParent) || (useRemainingHeight))
                 {
+                    totalWeight += childWeight;
                     childrenMatchParentCount++;
                 }
 
@@ -742,7 +740,7 @@ namespace Tizen.NUI
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
                 }
 
-                if (childWeight > 0)
+                if ((childWeight > 0) && ((childDesiredHeight == LayoutParamPolicies.MatchParent) || (childDesiredHeight == 0)))
                 {
                     float childMeasuredHeight = childLayout.MeasuredHeight.Size.AsDecimal();
 

--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -426,6 +426,7 @@ namespace Tizen.NUI
                 int childDesiredHeight = childLayout.Owner.HeightSpecification;
                 float childWeight = childLayout.Owner.Weight;
                 Extents childMargin = childLayout.Margin;
+                float childMarginHeight = childMargin.Top + childMargin.Bottom;
                 bool useRemainingWidth = (childDesiredWidth == 0) && (childWeight > 0);
                 bool needToMeasure = false;
 
@@ -486,6 +487,16 @@ namespace Tizen.NUI
                 if (needToMeasure == true)
                 {
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
+
+                    float childMeasuredHeight = childLayout.MeasuredHeight.Size.AsDecimal();
+                    if (childMeasuredHeight < 0)
+                    {
+                        maxHeight = Math.Max(maxHeight, childMarginHeight);
+                    }
+                    else
+                    {
+                        maxHeight = Math.Max(maxHeight, childMeasuredHeight + childMarginHeight);
+                    }
                 }
 
                 if ((childWeight > 0) && ((childDesiredWidth == LayoutParamPolicies.MatchParent) || (childDesiredWidth == 0)))
@@ -678,6 +689,7 @@ namespace Tizen.NUI
                 int childDesiredHeight = childLayout.Owner.HeightSpecification;
                 float childWeight = childLayout.Owner.Weight;
                 Extents childMargin = childLayout.Margin;
+                float childMarginWidth = childMargin.Start + childMargin.End;
                 bool useRemainingHeight = (childDesiredHeight == 0) && (childWeight > 0);
                 bool needToMeasure = false;
 
@@ -738,6 +750,16 @@ namespace Tizen.NUI
                 if (needToMeasure == true)
                 {
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
+
+                    float childMeasuredWidth = childLayout.MeasuredWidth.Size.AsDecimal();
+                    if (childMeasuredWidth < 0)
+                    {
+                        maxWidth = Math.Max(maxWidth, childMarginWidth);
+                    }
+                    else
+                    {
+                        maxWidth = Math.Max(maxWidth, childMeasuredWidth + childMarginWidth);
+                    }
                 }
 
                 if ((childWeight > 0) && ((childDesiredHeight == LayoutParamPolicies.MatchParent) || (childDesiredHeight == 0)))


### PR DESCRIPTION
View's Weight is considered in LinearLayout's calculation only if the
View's Specification is MatchParent.
Because Weight is used to divide the parent's space to each child.

Previously, WrapContent View's Weight was also added to the sum of
Weights.
This caused the weighted View's size was calculated incorrectly.

Now, only MatchParent View's Weight is added to the sum of Weights.
As a result, the weighted View's size is calculated correctly.

When a View's Specification was WrapContent, the View's LinearLayout did
not consider its child size correctly.
This caused that the View's Size became 0 incorrectly.

To resolve the above, LinearLayout always considers its child size and
the LinearLayout uses its child size when it calculates its own size.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
