### PR TITLE
[NUI] Fix Size2D not greater than int.MaxValue or less than int.MinValue

### DIFF
--- a/src/Tizen.NUI/src/public/Common/Size2D.cs
+++ b/src/Tizen.NUI/src/public/Common/Size2D.cs
@@ -133,7 +133,7 @@ namespace Tizen.NUI
             {
                 float ret = Interop.Vector2.WidthGet(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return (int)ret;
+                return ClampToInt(ret);
             }
         }
 
@@ -166,7 +166,7 @@ namespace Tizen.NUI
             {
                 float ret = Interop.Vector2.HeightGet(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return (int)ret;
+                return ClampToInt(ret);
             }
         }
 
@@ -457,5 +457,10 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
+
+        private static int ClampToInt(double v) =>
+            v > int.MaxValue ? int.MaxValue
+            : v < int.MinValue ? int.MinValue
+            : (int)v;
     }
 }


### PR DESCRIPTION
Since Size2D converts Width/Height from float to int internally,
Width/Height values may be greater than int.MaxValue or less than
int.MinValue.

To resolve the above issue, Width/Height values are checked if they
are greater than int.MaxValue or less than int.MinValue.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
