### PR TITLE
[NUI] Use ActionUpdateProperty for CornerRadius and Borderline

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1115,36 +1115,53 @@ namespace Tizen.NUI.BaseComponents
         {
             base.ApplyCornerRadius();
 
-            UpdateImage(0, null);
+            if (backgroundExtraData == null) return;
+
+            // Apply corner radius to IMAGE.
+            var cornerRadiusValue = backgroundExtraData.CornerRadius == null ? new PropertyValue() : new PropertyValue(backgroundExtraData.CornerRadius);
+            var cornerRadiusPolicyValue = new PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
+
+            // Make current propertyMap
+            PropertyMap currentPropertyMap = new PropertyMap();
+            currentPropertyMap[Visual.Property.CornerRadius] = cornerRadiusValue;
+            currentPropertyMap[Visual.Property.CornerRadiusPolicy] = cornerRadiusPolicyValue;
+            var temp = new PropertyValue(currentPropertyMap);
+
+            // Update corner radius properties to image by ActionUpdateProperty
+            this.DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, temp);
+
+            temp.Dispose();
+            currentPropertyMap.Dispose();
+            cornerRadiusValue.Dispose();
+            cornerRadiusPolicyValue.Dispose();
         }
 
         internal override void ApplyBorderline()
         {
             base.ApplyBorderline();
 
+            if (backgroundExtraData == null) return;
+
             // Apply borderline to IMAGE.
-            if (backgroundExtraData != null)
-            {
-                var borderlineColor = backgroundExtraData.BorderlineColor == null ? new PropertyValue(Color.Black) : new PropertyValue(backgroundExtraData.BorderlineColor);
+            var borderlineWidthValue = new PropertyValue(backgroundExtraData.BorderlineWidth);
+            var borderlineColorValue = backgroundExtraData.BorderlineColor == null ? new PropertyValue(Color.Black) : new PropertyValue(backgroundExtraData.BorderlineColor);
+            var borderlineOffsetValue = new PropertyValue(backgroundExtraData.BorderlineOffset);
 
-                // Apply to the image visual
-                PropertyMap imageMap = new PropertyMap();
-                PropertyValue imageValue = Tizen.NUI.Object.GetProperty(SwigCPtr, ImageView.Property.IMAGE);
-                if (imageValue.Get(imageMap) && !imageMap.Empty())
-                {
-                    imageMap[Visual.Property.BorderlineWidth] = new PropertyValue(backgroundExtraData.BorderlineWidth);
-                    imageMap[Visual.Property.BorderlineColor] = borderlineColor;
-                    imageMap[Visual.Property.BorderlineOffset] = new PropertyValue(backgroundExtraData.BorderlineOffset);
-                    var temp = new PropertyValue(imageMap);
-                    Tizen.NUI.Object.SetProperty(SwigCPtr, ImageView.Property.IMAGE, temp);
-                    temp.Dispose();
-                }
-                imageMap.Dispose();
-                imageValue.Dispose();
-                borderlineColor.Dispose();
-            }
+            // Make current propertyMap
+            PropertyMap currentPropertyMap = new PropertyMap();
+            currentPropertyMap[Visual.Property.BorderlineWidth] = borderlineWidthValue;
+            currentPropertyMap[Visual.Property.BorderlineColor] = borderlineColorValue;
+            currentPropertyMap[Visual.Property.BorderlineOffset] = borderlineOffsetValue;
+            var temp = new PropertyValue(currentPropertyMap);
 
-            UpdateImage(0, null);
+            // Update borderline properties to image by ActionUpdateProperty
+            this.DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, temp);
+
+            temp.Dispose();
+            currentPropertyMap.Dispose();
+            borderlineWidthValue.Dispose();
+            borderlineColorValue.Dispose();
+            borderlineOffsetValue.Dispose();
         }
 
         internal ResourceLoadingStatusType GetResourceStatus()

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -143,6 +143,14 @@ namespace Tizen.NUI.BaseComponents
             PageDown
         }
 
+        /// <summary>
+        /// Actions property value to update visual property.
+        /// Note : Only few kind of properies can be update. Update with invalid property action is undefined.
+        /// This property can be redefined by child class if it use different value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected int ActionUpdateProperty { get; set; } = Interop.Visual.GetActionUpdateProperty();
+
         internal enum PropertyRange
         {
             PROPERTY_START_INDEX = PropertyRanges.PROPERTY_REGISTRATION_START_INDEX,

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1023,37 +1023,23 @@ namespace Tizen.NUI.BaseComponents
         {
             if (backgroundExtraData == null) return;
 
-            var cornerRadius = backgroundExtraData.CornerRadius == null ? new PropertyValue() : new PropertyValue(backgroundExtraData.CornerRadius);
+            var cornerRadiusValue = backgroundExtraData.CornerRadius == null ? new PropertyValue() : new PropertyValue(backgroundExtraData.CornerRadius);
+            var cornerRadiusPolicyValue = new PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
 
-            // Apply to the background visual
-            PropertyMap backgroundMap = new PropertyMap();
-            PropertyValue background = Tizen.NUI.Object.GetProperty(SwigCPtr, View.Property.BACKGROUND);
+            // Make current propertyMap
+            PropertyMap currentPropertyMap = new PropertyMap();
+            currentPropertyMap[Visual.Property.CornerRadius] = cornerRadiusValue;
+            currentPropertyMap[Visual.Property.CornerRadiusPolicy] = cornerRadiusPolicyValue;
+            var temp = new PropertyValue(currentPropertyMap);
 
-            if (background.Get(backgroundMap) && !backgroundMap.Empty())
-            {
-                backgroundMap[Visual.Property.CornerRadius] = cornerRadius;
-                backgroundMap[Visual.Property.CornerRadiusPolicy] = new PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
-                var temp = new PropertyValue(backgroundMap);
-                Tizen.NUI.Object.SetProperty(SwigCPtr, View.Property.BACKGROUND, temp);
-                temp.Dispose();
-            }
-            backgroundMap.Dispose();
-            background.Dispose();
+            // Update corner radius properties to background and shadow by ActionUpdateProperty
+            DoAction(View.Property.BACKGROUND, ActionUpdateProperty, temp);
+            DoAction(View.Property.SHADOW, ActionUpdateProperty, temp);
 
-            // Apply to the shadow visual
-            PropertyMap shadowMap = new PropertyMap();
-            PropertyValue shadow = Tizen.NUI.Object.GetProperty(SwigCPtr, View.Property.SHADOW);
-            if (shadow.Get(shadowMap) && !shadowMap.Empty())
-            {
-                shadowMap[Visual.Property.CornerRadius] = cornerRadius;
-                shadowMap[Visual.Property.CornerRadiusPolicy] = new PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
-                var temp = new PropertyValue(shadowMap);
-                Tizen.NUI.Object.SetProperty(SwigCPtr, View.Property.SHADOW, temp);
-                temp.Dispose();
-            }
-            shadowMap.Dispose();
-            shadow.Dispose();
-            cornerRadius.Dispose();
+            temp.Dispose();
+            currentPropertyMap.Dispose();
+            cornerRadiusValue.Dispose();
+            cornerRadiusPolicyValue.Dispose();
         }
 
         /// TODO open as a protected level
@@ -1061,23 +1047,25 @@ namespace Tizen.NUI.BaseComponents
         {
             if (backgroundExtraData == null) return;
 
-            var borderlineColor = backgroundExtraData.BorderlineColor == null ? new PropertyValue(Color.Black) : new PropertyValue(backgroundExtraData.BorderlineColor);
+            var borderlineWidthValue = new PropertyValue(backgroundExtraData.BorderlineWidth);
+            var borderlineColorValue = backgroundExtraData.BorderlineColor == null ? new PropertyValue(Color.Black) : new PropertyValue(backgroundExtraData.BorderlineColor);
+            var borderlineOffsetValue = new PropertyValue(backgroundExtraData.BorderlineOffset);
 
-            // Apply to the background visual
-            PropertyMap backgroundMap = new PropertyMap();
-            PropertyValue background = Tizen.NUI.Object.GetProperty(SwigCPtr, View.Property.BACKGROUND);
-            if (background.Get(backgroundMap) && !backgroundMap.Empty())
-            {
-                backgroundMap[Visual.Property.BorderlineWidth] = new PropertyValue(backgroundExtraData.BorderlineWidth);
-                backgroundMap[Visual.Property.BorderlineColor] = borderlineColor;
-                backgroundMap[Visual.Property.BorderlineOffset] = new PropertyValue(backgroundExtraData.BorderlineOffset);
-                var temp = new PropertyValue(backgroundMap);
-                Tizen.NUI.Object.SetProperty(SwigCPtr, View.Property.BACKGROUND, temp);
-                temp.Dispose();
-            }
-            backgroundMap.Dispose();
-            background.Dispose();
-            borderlineColor.Dispose();
+            // Make current propertyMap
+            PropertyMap currentPropertyMap = new PropertyMap();
+            currentPropertyMap[Visual.Property.BorderlineWidth] = borderlineWidthValue;
+            currentPropertyMap[Visual.Property.BorderlineColor] = borderlineColorValue;
+            currentPropertyMap[Visual.Property.BorderlineOffset] = borderlineOffsetValue;
+            var temp = new PropertyValue(currentPropertyMap);
+
+            // Update borderline properties to background  by ActionUpdateProperty
+            DoAction(View.Property.BACKGROUND, ActionUpdateProperty, temp);
+
+            temp.Dispose();
+            currentPropertyMap.Dispose();
+            borderlineWidthValue.Dispose();
+            borderlineColorValue.Dispose();
+            borderlineOffsetValue.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
Due to the DALi's visual policy, we always create new visual
when some properties sensitive with visual's data.

Here, We make visual can change CornerRadius / Borderline
without destroy/create new visual.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
