### PR TITLE
[NUI]Set response body in binary format when intercepting http request.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpRequestInterceptor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebHttpRequestInterceptor.cs
@@ -15,6 +15,8 @@
  *
  */
 
+using System.Runtime.InteropServices;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -50,13 +52,25 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool AddResponseBody(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, uint jarg3);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponseBody")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool AddResponseBody(global::System.Runtime.InteropServices.HandleRef jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponse")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool AddResponse(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, uint jarg4);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_AddResponse")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool AddResponse(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg3, uint jarg4);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebRequestInterceptor_WriteResponseChunk")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool WriteResponseChunk(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, uint jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, EntryPoint = "CSharp_Dali_WebRequestInterceptor_WriteResponseChunk")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool WriteResponseChunk(global::System.Runtime.InteropServices.HandleRef jarg1, [MarshalAs(UnmanagedType.LPArray)] byte[] jarg2, uint jarg3);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/WebView/WebHttpRequestInterceptor.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebHttpRequestInterceptor.cs
@@ -188,6 +188,23 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Writes whole response body at once.
+        /// To call it, application should have full response body ready for the intercepted request.
+        /// This function can be used inside or outside WebContext.HttpRequestIntercepted.
+        /// After this call, any further call on WebHttpRequestInterceptor results in undefined behavior.
+        /// </summary>
+        /// <param name="body">Contents of response</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool SetResponseBody(byte[] body)
+        {
+            if (body == null)
+                return false;
+            bool result = Interop.WebHttpRequestInterceptor.AddResponseBody(interceptorHandle, body, (uint)body.Length);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return result;
+        }
+
+        /// <summary>
         /// Writes whole response body with headers at once.
         /// To call it, application should have full response headers and body ready for the intercepted request.
         /// This function can be used inside or outside WebContext.HttpRequestIntercepted.
@@ -197,6 +214,24 @@ namespace Tizen.NUI
         /// <param name="body">Contents of response</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool SetResponse(string headers, string body)
+        {
+            if (body == null)
+                return false;
+            bool result = Interop.WebHttpRequestInterceptor.AddResponse(interceptorHandle, headers, body, (uint)body.Length);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return result;
+        }
+
+        /// <summary>
+        /// Writes whole response body with headers at once.
+        /// To call it, application should have full response headers and body ready for the intercepted request.
+        /// This function can be used inside or outside WebContext.HttpRequestIntercepted.
+        /// After this call, any further call on WebHttpRequestInterceptor results in undefined behavior.
+        /// </summary>
+        /// <param name="headers">Headers of response</param>
+        /// <param name="body">Contents of response</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool SetResponse(string headers, byte[] body)
         {
             if (body == null)
                 return false;
@@ -219,6 +254,31 @@ namespace Tizen.NUI
         /// <param name="chunk">Chunk of response</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool WriteResponseChunk(string chunk)
+        {
+            int length = 0;
+            if (chunk != null)
+            {
+                length = chunk.Length;
+            }
+            bool result = Interop.WebHttpRequestInterceptor.WriteResponseChunk(interceptorHandle, chunk, (uint)length);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return result;
+        }
+
+        /// <summary>
+        /// Writes a part of response body.
+        /// This function can be called only OUTSIDE WebContext.HttpRequestIntercepted.
+        /// If it returns false, handling the request is done.
+        /// Any further calls result in undefined behavior.
+        /// User should always check return value, because response to this request might not be needed any more,
+        /// and the function can return false even though user still has data to write.
+        ///
+        /// After writing full response body in chunks using this function,
+        /// call it again with null as chunk, to signal that response body is finished.
+        /// </summary>
+        /// <param name="chunk">Chunk of response</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool WriteResponseChunk(byte[] chunk)
         {
             int length = 0;
             if (chunk != null)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The patch related in dali csharp binder side is
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/269640/

This patch is to add some APIs for setting response body in binary format when
http request is intercepted.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
