### PR TITLE
[NUI][AT-SPI] Fix memory management issues

### DIFF
--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -226,10 +226,10 @@ namespace Tizen.NUI.Accessibility
         public View GetCurrentlyHighlightedView()
         {
             var ptr = Interop.ControlDevel.DaliAccessibilityAccessibleGetCurrentlyHighlightedActor();
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            if (ptr == IntPtr.Zero)
-                return null;
-            return new View(ptr, true);
+
+            return this.GetInstanceSafely<View>(ptr);
         }
 
         /// <summary>
@@ -239,10 +239,9 @@ namespace Tizen.NUI.Accessibility
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool ClearCurrentlyHighlightedView()
         {
-            using (View view = GetCurrentlyHighlightedView())
-            {
-                return view?.ClearAccessibilityHighlight() ?? false;
-            }
+            var view = GetCurrentlyHighlightedView();
+
+            return view?.ClearAccessibilityHighlight() ?? false;
         }
         #endregion Method
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -229,10 +229,7 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                using (View view = Accessibility.Accessibility.Instance.GetCurrentlyHighlightedView())
-                {
-                    return view == this;
-                }
+                return (this == Accessibility.Accessibility.Instance.GetCurrentlyHighlightedView());
             }
         }
 
@@ -510,12 +507,7 @@ namespace Tizen.NUI.BaseComponents
                     InsertText = (startPosition, text) => AccessibilityInsertText(startPosition, Marshal.PtrToStringAnsi(text)),
                     SetTextContents = (newContents) => AccessibilitySetTextContents(Marshal.PtrToStringAnsi(newContents)),
                     DeleteText = (startPosition, endPosition) => AccessibilityDeleteText(startPosition, endPosition),
-                    ScrollToChild = (child) => {
-                        using (var view = new View(child, true))
-                        {
-                            return AccessibilityScrollToChild(view);
-                        }
-                    },
+                    ScrollToChild = (child) => AccessibilityScrollToChild(this.GetInstanceSafely<View>(child)),
                     GetSelectedChildrenCount = () => AccessibilityGetSelectedChildrenCount(),
                     GetSelectedChild = (selectedChildIndex) => View.getCPtr(AccessibilityGetSelectedChild(selectedChildIndex)).Handle,
                     SelectChild = (childIndex) => AccessibilitySelectChild(childIndex),


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This should eliminate error messages similar to this one:

```
E/NUI     ( 1540): BaseHandle.cs: Dispose(580) > [ERR] reference count is over than 2. Could be a memory leak. Need to check! 
E/NUI     ( 1540):  process:1540 thread:1, isDisposed:False, isDisposeQueued:False, me:Tizen.NUI.BaseComponents.View 
E/NUI     ( 1540):  disposeType:Explicit, name:, daliID:11, hash:61494432, refCnt:6
```

Previous code had two major issues:
1. It created a new `View` instance for the same `Dali::Actor`, so really `operator==` was the only method that worked correctly for it.
2. `Actor` handles created in dali-csharp-binder were not freed (unless the `using` idiom was used). `GetInstanceSafely<T>` takes care of that.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
