### PR TITLE
[NUI] Make SynchronousLoading use index key

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2882,7 +2882,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     PropertyMap bgMap = this.Background;
                     var temp = new PropertyValue(backgroundImageSynchronousLoading);
-                    bgMap.Add("synchronousLoading", temp);
+                    bgMap[ImageVisualProperty.SynchronousLoading] = temp;
                     temp.Dispose();
                     Background = bgMap;
                 }


### PR DESCRIPTION
Currently, View.cs 's BackgroundImageLoadingSynchronously use string key, instead of index key.

But all other properties about visuals use index key only.
(Instead of animatable properties)

This patch just sync up with standard frame

This patch required to merge this dali code : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/268756/

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>