### PR TITLE
[NUI][TV] Speed-up features for TV profile

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
@@ -57,6 +57,13 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetBrokenImageUrl")]
             public static extern string GetBrokenImageUrl(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_SetBlockControlStyleChangeSignalConnect")]
+            public static extern void SetBlockControlStyleChangeSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetBlockControlStyleChangeSignalConnect")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool GetBlockControlStyleChangeSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1212,11 +1212,10 @@ namespace Tizen.NUI.BaseComponents
                 PropertyValue currentResourceUrlValue = _imagePropertyMap?.Find(ImageVisualProperty.URL);
                 if((currentResourceUrlValue?.Get(out currentResourceUrl) ?? false) && !string.IsNullOrEmpty(currentResourceUrl))
                 {
-                    PropertyValue resourceUrl = new PropertyValue(_resourceUrl);
-                    PropertyMap imageMap = new PropertyMap();
-                    imageMap.Insert(ImageVisualProperty.URL, resourceUrl);
-                    PropertyValue setValue = new PropertyValue(imageMap);
-                    SetProperty(ImageView.Property.IMAGE, setValue);
+                    PropertyValue emptyValue = new PropertyValue();
+
+                    // Set empty value will remove Image visual
+                    SetProperty(ImageView.Property.IMAGE, emptyValue);
 
                     // Image visual is not exist anymore. We should ignore lazy UpdateImage
                     _imagePropertyUpdatedFlag = false;
@@ -1226,11 +1225,9 @@ namespace Tizen.NUI.BaseComponents
                         _imagePropertyUpdateProcessAttachedFlag = false;
                     }
                     // Update resourceUrl as null
-                    _imagePropertyMap[ImageVisualProperty.URL] = resourceUrl;
+                    _imagePropertyMap[ImageVisualProperty.URL] = emptyValue;
 
-                    resourceUrl?.Dispose();
-                    setValue?.Dispose();
-                    imageMap?.Dispose();
+                    emptyValue?.Dispose();
                 }
                 return;
             }

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -212,6 +212,24 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// Gets or sets whether to block control style change signal connection when we create new Control, or not.<br />
+        /// This property is used from theme manager.<br />
+        /// Also, this property is used only from TV profile.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool BlockControlStyleChangeSignalConnect
+        {
+            get
+            {
+                return Interop.StyleManager.GetBlockControlStyleChangeSignalConnect(SwigCPtr);
+            }
+            set
+            {
+                Interop.StyleManager.SetBlockControlStyleChangeSignalConnect(SwigCPtr, value);
+            }
+        }
+
         internal StyleManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Theme/DefaultThemeTV.cs
+++ b/src/Tizen.NUI/src/public/Theme/DefaultThemeTV.cs
@@ -16,6 +16,7 @@
  */
 #if PROFILE_TV
 using System.Collections.Generic;
+using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
 {
@@ -28,6 +29,10 @@ namespace Tizen.NUI
                 Id = DefaultId,
                 Version = DefaultVersion,
             };
+            // Don't connect control style changed signal as Default.
+            // Cuase current TizenTV don't use this signal.
+            // TODO : Maybe need to move this code some other position.
+            StyleManager.Instance.BlockControlStyleChangeSignalConnect = true;
             return theme;
         }
     }


### PR DESCRIPTION
1. Use empty property value when ResourceUrl is empty string. It will not create new PropertyMap.
2. Block control style change signal connect as default. Current TV profile doesn't use StyleManager now. We can block this

This patch required below dali codes
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/269221/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/269222/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/269226/

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>