### PR TITLE
[NUI][AT-SPI] Add AccessibilityStatesNotifyMode

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -465,7 +465,7 @@ namespace Tizen.NUI.Components
             base.OnInitialize();
             SetAccessibilityConstructor(Role.Dialog);
             AppendAccessibilityAttribute("sub-role", "Alert");
-            Show(); // calls AddPopup()
+            Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -135,7 +135,7 @@ namespace Tizen.NUI.Components
             base.OnInitialize();
             SetAccessibilityConstructor(Role.Dialog);
             AppendAccessibilityAttribute("sub-role", "Alert");
-            Show(); // calls AddPopup()
+            Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -395,7 +395,7 @@ namespace Tizen.NUI.Components
 
             CalculateSizeAndPosition();
             RegisterDefaultLabel();
-            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, true);
+            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Recursive);
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace Tizen.NUI.Components
         {
             Hide();
             UnregisterDefaultLabel();
-            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, true);
+            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Recursive);
             Dispose();
         }
 

--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -827,14 +827,14 @@ namespace Tizen.NUI.Components
                 View curHighlightedView = Accessibility.Accessibility.Instance.GetCurrentlyHighlightedView();
                 if (curHighlightedView != null)
                 {
-                    curHighlightedView.NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, false);
+                    curHighlightedView.NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Single);
                 }
             }
 
             if (appearedPage != null)
             {
                 appearedPage.RegisterDefaultLabel();
-                appearedPage.NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, false);
+                appearedPage.NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Single);
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -335,11 +335,11 @@ namespace Tizen.NUI.BaseComponents
         /// If recursive is true, all children of the Accessibility object will also re-emit the states.
         /// </remarks>
         /// <param name="states">Accessibility States</param>
-        /// <param name="recursive">Flag to point if notifications of children's state would be sent</param>
+        /// <param name="notifyMode">Controls the notification strategy</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void NotifyAccessibilityStatesChange(AccessibilityStates states, bool recursive)
+        public void NotifyAccessibilityStatesChange(AccessibilityStates states, AccessibilityStatesNotifyMode notifyMode)
         {
-            Interop.ControlDevel.DaliToolkitDevelControlNotifyAccessibilityStatesChange(SwigCPtr, (ulong)states, Convert.ToInt32(recursive));
+            Interop.ControlDevel.DaliToolkitDevelControlNotifyAccessibilityStatesChange(SwigCPtr, (ulong)states, (int)notifyMode);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -564,6 +564,26 @@ namespace Tizen.NUI.BaseComponents
     };
 
     /// <summary>
+    /// Notify mode for AccessibilityStates.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum AccessibilityStatesNotifyMode
+    {
+        /// <summary>
+        /// Notify about the change of states in this object only.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Justification = "Single is the most descriptive name for sending a single event")]
+        Single = 0,
+
+        /// <summary>
+        /// Notify about the change of states in this object and all its children.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Recursive = 1,
+    }
+
+    /// <summary>
     /// The relation between accessible objects.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSViewAccessibility.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSViewAccessibility.cs
@@ -457,7 +457,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object View");
             Assert.IsInstanceOf<View>(testingTarget, "Should be an instance of View type.");
 
-            testingTarget.NotifyAccessibilityStatesChange(AccessibilityStates.Busy, true);
+            testingTarget.NotifyAccessibilityStatesChange(AccessibilityStates.Busy, AccessibilityStatesNotifyMode.Recursive);
             var result = testingTarget.GetAccessibilityStates();
             tlog.Debug(tag, "AccessibilityStates : " + result);
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The different semantics of the second (`bool`) parameter of `EmitAccessibilityStatesChangedEvent` and `NotifyAccessibilityStatesChange` can cause confusion, since it represents the new value of the state in the former method, and the notification strategy in the latter.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
