### PR TITLE
[NUI][[Xaml] Support iterator property in xaml

### DIFF
--- a/src/Tizen.NUI/src/internal/EXaml/Action/RootAction.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Action/RootAction.cs
@@ -232,6 +232,18 @@ namespace Tizen.NUI.EXaml
             {
                 globalDataList.LongStrings = opInfo[0] as string;
             };
+
+            createOperations[(int)EXamlOperationType.CreateDPObject] = (GlobalDataList globalDataList, List<object> opInfo) =>
+            {
+                var operation = new CreateDPObject(globalDataList, opInfo);
+                globalDataList.Operations.Add(operation);
+            };
+
+            createOperations[(int)EXamlOperationType.GetProperty] = (GlobalDataList globalDataList, List<object> opInfo) =>
+            {
+                var operation = new GetProperty(globalDataList, opInfo);
+                globalDataList.Operations.Add(operation);
+            };
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/CreateDPObject.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/CreateDPObject.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
+using Tizen.NUI.Binding.Internals;
+using Tizen.NUI.Xaml;
+
+namespace Tizen.NUI.EXaml
+{
+    internal class CreateDPObject : Operation
+    {
+        public CreateDPObject(GlobalDataList globalDataList, List<object> operationInfos)
+        {
+            this.valueStr = operationInfos[0] as string;
+            this.typeIndex = (int)operationInfos[1];
+            this.globalDataList = globalDataList;
+        }
+
+        private GlobalDataList globalDataList;
+
+        public void Do()
+        {
+            if (0 > typeIndex)
+            {
+                object dpValue = null;
+
+                switch (typeIndex)
+                {
+                    case -3:
+                        dpValue = Convert.ToInt16(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+
+                    case -4:
+                        dpValue = Convert.ToInt32(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+
+                    case -5:
+                        dpValue = Convert.ToInt64(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+
+                    case -7:
+                        dpValue = Convert.ToUInt16(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+
+                    case -8:
+                        dpValue = Convert.ToUInt32(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+
+                    case -9:
+                        dpValue = Convert.ToInt64(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+
+                    case -15:
+                        dpValue = Convert.ToSingle(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+
+                    case -16:
+                        dpValue = Convert.ToDouble(GraphicsTypeManager.Instance.ConvertScriptToPixel(valueStr));
+                        break;
+                }
+
+                if (null == dpValue)
+                {
+                    throw new Exception($"Can't convert {valueStr} to DP value of typeIndex {typeIndex}");
+                }
+
+                globalDataList.GatheredInstances.Add(dpValue);
+            }
+            else
+            {
+                var type = globalDataList.GatheredTypes[typeIndex];
+                throw new Exception($"Can't convert DP value of type {type.FullName}");
+            }
+        }
+
+        private int typeIndex;
+        private string valueStr;
+    }
+}

--- a/src/Tizen.NUI/src/internal/EXaml/Operation/GetProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/GetProperty.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
+using Tizen.NUI.Binding.Internals;
+using Tizen.NUI.Xaml;
+
+namespace Tizen.NUI.EXaml
+{
+    internal class GetProperty : Operation
+    {
+        public GetProperty(GlobalDataList globalDataList, List<object> operationInfos)
+        {
+            instanceIndex = (int)operationInfos[0];
+            propertyIndex = (int)operationInfos[1];
+
+            this.globalDataList = globalDataList;
+        }
+
+        private GlobalDataList globalDataList;
+
+        public void Do()
+        {
+            object instance = globalDataList.GatheredInstances[instanceIndex];
+            if (null == instance)
+            {
+                throw new Exception(String.Format("Can't get instance by index {0}", instanceIndex));
+            }
+
+            var property = globalDataList.GatheredProperties[propertyIndex];
+
+            if (null == property)
+            {
+                throw new Exception(String.Format("Can't find property in type {0}", instance.GetType().FullName));
+            }
+
+            if (null == property.GetMethod)
+            {
+                throw new Exception(String.Format("Property {0} hasn't get method", property.Name));
+            }
+
+            var obj = property.GetMethod.Invoke(instance, new object[] { });
+            if (null == obj)
+            {
+                throw new Exception(String.Format("Instance of Property {0}.{1} is null", property.DeclaringType.FullName, property.Name));
+            }
+
+            globalDataList.GatheredInstances.Add(obj);
+        }
+
+        private int instanceIndex;
+        private int propertyIndex;
+    }
+}

--- a/src/Tizen.NUI/src/internal/EXaml/Utility/EXamlOperationType.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Utility/EXamlOperationType.cs
@@ -47,6 +47,8 @@ namespace Tizen.NUI.EXaml
         AddToResourceDictionary,
         RegisterXName,
         GetLongString,
+        CreateDPObject,
+        GetProperty,
         MAX
     }
 }


### PR DESCRIPTION
### Description of Change ###
Support iterator property in Xaml
Relate to https://github.com/nui-dali/Tizen.NUI.XamlBuild/pull/38.

Sample code
C#
```
    public class Property2
    {
        public int Property1
        {
            set;
            get;
        }
    }

    public class Property3
    {
        public Property2 Property2
        {
            set;
            get;
        } = new Property2();
    }

    public class TestXamlView : View
    {
        public Property3 Property3
        {
            set;
            get;
        } = new Property3();
    }

    public class TestXamlView1 : TestXamlView
    {
    }
```

Xaml
```
<?xml version="1.0" encoding="UTF-8" ?>
<l:TestXamlView1 x:Class="Tizen.NUI.Examples.TestIteratorProperty"
  xmlns="http://tizen.org/Tizen.NUI/2018/XAML"
  xmlns:l="clr-namespace:Tizen.NUI.Examples;"
  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">

    <l:TestXamlView1 x:Name="mainView">
        <l:TestXamlView1.Property3.Property2.Property1>
            <x:Int32>1</x:Int32>
        </l:TestXamlView1.Property3.Property2.Property1>
    </l:TestXamlView1>
    <l:TestXamlView1.Property3.Property2.Property1>
        <x:Int32>1</x:Int32>
    </l:TestXamlView1.Property3.Property2.Property1>
</l:TestXamlView1>
```


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
