### PR TITLE
[NUI] Fix duplicated unparent issue at Layer

### DIFF
--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -340,6 +340,15 @@ namespace Tizen.NUI
             if (null == child)
             {
                 throw new ArgumentNullException(nameof(child));
+            }
+            if (child.GetParent() == null) // Early out if child parent is null.
+                return;
+
+            if (child.GetParent() != this)
+            {
+                //throw new System.InvalidOperationException("You have deleted a view that is not a child of this layer.");
+                Tizen.Log.Error("NUI", "You have deleted a view that is not a child of this layer.");
+                return;
             }
             Interop.Actor.Remove(SwigCPtr, View.getCPtr(child));
             if (NDalicPINVOKE.SWIGPendingException.Pending)


### PR DESCRIPTION
View have some safe-guard when we try to child.Unparent() && Remove(child) dual times.
(child will have null parent after one of them.)

But Layer.Remove didn't have any defence code about that situation.

Tizen.NUI.Components.Menu.Dispose call layer.Remove(this) in Dispose function.
But before Dispose function call, we already called Unparented function somewhere.

This patch will guard that case,
and also guard some null & reference issue.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
