### PR TITLE
[NUI] Add Strikethrough Set/Get methods 

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -346,6 +346,10 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_PasteText")]
             public static extern void PasteText(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_STRIKETHROUGH_get")]
+            public static extern int StrikethroughGet();
+
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -315,6 +315,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_PasteText")]
             public static extern void PasteText(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_STRIKETHROUGH_get")]
+            public static extern int StrikethroughGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -181,6 +181,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabelSignal")]
             public static extern void DeleteTextLabelSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_STRIKETHROUGH_get")]
+            public static extern int StrikethroughGet();
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
@@ -387,6 +387,7 @@ namespace Tizen.NUI.BaseComponents
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputUnderline;
         });
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(InputShadow), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextConstants.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextConstants.cs
@@ -47,6 +47,38 @@ namespace Tizen.NUI.Text
         public string Rejected { get; set; }
     }
 
+
+    /// <summary>
+    /// A struct to pass data of Strikethrough PropertyMap. <br />
+    /// </summary>
+    /// <remarks>
+    /// The Strikethrough struct is used as an argument to SetStrikethrough and GetStrikethrough methods. <br />
+    /// See <see cref="Tizen.NUI.BaseComponents.TextLabel.SetStrikethrough"/>, <see cref="Tizen.NUI.BaseComponents.TextLabel.GetStrikethrough"/>, <see cref="Tizen.NUI.BaseComponents.TextField.SetStrikethrough"/>, <see cref="Tizen.NUI.BaseComponents.TextField.GetStrikethrough"/>, <see cref="Tizen.NUI.BaseComponents.TextEditor.SetStrikethrough"/> and <see cref="Tizen.NUI.BaseComponents.TextEditor.GetStrikethrough"/>. <br />
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1815: Override equals and operator equals on value types")]
+    public struct Strikethrough
+    {
+        /// <summary>
+        /// Whether the strikethrough is enabled (the default value is false).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Enable { get; set; }
+
+        /// <summary>
+        /// The color of the strikethrough (if not provided then the color of the text is used).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color Color { get; set; }
+
+        /// <summary>
+        /// The height in pixels of the strikethrough (if null, the default value is 1.0f).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float? Height { get; set; }
+
+    }
+
     /// <summary>
     /// A struct to pass data of FontStyle PropertyMap. <br />
     /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1485,7 +1485,7 @@ namespace Tizen.NUI.BaseComponents
                 using (var propertyValue = GetProperty(TextEditor.Property.SelectedText))
                 {
                     propertyValue.Get(out selectedText);
-                }                
+                }
                 return selectedText;
             }
         }
@@ -1544,7 +1544,7 @@ namespace Tizen.NUI.BaseComponents
                 using (var propertyValue = GetProperty(TextEditor.Property.SelectedTextStart))
                 {
                     propertyValue.Get(out selectedTextStart);
-                }                
+                }
                 return selectedTextStart;
             }
         }
@@ -1564,7 +1564,7 @@ namespace Tizen.NUI.BaseComponents
                 using (var propertyValue = GetProperty(TextEditor.Property.SelectedTextEnd))
                 {
                     propertyValue.Get(out selectedTextEnd);
-                }                
+                }
                 return selectedTextEnd;
             }
         }
@@ -1788,6 +1788,53 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set Strikethrough to TextEditor. <br />
+        /// </summary>
+        /// <param name="strikethrough">The Strikethrough</param>
+        /// <remarks>
+        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetStrikethrough method.
+        /// <code>
+        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
+        /// strikethrough.Enable = true;
+        /// strikethrough.Color = new Color("#3498DB");
+        /// strikethrough.Height = 2.0f;
+        /// editor.SetStrikethrough(strikethrough);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetStrikethrough(Strikethrough strikethrough)
+        {
+            using (var map = TextMapHelper.GetStrikethroughMap(strikethrough))
+            using (var propertyValue = new PropertyValue(map))
+            {
+                SetProperty(TextEditor.Property.Strikethrough, propertyValue);
+            }
+        }
+
+        /// <summary>
+        /// Get Strikethrough from TextEditor. <br />
+        /// </summary>
+        /// <returns>The Strikethrough</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Strikethrough GetStrikethrough()
+        {
+            Strikethrough strikethrough;
+            using (var propertyValue = GetProperty(TextEditor.Property.Strikethrough))
+            using (var map = new PropertyMap())
+            {
+                propertyValue.Get(map);
+                strikethrough = TextMapHelper.GetStrikethroughStruct(map);
+            }
+            return strikethrough;
+        }
+
+        /// <summary>
         /// The Placeholder property.
         /// The placeholder map contains the following keys :<br />
         /// <list type="table">
@@ -1835,7 +1882,7 @@ namespace Tizen.NUI.BaseComponents
 
                 if (TextMapHelper.IsValue(map, 1))
                     map.Add("textFocused", TextMapHelper.GetStringFromMap(map, 1, defalutText));
-                
+
                 if (TextMapHelper.IsValue(map, 2))
                 {
                     using (var color = TextMapHelper.GetColorFromMap(map, 2))
@@ -1843,7 +1890,7 @@ namespace Tizen.NUI.BaseComponents
                         map.Add("color", color);
                     }
                 }
-                
+
                 if (TextMapHelper.IsValue(map, 3))
                     map.Add("fontFamily", TextMapHelper.GetStringFromMap(map, 3, defalutText));
 
@@ -1862,10 +1909,10 @@ namespace Tizen.NUI.BaseComponents
 
                 if (TextMapHelper.IsValue(map, 5))
                     map.Add("pointSize", TextMapHelper.GetNullableFloatFromMap(map, 5));
-                
+
                 if (TextMapHelper.IsValue(map, 6))
                     map.Add("pixelSize", TextMapHelper.GetNullableFloatFromMap(map, 6));
-                
+
                 if (TextMapHelper.IsValue(map, 7))
                     map.Add("ellipsis", TextMapHelper.GetBoolFromMap(map, 7, false));
 
@@ -2501,6 +2548,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EllipsisPosition = Interop.TextEditor.EllipsisPositionGet();
             internal static readonly int MinLineSize = Interop.TextEditor.MinLineSizeGet();
             internal static readonly int InputFilter = Interop.TextEditor.InputFilterGet();
+            internal static readonly int Strikethrough = Interop.TextEditor.StrikethroughGet();
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -607,6 +607,7 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputUnderline).Get(out temp);
             return temp;
         }));
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowProperty = BindableProperty.Create(nameof(Shadow), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1767,7 +1767,7 @@ namespace Tizen.NUI.BaseComponents
                 using (var propertyValue = GetProperty(TextField.Property.SelectedText))
                 {
                     propertyValue.Get(out selectedText);
-                }                
+                }
                 return selectedText;
             }
         }
@@ -1787,7 +1787,7 @@ namespace Tizen.NUI.BaseComponents
                 using (var propertyValue = GetProperty(TextField.Property.SelectedTextStart))
                 {
                     propertyValue.Get(out selectedTextStart);
-                }                
+                }
                 return selectedTextStart;
             }
         }
@@ -1807,7 +1807,7 @@ namespace Tizen.NUI.BaseComponents
                 using (var propertyValue = GetProperty(TextField.Property.SelectedTextEnd))
                 {
                     propertyValue.Get(out selectedTextEnd);
-                }                
+                }
                 return selectedTextEnd;
             }
         }
@@ -1975,6 +1975,53 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set Strikethrough to TextField. <br />
+        /// </summary>
+        /// <param name="strikethrough">The Strikethrough</param>
+        /// <remarks>
+        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetStrikethrough method.
+        /// <code>
+        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
+        /// strikethrough.Enable = true;
+        /// strikethrough.Color = new Color("#3498DB");
+        /// strikethrough.Height = 2.0f;
+        /// field.SetStrikethrough(strikethrough);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetStrikethrough(Strikethrough strikethrough)
+        {
+            using (var map = TextMapHelper.GetStrikethroughMap(strikethrough))
+            using (var propertyValue = new PropertyValue(map))
+            {
+                SetProperty(TextField.Property.Strikethrough, propertyValue);
+            }
+        }
+
+        /// <summary>
+        /// Get Strikethrough from TextField. <br />
+        /// </summary>
+        /// <returns>The Strikethrough</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Strikethrough GetStrikethrough()
+        {
+            Strikethrough strikethrough;
+            using (var propertyValue = GetProperty(TextField.Property.Strikethrough))
+            using (var map = new PropertyMap())
+            {
+                propertyValue.Get(map);
+                strikethrough = TextMapHelper.GetStrikethroughStruct(map);
+            }
+            return strikethrough;
+        }
+
+        /// <summary>
         /// The Placeholder property.
         /// The placeholder map contains the following keys :<br />
         /// <list type="table">
@@ -2022,7 +2069,7 @@ namespace Tizen.NUI.BaseComponents
 
                 if (TextMapHelper.IsValue(map, 1))
                     map.Add("textFocused", TextMapHelper.GetStringFromMap(map, 1, defalutText));
-                
+
                 if (TextMapHelper.IsValue(map, 2))
                 {
                     using (var color = TextMapHelper.GetColorFromMap(map, 2))
@@ -2049,10 +2096,10 @@ namespace Tizen.NUI.BaseComponents
 
                 if (TextMapHelper.IsValue(map, 5))
                     map.Add("pointSize", TextMapHelper.GetNullableFloatFromMap(map, 5));
-                
+
                 if (TextMapHelper.IsValue(map, 6))
                     map.Add("pixelSize", TextMapHelper.GetNullableFloatFromMap(map, 6));
-                
+
                 if (TextMapHelper.IsValue(map, 7))
                     map.Add("ellipsis", TextMapHelper.GetBoolFromMap(map, 7, false));
 
@@ -2537,6 +2584,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int GrabHandleColor = Interop.TextField.GrabHandleColorGet();
             internal static readonly int EllipsisPosition = Interop.TextField.EllipsisPositionGet();
             internal static readonly int InputFilter = Interop.TextField.InputFilterGet();
+            internal static readonly int Strikethrough = Interop.TextField.StrikethroughGet();
+
         }
 
         internal class InputStyle

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -781,6 +781,7 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputUnderline).Get(out temp);
             return temp;
         }));
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowProperty = BindableProperty.Create(nameof(TextField.Shadow), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -293,7 +293,7 @@ namespace Tizen.NUI.BaseComponents
         /// </example>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetFontStyle(FontStyle fontStyle)
-        {            
+        {
             using (var fontStyleMap = TextMapHelper.GetFontStyleMap(fontStyle))
             {
                 SetValue(FontStyleProperty, fontStyleMap);
@@ -1019,6 +1019,53 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Set Strikethrough to TextLabel. <br />
+        /// </summary>
+        /// <param name="strikethrough">The Strikethrough</param>
+        /// <remarks>
+        /// SetStrikethrough specifies the strikethrough of the text through <see cref="Tizen.NUI.Text.Strikethrough"/>. <br />
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the SetStrikethrough method.
+        /// <code>
+        /// var strikethrough = new Tizen.NUI.Text.Strikethrough();
+        /// strikethrough.Enable = true;
+        /// strikethrough.Color = new Color("#3498DB");
+        /// strikethrough.Height = 2.0f;
+        /// label.SetStrikethrough(strikethrough);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetStrikethrough(Strikethrough strikethrough)
+        {
+            using (var map = TextMapHelper.GetStrikethroughMap(strikethrough))
+            using (var propertyValue = new PropertyValue(map))
+            {
+                SetProperty(TextLabel.Property.Strikethrough, propertyValue);
+            }
+        }
+
+        /// <summary>
+        /// Get Strikethrough from TextLabel. <br />
+        /// </summary>
+        /// <returns>The Strikethrough</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.Strikethrough"/>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Strikethrough GetStrikethrough()
+        {
+            Strikethrough strikethrough;
+            using (var propertyValue = GetProperty(TextLabel.Property.Strikethrough))
+            using (var map = new PropertyMap())
+            {
+                propertyValue.Get(map);
+                strikethrough = TextMapHelper.GetStrikethroughStruct(map);
+            }
+            return strikethrough;
+        }
+
+        /// <summary>
         /// The PixelSize property.<br />
         /// The size of font in pixels.<br />
         /// </summary>
@@ -1532,6 +1579,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int FontSizeScale = Interop.TextLabel.FontSizeScaleGet();
             internal static readonly int EnableFontSizeScale = Interop.TextLabel.EnableFontSizeScaleGet();
             internal static readonly int EllipsisPosition = Interop.TextLabel.EllipsisPositionGet();
+            internal static readonly int Strikethrough = Interop.TextLabel.StrikethroughGet();
         }
 
         private void OnShadowColorChanged(float x, float y, float z, float w)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -349,6 +349,7 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.UNDERLINE).Get(temp);
             return temp;
         }));
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowProperty = BindableProperty.Create(nameof(Shadow), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextMapHelper.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextMapHelper.cs
@@ -230,6 +230,49 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// This method converts a Strikethrough struct to a PropertyMap and returns it.
+        /// The returned map can be used for set Strikethrough PropertyMap in the SetStrikethrough method.
+        /// <param name="strikethrough">The Strikethrough struct value.</param>
+        /// <returns> A PropertyMap for Strikethrough property. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static PropertyMap GetStrikethroughMap(Strikethrough strikethrough)
+        {
+            var map = new PropertyMap();
+
+            map.Add("enable", strikethrough.Enable);
+
+            if (strikethrough.Color != null)
+                map.Add("color", strikethrough.Color);
+
+            if (strikethrough.Height != null)
+                map.Add("height", (float)strikethrough.Height);
+
+            return map;
+        }
+
+        /// <summary>
+        /// This method converts a Strikethrough map to a struct and returns it.
+        /// The returned struct can be returned to the user as a Strikethrough in the GetUnderline method.
+        /// <param name="map">The Strikethrough PropertyMap.</param>
+        /// <returns> A Strikethrough struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Strikethrough GetStrikethroughStruct(PropertyMap map)
+        {
+            var strikethrough = new Strikethrough();
+            if (null != map)
+            {
+                strikethrough.Enable = GetBoolFromMap(map, "enable", false);
+                strikethrough.Color = GetColorFromMap(map, "color");
+                strikethrough.Height = GetFloatFromMap(map, "height", 0.0f);
+            }
+
+            return strikethrough;
+        }
+
+
+        /// <summary>
         /// This method converts a Underline struct to a PropertyMap and returns it.
         /// The returned map can be used for set Underline PropertyMap in the SetUnderline method.
         /// <param name="underline">The Underline struct value.</param>
@@ -555,7 +598,7 @@ namespace Tizen.NUI.BaseComponents
             var selectionHandleImage = new SelectionHandleImage();
             if (null != leftImageMap)
                 selectionHandleImage.LeftImageUrl = GetStringFromMap(leftImageMap, "filename", defaultValue);
-            
+
             if (null != rightImageMap)
                 selectionHandleImage.RightImageUrl = GetStringFromMap(rightImageMap, "filename", defaultValue);
 

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextEditor.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextEditor.cs
@@ -27,6 +27,22 @@ namespace Tizen.NUI.Devel.Tests
             tlog.Info(tag, "Destroy() is called!");
         }
 
+        public bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
         [Test]
         [Category("P1")]
         [Description("TextEditor constructor. With status of Shown.")]
@@ -152,5 +168,38 @@ namespace Tizen.NUI.Devel.Tests
             testingTarget.Dispose();
             tlog.Debug(tag, $"TextEditorEnableFontSizeScale END (OK)");
         }
-    }   
+
+        [Test]
+        [Category("P1")]
+        [Description("TextEditor Strikethrough.")]
+        [Property("SPEC", "Tizen.NUI.TextEditor.GetStrikethrough M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.sabah@samsung.com")]
+        public void TextEditorStrikethrough()
+        {
+            tlog.Debug(tag, $"TextEditorStrikethrough START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var setStrikethrough = new Tizen.NUI.Text.Strikethrough()
+            {
+                Enable = true,
+                Color = new Color("#3498DB"),
+                Height = 2.0f
+            };
+
+            testingTarget.SetStrikethrough(setStrikethrough);
+
+            var getStrikethrough = testingTarget.GetStrikethrough();
+            Assert.AreEqual(getStrikethrough.Enable, setStrikethrough.Enable, "Should be equal!");
+            Assert.AreEqual(true, CheckColor(getStrikethrough.Color, setStrikethrough.Color), "Should be true!");
+            Assert.AreEqual(getStrikethrough.Height, setStrikethrough.Height, "Should be equal!");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"TextEditorStrikethrough END (OK)");
+        }
+    }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextField.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextField.cs
@@ -400,7 +400,7 @@ namespace Tizen.NUI.Devel.Tests
                 testingTarget.FontStyle = fontStyle;
                 Assert.IsNotNull(testingTarget.FontStyle, "Should not be null!");
             }
-            
+
             testingTarget.Dispose();
             tlog.Debug(tag, $"TextFieldFontFamily END (OK)");
         }
@@ -1842,6 +1842,39 @@ namespace Tizen.NUI.Devel.Tests
             }
 
             tlog.Debug(tag, $"TextFieldDispose END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextField Strikethrough.")]
+        [Property("SPEC", "Tizen.NUI.TextField.GetStrikethrough M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.sabah@samsung.com")]
+        public void TextFieldStrikethrough()
+        {
+            tlog.Debug(tag, $"TextFieldStrikethrough START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var setStrikethrough = new Tizen.NUI.Text.Strikethrough()
+            {
+                Enable = true,
+                Color = new Color("#3498DB"),
+                Height = 2.0f
+            };
+
+            testingTarget.SetStrikethrough(setStrikethrough);
+
+            var getStrikethrough = testingTarget.GetStrikethrough();
+            Assert.AreEqual(getStrikethrough.Enable, setStrikethrough.Enable, "Should be equal!");
+            Assert.AreEqual(true, CheckColor(getStrikethrough.Color, setStrikethrough.Color), "Should be true!");
+            Assert.AreEqual(getStrikethrough.Height, setStrikethrough.Height, "Should be equal!");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"TextFieldStrikethrough END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextLabel.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextLabel.cs
@@ -27,6 +27,22 @@ namespace Tizen.NUI.Devel.Tests
             tlog.Info(tag, "Destroy() is called!");
         }
 
+        public bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
         [Test]
         [Category("P1")]
         [Description("TextLabel FontSizeScale.")]
@@ -76,5 +92,38 @@ namespace Tizen.NUI.Devel.Tests
             testingTarget.Dispose();
             tlog.Debug(tag, $"TextLabelEnableFontSizeScale END (OK)");
         }
-    }   
+
+        [Test]
+        [Category("P1")]
+        [Description("TextLabel Strikethrough.")]
+        [Property("SPEC", "Tizen.NUI.TextLabel.GetStrikethrough M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.sabah@samsung.com")]
+        public void TextLabelStrikethrough()
+        {
+            tlog.Debug(tag, $"TextLabelStrikethrough START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var setStrikethrough = new Tizen.NUI.Text.Strikethrough()
+            {
+                Enable = true,
+                Color = new Color("#3498DB"),
+                Height = 2.0f
+            };
+
+            testingTarget.SetStrikethrough(setStrikethrough);
+
+            var getStrikethrough = testingTarget.GetStrikethrough();
+            Assert.AreEqual(getStrikethrough.Enable, setStrikethrough.Enable, "Should be equal!");
+            Assert.AreEqual(true, CheckColor(getStrikethrough.Color, setStrikethrough.Color), "Should be true!");
+            Assert.AreEqual(getStrikethrough.Height, setStrikethrough.Height, "Should be equal!");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"TextLabelStrikethrough END (OK)");
+        }
+    }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextMapHelper.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextMapHelper.cs
@@ -113,7 +113,7 @@ namespace Tizen.NUI.Devel.Tests
             tlog.Debug(tag, $"TextMapHelperGetFontWidthType START");
 
             FontWidthType fontWidthType;
-            
+
             fontWidthType = TextMapHelper.GetFontWidthType("ExtraCondensed");
             Assert.AreEqual(FontWidthType.ExtraCondensed, fontWidthType, "Should be equal!");
 
@@ -135,7 +135,7 @@ namespace Tizen.NUI.Devel.Tests
             tlog.Debug(tag, $"TextMapHelperGetFontWeightType START");
 
             FontWeightType fontWeightType;
-            
+
             fontWeightType = TextMapHelper.GetFontWeightType("Light");
             Assert.AreEqual(FontWeightType.Light, fontWeightType, "Should be equal!");
 
@@ -157,7 +157,7 @@ namespace Tizen.NUI.Devel.Tests
             tlog.Debug(tag, $"TextMapHelperGetFontSlantType START");
 
             FontSlantType fontSlantType;
-            
+
             fontSlantType = TextMapHelper.GetFontSlantType("Italic");
             Assert.AreEqual(FontSlantType.Italic, fontSlantType, "Should be equal!");
 
@@ -310,6 +310,68 @@ namespace Tizen.NUI.Devel.Tests
             }
 
             tlog.Debug(tag, $"TextMapHelperGetUnderlineMap END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextMapHelper GetStrikethroughStruct.")]
+        [Property("SPEC", "Tizen.NUI.TextMapHelper.GetStrikethroughStruct M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "bowon.ryu@samsung.com")]
+        public void TextMapHelperGetStrikethroughStruct()
+        {
+            tlog.Debug(tag, $"TextMapHelperGetStrikethroughStruct START");
+
+            using (var map = new PropertyMap())
+            {
+                var color = new Color("#3498DB");
+                map.Add("enable", true);
+                map.Add("color", color);
+                map.Add("height", (float)2.0f);
+
+                var strikethrough = TextMapHelper.GetStrikethroughStruct(map);
+                Assert.AreEqual(true, strikethrough.Enable, "Should be equal!");
+                Assert.AreEqual(2.0f, strikethrough.Height, "Should be equal!");
+                Assert.AreEqual(true, CheckColor(color, strikethrough.Color), "Should be true!");
+                color.Dispose();
+            }
+
+            tlog.Debug(tag, $"TextMapHelperGetStrikethroughStruct END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextMapHelper GetStrikethroughMap.")]
+        [Property("SPEC", "Tizen.NUI.TextMapHelper.GetStrikethroughMap M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "bowon.ryu@samsung.com")]
+        public void TextMapHelperGetStrikethroughMap()
+        {
+            tlog.Debug(tag, $"TextMapHelperGetStrikethroughMap START");
+
+            var strikethrough = new Tizen.NUI.Text.Strikethrough()
+            {
+                Enable = true,
+                Color = new Color("#3498DB"),
+                Height = 2.0f
+            };
+
+            using (PropertyMap map = TextMapHelper.GetStrikethroughMap(strikethrough))
+            {
+                var color = new Color();
+                map.Find(0, "enable").Get(out bool enable);
+                map.Find(0, "color").Get(color);
+                map.Find(0, "height").Get(out float height);
+
+                Assert.AreEqual(enable, strikethrough.Enable, "Should be equal!");
+                Assert.AreEqual(height, strikethrough.Height, "Should be equal!");
+                Assert.AreEqual(true, CheckColor(color, strikethrough.Color), "Should be true!");
+                color.Dispose();
+            }
+
+            tlog.Debug(tag, $"TextMapHelperGetStrikethroughMap END (OK)");
         }
 
         [Test]
@@ -499,7 +561,7 @@ namespace Tizen.NUI.Devel.Tests
         public void TextMapHelperGetFontSizeType()
         {
             tlog.Debug(tag, $"TextMapHelperGetFontSizeType START");
- 
+
             FontSizeType fontSizeType;
 
             fontSizeType = TextMapHelper.GetFontSizeType("PointSize");
@@ -510,7 +572,7 @@ namespace Tizen.NUI.Devel.Tests
 
             fontSizeType = TextMapHelper.GetFontSizeType("InvalidType");
             Assert.AreEqual(FontSizeType.PointSize, fontSizeType, "If invalid type, should be PointSize type!");
-      
+
             tlog.Debug(tag, $"TextMapHelperGetFontSizeType END (OK)");
         }
 
@@ -837,7 +899,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.AreEqual(camelCase, expectedResult, "Should be equal!");
 
             string emptyString = "";
-            expectedResult = TextMapHelper.GetCamelCase(emptyString);            
+            expectedResult = TextMapHelper.GetCamelCase(emptyString);
 
             Assert.AreEqual(emptyString, expectedResult, "Should be equal!");
 
@@ -1143,7 +1205,7 @@ namespace Tizen.NUI.Devel.Tests
             var intKey = 1;
             var intInvalidKey = 10;
             var value = "value";
-            
+
             using (var map = new PropertyMap())
             {
                 map.Add(intKey, value);


### PR DESCRIPTION
### Description of Change ###
Add Strikethrough Set/Get methods to NUI
Strikethrough is a typographical presentation of words with a horizontal line through their center

The strikethrough map contains the following keys:

- enable (bool): Whether the strikethrough is enabled (the default value is false)
- color (Color): The color of the strikethrough (If not provided then the color of the text is used)
- height (float): The height in pixels of the strikethrough (the default value is 1.f)

 
**Added**: 

- public void SetStrikethrough(Strikethrough strikethrough) // Method to TextLabel, TextEditor & TextField
- public Strikethrough GetStrikethrough() // Method to TextLabel, TextEditor & TextField

**Related patches on DALi**:

- Add Strikethrough Property : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/263388
- Extending Style - Adding Strikethrough :  https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/258031