### PR TITLE
[NUI][AT_SPI] Added Accessibility support to Menu control

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -394,6 +394,8 @@ namespace Tizen.NUI.Components
             layer.RaiseToTop();
 
             CalculateSizeAndPosition();
+            RegisterDefaultLabel();
+            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, true);
         }
 
         /// <summary>
@@ -404,6 +406,8 @@ namespace Tizen.NUI.Components
         public void Dismiss()
         {
             Hide();
+            UnregisterDefaultLabel();
+            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, true);
             Dispose();
         }
 
@@ -639,6 +643,28 @@ namespace Tizen.NUI.Components
             {
                 Scrim.Position2D = new Position2D(-Position2D.X, -Position2D.Y);
             }
+        }
+
+        /// <summary>
+        /// Initialize AT-SPI object.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnInitialize()
+        {
+            base.OnInitialize();
+            SetAccessibilityConstructor(Role.PopupMenu);
+            AppendAccessibilityAttribute("sub-role", "Alert");
+        }
+
+        /// <summary>
+        /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
+        {
+            var accessibilityStates = base.AccessibilityCalculateStates(states);
+            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
+            return accessibilityStates;
         }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/MenuItem.cs
+++ b/src/Tizen.NUI.Components/Controls/MenuItem.cs
@@ -236,5 +236,15 @@ namespace Tizen.NUI.Components
         {
             Layout = new AbsoluteLayout();
         }
+
+        /// <summary>
+        /// Initialize AT-SPI object.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnInitialize()
+        {
+            base.OnInitialize();
+            SetAccessibilityConstructor(Role.MenuItem);
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Added AT-SPI2 support to Menu control.

Now in A11y mode the UI context is rebuilt and proper navigation provided.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: none

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
