### PR TITLE
[NUI] Add Xaml line info for bindable object

### DIFF
--- a/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
@@ -167,6 +167,8 @@ namespace Tizen.NUI.Xaml
                             }
 
                             element.IsCreateByXaml = true;
+                            element.LineNumber = node.LineNumber;
+                            element.LinePosition = node.LinePosition;
                         }
                     }
                 }
@@ -292,6 +294,8 @@ namespace Tizen.NUI.Xaml
                     }
 
                     element.IsCreateByXaml = true;
+                    element.LineNumber = (node as ElementNode)?.LineNumber ?? -1;
+                    element.LinePosition = (node as ElementNode)?.LinePosition ?? -1;
                 }
                 return ret;
             }
@@ -432,6 +436,8 @@ namespace Tizen.NUI.Xaml
                     }
 
                     element.IsCreateByXaml = true;
+                    element.LineNumber = (node as ElementNode)?.LineNumber ?? -1;
+                    element.LinePosition = (node as ElementNode)?.LinePosition ?? -1;
                 }
             }
 

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -86,6 +86,12 @@ namespace Tizen.NUI.Binding
             set { SetValue(BindingContextProperty, value); }
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int LineNumber { get; set; } = -1;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int LinePosition { get; set; } = -1;
+
         void IDynamicResourceHandler.SetDynamicResource(BindableProperty property, string key)
         {
             SetDynamicResource(property, key, false);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Add Xaml line info for bindable object.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
