### PR TITLE
[NUI][AT-SPI] Fix accessibility activation for RecyclerViewItem

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -452,23 +452,5 @@ namespace Tizen.NUI.Components
             ClickEvent?.Invoke(this, nestedEventArgs);
             Clicked?.Invoke(this, eventArgs);
         }
-
-        internal override bool OnAccessibilityActivated()
-        {
-            using (var key = new Key())
-            {
-                key.State = Key.StateType.Down;
-                key.KeyPressedName = "Return";
-
-                // Touch Down
-                OnKey(key);
-
-                // Touch Up
-                key.State = Key.StateType.Up;
-                OnKey(key);
-            }
-
-            return true;
-        }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -855,6 +855,8 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public override bool OnKey(Key key)
         {
+            bool clicked = false;
+
             if (!IsEnabled || null == key)
             {
                 return false;
@@ -872,7 +874,7 @@ namespace Tizen.NUI.Components
             {
                 if (key.KeyPressedName == "Return")
                 {
-                    bool clicked = isPressed && IsEnabled;
+                    clicked = isPressed && IsEnabled;
 
                     isPressed = false;
 
@@ -892,7 +894,7 @@ namespace Tizen.NUI.Components
                     }
                 }
             }
-            return base.OnKey(key);
+            return base.OnKey(key) || clicked;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
@@ -58,40 +58,6 @@ namespace Tizen.NUI.Components
             }
         }
 
-        internal override bool OnAccessibilityActivated()
-        {
-            if (!IsEnabled)
-            {
-                return false;
-            }
-
-            // Touch Down
-            IsPressed = true;
-            UpdateState();
-
-            // Touch Up
-            bool clicked = IsPressed && IsEnabled;
-            IsPressed = false;
-
-            if (IsSelectable)
-            {
-                //IsSelected = !IsSelected;
-            }
-            else
-            {
-                UpdateState();
-            }
-
-            if (clicked)
-            {
-                ClickedEventArgs eventArgs = new ClickedEventArgs();
-                OnClickedInternal(eventArgs);
-            }
-            return true;
-        }
-
-
-
         /// <summary>
         /// Called when the ViewItem need to be updated
         /// </summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -191,6 +191,8 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool OnKey(Key key)
         {
+            bool clicked = false;
+
             if (!IsEnabled || null == key || null == BindingContext)
             {
                 return false;
@@ -208,7 +210,7 @@ namespace Tizen.NUI.Components
             {
                 if (key.KeyPressedName == "Return")
                 {
-                    bool clicked = IsPressed && IsEnabled;
+                    clicked = IsPressed && IsEnabled;
 
                     IsPressed = false;
 
@@ -246,7 +248,7 @@ namespace Tizen.NUI.Components
                     UpdateState();
                 }
             }
-            return base.OnKey(key);
+            return base.OnKey(key) || clicked;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -461,7 +461,17 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public virtual bool OnKeyboardEnter()
         {
-            return false;
+            using var key = new Key();
+
+            key.State = Key.StateType.Down;
+            key.KeyPressedName = "Return";
+
+            // Touch Down
+            OnKey(key);
+
+            // Touch Up
+            key.State = Key.StateType.Up;
+            return OnKey(key);
         }
 
         /// <summary>
@@ -576,7 +586,7 @@ namespace Tizen.NUI.BaseComponents
         /// <returns>True if this control can perform accessibility activation.</returns>
         internal virtual bool OnAccessibilityActivated()
         {
-            return false;
+            return OnKeyboardEnter();
         }
 
         /// <summary>


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->

This change fixes a bug where it was impossible to activate a `RecyclerViewItem` in Accessibility mode.

Because the implementation of `RecyclerViewItem.OnAccessibilityActivated` would look identical to `Button.OnAccessibilityActivated`, to avoid code duplication, accessibility activation is reimplemented in terms of `OnKeyboardEnter` for all controls, just like it is done in DALi.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
