### PR TITLE
[NUI][API9] Set null if callback removed

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -207,7 +207,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(keyCallback);
-                        keyCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            keyCallback = null;
+                        }
                     }
                 }
             }
@@ -240,7 +243,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(onRelayoutEventCallback);
-                        onRelayoutEventCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            onRelayoutEventCallback = null;
+                        }
                     }
                 }
             }
@@ -275,7 +281,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(interceptTouchDataCallback);
-                        interceptTouchDataCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            interceptTouchDataCallback = null;
+                        }
                     }
                 }
             }
@@ -321,7 +330,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal.Empty() == false)
                     {
                         signal.Disconnect(touchDataCallback);
-                        touchDataCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            touchDataCallback = null;
+                        }
                     }
                 }
             }
@@ -354,7 +366,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(hoverEventCallback);
-                        hoverEventCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            hoverEventCallback = null;
+                        }
                     }
                 }
             }
@@ -393,7 +408,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(wheelEventCallback);
-                        wheelEventCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            wheelEventCallback = null;
+                        }
                     }
                 }
 
@@ -432,7 +450,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(onWindowEventCallback);
-                        onWindowEventCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            onWindowEventCallback = null;
+                        }
                     }
                 }
             }
@@ -465,7 +486,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(offWindowEventCallback);
-                        offWindowEventCallback = null;
+                        if (signal?.Empty() == true)
+                        {
+                            offWindowEventCallback = null;
+                        }
                     }
                 }
             }
@@ -496,6 +520,10 @@ namespace Tizen.NUI.BaseComponents
                 if (visibilityChangedEventHandler == null && VisibilityChangedSignal(this).Empty() == false)
                 {
                     VisibilityChangedSignal(this).Disconnect(visibilityChangedEventCallback);
+                    if (VisibilityChangedSignal(this).Empty() == true)
+                    {
+                        visibilityChangedEventCallback = null;
+                    }
                 }
             }
         }
@@ -525,6 +553,10 @@ namespace Tizen.NUI.BaseComponents
                 if (layoutDirectionChangedEventHandler == null && LayoutDirectionChangedSignal(this).Empty() == false)
                 {
                     LayoutDirectionChangedSignal(this).Disconnect(layoutDirectionChangedEventCallback);
+                    if (LayoutDirectionChangedSignal(this).Empty() == true)
+                    {
+                        layoutDirectionChangedEventCallback = null;
+                    }
                 }
             }
         }
@@ -556,7 +588,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(ResourcesLoadedCallback);
-                        ResourcesLoadedCallback = null;
+                        if(signal?.Empty() == true)
+                        {
+                            ResourcesLoadedCallback = null;
+                        }
                     }
                 }
             }
@@ -616,7 +651,10 @@ namespace Tizen.NUI.BaseComponents
                     if (signal?.Empty() == false)
                     {
                         signal?.Disconnect(backgroundResourceLoadedCallback);
-                        backgroundResourceLoadedCallback = null;
+                        if(signal?.Empty() == true)
+                        {
+                            backgroundResourceLoadedCallback = null;
+                        }
                     }
                 }
             }

--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -91,6 +91,10 @@ namespace Tizen.NUI
                 if (windowFocusChangedEventHandler == null && windowFocusChangedSignal?.Empty() == false && windowFocusChangedEventCallback != null)
                 {
                     windowFocusChangedSignal?.Disconnect(windowFocusChangedEventCallback);
+                    if(windowFocusChangedSignal?.Empty() == true)
+                    {
+                        windowFocusChangedEventCallback = null;
+                    }
                 }
             }
         }
@@ -121,6 +125,10 @@ namespace Tizen.NUI
                 if (rootLayerTouchDataEventHandler == null && touchDataSignal?.Empty() == false && rootLayerTouchDataCallback != null)
                 {
                     touchDataSignal?.Disconnect(rootLayerTouchDataCallback);
+                    if(touchDataSignal?.Empty() == true)
+                    {
+                        rootLayerTouchDataCallback = null;
+                    }
                 }
             }
         }
@@ -156,6 +164,10 @@ namespace Tizen.NUI
                 if (stageWheelHandler == null && wheelSignal?.Empty() == false)
                 {
                     wheelSignal?.Disconnect(wheelEventCallback);
+                    if(wheelSignal?.Empty() == true)
+                    {
+                        wheelEventCallback = null;
+                    }
                 }
 
                 DetentEventHandler -= value;
@@ -163,6 +175,10 @@ namespace Tizen.NUI
                 if (DetentEventHandler == null && stageWheelSignal?.Empty() == false)
                 {
                     stageWheelSignal?.Disconnect(DetentEventCallback);
+                    if(stageWheelSignal?.Empty() == true)
+                    {
+                        DetentEventCallback = null;
+                    }
                 }
             }
         }
@@ -190,6 +206,10 @@ namespace Tizen.NUI
                 if (stageKeyHandler == null && keyEventSignal?.Empty() == false)
                 {
                     keyEventSignal?.Disconnect(stageKeyCallbackDelegate);
+                    if(keyEventSignal?.Empty() == true)
+                    {
+                        stageKeyCallbackDelegate = null;
+                    }
                 }
             }
         }
@@ -219,7 +239,10 @@ namespace Tizen.NUI
                 if (windowResizeEventHandler == null && resizeSignal?.Empty() == false && windowResizeEventCallback != null)
                 {
                     resizeSignal?.Disconnect(windowResizeEventCallback);
-                    windowResizeEventCallback = null;
+                    if(resizeSignal?.Empty() == true)
+                    {
+                        windowResizeEventCallback = null;
+                    }
                 }
             }
         }
@@ -256,6 +279,10 @@ namespace Tizen.NUI
                 if (windowFocusChangedEventHandler2 == null && windowFocusChangedSignal2?.Empty() == false && windowFocusChangedEventCallback2 != null)
                 {
                     windowFocusChangedSignal2?.Disconnect(windowFocusChangedEventCallback2);
+                    if(windowFocusChangedSignal2?.Empty() == true)
+                    {
+                        windowFocusChangedEventCallback2 = null;
+                    }
                 }
             }
         }
@@ -281,6 +308,10 @@ namespace Tizen.NUI
                 if (transitionEffectHandler == null && TransitionEffectEventSignal().Empty() == false)
                 {
                     TransitionEffectEventSignal().Disconnect(transitionEffectEventCallback);
+                    if(TransitionEffectEventSignal().Empty() == true)
+                    {
+                        transitionEffectEventCallback = null;
+                    }
                 }
             }
         }
@@ -306,6 +337,10 @@ namespace Tizen.NUI
                 if (keyboardRepeatSettingsChangedHandler == null && KeyboardRepeatSettingsChangedEventSignal().Empty() == false)
                 {
                     KeyboardRepeatSettingsChangedEventSignal().Disconnect(keyboardRepeatSettingsChangedEventCallback);
+                    if(KeyboardRepeatSettingsChangedEventSignal().Empty() == true)
+                    {
+                        keyboardRepeatSettingsChangedEventCallback = null;
+                    }
                 }
             }
         }
@@ -354,6 +389,10 @@ namespace Tizen.NUI
                 if (stageEventProcessingFinishedEventHandler == null && eventProcessingFinishedSignal?.Empty() == false)
                 {
                     eventProcessingFinishedSignal?.Disconnect(stageEventProcessingFinishedEventCallbackDelegate);
+                    if(eventProcessingFinishedSignal?.Empty() == true)
+                    {
+                        stageEventProcessingFinishedEventCallbackDelegate = null;
+                    }
                 }
             }
         }
@@ -378,6 +417,10 @@ namespace Tizen.NUI
                 if (stageContextLostEventHandler == null && contextLostSignal?.Empty() == false)
                 {
                     contextLostSignal?.Disconnect(stageContextLostEventCallbackDelegate);
+                    if(contextLostSignal?.Empty() == true)
+                    {
+                        stageContextLostEventCallbackDelegate = null;
+                    }
                 }
             }
         }
@@ -402,6 +445,10 @@ namespace Tizen.NUI
                 if (stageContextRegainedEventHandler == null && contextRegainedSignal?.Empty() == false)
                 {
                     contextRegainedSignal?.Disconnect(stageContextRegainedEventCallbackDelegate);
+                    if(contextRegainedSignal?.Empty() == true)
+                    {
+                        stageContextRegainedEventCallbackDelegate = null;
+                    }
                 }
             }
         }
@@ -426,6 +473,10 @@ namespace Tizen.NUI
                 if (stageSceneCreatedEventHandler == null && sceneCreatedSignal?.Empty() == false)
                 {
                     sceneCreatedSignal?.Disconnect(stageSceneCreatedEventCallbackDelegate);
+                    if(sceneCreatedSignal?.Empty() == true)
+                    {
+                        stageSceneCreatedEventCallbackDelegate = null;
+                    }
                 }
             }
         }
@@ -530,6 +581,7 @@ namespace Tizen.NUI
                 if( touchDataSignal?.Empty() == false )
                 {
                     touchDataSignal?.Disconnect(rootLayerTouchDataCallback);
+                    rootLayerTouchDataCallback = null;
                 }
             }
 
@@ -539,6 +591,7 @@ namespace Tizen.NUI
                 if( wheelSignal?.Empty() == false )
                 {
                     wheelSignal?.Disconnect(wheelEventCallback);
+                    wheelEventCallback = null;
                 }
             }
 
@@ -638,7 +691,7 @@ namespace Tizen.NUI
             {
                 using var signal = new WindowAuxiliaryMessageSignal(this);
                 signal.Disconnect(auxiliaryMessageEventCallback);
-                auxiliaryMessageEventHandler= null;
+                auxiliaryMessageEventHandler = null;
                 auxiliaryMessageEventCallback = null;
             }
         }
@@ -1135,6 +1188,10 @@ namespace Tizen.NUI
                         if (VisibilityChangedEventSignal.Empty() == false)
                         {
                             VisibilityChangedEventSignal.Disconnect(VisibilityChangedEventCallback);
+                            if (VisibilityChangedEventSignal.Empty())
+                            {
+                                VisibilityChangedEventCallback = null;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
When signal disconnected and signal become empty, let callback as null.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
