### PR TITLE
[NUI][AT-SPI] Clean up APIs related to AccessibilityStates

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -472,13 +472,14 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
+        protected override AccessibilityStates AccessibilityCalculateStates()
         {
-            var accessibilityStates = base.AccessibilityCalculateStates(states);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
-            return accessibilityStates;
-        }
+            var states = base.AccessibilityCalculateStates();
 
+            states[AccessibilityState.Modal] = true;
+
+            return states;
+        }
 
         /// <summary>
         /// Default title content of AlertDialog.

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -100,7 +100,7 @@ namespace Tizen.NUI.Components
 
                     if (Accessibility.Accessibility.IsEnabled && instance.IsHighlighted)
                     {
-                        instance.EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, newSelected);
+                        instance.EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, newSelected);
                     }
                 }
             }
@@ -217,12 +217,14 @@ namespace Tizen.NUI.Components
         /// Calculates current states for the button<br />
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
+        protected override AccessibilityStates AccessibilityCalculateStates()
         {
-            var accessibilityStates = base.AccessibilityCalculateStates(states);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Checked, this.IsSelected);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Enabled, this.IsEnabled);
-            return accessibilityStates;
+            var states = base.AccessibilityCalculateStates();
+
+            states[AccessibilityState.Checked] = this.IsSelected;
+            states[AccessibilityState.Enabled] = this.IsEnabled;
+
+            return states;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -142,11 +142,13 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
+        protected override AccessibilityStates AccessibilityCalculateStates()
         {
-            var accessibilityStates = base.AccessibilityCalculateStates(states);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
-            return accessibilityStates;
+            var states = base.AccessibilityCalculateStates();
+
+            states[AccessibilityState.Modal] = true;
+
+            return states;
         }
 
         private void OnRelayout(object sender, EventArgs e)

--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -395,7 +395,7 @@ namespace Tizen.NUI.Components
 
             CalculateSizeAndPosition();
             RegisterDefaultLabel();
-            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Recursive);
+            NotifyAccessibilityStatesChange(new AccessibilityStates(AccessibilityState.Visible, AccessibilityState.Showing), AccessibilityStatesNotifyMode.Recursive);
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace Tizen.NUI.Components
         {
             Hide();
             UnregisterDefaultLabel();
-            NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Recursive);
+            NotifyAccessibilityStatesChange(new AccessibilityStates(AccessibilityState.Visible, AccessibilityState.Showing), AccessibilityStatesNotifyMode.Recursive);
             Dispose();
         }
 
@@ -660,11 +660,13 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
+        protected override AccessibilityStates AccessibilityCalculateStates()
         {
-            var accessibilityStates = base.AccessibilityCalculateStates(states);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
-            return accessibilityStates;
+            var states = base.AccessibilityCalculateStates();
+
+            states[AccessibilityState.Modal] = true;
+
+            return states;
         }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -863,14 +863,14 @@ namespace Tizen.NUI.Components
                 View curHighlightedView = Accessibility.Accessibility.Instance.GetCurrentlyHighlightedView();
                 if (curHighlightedView != null)
                 {
-                    curHighlightedView.NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Single);
+                    curHighlightedView.NotifyAccessibilityStatesChange(new AccessibilityStates(AccessibilityState.Visible, AccessibilityState.Showing), AccessibilityStatesNotifyMode.Single);
                 }
             }
 
             if (appearedPage != null)
             {
                 appearedPage.RegisterDefaultLabel();
-                appearedPage.NotifyAccessibilityStatesChange(AccessibilityStates.Visible | AccessibilityStates.Showing, AccessibilityStatesNotifyMode.Single);
+                appearedPage.NotifyAccessibilityStatesChange(new AccessibilityStates(AccessibilityState.Visible, AccessibilityState.Showing), AccessibilityStatesNotifyMode.Single);
             }
         }
 

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -810,11 +810,13 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
+        protected override AccessibilityStates AccessibilityCalculateStates()
         {
-            var accessibilityStates = base.AccessibilityCalculateStates(states);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Modal, true);
-            return accessibilityStates;
+            var states = base.AccessibilityCalculateStates();
+
+            states[AccessibilityState.Modal] = true;
+
+            return states;
         }
 
         private void UpdateView()

--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -216,7 +216,7 @@ namespace Tizen.NUI.Components
             {
                 if (Accessibility.Accessibility.IsEnabled && IsHighlighted)
                 {
-                    EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, info.CurrentState.Contains(ControlState.Selected));
+                    EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, info.CurrentState.Contains(ControlState.Selected));
                 }
 
                 // SelectedChanged is invoked when button or key is unpressed.

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -78,11 +78,13 @@ namespace Tizen.NUI.Components
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override AccessibilityStates AccessibilityCalculateStates(ulong states)
+        protected override AccessibilityStates AccessibilityCalculateStates()
         {
-            var accessibilityStates = base.AccessibilityCalculateStates(states);
-            FlagSetter(ref accessibilityStates, AccessibilityStates.Checked, this.IsSelected);
-            return accessibilityStates;
+            var states = base.AccessibilityCalculateStates();
+
+            states[AccessibilityState.Checked] = this.IsSelected;
+
+            return states;
         }
 
         /// <summary>
@@ -367,7 +369,7 @@ namespace Tizen.NUI.Components
         {
             if (Accessibility.Accessibility.IsEnabled && IsHighlighted)
             {
-                EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, IsSelected);
+                EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, IsSelected);
             }
 
             ((SwitchExtension)Extension)?.OnSelectedChanged(this);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -122,24 +122,20 @@ namespace Tizen.NUI
             public static extern bool DaliToolkitDevelControlGrabAccessibilityHighlight(global::System.Runtime.InteropServices.HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityState")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityStates")]
             public static extern ulong DaliToolkitDevelControlGetAccessibilityStates(global::System.Runtime.InteropServices.HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ConvertState")]
-            public static extern IntPtr DaliToolkitDevelControlConvertState(ulong arg1);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_NotifyAccessibilityStateChange2")]
-            public static extern global::System.IntPtr DaliToolkitDevelControlNotifyAccessibilityStatesChange(global::System.Runtime.InteropServices.HandleRef arg1, ulong arg2, int arg3);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_NotifyAccessibilityStateChange")]
+            public static extern global::System.IntPtr DaliToolkitDevelControlNotifyAccessibilityStateChange(global::System.Runtime.InteropServices.HandleRef arg1, ulong arg2, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityEvent")]
             public static extern global::System.IntPtr DaliAccessibilityEmitAccessibilityEvent(global::System.Runtime.InteropServices.HandleRef arg1, int arg2_event);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityStateChangedEvent2")]
-            public static extern global::System.IntPtr DaliAccessibilityEmitAccessibilityStatesChangedEvent(global::System.Runtime.InteropServices.HandleRef arg1, ulong arg2_state, int arg3);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitAccessibilityStateChangedEvent")]
+            public static extern global::System.IntPtr DaliAccessibilityEmitAccessibilityStateChangedEvent(global::System.Runtime.InteropServices.HandleRef arg1, int arg2_state, int arg3);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitTextInsertedEvent")]
@@ -203,8 +199,12 @@ namespace Tizen.NUI
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityDoAction DoAction; // 3
 
+                // Note: this method departs from the usual idiom of having the same
+                // parameter types as the Accessible method in DALi, because states
+                // calculated by ControlAccessible::CalculateStates are passed here
+                // as a parameter.
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                public delegate IntPtr AccessibilityCalculateStates(ulong states);
+                public delegate ulong AccessibilityCalculateStates(ulong states);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityCalculateStates CalculateStates; // 4
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -321,247 +321,288 @@ namespace Tizen.NUI.BaseComponents
     };
 
     /// <summary>
-    /// The states of accessibility object.
+    /// Enumeration of possible AT-SPI states for an object.
     /// </summary>
+    /// <seealso cref="AccessibilityStates"/>
     /// <remarks>
     /// Object can be in many states at the same time.
     /// </remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    [Flags]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1028:EnumStorageShouldBeInt32", Justification = "System.Int32 type wouldn't have sufficient capacity")]
-    public enum AccessibilityStates : ulong
+    public enum AccessibilityState
     {
         /// <summary>
         /// Invalid state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Invalid                = (1UL << 0),
+        Invalid                = 0,
         /// <summary>
         /// Active state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Active                 = (1UL << 1),
+        Active                 = 1,
         /// <summary>
         /// Armed state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Armed                  = (1UL << 2),
+        Armed                  = 2,
         /// <summary>
         /// Busy state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Busy                   = (1UL << 3),
+        Busy                   = 3,
         /// <summary>
         /// Checked state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Checked                = (1UL << 4),
+        Checked                = 4,
         /// <summary>
         /// Collapsed state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Collapsed              = (1UL << 5),
+        Collapsed              = 5,
         /// <summary>
         /// Defunct state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Defunct                = (1UL << 6),
+        Defunct                = 6,
         /// <summary>
         /// Editable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Editable               = (1UL << 7),
+        Editable               = 7,
         /// <summary>
         /// Enabled state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Enabled                = (1UL << 8),
+        Enabled                = 8,
         /// <summary>
         /// Expandable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Expandable             = (1UL << 9),
+        Expandable             = 9,
         /// <summary>
         /// Expanded state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Expanded               = (1UL << 10),
+        Expanded               = 10,
         /// <summary>
         /// Focusable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Focusable              = (1UL << 11),
+        Focusable              = 11,
         /// <summary>
         /// Focused state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Focused                = (1UL << 12),
+        Focused                = 12,
         /// <summary>
         /// Had tooltip state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        HasTooltip             = (1UL << 13),
+        HasTooltip             = 13,
         /// <summary>
         /// Horizontal state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Horizontal             = (1UL << 14),
+        Horizontal             = 14,
         /// <summary>
         /// Iconified state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Iconified              = (1UL << 15),
+        Iconified              = 15,
         /// <summary>
         /// Modal state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Modal                  = (1UL << 16),
+        Modal                  = 16,
         /// <summary>
         /// Multi-line state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        MultiLine              = (1UL << 17),
+        MultiLine              = 17,
         /// <summary>
         /// Multi-selectable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        MultiSelectable        = (1UL << 18),
+        MultiSelectable        = 18,
         /// <summary>
         /// Opaque state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Opaque                 = (1UL << 19),
+        Opaque                 = 19,
         /// <summary>
         /// Pressed state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Pressed                = (1UL << 20),
+        Pressed                = 20,
         /// <summary>
         /// Resizeable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Resizeable             = (1UL << 21),
+        Resizeable             = 21,
         /// <summary>
         /// Selectable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Selectable             = (1UL << 22),
+        Selectable             = 22,
         /// <summary>
         /// Selected state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Selected               = (1UL << 23),
+        Selected               = 23,
         /// <summary>
         /// Sensitive state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Sensitive              = (1UL << 24),
+        Sensitive              = 24,
         /// <summary>
         /// Showing state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Showing                = (1UL << 25),
+        Showing                = 25,
         /// <summary>
         /// Single line state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        SingleLine             = (1UL << 26),
+        SingleLine             = 26,
         /// <summary>
         /// Stale state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Stale                  = (1UL << 27),
+        Stale                  = 27,
         /// <summary>
         /// Transient state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Transient              = (1UL << 28),
+        Transient              = 28,
         /// <summary>
         /// Vertical state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Vertical               = (1UL << 29),
+        Vertical               = 29,
         /// <summary>
         /// Visible state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Visible                = (1UL << 30),
+        Visible                = 30,
         /// <summary>
         /// Managed descendants state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        ManagesDescendants     = (1UL << 31),
+        ManagesDescendants     = 31,
         /// <summary>
         /// Indeterminate state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Indeterminate          = (1UL << 32),
+        Indeterminate          = 32,
         /// <summary>
         /// Required state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Required               = (1UL << 33),
+        Required               = 33,
         /// <summary>
         /// Truncated state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Truncated              = (1UL << 34),
+        Truncated              = 34,
         /// <summary>
         /// Animated state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Animated               = (1UL << 35),
+        Animated               = 35,
         /// <summary>
         /// Invalid entry state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        InvalidEntry           = (1UL << 36),
+        InvalidEntry           = 36,
         /// <summary>
         /// Supported auto completion state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        SupportsAutocompletion = (1UL << 37),
+        SupportsAutocompletion = 37,
         /// <summary>
         /// Selectable text state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        SelectableText         = (1UL << 38),
+        SelectableText         = 38,
         /// <summary>
         /// Default state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        IsDefault              = (1UL << 39),
+        IsDefault              = 39,
         /// <summary>
         /// Visited state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Visited                = (1UL << 40),
+        Visited                = 40,
         /// <summary>
         /// Checkable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Checkable              = (1UL << 41),
+        Checkable              = 41,
         /// <summary>
         /// Had popup state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        HasPopup               = (1UL << 42),
+        HasPopup               = 42,
         /// <summary>
         /// Read only state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        ReadOnly               = (1UL << 43),
+        ReadOnly               = 43,
         /// <summary>
         /// Highlighted state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Highlighted            = (1UL << 44),
+        Highlighted            = 44,
         /// <summary>
         /// Highlightable state.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Highlightable          = (1UL << 45),
+        Highlightable          = 45,
     };
+
+    /// <summary>
+    /// A collection of AccessibilityStates
+    /// </summary>
+    /// <seealso cref="AccessibilityState"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AccessibilityStates
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AccessibilityStates(params AccessibilityState[] states)
+        {
+            foreach (var state in states)
+            {
+                BitMask |= (1UL << (int)state);
+            }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal ulong BitMask { get; set; } = 0UL;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool this[AccessibilityState state]
+        {
+            get
+            {
+                return Convert.ToBoolean(BitMask & (1UL << (int)state));
+            }
+            set
+            {
+                if (value)
+                {
+                    // Set N-th bit
+                    BitMask |= (1UL << (int)state);
+                }
+                else
+                {
+                    // Clear N-th bit
+                    BitMask &= ~(1UL << (int)state);
+                }
+            }
+        }
+    }
 
     /// <summary>
     /// Notify mode for AccessibilityStates.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -307,13 +307,13 @@ namespace Tizen.NUI.BaseComponents
         {
             SetVisible(true);
 
-            if (((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
+            if (GetAccessibilityStates()[AccessibilityState.Modal])
             {
                 RegisterDefaultLabel();
 
                 if (Accessibility.Accessibility.IsEnabled)
                 {
-                    EmitAccessibilityStatesChangedEvent(AccessibilityStates.Showing, true);
+                    EmitAccessibilityStateChangedEvent(AccessibilityState.Showing, true);
                 }
             }
         }
@@ -331,13 +331,13 @@ namespace Tizen.NUI.BaseComponents
         {
             SetVisible(false);
 
-            if (((GetAccessibilityStates() & AccessibilityStates.Modal) != 0))
+            if (GetAccessibilityStates()[AccessibilityState.Modal])
             {
                 UnregisterDefaultLabel();
 
                 if (Accessibility.Accessibility.IsEnabled)
                 {
-                    EmitAccessibilityStatesChangedEvent(AccessibilityStates.Showing, false);
+                    EmitAccessibilityStateChangedEvent(AccessibilityState.Showing, false);
                 }
             }
         }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSViewAccessibility.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSViewAccessibility.cs
@@ -179,7 +179,7 @@ namespace Tizen.NUI.Devel.Tests
             var testingTarget = new AccessibilityRange();
             Assert.IsNotNull(testingTarget, "Can't create success object AccessibilityRange");
             Assert.IsInstanceOf<AccessibilityRange>(testingTarget, "Should be an instance of AccessibilityRange type.");
-                
+
             testingTarget.StartOffset = 10;
             Assert.AreEqual(10, testingTarget.StartOffset, "Should be equal!");
 
@@ -354,7 +354,7 @@ namespace Tizen.NUI.Devel.Tests
                     testingTarget.AppendAccessibilityRelation(child, AccessibilityRelationType.MemberOf);
                     var result = testingTarget.GetAccessibilityRelations();
                     tlog.Debug(tag, "AccessibilityRelations : " + result);
-                    
+
                     testingTarget.RemoveAccessibilityRelation(child, AccessibilityRelationType.MemberOf);
                     testingTarget.ClearAccessibilityRelations();
                 }
@@ -426,7 +426,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object View");
             Assert.IsInstanceOf<View>(testingTarget, "Should be an instance of View type.");
 
-           
+
             testingTarget.SetAccessibilityReadingInfoTypes(AccessibilityReadingInfoTypes.Description);
             var result = testingTarget.GetAccessibilityReadingInfoTypes();
             tlog.Debug(tag, "AccessibilityReadingInfoTypes : " + result);
@@ -457,7 +457,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object View");
             Assert.IsInstanceOf<View>(testingTarget, "Should be an instance of View type.");
 
-            testingTarget.NotifyAccessibilityStatesChange(AccessibilityStates.Busy, AccessibilityStatesNotifyMode.Recursive);
+            testingTarget.NotifyAccessibilityStatesChange(new AccessibilityStates(AccessibilityState.Busy), AccessibilityStatesNotifyMode.Recursive);
             var result = testingTarget.GetAccessibilityStates();
             tlog.Debug(tag, "AccessibilityStates : " + result);
 
@@ -540,14 +540,14 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("ViewAccessibility.EmitAccessibilityStatesChangedEvent.")]
-        [Property("SPEC", "Tizen.NUI.ViewAccessibility.EmitAccessibilityStatesChangedEvent M")]
+        [Description("ViewAccessibility.EmitAccessibilityStateChangedEvent.")]
+        [Property("SPEC", "Tizen.NUI.ViewAccessibility.EmitAccessibilityStateChangedEvent M")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void ViewAccessibilityEmitAccessibilityStatesChangedEvent()
+        public void ViewAccessibilityEmitAccessibilityStateChangedEvent()
         {
-            tlog.Debug(tag, $"ViewAccessibilityEmitAccessibilityStatesChangedEvent START");
+            tlog.Debug(tag, $"ViewAccessibilityEmitAccessibilityStateChangedEvent START");
 
             var testingTarget = new CheckBox()
             {
@@ -560,7 +560,7 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                testingTarget.EmitAccessibilityStatesChangedEvent(AccessibilityStates.Checked, true);
+                testingTarget.EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, true);
             }
             catch (Exception e)
             {
@@ -569,7 +569,7 @@ namespace Tizen.NUI.Devel.Tests
             }
 
             testingTarget.Dispose();
-            tlog.Debug(tag, $"ViewAccessibilityEmitAccessibilityStatesChangedEvent END (OK)");
+            tlog.Debug(tag, $"ViewAccessibilityEmitAccessibilityStateChangedEvent END (OK)");
         }
 
         [Test]


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This PR:
1. Restores the division into `enum AccessibilityState` (enumeration of possible states) and `class AccessibilityStates` (a collection of states), which was wrongly removed. DALi makes the same distinction between `Accessibility::State` and `Accessibility::States`.

2. Restores the AT-SPI standard-compliant values for  `AccessibilityState` enumeration (the same values as in the `at-spi2-core` library and in DALi `accessibility.h`).

3. Adds a convenient indexing syntax (e.g. `states[AccessibilityState.Modal] = true`) for manipulating the states collection without having to perform bitwise operations like `&` and `|` (because using a high level toolkit like `NUI` should not require performing bit operations) or using the cumbersome and roundabout way via `FlagSetter` (e.g. `FlagSetter(ref states, AccessibilityState.Modal, true)`, which is probably inefficient due to the use of generic and dynamic types).

4. Removes `FlagSetter`.

5. Removes `View.DuplicateStates` and returns the bitmask directly from `AccessibilityDelegate.CalculateStates`, to avoid an unnecessary memory allocation.

6. Removes the recently added parameter for `AccessibilityCalculateStates`, because it causes confusion, as this method shouldn't take any arguments (just like `CalculateStates` in DALi). It should only get parent states from `base` and add (or remove) its own states to this set (same as in DALi). The DALi-calculated states are rerouted through a new non-virtual method `AccessibilityCalculateStatesWrapper`.

7. Fixes `EmitAccessibilityStateChangedEvent` to take a single `AccessibilityState` as a parameter (the same as in DALi). `NotifyAccessibilityStatesChange` still takes an `AccessibilityStates` collection as a parameter (the same as in DALi), because it is equivalent to calling `EmitAccessibilityStateChangedEvent` in a loop for all specified states.

8. Updates some `Interop` symbol names. See the commit message for the dali-csharp-binder patch for more information on these changes.

Complementary dali-csharp-binder patch (merge at the same time):
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/270040/

The dali-csharp-binder also patch depends on the following dali-adaptor patch:
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/270102/

It is recommended to merge the dali-adaptor patch first, and after that, merge the dali-csharp-binder patch and this PR together.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
