### PR TITLE
[NUI][AT-SPI] Support multiple AT-SPI interfaces for View

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -384,10 +384,15 @@ namespace Tizen.NUI
                 public delegate bool AccessibilityDeselectChild(IntPtr self, int childIndex);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityDeselectChild DeselectChild; // 35
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate uint AccessibilityGetInterfaces(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetInterfaces GetInterfaces; // 36
             }
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityConstructor_NUI")]
-            public static extern void DaliToolkitDevelControlSetAccessibilityConstructor(HandleRef arg1_self, int arg2_role, int arg3_iface);
+            public static extern void DaliToolkitDevelControlSetAccessibilityConstructor(HandleRef arg1_self, int arg2_role);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_DuplicateString")]
             public static extern IntPtr DaliAccessibilityDuplicateString(string arg);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -463,7 +463,9 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetAccessibilityConstructor(Role role, AccessibilityInterface accessibilityInterface = AccessibilityInterface.None)
         {
-            Interop.ControlDevel.DaliToolkitDevelControlSetAccessibilityConstructor(SwigCPtr, (int)role, (int)accessibilityInterface);
+            // We have to store the interface flags until we remove SetAccessibilityConstructor and switch to native C# interfaces
+            AtspiInterfaceFlags = (1U << (int)accessibilityInterface);
+            Interop.ControlDevel.DaliToolkitDevelControlSetAccessibilityConstructor(SwigCPtr, (int)role);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -25,6 +25,7 @@ namespace Tizen.NUI.BaseComponents
     /// <summary>
     /// Accessibility interface.
     /// </summary>
+    // Values are from Dali::Accessibility::AtspiInterface
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum AccessibilityInterface
     {
@@ -37,17 +38,17 @@ namespace Tizen.NUI.BaseComponents
         /// Accessibility interface which can store numeric value
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Value = 1,
+        Value = 26,
         /// <summary>
         /// Accessibility interface which can store editable texts
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        EditableText = 2,
+        EditableText = 9,
         /// <summary>
         /// Accessibility interface which can store a set of selected items
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Selection = 3,
+        Selection = 21,
     }
 
     /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
@@ -24,6 +24,9 @@ namespace Tizen.NUI.BaseComponents
     {
         private static AccessibilityStates AccessibilityInitialStates = new AccessibilityStates();
 
+        // To be removed when native C# AT-SPI interfaces are implemented.
+        private uint? AtspiInterfaceFlags = null;
+
         private static void RegisterAccessibilityDelegate()
         {
             InitializeAccessibilityDelegateAccessibleInterface();
@@ -68,6 +71,7 @@ namespace Tizen.NUI.BaseComponents
 
             ad.CalculateStates = AccessibilityCalculateStatesWrapper;
             ad.GetDescription  = AccessibilityGetDescriptionWrapper;
+            ad.GetInterfaces   = AccessibilityGetInterfaces; // Not a wrapper, entirely private implementation
             ad.GetName         = AccessibilityGetNameWrapper;
         }
 
@@ -91,6 +95,29 @@ namespace Tizen.NUI.BaseComponents
             string description = GetViewFromRefObject(self).AccessibilityGetDescription();
 
             return DuplicateString(description);
+        }
+
+        private static uint AccessibilityGetInterfaces(IntPtr self)
+        {
+            // Currently a maximum of one AccessibilityInterface per View is supported.
+            // This will change when we implement AT-SPI interfaces as native C# interfaces.
+            // Then, this method will look like:
+            //
+            // uint flags = 0U;
+            // if (view is IAtspiSelection) flags |= (1U << (int)AccessibilityInterface.Selection)
+            // if (view is IAtspiValue) flags |= (1U << (int)AccessibilityInterface.Value)
+            // ...
+            // return flags;
+
+            View view = GetViewFromRefObject(self);
+
+            if (!view.AtspiInterfaceFlags.HasValue)
+            {
+                NUILog.Error("AtspiInterfaceFlags are not set!");
+                return 0U;
+            }
+
+            return view.AtspiInterfaceFlags.Value;
         }
 
         private static IntPtr AccessibilityGetNameWrapper(IntPtr self)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This patch adds `GetInterfaces` to `AccessibilityDelegate` which will allow to report any number of AT-SPI interfaces in any combinations back to DALi. Complementary changes to DALi make the AT-SPI bridge use `GetInterfaces` instead of `dynamic_cast` (which stops at the C++ language boundary).

Note however, that it is not yet possible to declare more than one AT-SPI interface for a given `Control` in NUI. There are more changes needed, such as removing `SetAccessibilityConstructor` and switching to native C# interfaces, and they will be done in separate PRs.

Related changes (merge everything at the same time, together with this PR):
1. https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/270772/
2. https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/270872/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
