### PR TITLE
[NUI][TV] Block ControlStyleChangeSignal connection on TV platform

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
@@ -57,6 +57,13 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_GetBrokenImageUrl")]
             public static extern string GetBrokenImageUrl(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_EnableControlStyleChangeSignals")]
+            public static extern void EnableControlStyleChangeSignals(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_IsControlStyleChangeSignalsEnabled")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsControlStyleChangeSignalsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -212,6 +212,24 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// Gets or sets whether to use control style change signal connection when we create new Control, or not.<br />
+        /// This property is used from theme manager.<br />
+        /// Also, this property is used only from TV profile.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool EnableControlStyleChangeSignals
+        {
+            get
+            {
+                return Interop.StyleManager.IsControlStyleChangeSignalsEnabled(SwigCPtr);
+            }
+            set
+            {
+                Interop.StyleManager.EnableControlStyleChangeSignals(SwigCPtr, value);
+            }
+        }
+
         internal StyleManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Theme/DefaultThemeTV.cs
+++ b/src/Tizen.NUI/src/public/Theme/DefaultThemeTV.cs
@@ -28,6 +28,10 @@ namespace Tizen.NUI
                 Id = DefaultId,
                 Version = DefaultVersion,
             };
+            // Don't connect control style changed signal as Default.
+            // Cause current TizenTV don't use this signal.
+            // TODO : Maybe need to move this code some other position.
+            StyleManager.Instance.EnableControlStyleChangeSignals = false;
             return theme;
         }
     }


### PR DESCRIPTION
Current Tizen TV doesn't use native dali's ControlChanage signal.
TV only use Theme feature now.

And internal profiling, signal connection spend lots of time
So now, we try to block TV didn't use this signal interaly.

This patch required below dali code :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/269148/

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
