### PR TITLE
[NUI] Support RequestLayout() while main loop is in idle state

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -348,7 +348,15 @@ namespace Tizen.NUI
         public void RequestLayout()
         {
             flags = flags | LayoutFlags.ForceLayout;
-            if (parent != null)
+            if (parent == null)
+            {
+                // If RequestLayout() is called while main loop is in idle state,
+                // then Awake() is required to awake main loop again and
+                // Layout can be re-calculated correctly.
+                // For performance, Awake() is called only by the root layout.
+                ProcessorController.Instance.Awake();
+            }
+            else
             {
                 LayoutGroup layoutGroup = parent as LayoutGroup;
                 if (layoutGroup != null && !layoutGroup.LayoutRequested)


### PR DESCRIPTION
Previously, RequestLayout() was not supported if it was called while
main loop was in idle state.

Now, RequestLayout() calls Awake() to awake main loop again and Layout
can be re-calculated correctly.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
