### PR TITLE
[NUI] Update ImageView properties lazy

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -88,5 +88,14 @@ namespace Tizen.NUI
 
             base.Dispose(type);
         }
+
+        /// <summary>
+        /// Awake ProcessorController. It will call ProcessController.processorCallback hardly
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Awake()
+        {
+            Interop.ProcessorController.Awake(SwigCPtr);
+        }
     } // class ProcessorController
 } // namespace Tizen.NUI

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
@@ -33,6 +33,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_RemoveCallback")]
             public static extern void RemoveCallback(global::System.Runtime.InteropServices.HandleRef processorController, Tizen.NUI.ProcessorController.ProcessorEventHandler processorCallback);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_Awake")]
+            public static extern void Awake(global::System.Runtime.InteropServices.HandleRef processorController);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -44,9 +44,8 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             string ret = "";
 
-            PropertyMap imageMap = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.IMAGE).Get(imageMap);
-            imageMap.Find(ImageVisualProperty.URL)?.Get(out ret);
+            imageView._imagePropertyMap?.Find(ImageVisualProperty.URL)?.Get(out ret);
+
             return ret;
         }));
 
@@ -94,6 +93,14 @@ namespace Tizen.NUI.BaseComponents
                 }
                 if (imageView._border == null)
                 {
+                    // Image properties are changed hardly. We should ignore lazy UpdateImage
+                    imageView._imagePropertyUpdatedFlag = false;
+                    imageView._imagePropertyMap?.Dispose();
+                    imageView._imagePropertyMap = null;
+                    if(map != null)
+                    {
+                        imageView._imagePropertyMap = new PropertyMap(map);
+                    }
                     Tizen.NUI.Object.SetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.IMAGE, new Tizen.NUI.PropertyValue(map));
                 }
             }
@@ -104,7 +111,14 @@ namespace Tizen.NUI.BaseComponents
             if (imageView._border == null)
             {
                 PropertyMap temp = new PropertyMap();
-                Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.IMAGE).Get(temp);
+
+                // Sync as current properties.
+                imageView.UpdateImage();
+                if(imageView._imagePropertyMap != null)
+                {
+                    temp.Merge(imageView._imagePropertyMap);
+                }
+
                 return temp;
             }
             else
@@ -180,6 +194,15 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
+                if(oldValue != null)
+                {
+                    bool oldBool = (bool)oldValue;
+                    bool newBool = (bool)newValue;
+                    if(oldBool == newBool)
+                    {
+                        return;
+                    }
+                }
                 imageView.UpdateImage(NpatchImageVisualProperty.BorderOnly, new PropertyValue((bool)newValue));
             }
         },
@@ -187,9 +210,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageView = (ImageView)bindable;
             bool ret = false;
-            PropertyMap imageMap = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.IMAGE).Get(imageMap);
-            imageMap.Find(ImageVisualProperty.BorderOnly)?.Get(out ret);
+
+            imageView._imagePropertyMap?.Find(NpatchImageVisualProperty.BorderOnly)?.Get(out ret);
+
             return ret;
         }));
 
@@ -200,14 +223,26 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
-                imageView._synchronousLoading = (bool)newValue;
-                imageView.UpdateImage(NpatchImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue));
+                if(oldValue != null)
+                {
+                    bool oldBool = (bool)oldValue;
+                    bool newBool = (bool)newValue;
+                    if(oldBool == newBool)
+                    {
+                        return;
+                    }
+                }
+                imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue));
             }
         },
         defaultValueCreator: (bindable) =>
         {
             var imageView = (ImageView)bindable;
-            return imageView._synchronousLoading;
+            bool ret = false;
+
+            imageView._imagePropertyMap?.Find(ImageVisualProperty.SynchronousLoading)?.Get(out ret);
+
+            return ret;
         });
 
         /// This will be public opened in tizen_7.0 after ACR done. Before ACR, need to be hidden as inhouse API.
@@ -217,14 +252,26 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
-                imageView._synchronousLoading = (bool)newValue;
-                imageView.UpdateImage(NpatchImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue));
+                if(oldValue != null)
+                {
+                    bool oldBool = (bool)oldValue;
+                    bool newBool = (bool)newValue;
+                    if(oldBool == newBool)
+                    {
+                        return;
+                    }
+                }
+                imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue));
             }
         },
         defaultValueCreator: (bindable) =>
         {
             var imageView = (ImageView)bindable;
-            return imageView._synchronousLoading;
+            bool ret = false;
+
+            imageView._imagePropertyMap?.Find(ImageVisualProperty.SynchronousLoading)?.Get(out ret);
+
+            return ret;
         });
 
         /// Intenal used, will never be opened.
@@ -234,6 +281,15 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
+                if(oldValue != null)
+                {
+                    bool oldBool = (bool)oldValue;
+                    bool newBool = (bool)newValue;
+                    if(oldBool == newBool)
+                    {
+                        return;
+                    }
+                }
                 imageView.UpdateImage(ImageVisualProperty.OrientationCorrection, new PropertyValue((bool)newValue));
             }
         },
@@ -242,9 +298,8 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
 
             bool ret = false;
-            PropertyMap imageMap = new PropertyMap();
-            Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.IMAGE).Get(imageMap);
-            imageMap?.Find(ImageVisualProperty.OrientationCorrection)?.Get(out ret);
+
+            imageView._imagePropertyMap?.Find(ImageVisualProperty.OrientationCorrection)?.Get(out ret);
 
             return ret;
         }));


### PR DESCRIPTION
Current Implementation create/destroy visual whenever properties changed.
This patch hold visual-sensitive properties and
create/destroy visual before next EventProcess called.

This patch required this dali code : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/268723/
Also, this patch required this NUI code : https://github.com/Samsung/TizenFX/pull/3827

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

