### PR TITLE
[NUI] Fix wrong prev size assigning on scroll relayout.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -755,8 +755,8 @@ namespace Tizen.NUI.Components
                 }
             }
 
-            previousContainerSize = ContentContainer.Size;
-            previousSize = Size;
+            previousContainerSize = new Size(ContentContainer.Size);
+            previousSize = new Size(Size);
         }
 
         private bool ReviseContainerPositionIfNeed()


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
