### PR TITLE
[NUI] fix warning for text components

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1599,8 +1599,11 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                SetProperty(TextEditor.Property.EnableEditing, new PropertyValue(value));
-                NotifyPropertyChanged();
+                using (var propertyValue = new PropertyValue(value))
+                {
+                    SetProperty(TextEditor.Property.EnableEditing, propertyValue);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -1758,10 +1761,9 @@ namespace Tizen.NUI.BaseComponents
         public void SetInputFilter(InputFilter inputFilter)
         {
             using (var map = TextMapHelper.GetInputFilterMap(inputFilter))
+            using (var propertyValue = new PropertyValue(map))
             {
-                var propertyValue = new PropertyValue(map);
                 SetProperty(TextEditor.Property.InputFilter, propertyValue);
-                propertyValue.Dispose();
             }
         }
 
@@ -1777,11 +1779,10 @@ namespace Tizen.NUI.BaseComponents
         {
             InputFilter inputFilter;
             using (var propertyValue = GetProperty(TextEditor.Property.InputFilter))
+            using (var map = new PropertyMap())
             {
-                var map = new PropertyMap();
                 propertyValue.Get(map);
                 inputFilter = TextMapHelper.GetInputFilterStruct(map);
-                map.Dispose();
             }
             return inputFilter;
         }
@@ -1836,19 +1837,27 @@ namespace Tizen.NUI.BaseComponents
                     map.Add("textFocused", TextMapHelper.GetStringFromMap(map, 1, defalutText));
                 
                 if (TextMapHelper.IsValue(map, 2))
-                    map.Add("color", TextMapHelper.GetColorFromMap(map, 2));
+                {
+                    using (var color = TextMapHelper.GetColorFromMap(map, 2))
+                    {
+                        map.Add("color", color);
+                    }
+                }
                 
                 if (TextMapHelper.IsValue(map, 3))
                     map.Add("fontFamily", TextMapHelper.GetStringFromMap(map, 3, defalutText));
 
                 if (TextMapHelper.IsValue(map, 4))
                 {
-                    var fontStyle = new PropertyMap();
-                    map.Find(4).Get(fontStyle);
-                    var fontStyleValue = new PropertyValue(fontStyle);
-                    map.Add("fontStyle", fontStyleValue);
-                    fontStyleValue.Dispose();
-                    fontStyle.Dispose();
+                    using (var properyValue = map.Find(4))
+                    using (var fontStyle = new PropertyMap())
+                    {
+                        properyValue.Get(fontStyle);
+                        using (var fontStyleValue = new PropertyValue(fontStyle))
+                        {
+                            map.Add("fontStyle", fontStyleValue);
+                        }
+                    }
                 }
 
                 if (TextMapHelper.IsValue(map, 5))

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -265,7 +265,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetFontStyle(FontStyle fontStyle)
         {
-            SetValue(FontStyleProperty, TextMapHelper.GetFontStyleMap(fontStyle));
+            using (var fontStyleMap = TextMapHelper.GetFontStyleMap(fontStyle))
+            {
+                SetValue(FontStyleProperty, fontStyleMap);
+            }
         }
 
         /// <summary>
@@ -278,7 +281,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetFontStyle()
         {
-            return TextMapHelper.GetFontStyleStruct((PropertyMap)GetValue(FontStyleProperty));
+            FontStyle fontStyle;
+            using (var fontStyleMap = (PropertyMap)GetValue(FontStyleProperty))
+            {
+                fontStyle = TextMapHelper.GetFontStyleStruct(fontStyleMap);
+            }
+            return fontStyle;
         }
 
         /// <summary>
@@ -569,12 +577,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (!String.IsNullOrEmpty(selectionHandleImage.LeftImageUrl))
             {
-                SetValue(SelectionHandleImageLeftProperty, TextMapHelper.GetFileNameMap(selectionHandleImage.LeftImageUrl));
+                using (var leftImageMap = TextMapHelper.GetFileNameMap(selectionHandleImage.LeftImageUrl))
+                {
+                    SetValue(SelectionHandleImageLeftProperty, leftImageMap);
+                }
             }
 
             if (!String.IsNullOrEmpty(selectionHandleImage.RightImageUrl))
             {
-                SetValue(SelectionHandleImageRightProperty, TextMapHelper.GetFileNameMap(selectionHandleImage.RightImageUrl));
+                using (var rightImageMap = TextMapHelper.GetFileNameMap(selectionHandleImage.RightImageUrl))
+                {
+                    SetValue(SelectionHandleImageRightProperty, rightImageMap);
+                }
             }
         }
 
@@ -588,7 +602,13 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectionHandleImage GetSelectionHandleImage()
         {
-            return TextMapHelper.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleImageLeftProperty), (PropertyMap)GetValue(SelectionHandleImageRightProperty));
+            SelectionHandleImage selectionHandleImage;
+            using (var leftImageMap = (PropertyMap)GetValue(SelectionHandleImageLeftProperty))
+            using (var rightImageMap = (PropertyMap)GetValue(SelectionHandleImageRightProperty))
+            {
+                selectionHandleImage = TextMapHelper.GetSelectionHandleImageStruct(leftImageMap, rightImageMap);
+            }
+            return selectionHandleImage;
         }
 
         /// <summary>
@@ -656,12 +676,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (!String.IsNullOrEmpty(selectionHandlePressedImage.LeftImageUrl))
             {
-                SetValue(SelectionHandlePressedImageLeftProperty, TextMapHelper.GetFileNameMap(selectionHandlePressedImage.LeftImageUrl));
+                using (var leftImageMap = TextMapHelper.GetFileNameMap(selectionHandlePressedImage.LeftImageUrl))
+                {
+                    SetValue(SelectionHandlePressedImageLeftProperty, leftImageMap);
+                }
             }
 
             if (!String.IsNullOrEmpty(selectionHandlePressedImage.RightImageUrl))
             {
-                SetValue(SelectionHandlePressedImageRightProperty, TextMapHelper.GetFileNameMap(selectionHandlePressedImage.RightImageUrl));
+                using (var rightImageMap = TextMapHelper.GetFileNameMap(selectionHandlePressedImage.RightImageUrl))
+                {
+                    SetValue(SelectionHandlePressedImageRightProperty, rightImageMap);
+                }
             }
         }
 
@@ -675,7 +701,13 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectionHandleImage GetSelectionHandlePressedImage()
         {
-            return TextMapHelper.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandlePressedImageLeftProperty), (PropertyMap)GetValue(SelectionHandlePressedImageRightProperty));
+            SelectionHandleImage selectionHandleImage;
+            using (var leftImageMap = (PropertyMap)GetValue(SelectionHandlePressedImageLeftProperty))
+            using (var rightImageMap = (PropertyMap)GetValue(SelectionHandlePressedImageRightProperty))
+            {
+                selectionHandleImage = TextMapHelper.GetSelectionHandleImageStruct(leftImageMap, rightImageMap);
+            }
+            return selectionHandleImage;
         }
 
         /// <summary>
@@ -743,12 +775,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (!String.IsNullOrEmpty(selectionHandleMarkerImage.LeftImageUrl))
             {
-                SetValue(SelectionHandleMarkerImageLeftProperty, TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.LeftImageUrl));
+                using (var leftImageMap = TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.LeftImageUrl))
+                {
+                    SetValue(SelectionHandleMarkerImageLeftProperty, leftImageMap);
+                }
             }
 
             if (!String.IsNullOrEmpty(selectionHandleMarkerImage.RightImageUrl))
             {
-                SetValue(SelectionHandleMarkerImageRightProperty, TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.RightImageUrl));
+                using (var rightImageMap = TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.RightImageUrl))
+                {
+                    SetValue(SelectionHandleMarkerImageRightProperty, rightImageMap);
+                }
             }
         }
 
@@ -762,7 +800,13 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectionHandleImage GetSelectionHandleMarkerImage()
         {
-            return TextMapHelper.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleMarkerImageLeftProperty), (PropertyMap)GetValue(SelectionHandleMarkerImageRightProperty));
+            SelectionHandleImage selectionHandleImage;
+            using (var leftImageMap = (PropertyMap)GetValue(SelectionHandleMarkerImageLeftProperty))
+            using (var rightImageMap = (PropertyMap)GetValue(SelectionHandleMarkerImageRightProperty))
+            {
+                selectionHandleImage = TextMapHelper.GetSelectionHandleImageStruct(leftImageMap, rightImageMap);
+            }
+            return selectionHandleImage;
         }
 
         /// <summary>
@@ -912,7 +956,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetInputFontStyle(FontStyle fontStyle)
         {
-            SetValue(InputFontStyleProperty, TextMapHelper.GetFontStyleMap(fontStyle));
+            using (var fontStyleMap = TextMapHelper.GetFontStyleMap(fontStyle))
+            {
+                SetValue(InputFontStyleProperty, fontStyleMap);
+            }
         }
 
         /// <summary>
@@ -925,7 +972,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetInputFontStyle()
         {
-            return TextMapHelper.GetFontStyleStruct((PropertyMap)GetValue(InputFontStyleProperty));
+            FontStyle fontStyle;
+            using (var fontStyleMap = (PropertyMap)GetValue(InputFontStyleProperty))
+            {
+                fontStyle = TextMapHelper.GetFontStyleStruct(fontStyleMap);
+            }
+            return fontStyle;
         }
 
         /// <summary>
@@ -1027,7 +1079,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetUnderline(Underline underline)
         {
-            SetValue(UnderlineProperty, TextMapHelper.GetUnderlineMap(underline));
+            using (var underlineMap = TextMapHelper.GetUnderlineMap(underline))
+            {
+                SetValue(UnderlineProperty, underlineMap);
+            }
         }
 
         /// <summary>
@@ -1040,7 +1095,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Underline GetUnderline()
         {
-            return TextMapHelper.GetUnderlineStruct((PropertyMap)GetValue(UnderlineProperty));
+            Underline underline;
+            using (var underlineMap = (PropertyMap)GetValue(UnderlineProperty))
+            {
+                underline = TextMapHelper.GetUnderlineStruct(underlineMap);
+            }
+            return underline;
         }
 
         /// <summary>
@@ -1105,7 +1165,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetShadow(Tizen.NUI.Text.Shadow shadow)
         {
-            SetValue(ShadowProperty, TextMapHelper.GetShadowMap(shadow));
+            using (var shadowMap = TextMapHelper.GetShadowMap(shadow))
+            {
+                SetValue(ShadowProperty, shadowMap);
+            }
         }
 
         /// <summary>
@@ -1118,7 +1181,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Tizen.NUI.Text.Shadow GetShadow()
         {
-            return TextMapHelper.GetShadowStruct((PropertyMap)GetValue(ShadowProperty));
+            Tizen.NUI.Text.Shadow shadow;
+            using (var shadowMap = (PropertyMap)GetValue(ShadowProperty))
+            {
+                shadow = TextMapHelper.GetShadowStruct(shadowMap);
+            }
+            return shadow;
         }
 
         /// <summary>
@@ -1218,7 +1286,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetOutline(Outline outline)
         {
-            SetValue(OutlineProperty, TextMapHelper.GetOutlineMap(outline));
+            using (var outlineMap = TextMapHelper.GetOutlineMap(outline))
+            {
+                SetValue(OutlineProperty, outlineMap);
+            }
         }
 
         /// <summary>
@@ -1231,7 +1302,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Outline GetOutline()
         {
-            return TextMapHelper.GetOutlineStruct((PropertyMap)GetValue(OutlineProperty));
+            Outline outline;
+            using (var outlineMap = (PropertyMap)GetValue(OutlineProperty))
+            {
+                outline = TextMapHelper.GetOutlineStruct(outlineMap);
+            }
+            return outline;
         }
 
         /// <summary>
@@ -1368,9 +1444,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp = 0;
-                GetProperty(TextEditor.Property.LineCount).Get(out temp);
-                return temp;
+                int lineCount = 0;
+                using (var propertyValue = GetProperty(TextEditor.Property.LineCount))
+                {
+                    propertyValue.Get(out lineCount);
+                }
+                return lineCount;
             }
         }
 
@@ -1402,9 +1481,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                string temp;
-                GetProperty(TextEditor.Property.SelectedText).Get(out temp);
-                return temp;
+                string selectedText;
+                using (var propertyValue = GetProperty(TextEditor.Property.SelectedText))
+                {
+                    propertyValue.Get(out selectedText);
+                }                
+                return selectedText;
             }
         }
 
@@ -1458,9 +1540,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                GetProperty(TextEditor.Property.SelectedTextStart).Get(out temp);
-                return temp;
+                int selectedTextStart;
+                using (var propertyValue = GetProperty(TextEditor.Property.SelectedTextStart))
+                {
+                    propertyValue.Get(out selectedTextStart);
+                }                
+                return selectedTextStart;
             }
         }
 
@@ -1475,9 +1560,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                GetProperty(TextEditor.Property.SelectedTextEnd).Get(out temp);
-                return temp;
+                int selectedTextEnd;
+                using (var propertyValue = GetProperty(TextEditor.Property.SelectedTextEnd))
+                {
+                    propertyValue.Get(out selectedTextEnd);
+                }                
+                return selectedTextEnd;
             }
         }
 
@@ -1502,9 +1590,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                bool temp;
-                GetProperty(TextEditor.Property.EnableEditing).Get(out temp);
-                return temp;
+                bool enableEditing;
+                using (var propertyValue = GetProperty(TextEditor.Property.EnableEditing))
+                {
+                    propertyValue.Get(out enableEditing);
+                }
+                return enableEditing;
             }
             set
             {
@@ -1533,16 +1624,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                using (PropertyValue propertyValue = GetProperty(TextEditor.Property.HorizontalScrollPosition))
+                int horizontalScrollPosition;
+                using (var propertyValue = GetProperty(TextEditor.Property.HorizontalScrollPosition))
                 {
-                    propertyValue.Get(out temp);
+                    propertyValue.Get(out horizontalScrollPosition);
                 }
-                return temp;
+                return horizontalScrollPosition;
             }
             set
             {
-                using (PropertyValue propertyValue = new PropertyValue(value))
+                using (var propertyValue = new PropertyValue(value))
                 {
                     SetProperty(TextEditor.Property.HorizontalScrollPosition, propertyValue);
                     NotifyPropertyChanged();
@@ -1570,16 +1661,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                using (PropertyValue propertyValue = GetProperty(TextEditor.Property.VerticalScrollPosition))
+                int verticalScrollPosition;
+                using (var propertyValue = GetProperty(TextEditor.Property.VerticalScrollPosition))
                 {
-                    propertyValue.Get(out temp);
+                    propertyValue.Get(out verticalScrollPosition);
                 }
-                return temp;
+                return verticalScrollPosition;
             }
             set
             {
-                using (PropertyValue propertyValue = new PropertyValue(value))
+                using (var propertyValue = new PropertyValue(value))
                 {
                     SetProperty(TextEditor.Property.VerticalScrollPosition, propertyValue);
                     NotifyPropertyChanged();
@@ -1607,16 +1698,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                using (PropertyValue propertyValue = GetProperty(TextEditor.Property.PrimaryCursorPosition))
+                int primaryCursorPosition;
+                using (var propertyValue = GetProperty(TextEditor.Property.PrimaryCursorPosition))
                 {
-                    propertyValue.Get(out temp);
+                    propertyValue.Get(out primaryCursorPosition);
                 }
-                return temp;
+                return primaryCursorPosition;
             }
             set
             {
-                using (PropertyValue propertyValue = new PropertyValue(value))
+                using (var propertyValue = new PropertyValue(value))
                 {
                     SetProperty(TextEditor.Property.PrimaryCursorPosition, propertyValue);
                     NotifyPropertyChanged();
@@ -1666,7 +1757,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public void SetInputFilter(InputFilter inputFilter)
         {
-            SetProperty(TextEditor.Property.InputFilter, new PropertyValue(TextMapHelper.GetInputFilterMap(inputFilter)));
+            using (var map = TextMapHelper.GetInputFilterMap(inputFilter))
+            {
+                var propertyValue = new PropertyValue(map);
+                SetProperty(TextEditor.Property.InputFilter, propertyValue);
+                propertyValue.Dispose();
+            }
         }
 
         /// <summary>
@@ -1679,9 +1775,15 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public InputFilter GetInputFilter()
         {
-            var map = new PropertyMap();
-            GetProperty(TextEditor.Property.InputFilter).Get(map);
-            return TextMapHelper.GetInputFilterStruct(map);
+            InputFilter inputFilter;
+            using (var propertyValue = GetProperty(TextEditor.Property.InputFilter))
+            {
+                var map = new PropertyMap();
+                propertyValue.Get(map);
+                inputFilter = TextMapHelper.GetInputFilterStruct(map);
+                map.Dispose();
+            }
+            return inputFilter;
         }
 
         /// <summary>
@@ -1797,7 +1899,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPlaceholder(Placeholder placeholder)
         {
-            SetValue(PlaceholderProperty, TextMapHelper.GetPlaceholderMap(placeholder));
+            using (var placeholderMap = TextMapHelper.GetPlaceholderMap(placeholder))
+            {
+                SetValue(PlaceholderProperty, placeholderMap);
+            }
         }
 
         /// <summary>
@@ -1810,7 +1915,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Placeholder GetPlaceholder()
         {
-            return TextMapHelper.GetPlaceholderStruct((PropertyMap)GetValue(PlaceholderProperty));
+            Placeholder placeholder;
+            using (var placeholderMap = (PropertyMap)GetValue(PlaceholderProperty))
+            {
+                placeholder = TextMapHelper.GetPlaceholderStruct(placeholderMap);
+            }
+            return placeholder;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -332,7 +332,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetFontStyle(FontStyle fontStyle)
         {
-            SetValue(FontStyleProperty, TextMapHelper.GetFontStyleMap(fontStyle));
+            using (var fontStyleMap = TextMapHelper.GetFontStyleMap(fontStyle))
+            {
+                SetValue(FontStyleProperty, fontStyleMap);
+            }
         }
 
         /// <summary>
@@ -345,7 +348,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetFontStyle()
         {
-            return TextMapHelper.GetFontStyleStruct((PropertyMap)GetValue(FontStyleProperty));
+            FontStyle fontStyle;
+            using (var fontStyleMap = (PropertyMap)GetValue(FontStyleProperty))
+            {
+                fontStyle = TextMapHelper.GetFontStyleStruct(fontStyleMap);
+            }
+            return fontStyle;
         }
 
         /// <summary>
@@ -814,12 +822,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (!String.IsNullOrEmpty(selectionHandleImage.LeftImageUrl))
             {
-                SetValue(SelectionHandleImageLeftProperty, TextMapHelper.GetFileNameMap(selectionHandleImage.LeftImageUrl));
+                using (var leftImageMap = TextMapHelper.GetFileNameMap(selectionHandleImage.LeftImageUrl))
+                {
+                    SetValue(SelectionHandleImageLeftProperty, leftImageMap);
+                }
             }
 
             if (!String.IsNullOrEmpty(selectionHandleImage.RightImageUrl))
             {
-                SetValue(SelectionHandleImageRightProperty, TextMapHelper.GetFileNameMap(selectionHandleImage.RightImageUrl));
+                using (var rightImageMap = TextMapHelper.GetFileNameMap(selectionHandleImage.RightImageUrl))
+                {
+                    SetValue(SelectionHandleImageRightProperty, rightImageMap);
+                }
             }
         }
 
@@ -833,7 +847,13 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectionHandleImage GetSelectionHandleImage()
         {
-            return TextMapHelper.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleImageLeftProperty), (PropertyMap)GetValue(SelectionHandleImageRightProperty));
+            SelectionHandleImage selectionHandleImage;
+            using (var leftImageMap = (PropertyMap)GetValue(SelectionHandleImageLeftProperty))
+            using (var rightImageMap = (PropertyMap)GetValue(SelectionHandleImageRightProperty))
+            {
+                selectionHandleImage = TextMapHelper.GetSelectionHandleImageStruct(leftImageMap, rightImageMap);
+            }
+            return selectionHandleImage;
         }
 
         /// <summary>
@@ -901,12 +921,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (!String.IsNullOrEmpty(selectionHandlePressedImage.LeftImageUrl))
             {
-                SetValue(SelectionHandlePressedImageLeftProperty, TextMapHelper.GetFileNameMap(selectionHandlePressedImage.LeftImageUrl));
+                using (var leftImageMap = TextMapHelper.GetFileNameMap(selectionHandlePressedImage.LeftImageUrl))
+                {
+                    SetValue(SelectionHandlePressedImageLeftProperty, leftImageMap);
+                }
             }
 
             if (!String.IsNullOrEmpty(selectionHandlePressedImage.RightImageUrl))
             {
-                SetValue(SelectionHandlePressedImageRightProperty, TextMapHelper.GetFileNameMap(selectionHandlePressedImage.RightImageUrl));
+                using (var rightImageMap = TextMapHelper.GetFileNameMap(selectionHandlePressedImage.RightImageUrl))
+                {
+                    SetValue(SelectionHandlePressedImageRightProperty, rightImageMap);
+                }
             }
         }
 
@@ -920,7 +946,13 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectionHandleImage GetSelectionHandlePressedImage()
         {
-            return TextMapHelper.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandlePressedImageLeftProperty), (PropertyMap)GetValue(SelectionHandlePressedImageRightProperty));
+            SelectionHandleImage selectionHandleImage;
+            using (var leftImageMap = (PropertyMap)GetValue(SelectionHandlePressedImageLeftProperty))
+            using (var rightImageMap = (PropertyMap)GetValue(SelectionHandlePressedImageRightProperty))
+            {
+                selectionHandleImage = TextMapHelper.GetSelectionHandleImageStruct(leftImageMap, rightImageMap);
+            }
+            return selectionHandleImage;
         }
 
         /// <summary>
@@ -988,12 +1020,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (!String.IsNullOrEmpty(selectionHandleMarkerImage.LeftImageUrl))
             {
-                SetValue(SelectionHandleMarkerImageLeftProperty, TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.LeftImageUrl));
+                using (var leftImageMap = TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.LeftImageUrl))
+                {
+                    SetValue(SelectionHandleMarkerImageLeftProperty, leftImageMap);
+                }
             }
 
             if (!String.IsNullOrEmpty(selectionHandleMarkerImage.RightImageUrl))
             {
-                SetValue(SelectionHandleMarkerImageRightProperty, TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.RightImageUrl));
+                using (var rightImageMap = TextMapHelper.GetFileNameMap(selectionHandleMarkerImage.RightImageUrl))
+                {
+                    SetValue(SelectionHandleMarkerImageRightProperty, rightImageMap);
+                }
             }
         }
 
@@ -1007,7 +1045,13 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public SelectionHandleImage GetSelectionHandleMarkerImage()
         {
-            return TextMapHelper.GetSelectionHandleImageStruct((PropertyMap)GetValue(SelectionHandleMarkerImageLeftProperty), (PropertyMap)GetValue(SelectionHandleMarkerImageRightProperty));
+            SelectionHandleImage selectionHandleImage;
+            using (var leftImageMap = (PropertyMap)GetValue(SelectionHandleMarkerImageLeftProperty))
+            using (var rightImageMap = (PropertyMap)GetValue(SelectionHandleMarkerImageRightProperty))
+            {
+                selectionHandleImage = TextMapHelper.GetSelectionHandleImageStruct(leftImageMap, rightImageMap);
+            }
+            return selectionHandleImage;
         }
 
         /// <summary>
@@ -1189,7 +1233,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetInputFontStyle(FontStyle fontStyle)
         {
-            SetValue(InputFontStyleProperty, TextMapHelper.GetFontStyleMap(fontStyle));
+            using (var fontStyleMap = TextMapHelper.GetFontStyleMap(fontStyle))
+            {
+                SetValue(InputFontStyleProperty, fontStyleMap);
+            }
         }
 
         /// <summary>
@@ -1202,7 +1249,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetInputFontStyle()
         {
-            return TextMapHelper.GetFontStyleStruct((PropertyMap)GetValue(InputFontStyleProperty));
+            FontStyle fontStyle;
+            using (var fontStyleMap = (PropertyMap)GetValue(InputFontStyleProperty))
+            {
+                fontStyle = TextMapHelper.GetFontStyleStruct(fontStyleMap);
+            }
+            return fontStyle;
         }
 
         /// <summary>
@@ -1268,7 +1320,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetUnderline(Underline underline)
         {
-            SetValue(UnderlineProperty, TextMapHelper.GetUnderlineMap(underline));
+            using (var underlineMap = TextMapHelper.GetUnderlineMap(underline))
+            {
+                SetValue(UnderlineProperty, underlineMap);
+            }
         }
 
         /// <summary>
@@ -1281,7 +1336,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Underline GetUnderline()
         {
-            return TextMapHelper.GetUnderlineStruct((PropertyMap)GetValue(UnderlineProperty));
+            Underline underline;
+            using (var underlineMap = (PropertyMap)GetValue(UnderlineProperty))
+            {
+                underline = TextMapHelper.GetUnderlineStruct(underlineMap);
+            }
+            return underline;
         }
 
         /// <summary>
@@ -1346,7 +1406,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetShadow(Tizen.NUI.Text.Shadow shadow)
         {
-            SetValue(ShadowProperty, TextMapHelper.GetShadowMap(shadow));
+            using (var shadowMap = TextMapHelper.GetShadowMap(shadow))
+            {
+                SetValue(ShadowProperty, shadowMap);
+            }
         }
 
         /// <summary>
@@ -1359,7 +1422,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Tizen.NUI.Text.Shadow GetShadow()
         {
-            return TextMapHelper.GetShadowStruct((PropertyMap)GetValue(ShadowProperty));
+            Tizen.NUI.Text.Shadow shadow;
+            using (var shadowMap = (PropertyMap)GetValue(ShadowProperty))
+            {
+                shadow = TextMapHelper.GetShadowStruct(shadowMap);
+            }
+            return shadow;
         }
 
         /// <summary>
@@ -1459,7 +1527,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetOutline(Outline outline)
         {
-            SetValue(OutlineProperty, TextMapHelper.GetOutlineMap(outline));
+            using (var outlineMap = TextMapHelper.GetOutlineMap(outline))
+            {
+                SetValue(OutlineProperty, outlineMap);
+            }
         }
 
         /// <summary>
@@ -1472,7 +1543,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Outline GetOutline()
         {
-            return TextMapHelper.GetOutlineStruct((PropertyMap)GetValue(OutlineProperty));
+            Outline outline;
+            using (var outlineMap = (PropertyMap)GetValue(OutlineProperty))
+            {
+                outline = TextMapHelper.GetOutlineStruct(outlineMap);
+            }
+            return outline;
         }
 
         /// <summary>
@@ -1552,7 +1628,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetHiddenInput(HiddenInput hiddenInput)
         {
-            SetValue(HiddenInputSettingsProperty, TextMapHelper.GetHiddenInputMap(hiddenInput));
+            using (var hiddenInputMap = TextMapHelper.GetHiddenInputMap(hiddenInput))
+            {
+                SetValue(HiddenInputSettingsProperty, hiddenInputMap);
+            }
         }
 
         /// <summary>
@@ -1565,7 +1644,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public HiddenInput GetHiddenInput()
         {
-            return TextMapHelper.GetHiddenInputStruct((PropertyMap)GetValue(HiddenInputSettingsProperty));
+            HiddenInput hiddenInput;
+            using (var hiddenInputMap = (PropertyMap)GetValue(HiddenInputSettingsProperty))
+            {
+                hiddenInput = TextMapHelper.GetHiddenInputStruct(hiddenInputMap);
+            }
+            return hiddenInput;
         }
 
         /// <summary>
@@ -1655,9 +1739,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                string temp;
-                GetProperty(TextField.Property.SelectedText).Get(out temp);
-                return temp;
+                string selectedText;
+                using (var propertyValue = GetProperty(TextField.Property.SelectedText))
+                {
+                    propertyValue.Get(out selectedText);
+                }                
+                return selectedText;
             }
         }
 
@@ -1672,9 +1759,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                GetProperty(TextField.Property.SelectedTextStart).Get(out temp);
-                return temp;
+                int selectedTextStart;
+                using (var propertyValue = GetProperty(TextField.Property.SelectedTextStart))
+                {
+                    propertyValue.Get(out selectedTextStart);
+                }                
+                return selectedTextStart;
             }
         }
 
@@ -1689,9 +1779,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                GetProperty(TextField.Property.SelectedTextEnd).Get(out temp);
-                return temp;
+                int selectedTextEnd;
+                using (var propertyValue = GetProperty(TextField.Property.SelectedTextEnd))
+                {
+                    propertyValue.Get(out selectedTextEnd);
+                }                
+                return selectedTextEnd;
             }
         }
 
@@ -1716,9 +1809,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                bool temp;
-                GetProperty(TextField.Property.EnableEditing).Get(out temp);
-                return temp;
+                bool enableEditing;
+                using (var propertyValue = GetProperty(TextField.Property.EnableEditing))
+                {
+                    propertyValue.Get(out enableEditing);
+                }
+                return enableEditing;
             }
             set
             {
@@ -1747,12 +1843,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp;
-                using (PropertyValue propertyValue = GetProperty(TextField.Property.PrimaryCursorPosition))
+                int primaryCursorPosition;
+                using (var propertyValue = GetProperty(TextField.Property.PrimaryCursorPosition))
                 {
-                    propertyValue.Get(out temp);
+                    propertyValue.Get(out primaryCursorPosition);
                 }
-                return temp;
+                return primaryCursorPosition;
             }
             set
             {
@@ -1824,7 +1920,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public void SetInputFilter(InputFilter inputFilter)
         {
-            SetProperty(TextField.Property.InputFilter, new PropertyValue(TextMapHelper.GetInputFilterMap(inputFilter)));
+            using (var map = TextMapHelper.GetInputFilterMap(inputFilter))
+            {
+                var propertyValue = new PropertyValue(map);
+                SetProperty(TextField.Property.InputFilter, propertyValue);
+                propertyValue.Dispose();
+            }
         }
 
         /// <summary>
@@ -1837,9 +1938,15 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public InputFilter GetInputFilter()
         {
-            var map = new PropertyMap();
-            GetProperty(TextField.Property.InputFilter).Get(map);
-            return TextMapHelper.GetInputFilterStruct(map);
+            InputFilter inputFilter;
+            using (var propertyValue = GetProperty(TextField.Property.InputFilter))
+            {
+                var map = new PropertyMap();
+                propertyValue.Get(map);
+                inputFilter = TextMapHelper.GetInputFilterStruct(map);
+                map.Dispose();
+            }
+            return inputFilter;
         }
 
         /// <summary>
@@ -1955,7 +2062,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetPlaceholder(Placeholder placeholder)
         {
-            SetValue(PlaceholderProperty, TextMapHelper.GetPlaceholderMap(placeholder));
+            using (var placeholderMap = TextMapHelper.GetPlaceholderMap(placeholder))
+            {
+                SetValue(PlaceholderProperty, placeholderMap);
+            }
         }
 
         /// <summary>
@@ -1968,7 +2078,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Placeholder GetPlaceholder()
         {
-            return TextMapHelper.GetPlaceholderStruct((PropertyMap)GetValue(PlaceholderProperty));
+            Placeholder placeholder;
+            using (var placeholderMap = (PropertyMap)GetValue(PlaceholderProperty))
+            {
+                placeholder = TextMapHelper.GetPlaceholderStruct(placeholderMap);
+            }
+            return placeholder;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -515,18 +515,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                PropertyMap map = new PropertyMap();
-                GetProperty(TextField.Property.SHADOW).Get(map);
-                Vector2 shadowOffset = new Vector2();
-                map.Find(TextField.Property.SHADOW, "offset")?.Get(shadowOffset);
-                return new Vector2(OnShadowOffsetChanged, shadowOffset.X, shadowOffset.Y);
+                float x = 0.0f, y = 0.0f;
+                using (var propertyValue = Shadow.Find(TextField.Property.SHADOW, "offset"))
+                using (var shadowOffset = new Vector2())
+                {
+                    if (null != propertyValue)
+                    {
+                        propertyValue.Get(shadowOffset);
+                        x = shadowOffset.X;
+                        y = shadowOffset.Y;
+                    }
+                }
+                return new Vector2(OnShadowOffsetChanged, x, y);
             }
             set
             {
-                PropertyMap temp = new PropertyMap();
-                temp.Insert("offset", new PropertyValue(value));
-                SetValue(ShadowProperty, temp);
-                NotifyPropertyChanged();
+                using (var map = new PropertyMap())
+                {
+                    map.Add("offset", value);
+                    var shadowMap = Shadow;
+                    shadowMap.Merge(map);
+                    SetValue(ShadowProperty, shadowMap);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -555,18 +566,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                PropertyMap map = new PropertyMap();
-                GetProperty(TextField.Property.SHADOW).Get(map);
-                Vector4 shadowColor = new Vector4();
-                map.Find(TextField.Property.SHADOW, "color")?.Get(shadowColor);
-                return new Vector4(OnShadowColorChanged, shadowColor.X, shadowColor.Y, shadowColor.Z, shadowColor.W);
+                float x = 0.0f, y = 0.0f, z = 0.0f, w = 0.0f;
+                using (var propertyValue = Shadow.Find(TextField.Property.SHADOW, "color"))
+                using (var shadowColor = new Vector4())
+                {
+                    if (null != propertyValue)
+                    {
+                        propertyValue.Get(shadowColor);
+                        x = shadowColor.X;
+                        y = shadowColor.Y;
+                        z = shadowColor.Z;
+                        w = shadowColor.W;
+                    }
+                }
+                return new Vector4(OnShadowColorChanged, x, y, z, w);
             }
             set
             {
-                PropertyMap temp = new PropertyMap();
-                temp.Insert("color", new PropertyValue(value));
-                SetValue(ShadowProperty, temp);
-                NotifyPropertyChanged();
+                using (var map = new PropertyMap())
+                {
+                    map.Add("color", value);
+                    var shadowMap = Shadow;
+                    shadowMap.Merge(map);
+                    SetValue(ShadowProperty, shadowMap);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -1818,8 +1842,11 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                SetProperty(TextField.Property.EnableEditing, new PropertyValue(value));
-                NotifyPropertyChanged();
+                using (var propertyValue = new PropertyValue(value))
+                {
+                    SetProperty(TextField.Property.EnableEditing, propertyValue);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -1921,10 +1948,9 @@ namespace Tizen.NUI.BaseComponents
         public void SetInputFilter(InputFilter inputFilter)
         {
             using (var map = TextMapHelper.GetInputFilterMap(inputFilter))
+            using (var propertyValue = new PropertyValue(map))
             {
-                var propertyValue = new PropertyValue(map);
                 SetProperty(TextField.Property.InputFilter, propertyValue);
-                propertyValue.Dispose();
             }
         }
 
@@ -1940,11 +1966,10 @@ namespace Tizen.NUI.BaseComponents
         {
             InputFilter inputFilter;
             using (var propertyValue = GetProperty(TextField.Property.InputFilter))
+            using (var map = new PropertyMap())
             {
-                var map = new PropertyMap();
                 propertyValue.Get(map);
                 inputFilter = TextMapHelper.GetInputFilterStruct(map);
-                map.Dispose();
             }
             return inputFilter;
         }
@@ -1999,19 +2024,27 @@ namespace Tizen.NUI.BaseComponents
                     map.Add("textFocused", TextMapHelper.GetStringFromMap(map, 1, defalutText));
                 
                 if (TextMapHelper.IsValue(map, 2))
-                    map.Add("color", TextMapHelper.GetColorFromMap(map, 2));
-                
+                {
+                    using (var color = TextMapHelper.GetColorFromMap(map, 2))
+                    {
+                        map.Add("color", color);
+                    }
+                }
+
                 if (TextMapHelper.IsValue(map, 3))
                     map.Add("fontFamily", TextMapHelper.GetStringFromMap(map, 3, defalutText));
 
                 if (TextMapHelper.IsValue(map, 4))
                 {
-                    var fontStyle = new PropertyMap();
-                    map.Find(4).Get(fontStyle);
-                    var fontStyleValue = new PropertyValue(fontStyle);
-                    map.Add("fontStyle", fontStyleValue);
-                    fontStyleValue.Dispose();
-                    fontStyle.Dispose();
+                    using (var properyValue = map.Find(4))
+                    using (var fontStyle = new PropertyMap())
+                    {
+                        properyValue.Get(fontStyle);
+                        using (var fontStyleValue = new PropertyValue(fontStyle))
+                        {
+                            map.Add("fontStyle", fontStyleValue);
+                        }
+                    }
                 }
 
                 if (TextMapHelper.IsValue(map, 5))

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -440,20 +440,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                Vector2 shadowOffset = new Vector2();
-                Shadow.Find(TextLabel.Property.SHADOW, "offset")?.Get(shadowOffset);
-                return new Vector2(OnShadowOffsetChanged, shadowOffset.X, shadowOffset.Y);
+                float x = 0.0f, y = 0.0f;
+                using (var propertyValue = Shadow.Find(TextLabel.Property.SHADOW, "offset"))
+                using (var shadowOffset = new Vector2())
+                {
+                    if (null != propertyValue)
+                    {
+                        propertyValue.Get(shadowOffset);
+                        x = shadowOffset.X;
+                        y = shadowOffset.Y;
+                    }
+                }
+                return new Vector2(OnShadowOffsetChanged, x, y);
             }
             set
             {
-                PropertyMap temp = new PropertyMap();
-                temp.Insert("offset", new PropertyValue(value));
+                using (var map = new PropertyMap())
+                {
+                    map.Add("offset", value);
 
-                PropertyMap shadowMap = Shadow;
-                shadowMap.Merge(temp);
+                    var shadowMap = Shadow;
+                    shadowMap.Merge(map);
 
-                SetValue(ShadowProperty, shadowMap);
-                NotifyPropertyChanged();
+                    SetValue(ShadowProperty, shadowMap);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -483,20 +494,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                Vector4 shadowColor = new Vector4();
-                Shadow.Find(TextLabel.Property.SHADOW, "color")?.Get(shadowColor);
-                return new Vector4(OnShadowColorChanged, shadowColor.X, shadowColor.Y, shadowColor.Z, shadowColor.W);
+                float x = 0.0f, y = 0.0f, z = 0.0f, w = 0.0f;
+                using (var propertyValue = Shadow.Find(TextLabel.Property.SHADOW, "color"))
+                using (var shadowColor = new Vector4())
+                {
+                    if (null != propertyValue)
+                    {
+                        propertyValue.Get(shadowColor);
+                        x = shadowColor.X;
+                        y = shadowColor.Y;
+                        z = shadowColor.Z;
+                        w = shadowColor.W;
+                    }
+                }
+                return new Vector4(OnShadowColorChanged, x, y, z, w);
             }
             set
             {
-                PropertyMap temp = new PropertyMap();
-                temp.Insert("color", new PropertyValue(value));
-
-                PropertyMap shadowMap = Shadow;
-                shadowMap.Merge(temp);
-
-                SetValue(ShadowProperty, shadowMap);
-                NotifyPropertyChanged();
+                using (var map = new PropertyMap())
+                {
+                    map.Add("color", value);
+                    var shadowMap = Shadow;
+                    shadowMap.Merge(map);
+                    SetValue(ShadowProperty, shadowMap);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -526,20 +548,22 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 bool underlineEnabled = false;
-                Underline.Find(TextLabel.Property.UNDERLINE, "enable")?.Get(out underlineEnabled);
+                using (var propertyValue = Underline.Find(TextLabel.Property.UNDERLINE, "enable"))
+                {
+                    propertyValue.Get(out underlineEnabled);
+                }
                 return underlineEnabled;
             }
             set
             {
-                PropertyMap temp = new PropertyMap();
-                temp.Add("enable", new PropertyValue(value));
-
-                PropertyMap undelineMap = Underline;
-                undelineMap.Merge(temp);
-
-                SetValue(UnderlineProperty, undelineMap);
-                NotifyPropertyChanged();
-
+                using (var map = new PropertyMap())
+                {
+                    map.Add("enable", value);
+                    var undelineMap = Underline;
+                    undelineMap.Merge(map);
+                    SetValue(UnderlineProperty, undelineMap);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -569,20 +593,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                Vector4 underlineColor = new Vector4();
-                Underline.Find(TextLabel.Property.UNDERLINE, "color")?.Get(underlineColor);
-                return new Vector4(OnUnderlineColorChanged, underlineColor.X, underlineColor.Y, underlineColor.Z, underlineColor.W);
+                float x = 0.0f, y = 0.0f, z = 0.0f, w = 0.0f;
+                using (var propertyValue = Underline.Find(TextLabel.Property.UNDERLINE, "color"))
+                using (var underlineColor = new Vector4())
+                {
+                    if (null != propertyValue)
+                    {
+                        propertyValue.Get(underlineColor);
+                        x = underlineColor.X;
+                        y = underlineColor.Y;
+                        z = underlineColor.Z;
+                        w = underlineColor.W;
+                    }
+                }
+                return new Vector4(OnUnderlineColorChanged, x, y, z, w);
             }
             set
             {
-                PropertyMap temp = new PropertyMap();
-                temp.Insert("color", new PropertyValue(value));
-
-                PropertyMap undelineMap = Underline;
-                undelineMap.Merge(temp);
-
-                SetValue(UnderlineProperty, undelineMap);
-                NotifyPropertyChanged();
+                using (var map = new PropertyMap())
+                {
+                    map.Add("color", value);
+                    var undelineMap = Underline;
+                    undelineMap.Merge(map);
+                    SetValue(UnderlineProperty, undelineMap);
+                    NotifyPropertyChanged();
+                }
             }
         }
 
@@ -612,19 +647,25 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 float underlineHeight = 0.0f;
-                Underline.Find(TextLabel.Property.UNDERLINE, "height")?.Get(out underlineHeight);
+                using (var propertyValue = Underline.Find(TextLabel.Property.UNDERLINE, "height"))
+                {
+                    if (null != propertyValue)
+                    {
+                        propertyValue.Get(out underlineHeight);
+                    }
+                }
                 return underlineHeight;
             }
             set
             {
-                PropertyMap temp = new PropertyMap();
-                temp.Insert("height", new PropertyValue(value));
-
-                PropertyMap undelineMap = Underline;
-                undelineMap.Merge(temp);
-
-                SetValue(UnderlineProperty, undelineMap);
-                NotifyPropertyChanged();
+                using (var map = new PropertyMap())
+                {
+                    map.Add("height", value);
+                    var undelineMap = Underline;
+                    undelineMap.Merge(map);
+                    SetValue(UnderlineProperty, undelineMap);
+                    NotifyPropertyChanged();
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -293,8 +293,11 @@ namespace Tizen.NUI.BaseComponents
         /// </example>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetFontStyle(FontStyle fontStyle)
-        {
-            SetValue(FontStyleProperty, TextMapHelper.GetFontStyleMap(fontStyle));
+        {            
+            using (var fontStyleMap = TextMapHelper.GetFontStyleMap(fontStyle))
+            {
+                SetValue(FontStyleProperty, fontStyleMap);
+            }
         }
 
         /// <summary>
@@ -307,7 +310,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public FontStyle GetFontStyle()
         {
-            return TextMapHelper.GetFontStyleStruct((PropertyMap)GetValue(FontStyleProperty));
+            FontStyle fontStyle;
+            using (var fontStyleMap = (PropertyMap)GetValue(FontStyleProperty))
+            {
+                fontStyle = TextMapHelper.GetFontStyleStruct(fontStyleMap);
+            }
+            return fontStyle;
         }
 
         /// <summary>
@@ -773,7 +781,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetUnderline(Underline underline)
         {
-            SetValue(UnderlineProperty, TextMapHelper.GetUnderlineMap(underline));
+            using (var underlineMap = TextMapHelper.GetUnderlineMap(underline))
+            {
+                SetValue(UnderlineProperty, underlineMap);
+            }
         }
 
         /// <summary>
@@ -786,7 +797,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Underline GetUnderline()
         {
-            return TextMapHelper.GetUnderlineStruct((PropertyMap)GetValue(UnderlineProperty));
+            Underline underline;
+            using (var underlineMap = (PropertyMap)GetValue(UnderlineProperty))
+            {
+                underline = TextMapHelper.GetUnderlineStruct(underlineMap);
+            }
+            return underline;
         }
 
         /// <summary>
@@ -834,7 +850,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetShadow(Tizen.NUI.Text.Shadow shadow)
         {
-            SetValue(ShadowProperty, TextMapHelper.GetShadowMap(shadow));
+            using (var shadowMap = TextMapHelper.GetShadowMap(shadow))
+            {
+                SetValue(ShadowProperty, shadowMap);
+            }
         }
 
         /// <summary>
@@ -847,7 +866,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Tizen.NUI.Text.Shadow GetShadow()
         {
-            return TextMapHelper.GetShadowStruct((PropertyMap)GetValue(ShadowProperty));
+            Tizen.NUI.Text.Shadow shadow;
+            using (var shadowMap = (PropertyMap)GetValue(ShadowProperty))
+            {
+                shadow = TextMapHelper.GetShadowStruct(shadowMap);
+            }
+            return shadow;
         }
 
         /// <summary>
@@ -929,7 +953,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetOutline(Outline outline)
         {
-            SetValue(OutlineProperty, TextMapHelper.GetOutlineMap(outline));
+            using (var outlineMap = TextMapHelper.GetOutlineMap(outline))
+            {
+                SetValue(OutlineProperty, outlineMap);
+            }
         }
 
         /// <summary>
@@ -942,7 +969,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Outline GetOutline()
         {
-            return TextMapHelper.GetOutlineStruct((PropertyMap)GetValue(OutlineProperty));
+            Outline outline;
+            using (var outlineMap = (PropertyMap)GetValue(OutlineProperty))
+            {
+                outline = TextMapHelper.GetOutlineStruct(outlineMap);
+            }
+            return outline;
         }
 
         /// <summary>
@@ -1044,9 +1076,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp = 0;
-                GetProperty(TextLabel.Property.LineCount).Get(out temp);
-                return temp;
+                int lineCount = 0;
+                using (var propertyValue = GetProperty(TextLabel.Property.LineCount))
+                {
+                    propertyValue.Get(out lineCount);
+                }
+                return lineCount;
             }
         }
 
@@ -1077,9 +1112,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                int temp = 0;
-                GetProperty(TextLabel.Property.TextDirection).Get(out temp);
-                return (TextDirection)temp;
+                int textDirection = 0;
+                using (var propertyValue = GetProperty(TextLabel.Property.TextDirection))
+                {
+                    propertyValue.Get(out textDirection);
+                }
+                return (TextDirection)textDirection;
             }
         }
 
@@ -1167,7 +1205,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetTextFit(TextFit textFit)
         {
-            SetValue(TextFitProperty, TextMapHelper.GetTextFitMap(textFit));
+            using (var textFitMap = TextMapHelper.GetTextFitMap(textFit))
+            {
+                SetValue(TextFitProperty, textFitMap);
+            }
         }
 
         /// <summary>
@@ -1182,7 +1223,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public TextFit GetTextFit()
         {
-            return TextMapHelper.GetTextFitStruct((PropertyMap)GetValue(TextFitProperty));
+            TextFit textFit;
+            using (var textFitMap = (PropertyMap)GetValue(TextFitProperty))
+            {
+                textFit = TextMapHelper.GetTextFitStruct(textFitMap);
+            }
+            return textFit;
         }
 
         /// <summary>


### PR DESCRIPTION
- There were too many dispose warnings in the legacy code.
- Fix warnings to avoid wasting memory.
- Changed some variables to meaningful names

CA2000 :
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2000