### PR TITLE
[Connection] Do not use Lazy for Singleton

### DIFF
--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -70,8 +70,8 @@ namespace Tizen.Network.Connection
 
     internal class ConnectionInternalManager
     {
-        private static readonly Lazy<ConnectionInternalManager> s_instance =
-            new Lazy<ConnectionInternalManager>(() => new ConnectionInternalManager());
+        private static ConnectionInternalManager s_instance = null;
+        private static readonly object _lock = new object();
 
         private EventHandler<ConnectionTypeEventArgs> _ConnectionTypeChanged = null;
         private EventHandler<AddressEventArgs> _IPAddressChanged = null;
@@ -91,8 +91,15 @@ namespace Tizen.Network.Connection
         {
             get
             {
-                Log.Info(Globals.LogTag, "ConnectionInternalManager.Instance");
-                return s_instance.Value;
+                lock (_lock)
+                {
+                    if (s_instance == null)
+                    {
+                        s_instance = new ConnectionInternalManager();
+                    }
+                    Log.Info(Globals.LogTag, "ConnectionInternalManager.Instance");
+                    return s_instance;
+                }
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
When Lazy is used, if an exception occurs when a singleton object (ConnectionInternalManager) is created, the exception is cached and thrown continuously.
Same as https://github.com/Samsung/TizenFX/pull/3888