### PR TITLE
[NUI] Add API so that user can copy properties, bindings from other container

### DIFF
--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Tizen.NUI.Binding.Internals;
 
@@ -67,7 +68,7 @@ namespace Tizen.NUI.Binding
                 }
             }));
 
-        readonly List<BindablePropertyContext> properties = new List<BindablePropertyContext>(4);
+        readonly Dictionary<BindableProperty, BindablePropertyContext> properties = new Dictionary<BindableProperty, BindablePropertyContext>(4);
 
         bool applying;
         object inheritedContext;
@@ -115,7 +116,7 @@ namespace Tizen.NUI.Binding
                 {
                     nameToBindableProperty2.TryGetValue(keyValuePair.Key, out var bindableProperty);
 
-                    if (null != bindableProperty)
+                    if (null != bindableProperty && (SettedPropeties.Contains(bindableProperty) || other.SettedPropeties.Contains(bindableProperty)))
                     {
                         object value = other.GetValue(bindableProperty);
 
@@ -124,6 +125,34 @@ namespace Tizen.NUI.Binding
                             SetValue(keyValuePair.Value, value);
                         }
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copy all binding from other object.
+        /// </summary>
+        /// <param name="other"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void CopyBindingRelationShip(BindableObject other)
+        {
+            if (null == other)
+            {
+                return;
+            }
+
+            foreach (var property in properties)
+            {
+                RemoveBinding(property.Key);
+            }
+
+            foreach (var property in other.properties)
+            {
+                if (null != property.Value.Binding)
+                {
+                    var binding = property.Value.Binding;
+                    other.RemoveBinding(property.Key);
+                    SetBinding(property.Key, binding);
                 }
             }
         }
@@ -292,6 +321,22 @@ namespace Tizen.NUI.Binding
                 OnPropertyChanged(property.PropertyName);
                 OnPropertyChangedWithData(property);
             }
+
+            SettedPropeties.Add(property);
+        }
+
+        private HashSet<BindableProperty> settedPropeties;
+        private HashSet<BindableProperty> SettedPropeties
+        {
+            get
+            {
+                if (null == settedPropeties)
+                {
+                    settedPropeties = new HashSet<BindableProperty>();
+                }
+
+                return settedPropeties;
+            }
         }
 
         internal void SetValueAndForceSendChangeSignal(BindableProperty property, object value)
@@ -435,9 +480,8 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void UnapplyBindings()
         {
-            for (int i = 0, _propertiesCount = properties.Count; i < _propertiesCount; i++)
+            foreach (var context in properties.Values)
             {
-                BindablePropertyContext context = properties[i];
                 if (context.Binding == null)
                     continue;
 
@@ -464,10 +508,8 @@ namespace Tizen.NUI.Binding
         {
             var values = new object[2];
 
-            for (var i = 0; i < properties.Count; i++)
+            foreach (var context in properties.Values)
             {
-                BindablePropertyContext context = properties[i];
-
                 if (ReferenceEquals(context.Property, property0))
                 {
                     values[0] = context.Value;
@@ -502,10 +544,8 @@ namespace Tizen.NUI.Binding
         {
             var values = new object[3];
 
-            for (var i = 0; i < properties.Count; i++)
+            foreach (var context in properties.Values)
             {
-                BindablePropertyContext context = properties[i];
-
                 if (ReferenceEquals(context.Property, property0))
                 {
                     values[0] = context.Value;
@@ -544,9 +584,8 @@ namespace Tizen.NUI.Binding
         internal object[] GetValues(params BindableProperty[] properties)
         {
             var values = new object[properties.Length];
-            for (var i = 0; i < this.properties.Count; i++)
+            foreach (var context in this.properties.Values)
             {
-                var context = this.properties[i];
                 var index = properties.IndexOf(context.Property);
                 if (index < 0)
                     continue;
@@ -747,7 +786,7 @@ namespace Tizen.NUI.Binding
 
         internal void ApplyBindings(bool skipBindingContext, bool fromBindingContextChanged)
         {
-            var prop = properties.ToArray();
+            var prop = properties.Values.ToArray();
             for (int i = 0, propLength = prop.Length; i < propLength; i++)
             {
                 BindablePropertyContext context = prop[i];
@@ -833,24 +872,12 @@ namespace Tizen.NUI.Binding
             else
                 context.Attributes = BindableContextAttributes.IsDefaultValueCreated;
 
-            properties.Add(context);
+            properties.Add(property, context);
             return context;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        BindablePropertyContext GetContext(BindableProperty property)
-        {
-            List<BindablePropertyContext> propertyList = properties;
-
-            for (var i = 0; i < propertyList.Count; i++)
-            {
-                BindablePropertyContext context = propertyList[i];
-                if (ReferenceEquals(context.Property, property))
-                    return context;
-            }
-
-            return null;
-        }
+        BindablePropertyContext GetContext(BindableProperty property) => properties.TryGetValue(property, out var result) ? result : null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         BindablePropertyContext GetOrCreateContext(BindableProperty property)
@@ -1074,6 +1101,56 @@ namespace Tizen.NUI.Binding
         internal void RemoveChildBindableObject(BindableObject child)
         {
             children.Remove(child);
+        }
+
+        internal void ReplaceBindingElement(Dictionary<string, object> oldNameScope, Dictionary<string, object> newNameScope)
+        {
+            var xElementToNameOfOld = new Dictionary<object, string>();
+
+            foreach (var pair in oldNameScope)
+            {
+                xElementToNameOfOld.Add(pair.Value, pair.Key);
+            }
+
+            foreach (var property in properties)
+            {
+                if (property.Value.Binding is Binding binding && null != binding.Source)
+                {
+                    string xName;
+                    xElementToNameOfOld.TryGetValue(binding.Source, out xName);
+
+                    if (null != xName)
+                    {
+                        var newObject = newNameScope[xName];
+                        binding.Unapply();
+                        binding.Source = newObject;
+                        SetBinding(property.Key, binding);
+                    }
+                }
+            }
+
+            if (null != BindingContext)
+            {
+                string xName;
+                xElementToNameOfOld.TryGetValue(BindingContext, out xName);
+
+                if (null != xName)
+                {
+                    var newObject = newNameScope[xName];
+                    BindingContext = newObject;
+                }
+            }
+        }
+
+        internal void ClearBinding()
+        {
+            foreach (var property in properties)
+            {
+                if (null != property.Value.Binding)
+                {
+                    property.Value.Binding.Unapply();
+                }
+            }
         }
 
         private List<BindableObject> children = new List<BindableObject>();

--- a/src/Tizen.NUI/src/public/XamlBinding/Internals/NameScope.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Internals/NameScope.cs
@@ -32,7 +32,37 @@ namespace Tizen.NUI.Binding.Internals
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty NameScopeProperty = BindableProperty.CreateAttached("NameScope", typeof(INameScope), typeof(NameScope), default(INameScope));
 
-        readonly Dictionary<string, object> names = new Dictionary<string, object>();
+        private readonly Dictionary<string, object> names = new Dictionary<string, object>();
+        internal Dictionary<string, object> NameToElement
+        {
+            get
+            {
+                return names;
+            }
+        }
+
+        internal bool Equal(NameScope other)
+        {
+            if (null == other)
+            {
+                return false;
+            }
+
+            if (names.Count != other.names.Count)
+            {
+                return false;
+            }
+
+            foreach (var pair in names)
+            {
+                if (!other.names.ContainsKey(pair.Key))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
         object INameScope.FindByName(string name)
         {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

To support Beholder, add the API so that Beholder can copy new View to old View without dispose the elements which has xName.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
