### PR TITLE
[NUI] Fix crash when View.BackgroundImage is set

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2399,7 +2399,7 @@ namespace Tizen.NUI.BaseComponents
             var borderlineOffset = new PropertyValue(backgroundExtraData.BorderlineOffset);
             var synchronousLoading = new PropertyValue(backgroundImageSynchronousLoading);
             var npatchType = new PropertyValue((int)Visual.Type.NPatch);
-            var border = new PropertyValue(backgroundExtraData.BackgroundImageBorder);
+            var border = (backgroundExtraData.BackgroundImageBorder != null) ? new PropertyValue(backgroundExtraData.BackgroundImageBorder) : null;
             var imageType = new PropertyValue((int)Visual.Type.Image);
 
             map.Add(ImageVisualProperty.URL, url)


### PR DESCRIPTION
Previously, View.BackgroundImage is set, PropertyValue constructor can
be called with null pointer and this causes crash.

Now, it has been fixed not to pass null pointer to PropertyValue
constructor.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
