### PR TITLE
[NUI][ATSPI] Fix for DefaultLabel

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -821,6 +821,7 @@ namespace Tizen.NUI.Components
         {
             if (disappearedPage != null)
             {
+                disappearedPage.UnregisterDefaultLabel();
                 //We can call disappearedPage.NotifyAccessibilityStatesChange
                 //To reduce accessibility events, we are using currently highlighted view instead
                 View curHighlightedView = Accessibility.Accessibility.Instance.GetCurrentlyHighlightedView();
@@ -832,6 +833,7 @@ namespace Tizen.NUI.Components
 
             if (appearedPage != null)
             {
+                appearedPage.RegisterDefaultLabel();
                 appearedPage.NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, false);
             }
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -166,12 +166,12 @@ namespace Tizen.NUI
             public static extern void DaliAccessibilityDeleteRange(IntPtr arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_Add_Popup")]
-            public static extern void DaliAccessibilityBridgeRegisterPopup(global::System.Runtime.InteropServices.HandleRef arg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_RegisterDefaultLabel")]
+            public static extern void DaliAccessibilityBridgeRegisterDefaultLabel(global::System.Runtime.InteropServices.HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_Remove_Popup")]
-            public static extern void DaliAccessibilityBridgeRemovePopup(global::System.Runtime.InteropServices.HandleRef arg1);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Bridge_UnregisterDefaultLabel")]
+            public static extern void DaliAccessibilityBridgeUnregisterDefaultLabel(global::System.Runtime.InteropServices.HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_GetCurrentlyHighlightedActor")]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -424,22 +424,28 @@ namespace Tizen.NUI.BaseComponents
         ///////////////////////////////////////////////////////////////////
 
         /// <summary>
-        /// Registers popup component to accessibility tree.
+        /// Registers component as a source of an accessibility "default label".
+        /// The "Default label" is a text that could be read by screen-reader immediately
+        /// after the navigation context has changed (window activates, popup shows up, tab changes)
+        /// and before first UI element is highlighted.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void RegisterPopup()
+        public void RegisterDefaultLabel()
         {
-            Interop.ControlDevel.DaliAccessibilityBridgeRegisterPopup(SwigCPtr);
+            Interop.ControlDevel.DaliAccessibilityBridgeRegisterDefaultLabel(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>
-        /// Removes the previously added popup to accessibility tree.
+        /// Unregisters component that has been registered previously as a source of an accessibility "default label".
+        /// The "Default label" is a text that could be read by screen-reader immediately
+        /// after the navigation context has changed (window activates, popup shows up, tab changes)
+        /// and before first UI element is highlighted.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void RemovePopup()
+        public void UnregisterDefaultLabel()
         {
-            Interop.ControlDevel.DaliAccessibilityBridgeRemovePopup(SwigCPtr);
+            Interop.ControlDevel.DaliAccessibilityBridgeUnregisterDefaultLabel(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -303,12 +303,17 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public void Show()
         {
-            if (Accessibility.Accessibility.Enabled && ((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
-            {
-                RegisterPopup();
-            }
-
             SetVisible(true);
+
+            if (((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
+            {
+                RegisterDefaultLabel();
+
+                if (Accessibility.Accessibility.Enabled)
+                {
+                    EmitAccessibilityStatesChangedEvent(AccessibilityStates.Showing, true);
+                }
+            }
         }
 
         /// <summary>
@@ -324,9 +329,14 @@ namespace Tizen.NUI.BaseComponents
         {
             SetVisible(false);
 
-            if (Accessibility.Accessibility.Enabled && ((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
+            if (((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
             {
-                RemovePopup();
+                UnregisterDefaultLabel();
+
+                if (Accessibility.Accessibility.Enabled)
+                {
+                    EmitAccessibilityStatesChangedEvent(AccessibilityStates.Showing, false);
+                }
             }
         }
 

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSViewAccessibility.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSViewAccessibility.cs
@@ -467,14 +467,14 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("ViewAccessibility.View.RegisterPopup.")]
-        [Property("SPEC", "Tizen.NUI.ViewAccessibility.View.RegisterPopup M")]
+        [Description("ViewAccessibility.View.RegisterDefaultLabel.")]
+        [Property("SPEC", "Tizen.NUI.ViewAccessibility.View.RegisterDefaultLabel M")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void ViewAccessibilityRegisterPopup()
+        public void ViewAccessibilityRegisterDefaultLabel()
         {
-            tlog.Debug(tag, $"ViewAccessibilityRegisterPopup START");
+            tlog.Debug(tag, $"ViewAccessibilityRegisterDefaultLabel START");
 
             var testingTarget = new View()
             {
@@ -489,8 +489,8 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                testingTarget.RegisterPopup();
-                testingTarget.RemovePopup();
+                testingTarget.RegisterDefaultLabel();
+                testingTarget.UnregisterDefaultLabel();
             }
             catch (Exception e)
             {
@@ -499,7 +499,7 @@ namespace Tizen.NUI.Devel.Tests
             }
 
             testingTarget.Dispose();
-            tlog.Debug(tag, $"ViewAccessibilityRegisterPopup END (OK)");
+            tlog.Debug(tag, $"ViewAccessibilityRegisterDefaultLabel END (OK)");
         }
 
         [Test]


### PR DESCRIPTION
### Description of Change ###
Replaces existing API RegisterPopup()/RemovePopup() by RegisterDefaultLabel()/UnregisterDefaultLabel()

The "Default label" is a text that could be read by screen-reader immediately after
the navigation context has changed (window activates, popup shows up, tab changes)
and before first UI element is highlighted.

New API names better describe the wider applicability of this feature, which is not only for popup.


### API Changes ###
 - ACR: None

Changed:
 - void RegisterPopup() => void RegisterDefaultLabel()
 - void RemovePopup() => void UnregisterDefaultLabel()

Related changes in DALi:

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/267321/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/267323/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/267375/