### PR TITLE
[NUI] Use CurrentCulture to prevent exception

### DIFF
--- a/src/Tizen.NUI.Components/Controls/DatePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/DatePicker.cs
@@ -294,9 +294,8 @@ namespace Tizen.NUI.Components
         //FIXME: There is no way to know when system locale changed in NUI.
         //       Pickers order and Month text has to be follow system locale.
         private void PickersOrderSet()
-        {           
-            String locale = Environment.GetEnvironmentVariable("LC_TIME");
-            DateTimeFormatInfo DateFormat = new CultureInfo(locale, false ).DateTimeFormat;
+        {
+            DateTimeFormatInfo DateFormat = CultureInfo.CurrentCulture.DateTimeFormat;
             String temp = DateFormat.ShortDatePattern;
             String[] strArray = temp.Split(' ', '/');
             foreach (String format in strArray) {
@@ -308,8 +307,7 @@ namespace Tizen.NUI.Components
 
         private void SetMonthText()
         {
-            String locale = Environment.GetEnvironmentVariable("LC_TIME");
-            CultureInfo info = new CultureInfo(locale);
+            CultureInfo info = CultureInfo.CurrentCulture;
             monthPicker.DisplayedValues = new ReadOnlyCollection<string>(info.DateTimeFormat.AbbreviatedMonthNames);
         }
     }

--- a/src/Tizen.NUI.Components/Controls/TimePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/TimePicker.cs
@@ -426,8 +426,7 @@ namespace Tizen.NUI.Components
             Remove(ampmPicker);
 
             //Get current system locale's time pattern
-            String locale = Environment.GetEnvironmentVariable("LC_TIME");
-            DateTimeFormatInfo timeFormatInfo = new CultureInfo(locale, false ).DateTimeFormat;
+            DateTimeFormatInfo timeFormatInfo = CultureInfo.CurrentCulture.DateTimeFormat;
             String timePattern = timeFormatInfo.ShortTimePattern;
             String[] timePatternArray = timePattern.Split(' ', ':');
 
@@ -449,8 +448,7 @@ namespace Tizen.NUI.Components
         {
             //FIXME: There is no localeChanged Event for Component now
             //       AMPM text has to update when system locale changed.
-            String locale = Environment.GetEnvironmentVariable("LC_TIME");
-            CultureInfo info = new CultureInfo(locale);
+            CultureInfo info = CultureInfo.CurrentCulture;
             ampmText = new string[] {info.DateTimeFormat.AMDesignator, info.DateTimeFormat.PMDesignator};
             ampmPicker.DisplayedValues = new ReadOnlyCollection<string>(ampmText);
         }


### PR DESCRIPTION
### Description of Change ###

[NUI] Use CurrentCulture to prevent exception
A crash is occurring because the Date, Time picker are requesting a date format with the wrong formatted string from LC_TIME.
To fix it to use "CurrentCulture" according to .NET guide.

### API Changes ###
No changes