### PR TITLE
Revert "[NUI] Ignore ResizePolicy when View size is calculated by Lay…

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1948,9 +1948,6 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                // Store ResizePolicy to restore it when Layout is unset.
-                widthResizePolicy = value;
-
                 SetValue(WidthResizePolicyProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1968,9 +1965,6 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                // Store ResizePolicy to restore it when Layout is unset.
-                heightResizePolicy = value;
-
                 SetValue(HeightResizePolicyProperty, value);
                 NotifyPropertyChanged();
             }
@@ -2703,13 +2697,6 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                // ResizePolicy is restored when Layout is unset and it is considered when View size is calculated.
-                // SetValue(LayoutProperty, value) sets InternalLayout only if layout is not null.
-                if (value == null)
-                {
-                    RestoreResizePolicy();
-                }
-
                 SetValue(LayoutProperty, value);
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -31,14 +31,6 @@ namespace Tizen.NUI.BaseComponents
     public partial class View
     {
         private MergedStyle mergedStyle = null;
-
-        // Ignore WidthResizePolicy and HeightResizePolicy when Layout is set.
-        // Restore WidthResizePolicy and HeightResizePolicy when Layout is unset.
-        // See also IgnoreResizePolicy() and RestoreResizePolicy().
-        private ResizePolicyType widthResizePolicy = ResizePolicyType.Fixed;
-        private ResizePolicyType heightResizePolicy = ResizePolicyType.Fixed;
-        private bool isIgnoredResizePolicy = false;
-
         internal string styleName;
 
         internal MergedStyle MergedStyle
@@ -197,17 +189,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetLayout(LayoutItem layout)
         {
-            // ResizePolicy is restored when Layout is unset and it is considered when View size is calculated.
-            if (layout == null)
-            {
-                RestoreResizePolicy();
-            }
-            // ResizePolicy is stored when Layout is set and it is ignored when View size is calculated.
-            else
-            {
-                IgnoreResizePolicy();
-            }
-
             Window.Instance.LayoutController.CreateProcessCallback();
             this.layout = layout;
             this.layout?.AttachToOwner(this);
@@ -1029,8 +1010,6 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         internal void ResetLayout()
         {
-            // ResizePolicy is restored when Layout is unset and it is considered when View size is calculated.
-            RestoreResizePolicy();
             layout = null;
         }
 
@@ -1508,33 +1487,6 @@ namespace Tizen.NUI.BaseComponents
             if (themeData == null) themeData = new ThemeData();
 
             return themeData.selectorData ?? (themeData.selectorData = new ViewSelectorData());
-        }
-
-        // ResizePolicy is stored when Layout is set and it is ignored when View size is calculated.
-        private void IgnoreResizePolicy()
-        {
-            if (isIgnoredResizePolicy) return;
-            isIgnoredResizePolicy = true;
-
-            widthResizePolicy = WidthResizePolicy;
-            heightResizePolicy = HeightResizePolicy;
-
-            // Set bindable property directly not to store width/heightResizePolicy duplicately.
-            SetValue(WidthResizePolicyProperty, ResizePolicyType.Fixed);
-            SetValue(HeightResizePolicyProperty, ResizePolicyType.Fixed);
-            NotifyPropertyChanged();
-        }
-
-        // ResizePolicy is restored when Layout is unset and it is considered when View size is calculated.
-        private void RestoreResizePolicy()
-        {
-            if (!isIgnoredResizePolicy) return;
-            isIgnoredResizePolicy = false;
-
-            // Set bindable property directly not to store width/heightResizePolicy duplicately.
-            SetValue(WidthResizePolicyProperty, widthResizePolicy);
-            SetValue(HeightResizePolicyProperty, heightResizePolicy);
-            NotifyPropertyChanged();
         }
     }
 }


### PR DESCRIPTION
…out"

This reverts commit eeaaecd33da254f5447910ecd9b0cab89407d4ba.

By applying the original PR, TextLabel size could not be calculated
correctly because TextLabel size should be calculated in DALi.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
