### PR TITLE
[NUI][ATSPI] CollectionView - Show highlighed descendant

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -850,16 +850,29 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override bool AccessibilityScrollToChild(View child)
         {
-            foreach (RecyclerViewItem item in ContentContainer.Children.Where((item) => item is RecyclerViewItem))
+            if (ScrollingDirection == Direction.Horizontal)
             {
-                if (child == item)
+                if (child.ScreenPosition.X + child.Size.Width <= this.ScreenPosition.X)
                 {
-                    ScrollToIndex(item.Index);
-                    return true;
+                    ScrollTo((float)(child.ScreenPosition.X - ContentContainer.ScreenPosition.X), false);
+                }
+                else if (child.ScreenPosition.X >= this.ScreenPosition.X + this.Size.Width)
+                {
+                    ScrollTo((float)(child.ScreenPosition.X + child.Size.Width - ContentContainer.ScreenPosition.X - this.Size.Width), false);
                 }
             }
-
-            return false;
+            else
+            {
+                if (child.ScreenPosition.Y + child.Size.Height <= this.ScreenPosition.Y)
+                {
+                    ScrollTo((float)(child.ScreenPosition.Y - ContentContainer.ScreenPosition.Y), false);
+                }
+                else if (child.ScreenPosition.Y >= this.ScreenPosition.Y + this.Size.Height)
+                {
+                    ScrollTo((float)(child.ScreenPosition.Y + child.Size.Height - ContentContainer.ScreenPosition.Y - this.Size.Height), false);
+                }
+            }
+            return true;
         }
 
         // Realize and Decorate the item.


### PR DESCRIPTION
The 1st generation child ContentContainer is always showing. So
it was not able to show highlighted descendant by AccessibilityScrollToChild.

The child is a descendant of CollectionView from following patch.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/266414/

With this patch set, It is possible to show highlighted descendant.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
