### PR TITLE
[NUI] Catch DllNotFoundException in IsSupportedMultiWindow() for desktop

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -43,7 +43,14 @@ namespace Tizen.NUI
         static internal bool IsSupportedMultiWindow()
         {
             bool isSupported = false;
-            Information.TryGetValue("http://tizen.org/feature/opengles.surfaceless_context", out isSupported);
+            try
+            {
+                Information.TryGetValue("http://tizen.org/feature/opengles.surfaceless_context", out isSupported);
+            }
+            catch (DllNotFoundException e)
+            {
+                Tizen.Log.Fatal("NUI", $"{e}\n");
+            }
             return isSupported;
         }
 


### PR DESCRIPTION
To support multi-window, creating a new Window calls
Window.IsSupportedMultiWindow().

Since libcapi-system-info.so.0 is not installed by default on desktop
environment, calling Window.IsSupportedMultiWindow() causes crash by
DllNotFoundException.

Not to cause crash by calling Window.IsSupportedMultiWindow() on
desktop, DllNotFoundException is caught.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
