### PR TITLE
[NUI] Get native image PropertyMap instead of cached.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
@@ -295,7 +295,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 int ret = -1;
-                PropertyMap map = Image;
+                PropertyMap map = base.Image;
                 if (map != null)
                 {
                     PropertyValue val = map.Find(ImageVisualProperty.TotalFrameNumber);
@@ -340,7 +340,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 int ret = -1;
-                PropertyMap map = Image;
+                PropertyMap map = base.Image;
                 if (map != null)
                 {
                     PropertyValue val = map.Find(ImageVisualProperty.CurrentFrameNumber);

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -260,10 +260,13 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (_border == null)
                 {
-                    // Sync as current properties.
-                    UpdateImage();
-
-                    return _imagePropertyMap == null ? new PropertyMap() : new PropertyMap(_imagePropertyMap);
+                    // Get current properties force.
+                    // TODO: Need to make some flag that we only need cached property map.
+                    PropertyMap returnValue = new PropertyMap();
+                    PropertyValue image = GetProperty(ImageView.Property.IMAGE);
+                    image?.Get(returnValue);
+                    image?.Dispose();
+                    return returnValue;
                 }
                 else
                 {

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -110,15 +110,10 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (imageView._border == null)
             {
+                // Get current properties force.
+                // TODO: Need to make some flag that we only need cached property map.
                 PropertyMap temp = new PropertyMap();
-
-                // Sync as current properties.
-                imageView.UpdateImage();
-                if(imageView._imagePropertyMap != null)
-                {
-                    temp.Merge(imageView._imagePropertyMap);
-                }
-
+                Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.IMAGE).Get(temp);
                 return temp;
             }
             else

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -146,7 +146,7 @@ namespace Tizen.NUI.BaseComponents
                 string ret = currentStates.url;
                 NUILog.Debug($"<[{GetId()}] GET");
 
-                PropertyMap map = Image;
+                PropertyMap map = base.Image;
                 if (map != null)
                 {
                     PropertyValue val = map.Find(ImageVisualProperty.URL);
@@ -204,7 +204,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 int ret = -1;
-                PropertyMap map = Image;
+                PropertyMap map = base.Image;
                 if (map != null)
                 {
                     PropertyValue val = map.Find(ImageVisualProperty.TotalFrameNumber);
@@ -266,7 +266,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 int ret = 0;
-                PropertyMap map = Image;
+                PropertyMap map = base.Image;
                 if (map != null)
                 {
                     PropertyValue val = map.Find(ImageVisualProperty.CurrentFrameNumber);
@@ -311,7 +311,7 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Debug($"<[{GetId()}] SET loopMode={currentStates.loopMode}>");
                 PropertyMap map = new PropertyMap();
                 map.Add(ImageVisualProperty.LoopingMode, new PropertyValue((int)currentStates.loopMode));
-                DoAction(ImageView.Property.IMAGE, Interop.Visual.GetActionUpdateProperty(), new PropertyValue(map));
+                DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, new PropertyValue(map));
             }
             get
             {
@@ -381,7 +381,7 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Debug($"<[{GetId()}]SET currentStates.loopCount={currentStates.loopCount}>");
                 PropertyMap map = new PropertyMap();
                 map.Add(ImageVisualProperty.LoopCount, new PropertyValue(currentStates.loopCount));
-                DoAction(ImageView.Property.IMAGE, Interop.Visual.GetActionUpdateProperty(), new PropertyValue(map));
+                DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, new PropertyValue(map));
             }
             get
             {
@@ -437,7 +437,7 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Debug($"<[{GetId()}]SET val={currentStates.stopEndAction}>");
                 PropertyMap map = new PropertyMap();
                 map.Add(ImageVisualProperty.StopBehavior, new PropertyValue((int)currentStates.stopEndAction));
-                DoAction(ImageView.Property.IMAGE, Interop.Visual.GetActionUpdateProperty(), new PropertyValue(map));
+                DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, new PropertyValue(map));
             }
             get
             {
@@ -496,7 +496,7 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Debug($"<[{GetId()}]SET currentStates.redrawInScalingDown={currentStates.redrawInScalingDown}>");
                 PropertyMap map = new PropertyMap();
                 map.Add(ImageVisualProperty.RedrawInScalingDown, new PropertyValue(currentStates.redrawInScalingDown));
-                DoAction(ImageView.Property.IMAGE, Interop.Visual.GetActionUpdateProperty(), new PropertyValue(map));
+                DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, new PropertyValue(map));
             }
             get
             {
@@ -554,7 +554,7 @@ namespace Tizen.NUI.BaseComponents
 
             PropertyMap map = new PropertyMap();
             map.Add(ImageVisualProperty.PlayRange, new PropertyValue(array));
-            DoAction(ImageView.Property.IMAGE, Interop.Visual.GetActionUpdateProperty(), new PropertyValue(map));
+            DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, new PropertyValue(map));
             NUILog.Debug($"  [{GetId()}] currentStates.min:({currentStates.framePlayRangeMin}, max:{currentStates.framePlayRangeMax})>");
         }
 
@@ -668,7 +668,7 @@ namespace Tizen.NUI.BaseComponents
 
             PropertyMap map = new PropertyMap();
             map.Add(ImageVisualProperty.PlayRange, new PropertyValue(array));
-            DoAction(ImageView.Property.IMAGE, Interop.Visual.GetActionUpdateProperty(), new PropertyValue(map));
+            DoAction(ImageView.Property.IMAGE, ActionUpdateProperty, new PropertyValue(map));
             NUILog.Debug($"  [{GetId()}] currentStates.mark1:{currentStates.mark1}, mark2:{currentStates.mark2} >");
         }
 


### PR DESCRIPTION
When we try to get cached property map for animated image,
It will not return internal-updated values
something like "CurrentFrame" for animated image.

This patch make we return Current PropertyMap always
instead of cached property map.

Actually, the best way to fix is, create some flags when we
try to get time-sensitive values.
But it need to fixup some codes and test. So just make hot-fix.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
