### PR TITLE
[NUI][ATSPI] Calculate states based on DALi

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -412,11 +412,11 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates()
+        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
         {
-            var states = base.AccessibilityCalculateStates();
-            FlagSetter(ref states, AccessibilityStates.Modal, true);
-            return states;
+            var accessibilityStates = base.AccessibilityCalculateStates(states);
+            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
+            return accessibilityStates;
         }
 
 

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -217,12 +217,12 @@ namespace Tizen.NUI.Components
         /// Calculates current states for the button<br />
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates()
+        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
         {
-            var states = base.AccessibilityCalculateStates();
-            FlagSetter(ref states, AccessibilityStates.Checked, this.IsSelected);
-            FlagSetter(ref states, AccessibilityStates.Enabled, this.IsEnabled);
-            return states;
+            var accessibilityStates = base.AccessibilityCalculateStates(states);
+            FlagSetter(ref accessibilityStates, AccessibilityStates.Checked, this.IsSelected);
+            FlagSetter(ref accessibilityStates, AccessibilityStates.Enabled, this.IsEnabled);
+            return accessibilityStates;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -111,11 +111,11 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates()
+        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
         {
-            var states = base.AccessibilityCalculateStates();
-            FlagSetter(ref states, AccessibilityStates.Modal, true);
-            return states;
+            var accessibilityStates = base.AccessibilityCalculateStates(states);
+            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
+            return accessibilityStates;
         }
 
         private void OnRelayout(object sender, EventArgs e)

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -726,11 +726,11 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates()
+        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
         {
-            var states = base.AccessibilityCalculateStates();
-            FlagSetter(ref states, AccessibilityStates.Modal, true);
-            return states;
+            var accessibilityStates = base.AccessibilityCalculateStates(states);
+            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
+            return accessibilityStates;
         }
 
         private void UpdateView()

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -78,11 +78,11 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates()
+        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
         {
-            var states = base.AccessibilityCalculateStates();
-            FlagSetter(ref states, AccessibilityStates.Checked, this.IsSelected);
-            return states;
+            var accessibilityStates = base.AccessibilityCalculateStates(states);
+            FlagSetter(ref accessibilityStates, AccessibilityStates.Checked, this.IsSelected);
+            return accessibilityStates;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -208,7 +208,7 @@ namespace Tizen.NUI
                 public AccessibilityDoAction DoAction; // 3
 
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                public delegate IntPtr AccessibilityCalculateStates();
+                public delegate IntPtr AccessibilityCalculateStates(ulong states);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityCalculateStates CalculateStates; // 4
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -481,7 +481,7 @@ namespace Tizen.NUI.BaseComponents
                     GetName = () => DuplicateString(AccessibilityGetName()),
                     GetDescription = () => DuplicateString(AccessibilityGetDescription()),
                     DoAction = (name) => AccessibilityDoAction(Marshal.PtrToStringAnsi(name)),
-                    CalculateStates = () => DuplicateStates(AccessibilityCalculateStates()),
+                    CalculateStates = (states) => DuplicateStates(AccessibilityCalculateStates(states)),
                     GetActionCount = () => AccessibilityGetActionCount(),
                     GetActionName = (index) => DuplicateString(AccessibilityGetActionName(index)),
                     ShouldReportZeroChildren = () => AccessibilityShouldReportZeroChildren(),
@@ -626,21 +626,20 @@ namespace Tizen.NUI.BaseComponents
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual AccessibilityStates AccessibilityCalculateStates()
+        protected virtual AccessibilityStates AccessibilityCalculateStates(ulong states)
         {
-            AccessibilityStates states = 0;
+            AccessibilityStates _states = (AccessibilityStates)states;
 
-            FlagSetter(ref states, AccessibilityStates.Highlightable, this.AccessibilityHighlightable);
-            FlagSetter(ref states, AccessibilityStates.Focusable, this.Focusable);
-            FlagSetter(ref states, AccessibilityStates.Focused, this.State == States.Focused);
-            FlagSetter(ref states, AccessibilityStates.Highlighted, this.IsHighlighted);
-            FlagSetter(ref states, AccessibilityStates.Enabled, this.State != States.Disabled);
-            FlagSetter(ref states, AccessibilityStates.Sensitive, this.Sensitive);
-            FlagSetter(ref states, AccessibilityStates.Visible, true);
-            FlagSetter(ref states, AccessibilityStates.Showing, this.Visibility);
-            FlagSetter(ref states, AccessibilityStates.Defunct, !this.IsOnWindow);
+            FlagSetter(ref _states, AccessibilityStates.Highlightable, this.AccessibilityHighlightable);
+            FlagSetter(ref _states, AccessibilityStates.Focusable, this.Focusable);
+            FlagSetter(ref _states, AccessibilityStates.Focused, this.State == States.Focused);
+            FlagSetter(ref _states, AccessibilityStates.Highlighted, this.IsHighlighted);
+            FlagSetter(ref _states, AccessibilityStates.Enabled, this.State != States.Disabled);
+            FlagSetter(ref _states, AccessibilityStates.Sensitive, this.Sensitive);
+            FlagSetter(ref _states, AccessibilityStates.Visible, true);
+            FlagSetter(ref _states, AccessibilityStates.Defunct, !this.IsOnWindow);
 
-            return states;
+            return _states;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -303,7 +303,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public void Show()
         {
-            if (Accessibility.Accessibility.Enabled && ((AccessibilityCalculateStates() & AccessibilityStates.Modal) != 0))
+            if (Accessibility.Accessibility.Enabled && ((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
             {
                 RegisterPopup();
             }
@@ -324,7 +324,7 @@ namespace Tizen.NUI.BaseComponents
         {
             SetVisible(false);
 
-            if (Accessibility.Accessibility.Enabled && ((AccessibilityCalculateStates() & AccessibilityStates.Modal) != 0))
+            if (Accessibility.Accessibility.Enabled && ((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
             {
                 RemovePopup();
             }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSAlertDialog.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSAlertDialog.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI.Components.Devel.Tests
 
             public AccessibilityStates OnAccessibilityCalculateStates()
             {
-                return base.AccessibilityCalculateStates();
+                return GetAccessibilityStates();
             }
         }
 

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSDialog.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSDialog.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI.Components.Devel.Tests
 
             public void MyAccessibilityCalculateStates()
             {
-                base.AccessibilityCalculateStates();
+                GetAccessibilityStates();//base.AccessibilityCalculateStates();
             }
         }
 

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSSwitch.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSSwitch.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI.Components.Devel.Tests
 
             public void OnAccessibilityCalculateStates()
             {
-                base.AccessibilityCalculateStates();
+                GetAccessibilityStates();
             }
 
             public void MyOnControlStateChanged(ControlStateChangedEventArgs controlStateChangedInfo)


### PR DESCRIPTION
We do not have to same job calculating states.
This patch sets make the View use DALi states.
If there is NUI specific state, then it will be overwritten.

This depends on following change.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/266577/
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
