### PR TITLE
[NUI] Fix bug when ResourceUrl is empty string

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1233,13 +1233,12 @@ namespace Tizen.NUI.BaseComponents
                 // Unregist and dettach Process only if previous resourceUrl was not empty
                 string currentResourceUrl = "";
                 PropertyValue currentResourceUrlValue = _imagePropertyMap?.Find(ImageVisualProperty.URL);
-                if((currentResourceUrlValue?.Get(out currentResourceUrl) ?? false) && string.IsNullOrEmpty(currentResourceUrl))
+                if((currentResourceUrlValue?.Get(out currentResourceUrl) ?? false) && !string.IsNullOrEmpty(currentResourceUrl))
                 {
-                    PropertyValue resourceUrl = new PropertyValue(_resourceUrl);
-                    PropertyMap imageMap = new PropertyMap();
-                    imageMap.Insert(ImageVisualProperty.URL, resourceUrl);
-                    PropertyValue setValue = new PropertyValue(imageMap);
-                    SetProperty(ImageView.Property.IMAGE, setValue);
+                    PropertyValue emptyValue = new PropertyValue();
+
+                    // Remove current registed Image.
+                    SetProperty(ImageView.Property.IMAGE, emptyValue);
 
                     // Image visual is not exist anymore. We should ignore lazy UpdateImage
                     _imagePropertyUpdatedFlag = false;
@@ -1249,11 +1248,9 @@ namespace Tizen.NUI.BaseComponents
                         _imagePropertyUpdateProcessAttachedFlag = false;
                     }
                     // Update resourceUrl as null
-                    _imagePropertyMap[ImageVisualProperty.URL] = resourceUrl;
+                    _imagePropertyMap[ImageVisualProperty.URL] = emptyValue;
 
-                    resourceUrl?.Dispose();
-                    setValue?.Dispose();
-                    imageMap?.Dispose();
+                    emptyValue?.Dispose();
                 }
                 return;
             }


### PR DESCRIPTION
Previous code unregist visual when ResourceUrl use empty URL string.
After #3829, this action was changed.
So I fix this bug

This patch required below dali codes:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/269231/

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>