### PR TITLE
[NUI] Integrate TouchAreaOffset from API9

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
@@ -199,6 +199,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetMaximumSize")]
             public static extern global::System.IntPtr Actor_GetMaximumSize(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_DevelActor_Property_SetTouchAreaOffset")]
+            public static extern void SetTouchAreaOffset(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, int jarg4, int jarg5);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_DevelActor_Property_GetTouchAreaOffset")]
+            public static extern void GetTouchAreaOffset(global::System.Runtime.InteropServices.HandleRef jarg1, out int jarg2, out int jarg3, out int jarg4, out int jarg5);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -1278,5 +1278,51 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// TouchArea can expand the view's touchable area.<br/>
+        /// If you set the TouchAreaOffset on an view, when you touch the view, the touch area is used rather than the size of the view.<br/>
+        /// This is based on the top left x, y coordinates.<br/>
+        /// example) <br/>
+        ///  view.Size = new Size(100, 100);<br/>
+        ///  view.TouchAreaOffset = new Offset(-10, 20, 30, -40); // left, right, bottom, top <br/>
+        /// then touch area is 130x170.<br/>
+        /// this is view.width + TouchAreaOffset.right - TouchAreaOffset.left and view.height + TouchAreaOffset.bottom - TouchAreaOffset.top <br/>
+        /// +---------------------+ <br/>
+        /// |         ^           | <br/>
+        /// |         |           | <br/>
+        /// |         | -40       | <br/>
+        /// |         |           | <br/>
+        /// |         |           | <br/>
+        /// |    +----+----+      | <br/>
+        /// |    |         |      | <br/>
+        /// | -10|         | 20   | <br/>
+        /// |<---+         +----->| <br/>
+        /// |    |         |      | <br/>
+        /// |    |         |      | <br/>
+        /// |    +----+----+      | <br/>
+        /// |         |           | <br/>
+        /// |         | 30        | <br/>
+        /// |         |           | <br/>
+        /// |         v           | <br/>
+        /// +---------------------+ <br/>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Offset TouchAreaOffset
+        {
+            get
+            {
+                Interop.ActorInternal.GetTouchAreaOffset(SwigCPtr, out int left, out int right, out int bottom, out int top);
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return new Offset(left, right, bottom, top);
+            }
+            set
+            {
+                Interop.ActorInternal.SetTouchAreaOffset(SwigCPtr, value.Left, value.Right, value.Bottom, value.Top);
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
     }
 }

--- a/src/Tizen.NUI/src/public/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/NUIConstants.cs
@@ -1806,6 +1806,55 @@ namespace Tizen.NUI
         NoThirdParty
     }
 
+
+    /// <summary>
+    /// Offset has left, right, bottom, top value.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct Offset
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="left">left offset</param>
+        /// <param name="right">right offset</param>
+        /// <param name="bottom">bottom offset</param>
+        /// <param name="top">top offset</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Offset(int left, int right, int bottom, int top)
+        {
+            Left = left;
+            Right = right;
+            Bottom = bottom;
+            Top = top;
+        }
+
+        /// <summary>
+        /// Left
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Left {get; set;}
+
+        /// <summary>
+        /// Right
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Right {get; set;}
+
+        /// <summary>
+        /// Bottom
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Bottom {get; set;}
+
+        /// <summary>
+        /// Top
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Top {get; set;}
+
+    }
+
     /// <summary>
     /// TODO This is to get TizenFX resource path. It needs to be fixed to use application framework API in the future.
     /// Internal use only. Do not open this API.

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TouchGestureSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TouchGestureSample.cs
@@ -9,7 +9,6 @@ namespace Tizen.NUI.Samples
     public class TouchGestureSample : IExample
     {
         private View root;
-        GestureDetectorManager mGestureDetector;
         private TextLabel frontView;
         private TextLabel backView;
 
@@ -33,6 +32,7 @@ namespace Tizen.NUI.Samples
                 BackgroundColor = new Color(1.0f, 0.0f, 0.0f, 1.0f),
             };
             frontView.TouchEvent += OnFrontTouchEvent;
+            frontView.TouchAreaOffset = new Offset(-10, 20, 30, -40); // left, right, bottom, top
 
 
             backView = new TextLabel
@@ -44,7 +44,6 @@ namespace Tizen.NUI.Samples
                 BackgroundColor = new Color(1.0f, 1.0f, 0.0f, 1.0f),
             };
 
-            mGestureDetector = new GestureDetectorManager(backView, new MyGestureListener());
             backView.TouchEvent += OnBackTouchEvent;
 
             backView.Add(frontView);
@@ -63,37 +62,9 @@ namespace Tizen.NUI.Samples
         private bool OnBackTouchEvent(object source, View.TouchEventArgs e)
         {
             Tizen.Log.Error("NUI", $"OnBackTouchEvent {e.Touch.GetState(0)}\n");
-            mGestureDetector.FeedTouchEvent(source, e, this);
             return false;
         }
 
-        class MyGestureListener : GestureDetectorManager.GestureListener
-        {
-          public override void OnTap(object sender, TapGestureDetector.DetectedEventArgs e, object userData)
-          {
-            Tizen.Log.Error("NUI", $"OnTap \n");
-            if(userData != null)
-            {
-              TouchGestureSample sample = (TouchGestureSample) userData;
-              sample.ChangeText();
-            }
-          }
-
-          public override void OnPan(object sender, PanGestureDetector.DetectedEventArgs e, object userData)
-          {
-            Tizen.Log.Error("NUI", $"OnPan \n");
-          }
-
-          public override void OnPinch(object sender, PinchGestureDetector.DetectedEventArgs e, object userData)
-          {
-            Tizen.Log.Error("NUI", $"OnPinch \n");
-          }
-
-          public override void OnLongPress(object sender, LongPressGestureDetector.DetectedEventArgs e, object userData)
-          {
-            Tizen.Log.Error("NUI", $"OnLongPress \n");
-          }
-        }
 
         public void Deactivate()
         {


### PR DESCRIPTION
1. [NUI] Add TouchArea property.
Default touchable area is view's size.
TouchArea can reset the view's touchable area.

This is usefull when the view is small, but it should have a larger touch area.

for example

      View view = new View();
      view.Size = new Size(10, 10);
      view.TouchEvent += OnTouchEvent;
      view.TouchArea = new Size2D(200, 200);

The view is small, If you want to set the touch area to a larger area,
you can use the TouchArea property.

2. [NUI] change type from Size2D to Size at TouchArea api

3. [NUI] Change  TouchArea to TouchAreaOffset (#2948)

    You can expand the touch area.

    for example)
      View view = new View();
      view.Size = new Size(10, 10);
      view.TouchEvent += OnTouch;
      view.TouchAreaOffset = new Offset(-100, 100, 100, -100); // left, right, bottom, top

    then touch area is 210x210.
    this is view.width  -touchAreaOffset.left + touchAreaOffset.right
    and view.height + touchAreaOffset.bottom  -touchAreaOffset.top

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
