### PR TITLE
[NUI][ATSPI] remove duplicated calculation for states

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -636,14 +636,9 @@ namespace Tizen.NUI.BaseComponents
         {
             AccessibilityStates accessibilityStates = (AccessibilityStates)states;
 
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Highlightable, this.AccessibilityHighlightable);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Focusable, this.Focusable);
             FlagSetter(ref accessibilityStates, AccessibilityStates.Focused, this.State == States.Focused);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Highlighted, this.IsHighlighted);
             FlagSetter(ref accessibilityStates, AccessibilityStates.Enabled, this.State != States.Disabled);
             FlagSetter(ref accessibilityStates, AccessibilityStates.Sensitive, this.Sensitive);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Visible, true);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Defunct, !this.IsOnWindow);
 
             return accessibilityStates;
         }


### PR DESCRIPTION
The HIGHLIHGTED state is calculated on parent class ControlAccessible
The get of IsHighlighted is doing exactly same calculation.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
