### PR TITLE
[Sticker] Add Sticker APIs

### DIFF
--- a/src/Tizen.Uix.Sticker/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Uix.Sticker/Interop/Interop.Libraries.cs
@@ -1,0 +1,31 @@
+/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+/// <summary>
+/// The Partial Interop class.
+/// </summary>
+internal static partial class Interop
+{
+    /// <summary>
+    /// The Partial Libraries class.
+    /// </summary>
+    internal static partial class Libraries
+    {
+        internal const string StickerConsumer = "libcapi-ui-sticker-consumer.so";
+        internal const string StickerProvider = "libcapi-ui-sticker-provider.so";
+    }
+}

--- a/src/Tizen.Uix.Sticker/Interop/Interop.StickerConsumer.cs
+++ b/src/Tizen.Uix.Sticker/Interop/Interop.StickerConsumer.cs
@@ -1,0 +1,94 @@
+/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+using System.Runtime.InteropServices;
+using Tizen;
+using static Interop.StickerData;
+using Tizen.Uix.Sticker;
+
+/// <summary>
+/// Partial Interop Class
+/// </summary>
+internal static partial class Interop
+{
+    /// <summary>
+    /// StickerConsumer Interop Class
+    /// </summary>
+    internal static class StickerConsumer
+    {
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_create")]
+        internal static extern ErrorCode StickerConsumerCreate(out IntPtr stickerConsumer);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_destroy")]
+        internal static extern ErrorCode StickerConsumerDestroy(IntPtr stickerConsumer);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_data_foreach_all")]
+        internal static extern ErrorCode StickerConsumerDataForeachAll(IntPtr stickerConsumer, int offset, int count, out int result, StickerConsumerDataForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_data_foreach_by_keyword")]
+        internal static extern ErrorCode StickerConsumerDataForeachByKeyword(IntPtr stickerConsumer, int offset, int count, out int result, string keyword, StickerConsumerDataForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_data_foreach_by_group")]
+        internal static extern ErrorCode StickerConsumerDataForeachByGroup(IntPtr stickerConsumer, int offset, int count, out int result, string group, StickerConsumerDataForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_data_foreach_by_type")]
+        internal static extern ErrorCode StickerConsumerDataForeachByType(IntPtr stickerConsumer, int offset, int count, out int result, UriType uriType, StickerConsumerDataForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_group_list_foreach_all")]
+        internal static extern ErrorCode StickerConsumerGroupListForeachAll(IntPtr stickerConsumer, StickerConsumerGroupListForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_keyword_list_foreach_all")]
+        internal static extern ErrorCode StickerConsumerKeywordListForeachAll(IntPtr stickerConsumer, StickerConsumerKeywordListForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_data_foreach_by_display_type")]
+        internal static extern ErrorCode StickerConsumerDataForeachByDisplayType(IntPtr stickerConsumer, int offset, int count, out int result, DisplayType type, StickerConsumerDataForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_group_list_foreach_by_display_type")]
+        internal static extern ErrorCode StickerConsumerGroupListForeachByDisplayType(IntPtr stickerConsumer, DisplayType type, StickerConsumerGroupListForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_add_recent_data")]
+        internal static extern ErrorCode StickerConsumerAddRecentData(IntPtr stickerConsumer, SafeStickerDataHandle stickerData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_get_recent_data_list")]
+        internal static extern ErrorCode StickerConsumerGetRecentDataList(IntPtr stickerConsumer, int count, out int result, StickerConsumerDataForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_set_event_cb")]
+        internal static extern ErrorCode StickerConsumerSetEventCB(IntPtr stickerConsumer, StickerConsumerEventCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_unset_event_cb")]
+        internal static extern ErrorCode StickerConsumerUnsetEventCB(IntPtr stickerConsumer);
+
+        [DllImport(Libraries.StickerConsumer, EntryPoint = "sticker_consumer_group_image_list_foreach_all")]
+        internal static extern ErrorCode StickerConsumerGroupImageListForeachAll(IntPtr stickerConsumer, StickerConsumerGroupImageListForeachCallback callback, IntPtr userData);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerConsumerDataForeachCallback(IntPtr stickerData, IntPtr userData);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerConsumerGroupListForeachCallback(IntPtr group, IntPtr userData);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerConsumerKeywordListForeachCallback(IntPtr keyword, IntPtr userData);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerConsumerEventCallback(EventType type, IntPtr stickerData, IntPtr userData);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerConsumerGroupImageListForeachCallback(IntPtr group, UriType type, IntPtr uri, IntPtr userData);
+    }
+}

--- a/src/Tizen.Uix.Sticker/Interop/Interop.StickerData.cs
+++ b/src/Tizen.Uix.Sticker/Interop/Interop.StickerData.cs
@@ -1,0 +1,140 @@
+/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+using System.Runtime.InteropServices;
+using Tizen;
+using Tizen.Uix.Sticker;
+
+/// <summary>
+/// Partial Interop Class
+/// </summary>
+internal static partial class Interop
+{    
+    /// <summary>
+    /// StickerData Interop Class
+    /// </summary>
+    internal static class StickerData
+    {
+        internal static string LogTag = "Tizen.Uix.Sticker";
+        internal enum ErrorCode
+        {
+            None = Tizen.Internals.Errors.ErrorCode.None,                          /* Successful */
+            NotSupported = Tizen.Internals.Errors.ErrorCode.NotSupported,          /* Sticker NOT supported */
+            PermissionDenied = Tizen.Internals.Errors.ErrorCode.PermissionDenied,  /* Permission denied */
+            InvalidParameter = Tizen.Internals.Errors.ErrorCode.InvalidParameter,  /* Invalid parameter */
+            OutOfMemory = Tizen.Internals.Errors.ErrorCode.OutOfMemory,            /* Out of Memory */
+            OperationFailed = -0x03050000 | 0x0001,         /* Operation failed */
+            FileExists = Tizen.Internals.Errors.ErrorCode.FileExists,              /* File exists */
+            NoData = Tizen.Internals.Errors.ErrorCode.NoData,                      /* No data available */
+            NoSuchFile = Tizen.Internals.Errors.ErrorCode.NoSuchFile,              /* No such file */
+        };
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_create")]
+        internal static extern ErrorCode StickerDataCreate(out SafeStickerDataHandle stickerData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_destroy")]
+        internal static extern ErrorCode StickerDataDestroy(IntPtr stickerData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_clone")]
+        internal static extern ErrorCode StickerDataClone(IntPtr originData, out IntPtr targetData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_handle")]
+        internal static extern ErrorCode StickerDataGetHandle(string uri, out IntPtr stickerData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_app_id")]
+        internal static extern ErrorCode StickerDataGetAppId(SafeStickerDataHandle stickerData, out string appId);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_set_uri")]
+        internal static extern ErrorCode StickerDataSetUri(SafeStickerDataHandle stickerData, UriType uriType, string uri);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_uri")]
+        internal static extern ErrorCode StickerDataGetUri(SafeStickerDataHandle stickerData, out UriType uriType, out string uri);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_foreach_keyword")]
+        internal static extern ErrorCode StickerDataForeachKeyword(SafeStickerDataHandle stickerData, StickerDataKeywordForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_add_keyword")]
+        internal static extern ErrorCode StickerDataAddKeyword(SafeStickerDataHandle stickerData, string keyword);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_remove_keyword")]
+        internal static extern ErrorCode StickerDataRemoveKeyword(SafeStickerDataHandle stickerData, string keyword);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_set_group_name")]
+        internal static extern ErrorCode StickerDataSetGroupName(SafeStickerDataHandle stickerData, string group);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_group_name")]
+        internal static extern ErrorCode StickerDataGetGroupName(SafeStickerDataHandle stickerData, out string group);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_set_thumbnail")]
+        internal static extern ErrorCode StickerDataSetThumbnail(SafeStickerDataHandle stickerData, string thumbnail);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_thumbnail")]
+        internal static extern ErrorCode StickerDataGetThumbnail(SafeStickerDataHandle stickerData, out string thumbnail);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_set_description")]
+        internal static extern ErrorCode StickerDataSetDescription(SafeStickerDataHandle stickerData, string description);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_description")]
+        internal static extern ErrorCode StickerDataGetDescription(SafeStickerDataHandle stickerData, out string description);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_date")]
+        internal static extern ErrorCode StickerDataGetDate(SafeStickerDataHandle stickerData, out string date);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_set_display_type")]
+        internal static extern ErrorCode StickerDataSetDisplayType(SafeStickerDataHandle stickerData, DisplayType type);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_data_get_display_type")]
+        internal static extern ErrorCode StickerDataGetDisplayType(SafeStickerDataHandle stickerData, out DisplayType type);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerDataKeywordForeachCallback(string keyword, IntPtr userData);
+
+        internal sealed class SafeStickerDataHandle : SafeHandle
+        {
+            public SafeStickerDataHandle(IntPtr handle)
+                : base(IntPtr.Zero, true)
+            {
+                SetHandle(handle);
+            }
+
+            public SafeStickerDataHandle()
+                : base(IntPtr.Zero, true)
+            {
+            }
+
+            public override bool IsInvalid
+            {
+                get { return this.handle == IntPtr.Zero; }
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                if (!IsInvalid)
+                {
+                    ErrorCode error = StickerDataDestroy(this.handle);
+                    if (error != ErrorCode.None)
+                    {
+                        Log.Error(LogTag, "Destroy Failed with error " + error);
+                    }
+                }
+                this.SetHandle(IntPtr.Zero);
+                return true;
+            }
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Interop/Interop.StickerProvider.cs
+++ b/src/Tizen.Uix.Sticker/Interop/Interop.StickerProvider.cs
@@ -1,0 +1,70 @@
+/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+using System.Runtime.InteropServices;
+using Tizen;
+using static Interop.StickerData;
+using Tizen.Uix.Sticker;
+
+/// <summary>
+/// Partial Interop Class
+/// </summary>
+internal static partial class Interop
+{
+    /// <summary>
+    /// StickerProvider Interop Class
+    /// </summary>
+    internal static class StickerProvider
+    {
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_create")]
+        internal static extern ErrorCode StickerProviderCreate(out IntPtr stickerProvider);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_destroy")]
+        internal static extern ErrorCode StickerProviderDestroy(IntPtr stickerProvider);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_insert_data")]
+        internal static extern ErrorCode StickerProviderInsertData(IntPtr stickerProvider, SafeStickerDataHandle stickerData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_insert_data_by_json_file")]
+        internal static extern ErrorCode StickerProviderInsertDataByJsonFile(IntPtr stickerProvider, string jsonPath, StickerProviderInsertFinishedCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_update_data")]
+        internal static extern ErrorCode StickerProviderUpdateData(IntPtr stickerProvider, SafeStickerDataHandle stickerData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_delete_data")]
+        internal static extern ErrorCode StickerProviderDeleteData(IntPtr stickerProvider, SafeStickerDataHandle stickerData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_delete_data_by_uri")]
+        internal static extern ErrorCode StickerProviderDeleteDataByUri(IntPtr stickerProvider, string uri);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_get_sticker_count")]
+        internal static extern ErrorCode StickerProviderGetStickerCount(IntPtr stickerProvider, out int count);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_data_foreach_all")]
+        internal static extern ErrorCode StickerProviderDataForeachAll(IntPtr stickerProvider, int offset, int count, out int result, StickerProviderDataForeachCallback callback, IntPtr userData);
+
+        [DllImport(Libraries.StickerProvider, EntryPoint = "sticker_provider_set_group_image")]
+        internal static extern ErrorCode StickerProviderSetGroupImage(IntPtr stickerProvider, string group, UriType uriType, string uri);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerProviderDataForeachCallback(IntPtr stickerData, IntPtr userData);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void StickerProviderInsertFinishedCallback(ErrorCode error, IntPtr userData);
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker.csproj
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tizen\Tizen.csproj" />
+    <ProjectReference Include="..\Tizen.Log\Tizen.Log.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker.sln
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker.sln
@@ -1,0 +1,65 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31729.503
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Uix.Sticker", "Tizen.Uix.Sticker.csproj", "{F135922C-6960-4A3C-BC18-75695C10A20E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen", "..\Tizen\Tizen.csproj", "{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Log", "..\Tizen.Log\Tizen.Log.csproj", "{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Debug|x64.Build.0 = Debug|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Debug|x86.Build.0 = Debug|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Release|x64.ActiveCfg = Release|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Release|x64.Build.0 = Release|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Release|x86.ActiveCfg = Release|Any CPU
+		{F135922C-6960-4A3C-BC18-75695C10A20E}.Release|x86.Build.0 = Release|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Debug|x64.Build.0 = Debug|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Debug|x86.Build.0 = Debug|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Release|x64.ActiveCfg = Release|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Release|x64.Build.0 = Release|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Release|x86.ActiveCfg = Release|Any CPU
+		{9690B61E-DC99-4D87-A05F-ABCAF49DDF76}.Release|x86.Build.0 = Release|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Debug|x64.Build.0 = Debug|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Debug|x86.Build.0 = Debug|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Release|x64.ActiveCfg = Release|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Release|x64.Build.0 = Release|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Release|x86.ActiveCfg = Release|Any CPU
+		{7CCDA9A8-B449-4B00-AA6E-C5391051A7DA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {34ED02F0-D911-443F-8905-1B04A1B81D09}
+	EndGlobalSection
+EndGlobal

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/DeletedEventArgs.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/DeletedEventArgs.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tizen.Uix.Sticker
+{
+    /// <summary>
+    /// Provides data for the <see cref="StickerConsumer.Deleted"/> event.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public class DeletedEventArgs : EventArgs
+    {
+        private StickerData _data;
+        internal DeletedEventArgs(IntPtr data)
+        {
+            _data = new StickerData(data);
+        }
+
+        /// <summary>
+        /// Gets the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public StickerData Data
+        {
+            get
+            {
+                return _data;
+            }
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/ExceptionFactory.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/ExceptionFactory.cs
@@ -1,0 +1,50 @@
+﻿/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+using static Interop.StickerData;
+
+namespace Tizen.Uix.Sticker
+{
+    internal static class ExceptionFactory
+    {
+        internal static Exception CreateException(ErrorCode err)
+        {
+            Log.Error(LogTag, "Error " + err);
+            switch (err)
+            {
+                case ErrorCode.NotSupported:
+                    return new NotSupportedException("Sticker NOT supported");
+                case ErrorCode.PermissionDenied:
+                    return new UnauthorizedAccessException("Permission Denied");
+                case ErrorCode.InvalidParameter:
+                    return new ArgumentException("Invalid Parameters Provided");
+                case ErrorCode.OutOfMemory:
+                    return new InvalidOperationException("Out Of Memory");
+                case ErrorCode.OperationFailed:
+                    return new InvalidOperationException("Operation Failed");
+                case ErrorCode.FileExists:
+                    return new InvalidOperationException("File exists");
+                case ErrorCode.NoData:
+                    return new InvalidOperationException("No data available");
+                case ErrorCode.NoSuchFile:
+                    return new InvalidOperationException("No such file");
+            }
+            return new InvalidOperationException("Unknown error : {err.ToString()}");
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/GroupImage.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/GroupImage.cs
@@ -1,0 +1,105 @@
+﻿/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+
+namespace Tizen.Uix.Sticker
+{
+    /// <summary>
+    /// This structure represents an image of sticker group.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public struct GroupImage
+    {
+        /// <summary>
+        /// The public constructor.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <param name="groupName">The group name for setting group image.</param>
+        /// <param name="uriType">The URI type of the image file.</param>
+        /// <param name="uri">The URI of the image file.</param>
+        public GroupImage(string groupName, UriType uriType, string uri)
+        {
+            GroupName = groupName;
+            UriType = uriType;
+            Uri = uri;
+        }
+
+        /// <summary>
+        /// The name of the group.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public string GroupName { get; }
+
+        /// <summary>
+        /// The URI type of the image file.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public UriType UriType { get; }
+
+        /// <summary>
+        /// The URI of the image file.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public string Uri { get; }
+
+        /// <summary>
+        /// Compares an object to an instance of <see cref="GroupImage"/> for equality.
+        /// </summary>
+        /// <param name="obj">A <see cref="Object"/> to compare.</param>
+        /// <returns>true if the two group images are equal; otherwise, false.</returns>
+        /// /// <since_tizen> 10 </since_tizen>
+        public override bool Equals(object obj)
+        {
+            return obj is GroupImage && this == (GroupImage)obj;
+        }
+
+        /// <summary>
+        /// Gets the hash code for this instance of <see cref="GroupImage"/>.
+        /// </summary>
+        /// <returns>The hash code for this instance of <see cref="GroupImage"/>.</returns>
+        /// <since_tizen> 10 </since_tizen>
+        public override int GetHashCode()
+        {
+            return new { GroupName, UriType, Uri }.GetHashCode();
+        }
+
+        /// <summary>
+        /// Compares two instances of <see cref="GroupImage"/> for equality.
+        /// </summary>
+        /// <param name="groupImage1">A <see cref="GroupImage"/> to compare.</param>
+        /// <param name="groupImage2">A <see cref="GroupImage"/> to compare.</param>
+        /// <returns>true if the two instances of <see cref="GroupImage"/> are equal; otherwise false.</returns>
+        /// <since_tizen> 10 </since_tizen>
+        public static bool operator ==(GroupImage groupImage1, GroupImage groupImage2)
+        {
+            return groupImage1.GroupName == groupImage2.GroupName && groupImage1.UriType == groupImage2.UriType && groupImage1.Uri == groupImage2.Uri;
+        }
+
+        /// <summary>
+        /// Compares two instances of <see cref="GroupImage"/> for inequality.
+        /// </summary>
+        /// <param name="groupImage1">A <see cref="GroupImage"/> to compare.</param>
+        /// <param name="groupImage2">A <see cref="GroupImage"/> to compare.</param>
+        /// <returns>true if the two instances of <see cref="GroupImage"/> are not equal; otherwise false.</returns>
+        /// <since_tizen> 10 </since_tizen>
+        public static bool operator !=(GroupImage groupImage1, GroupImage groupImage2)
+        {
+            return !(groupImage1 == groupImage2);
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/InsertedEventArgs.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/InsertedEventArgs.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tizen.Uix.Sticker
+{
+    /// <summary>
+    /// Provides data for the <see cref="StickerConsumer.Inserted"/> event.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public class InsertedEventArgs : EventArgs
+    {
+        private StickerData _data;
+        internal InsertedEventArgs(IntPtr data)
+        {
+            _data = new StickerData(data);
+        }
+
+        /// <summary>
+        /// Gets the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public StickerData Data
+        {
+            get
+            {
+                return _data;
+            }
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/StickerConsumer.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/StickerConsumer.cs
@@ -1,0 +1,537 @@
+﻿/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using static Interop.StickerData;
+using static Interop.StickerConsumer;
+
+namespace Tizen.Uix.Sticker
+{
+    /// <summary>
+    /// Enumeration for the event type.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    internal enum EventType
+    {
+        /// <summary>
+        /// A sticker data has been added.
+        /// </summary>
+        Insert = 0,
+        /// <summary>
+        /// A sticker data has been removed.
+        /// </summary>
+        Delete = 1,
+        /// <summary>
+        /// A sticker data has been updated.
+        /// </summary>
+        Update = 2
+    };
+
+    /// <summary>
+    /// The StickerConsumer provides the methods to retrieve sticker data.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public static class StickerConsumer
+    {
+        private static IntPtr _handle = IntPtr.Zero;
+        private static event EventHandler<InsertedEventArgs> _inserted;
+        private static event EventHandler<DeletedEventArgs> _deleted;
+        private static event EventHandler<UpdatedEventArgs> _updated;
+        private static StickerConsumerEventCallback _eventDelegate;
+
+        /// <summary>
+        /// Gets a flag indicating whether the StickerConsumer is initialized
+        /// </summary>
+        public static bool Initialized { get; private set; }
+
+        /// <summary>
+        /// Initialize sticker consumer.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <privilege>http://tizen.org/privilege/mediastorage</privilege>
+        /// <privlevel>public</privlevel>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">This exception can be due to permission denied.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to out of memory.
+        /// 2) This exception can be due to operation failed.
+        /// </exception>
+        public static void Initialize()
+        {
+            if (!Initialized)
+            {
+                IntPtr handle;
+                ErrorCode error = StickerConsumerCreate(out handle);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "Create Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+                _handle = handle;
+                Initialized = true;
+            }
+            else
+            {
+                Log.Debug(LogTag, "Already initialized");
+            }
+        }
+
+        /// <summary>
+        /// Deinitialize the sticker consumer.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        /// <pre>
+        /// StickerConsumer must be initialized.
+        /// </pre>
+        public static void Deinitialize()
+        {
+            ErrorCode error = StickerConsumerDestroy(_handle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "Destroy Failed with error " + error);
+                if (error == ErrorCode.InvalidParameter)
+                    throw ExceptionFactory.CreateException(ErrorCode.OperationFailed);
+                else
+                    throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves all sticker data in the sticker database.
+        /// If you set the <paramref name="offset"/> as 10 and <paramref name="count"/> as 10, then only records from 10 to 19 will be retrieved.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="offset">The start position (Starting from zero).</param>
+        /// <param name="count">The number of stickers to be retrieved with respect to the offset.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<StickerData> GetAllStickers(int offset, int count)
+        {
+            var stickers = new List<StickerData>();
+            StickerConsumerDataForeachCallback _dataForeachDelegate = (IntPtr stickerData, IntPtr userData) =>
+            {
+                StickerData data = new StickerData(stickerData);
+                stickers.Add(data);
+            };
+            ErrorCode error = StickerConsumerDataForeachAll(_handle, offset, count, out var result, _dataForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetAllStickers Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return stickers;
+        }
+
+        /// <summary>
+        /// Retrieves all sticker data in the sticker database using keyword.
+        /// If you set the <paramref name="offset"/> as 10 and <paramref name="count"/> as 10, then only records from 10 to 19 will be retrieved.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="offset">The start position (Starting from zero).</param>
+        /// <param name="count">The number of stickers to be retrieved with respect to the offset.</param>
+        /// <param name="keyword">The keyword of the sticker for getting sticker data.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<StickerData> GetStickersByKeyword(int offset, int count, string keyword)
+        {
+            var stickers = new List<StickerData>();
+            StickerConsumerDataForeachCallback _dataForeachDelegate = (IntPtr stickerData, IntPtr userData) =>
+            {
+                StickerData data = new StickerData(stickerData);
+                stickers.Add(data);
+            };
+            ErrorCode error = StickerConsumerDataForeachByKeyword(_handle, offset, count, out var result, keyword, _dataForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetStickersByKeyword Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return stickers;
+        }
+
+        /// <summary>
+        /// Retrieves all sticker data in the sticker database using group name.
+        /// If you set the <paramref name="offset"/> as 10 and <paramref name="count"/> as 10, then only records from 10 to 19 will be retrieved.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="offset">The start position (Starting from zero).</param>
+        /// <param name="count">The number of stickers to be retrieved with respect to the offset.</param>
+        /// <param name="groupName">The group name of the sticker for getting sticker data.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<StickerData> GetStickersByGroup(int offset, int count, string groupName)
+        {
+            var stickers = new List<StickerData>();
+            StickerConsumerDataForeachCallback _dataForeachDelegate = (IntPtr stickerData, IntPtr userData) =>
+            {
+                StickerData data = new StickerData(stickerData);
+                stickers.Add(data);
+            };
+            ErrorCode error = StickerConsumerDataForeachByGroup(_handle, offset, count, out var result, groupName, _dataForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetStickersByGroup Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return stickers;
+        }
+
+        /// <summary>
+        /// Retrieves all sticker data in the sticker database using URI type.
+        /// If you set the <paramref name="offset"/> as 10 and <paramref name="count"/> as 10, then only records from 10 to 19 will be retrieved.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="offset">The start position (Starting from zero).</param>
+        /// <param name="count">The number of stickers to be retrieved with respect to the offset.</param>
+        /// <param name="uriType">The URI type of the sticker for getting sticker data.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<StickerData> GetStickersByUriType(int offset, int count, UriType uriType)
+        {
+            var stickers = new List<StickerData>();
+            StickerConsumerDataForeachCallback _dataForeachDelegate = (IntPtr stickerData, IntPtr userData) =>
+            {
+                StickerData data = new StickerData(stickerData);
+                stickers.Add(data);
+            };
+            ErrorCode error = StickerConsumerDataForeachByType(_handle, offset, count, out var result, uriType, _dataForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetStickersByUriType Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return stickers;
+        }
+
+        /// <summary>
+        /// Retrieves all sticker data in the sticker database using display type.
+        /// If you set the <paramref name="offset"/> as 10 and <paramref name="count"/> as 10, then only records from 10 to 19 will be retrieved.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="offset">The start position (Starting from zero).</param>
+        /// <param name="count">The number of stickers to be retrieved with respect to the offset.</param>
+        /// <param name="displayType">The display type of the sticker for getting sticker data.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<StickerData> GetStickersByDisplayType(int offset, int count, DisplayType displayType)
+        {
+            var stickers = new List<StickerData>();
+            StickerConsumerDataForeachCallback _dataForeachDelegate = (IntPtr stickerData, IntPtr userData) =>
+            {
+                StickerData data = new StickerData(stickerData);
+                stickers.Add(data);
+            };
+            ErrorCode error = StickerConsumerDataForeachByDisplayType(_handle, offset, count, out var result, displayType, _dataForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetStickersByDisplayType Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return stickers;
+        }
+
+        /// <summary>
+        /// Retrieves all group names in the sticker database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<string> GetAllGroupNames()
+        {
+            var groupNames = new List<string>();
+            StickerConsumerGroupListForeachCallback _groupForeachDelegate = (IntPtr group, IntPtr userData) =>
+            {
+                string groupName = Marshal.PtrToStringAnsi(group);
+                groupNames.Add(groupName);
+            };
+            ErrorCode error = StickerConsumerGroupListForeachAll(_handle, _groupForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetAllGroupNames Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return groupNames;
+        }
+
+        /// <summary>
+        /// Retrieves all group names assigned to stickers with a matching display <paramref name="displayType"/>.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="displayType">The display type of the sticker for getting sticker data.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<string> GetGroupNamesByDisplayType(DisplayType displayType)
+        {
+            var groupNames = new List<string>();
+            StickerConsumerGroupListForeachCallback _groupForeachDelegate = (IntPtr group, IntPtr userData) =>
+            {
+                string groupName = Marshal.PtrToStringAnsi(group);
+                groupNames.Add(groupName);
+            };
+            ErrorCode error = StickerConsumerGroupListForeachByDisplayType(_handle, displayType, _groupForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetGroupNamesByDisplayType Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return groupNames;
+        }
+
+        /// <summary>
+        /// Retrieves all keywords in the sticker database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<string> GetAllKeywords()
+        {
+            var keywords = new List<string>();
+            StickerConsumerKeywordListForeachCallback _keywordForeachDelegate = (IntPtr keyword, IntPtr userData) =>
+            {
+                string stickerKeyword = Marshal.PtrToStringAnsi(keyword);
+                keywords.Add(stickerKeyword);
+            };
+            ErrorCode error = StickerConsumerKeywordListForeachAll(_handle, _keywordForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetAllKeywords Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return keywords;
+        }
+
+        /// <summary>
+        /// Adds entry to recently used stickers list.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="data">The sticker data class</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static void AddRecentData(StickerData data)
+        {
+            ErrorCode error = StickerConsumerAddRecentData(_handle, data.SafeStickerDataHandle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "AddRecentData Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Gets recently used stickers list.
+        /// The most recently used stickers are delivered in order.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="count">The number of stickers that you want to receive.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<StickerData> GetRecentStickers(int count)
+        {
+            var stickers = new List<StickerData>();
+            StickerConsumerDataForeachCallback _dataForeachDelegate = (IntPtr stickerData, IntPtr userData) =>
+            {
+                StickerData data = new StickerData(stickerData);
+                stickers.Add(data);
+            };
+            ErrorCode error = StickerConsumerGetRecentDataList(_handle, count, out var result, _dataForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetRecentStickers Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return stickers;
+        }
+
+        private static void RegisterEventOccurredCallback()
+        {
+            _eventDelegate = (EventType type, IntPtr stickerData, IntPtr userData) =>
+            {
+                if (type == EventType.Insert)
+                {
+                    if (_inserted != null)
+                    {
+                        InsertedEventArgs args = new InsertedEventArgs(stickerData);
+                        _inserted?.Invoke(null, args);
+                    }
+                }
+                else if (type == EventType.Delete)
+                {
+                    if (_deleted != null)
+                    {
+                        DeletedEventArgs args = new DeletedEventArgs(stickerData);
+                        _deleted?.Invoke(null, args);
+                    }
+                }
+                else if (type == EventType.Update)
+                {
+                    if (_updated != null)
+                    {
+                        UpdatedEventArgs args = new UpdatedEventArgs(stickerData);
+                        _updated?.Invoke(null, args);
+                    }
+                }
+            };
+            ErrorCode error = StickerConsumerSetEventCB(_handle, _eventDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "Add EventOccurred Failed with error " + error);
+            }
+        }
+
+        private static void UnregisterEventOccurredCallback()
+        {
+            ErrorCode error = StickerConsumerUnsetEventCB(_handle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "Remove EventOccurred Failed with error " + error);
+            }
+        }
+
+        /// <summary>
+        /// Called when the stickers are inserted.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public static event EventHandler<InsertedEventArgs> Inserted
+        {
+            add
+            {
+                if (_inserted == null && _deleted == null && _updated == null)
+                {
+                    RegisterEventOccurredCallback();
+                }
+                _inserted += value;
+            }
+
+            remove
+            {
+                _inserted -= value;
+                if (_inserted == null && _deleted == null && _updated == null)
+                {
+                    UnregisterEventOccurredCallback();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when the stickers are deleted.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public static event EventHandler<DeletedEventArgs> Deleted
+        {
+            add
+            {
+                if (_inserted == null && _deleted == null && _updated == null)
+                {
+                    RegisterEventOccurredCallback();
+                }
+                _deleted += value;
+            }
+
+            remove
+            {
+                _deleted -= value;
+                if (_inserted == null && _deleted == null && _updated == null)
+                {
+                    UnregisterEventOccurredCallback();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when the stickers are updated.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public static event EventHandler<UpdatedEventArgs> Updated
+        {
+            add
+            {
+                if (_inserted == null && _deleted == null && _updated == null)
+                {
+                    RegisterEventOccurredCallback();
+                }
+                _updated += value;
+            }
+
+            remove
+            {
+                _updated -= value;
+                if (_inserted == null && _deleted == null && _updated == null)
+                {
+                    UnregisterEventOccurredCallback();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Retrieves images of all sticker groups in the database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static IEnumerable<GroupImage> GetGroupImageList()
+        {
+            var imageList = new List<GroupImage>();
+            StickerConsumerGroupImageListForeachCallback _groupImageForeachDelegate = (IntPtr group, UriType type, IntPtr uri, IntPtr userData) =>
+            {
+                imageList.Add(new GroupImage(Marshal.PtrToStringAnsi(group), type, Marshal.PtrToStringAnsi(uri)));
+            };
+            ErrorCode error = StickerConsumerGroupImageListForeachAll(_handle, _groupImageForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetGroupImageList Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return imageList;
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/StickerData.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/StickerData.cs
@@ -1,0 +1,455 @@
+﻿/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+using System.Collections.Generic;
+using static Interop.StickerData;
+
+namespace Tizen.Uix.Sticker
+{
+    /// <summary>
+    /// Enumeration for the URI type.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public enum UriType
+    {
+        /// <summary>
+        /// Local path URI
+        /// </summary>
+        LocalPath = 1,
+        /// <summary>
+        /// Web resource URI
+        /// </summary>
+        WebResource = 2
+    };
+
+    /// <summary>
+    /// Enumeration for the display type.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public enum DisplayType
+    {
+        /// <summary>
+        /// Emoji type
+        /// </summary>
+        Emoji = 1,
+        /// <summary>
+        /// Wallpaper type
+        /// </summary>
+        Wallpaper = 2
+    };
+
+    /// <summary>
+    /// The StickerData provides the methods to get/set the sticker data.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public class StickerData : IDisposable
+    {
+        internal SafeStickerDataHandle _handle;
+        private bool _disposed = false;
+
+        /// <summary>
+        /// The public constructor.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to out of memory.
+        /// 2) This exception can be due to operation failed.
+        /// </exception>
+        public StickerData()
+        {
+            SafeStickerDataHandle handle;
+            ErrorCode error = StickerDataCreate(out handle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "StickerData Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+            _handle = handle;
+        }
+
+        internal SafeStickerDataHandle SafeStickerDataHandle
+        {
+            get
+            {
+                return _handle;
+            }
+        }
+
+        internal StickerData(SafeStickerDataHandle handle)
+        {
+            _handle = handle;
+        }
+
+        internal StickerData(IntPtr handle)
+        {
+            IntPtr cloneHandle;
+            ErrorCode error = StickerDataClone(handle, out cloneHandle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "StickerData Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            _handle = new SafeStickerDataHandle(cloneHandle);
+        }
+
+        /// <summary>
+        /// The destructor of the StickerData class.
+        /// </summary>
+        ~StickerData()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Release any unmanaged resources used by this object.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Release any unmanaged resources used by this object.
+        /// </summary>
+        /// <param name="disposing">
+        /// If true, disposes any disposable objects. If false, does not dispose disposable objects.
+        /// </param>
+        /// <since_tizen> 10 </since_tizen>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                _handle?.Dispose();
+                _handle = null;
+            }
+
+            _disposed = true;
+        }
+
+        /// <summary>
+        /// Gets the name of the sticker provider application from sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to no data available.</exception>
+        public string AppId
+        {
+            get
+            {
+                string appId;
+                ErrorCode error = StickerDataGetAppId(_handle, out appId);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetAppId Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return appId;
+            }
+        }
+
+        /// <summary>
+        /// Gets the URI from sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to no data available.</exception>
+        public string Uri
+        {
+            get
+            {
+                string uri;
+                UriType uriType;
+                ErrorCode error = StickerDataGetUri(_handle, out uriType, out uri);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetUri Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return uri;
+            }
+        }
+
+        /// <summary>
+        /// Gets the URI type from sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to no data available.</exception>
+        public UriType UriType
+        {
+            get
+            {
+                string uri;
+                UriType uriType;
+                ErrorCode error = StickerDataGetUri(_handle, out uriType, out uri);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetUriType Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return uriType;
+            }
+        }
+
+        /// <summary>
+        /// Sets the URI of the sticker data.
+        /// </summary>
+        /// <remarks><paramref name="uri"/> must be a path inside the app package directory like 'res/smile.png' when the type of URI is local path.</remarks>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="uriType">The URI type to be saved.</param>
+        /// <param name="uri">The URI to be saved.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        public void SetUri(UriType uriType, string uri)
+        {
+            ErrorCode error = StickerDataSetUri(_handle, uriType, uri);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "SetUri Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Adds a keyword of the sticker to the list.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="keyword">The keyword to be saved.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        public void AddKeyword(string keyword)
+        {
+            ErrorCode error = StickerDataAddKeyword(_handle, keyword);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "AddKeyword Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Removes a keyword of the sticker from the list.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="keyword">The keyword to be removed.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        public void RemoveKeyword(string keyword)
+        {
+            ErrorCode error = StickerDataRemoveKeyword(_handle, keyword);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "RemoveKeyword Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves all keywords of the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to no data available.</exception>
+        public IEnumerable<string> GetAllKeywords()
+        {
+            var keywords = new List<string>();
+            StickerDataKeywordForeachCallback _keywordDelegate = (string keyword, IntPtr userData) =>
+            {
+                keywords.Add(keyword);
+            };
+
+            ErrorCode error = StickerDataForeachKeyword(_handle, _keywordDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetAllKeywords Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return keywords.AsReadOnly();
+        }
+
+        /// <summary>
+        /// Gets/Sets the group name of the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to no data available.</exception>
+        public string GroupName
+        {
+            get
+            {
+                string groupName;
+                ErrorCode error = StickerDataGetGroupName(_handle, out groupName);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetGroupName Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return groupName;
+            }
+            set
+            {
+                ErrorCode error = StickerDataSetGroupName(_handle, value);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "SetGroupName Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets/Sets the thumbnail local path of the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        public string Thumbnail
+        {
+            get
+            {
+                string thumbnail;
+                ErrorCode error = StickerDataGetThumbnail(_handle, out thumbnail);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetThumbnail Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return thumbnail;
+            }
+            set
+            {
+                ErrorCode error = StickerDataSetThumbnail(_handle, value);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "SetThumbnail Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets/Sets the description of the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        public string Description
+        {
+            get
+            {
+                string description;
+                ErrorCode error = StickerDataGetDescription(_handle, out description);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetDescription Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return description;
+            }
+            set
+            {
+                ErrorCode error = StickerDataSetDescription(_handle, value);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "SetDescription Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the last update date from sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to no data available.</exception>
+        public DateTime LastUpdated
+        {
+            get
+            {
+                string date;
+                ErrorCode error = StickerDataGetDate(_handle, out date);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetDate Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return Convert.ToDateTime(date);
+            }
+        }
+
+        /// <summary>
+        /// Gets/Sets the display type of the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        public DisplayType DisplayType
+        {
+            get
+            {
+                DisplayType displayType;
+                ErrorCode error = StickerDataGetDisplayType(_handle, out displayType);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "GetDisplayType Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return displayType;
+            }
+            set
+            {
+                ErrorCode error = StickerDataSetDisplayType(_handle, value);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "SetDisplayType Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+            }
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/StickerProvider.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/StickerProvider.cs
@@ -1,0 +1,301 @@
+﻿/*
+* Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using static Interop.StickerData;
+using static Interop.StickerProvider;
+
+namespace Tizen.Uix.Sticker
+{
+    /// <summary>
+    /// The StickerProvider provides the methods to create/update/delete the sticker data.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public static class StickerProvider
+    {
+        private static IntPtr _handle = IntPtr.Zero;
+        private static StickerProviderInsertFinishedCallback _insertDelegate;
+
+        /// <summary>
+        /// Gets a flag indicating whether the StickerProvider is initialized
+        /// </summary>
+        public static bool Initialized { get; private set; }
+
+        /// <summary>
+        /// Initialize sticker provider.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to out of memory.
+        /// 2) This exception can be due to operation failed.
+        /// </exception>
+        public static void Initialize()
+        {
+            if (!Initialized)
+            {
+                IntPtr handle;
+                ErrorCode error = StickerProviderCreate(out handle);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "Create Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+                _handle = handle;
+                Initialized = true;
+            }
+            else
+            {
+                Log.Debug(LogTag, "Already initialized");
+            }
+        }
+
+        /// <summary>
+        /// Deinitialize the sticker provider.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        /// <pre>
+        /// StickerProvider must be initialized.
+        /// </pre>
+        public static void Deinitialize()
+        {
+            ErrorCode error = StickerProviderDestroy(_handle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "Destroy Failed with error " + error);
+                if (error == ErrorCode.InvalidParameter)
+                    throw ExceptionFactory.CreateException(ErrorCode.OperationFailed);
+                else
+                    throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Inserts a sticker data to the sticker database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="data">The sticker data to be saved.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to operation failed.
+        /// 2) This exception can be due to file exists.
+        /// 3) This exception can be due to no such file.
+        /// </exception>
+        public static void InsertData(StickerData data)
+        {
+            ErrorCode error = StickerProviderInsertData(_handle, data.SafeStickerDataHandle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "InsertData Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Inserts a sticker data using JSON file.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <remarks>
+        /// All data except thumbnail, description, and display_type must be set in the JSON file to insert the sticker data.
+        /// <paramref name="jsonPath"/> must have a non-null value and must be an existing file.
+        /// If the URI type is lacal path, the sticker file is copied to a sticker directory.
+        /// It is recommended to delete your sticker files after inserting a sticker data.
+        /// </remarks>
+        /// <param name="jsonPath">The path of JSON file containing sticker data to be saved</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static Task InsertData(string jsonPath)
+        {
+            var task = new TaskCompletionSource<bool>();
+            _insertDelegate = (ErrorCode errorCode, IntPtr userData) =>
+            {
+                if (errorCode != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "Exception occurred while inserting");
+                    throw ExceptionFactory.CreateException(errorCode);
+                }
+                else
+                {
+                    task.SetResult(true);
+                }
+            };
+            ErrorCode error = StickerProviderInsertDataByJsonFile(_handle, jsonPath, _insertDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "InsertData Failed with error " + error);
+                task.SetException(ExceptionFactory.CreateException(error));
+            }
+            return task.Task;
+        }
+
+        /// <summary>
+        /// Updates a sticker data in the sticker database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="data">The sticker data to be updated.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to operation failed.
+        /// 2) This exception can be due to file exists.
+        /// 3) This exception can be due to no such file.
+        /// </exception>
+        public static void UpdateData(StickerData data)
+        {
+            ErrorCode error = StickerProviderUpdateData(_handle, data.SafeStickerDataHandle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "UpdateData Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Deletes a sticker data in the sticker database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="data">The sticker data to be deleted.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static void DeleteData(StickerData data)
+        {
+            ErrorCode error = StickerProviderDeleteData(_handle, data.SafeStickerDataHandle);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "DeleteData Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Deletes a sticker data in the sticker database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="uri">The URI of the sticker data to be deleted.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to operation failed.
+        /// 2) This exception can be due to no such file.
+        /// </exception>
+        public static void DeleteData(string uri)
+        {
+            ErrorCode error = StickerProviderDeleteDataByUri(_handle, uri);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "DeleteData Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+
+        /// <summary>
+        /// Gets the count of stickers stored by the provider application.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="InvalidOperationException">This exception can be due to operation failed.</exception>
+        public static int StickerCount
+        {
+            get
+            {
+                int _count = 0;
+                ErrorCode error = StickerProviderGetStickerCount(_handle, out _count);
+                if (error != ErrorCode.None)
+                {
+                    Log.Error(LogTag, "StickerCount Failed with error " + error);
+                    throw ExceptionFactory.CreateException(error);
+                }
+
+                return _count;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves all sticker data in the sticker database.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="offset">The start position (Starting from zero).</param>
+        /// <param name="count">The number of stickers to be retrieved with respect to the offset.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to out of memory.
+        /// 2) This exception can be due to operation failed.
+        /// </exception>
+        public static IEnumerable<StickerData> GetAllStickers(int offset, int count)
+        {
+            var stickers = new List<StickerData>();
+            StickerProviderDataForeachCallback _dataForeachDelegate = (IntPtr stickerData, IntPtr userData) =>
+            {
+                StickerData data = new StickerData(stickerData);
+                stickers.Add(data);
+            };
+            ErrorCode error = StickerProviderDataForeachAll(_handle, offset, count, out var result, _dataForeachDelegate, IntPtr.Zero);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "GetAllStickers Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+
+            return stickers;
+        }
+
+        /// <summary>
+        /// Sets the image of the sticker group.
+        /// URI must be a relative path like '/res/smile.png' when URI type is local path.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        /// <feature>http://tizen.org/feature/ui_service.sticker</feature>
+        /// <param name="groupImage">The group image to be set.</param>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// This can occur due to the following reasons:
+        /// 1) This exception can be due to operation failed.
+        /// 2) This exception can be due to no such file.
+        /// </exception>
+        public static void SetGroupImage(GroupImage groupImage)
+        {
+            ErrorCode error = StickerProviderSetGroupImage(_handle, groupImage.GroupName, groupImage.UriType, groupImage.Uri);
+            if (error != ErrorCode.None)
+            {
+                Log.Error(LogTag, "SetGroupImage Failed with error " + error);
+                throw ExceptionFactory.CreateException(error);
+            }
+        }
+    }
+}

--- a/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/UpdatedEventArgs.cs
+++ b/src/Tizen.Uix.Sticker/Tizen.Uix.Sticker/UpdatedEventArgs.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tizen.Uix.Sticker
+{
+    /// <summary>
+    /// Provides data for the <see cref="StickerConsumer.Updated"/> event.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    public class UpdatedEventArgs : EventArgs
+    {
+        private StickerData _data;
+        internal UpdatedEventArgs(IntPtr data)
+        {
+            _data = new StickerData(data);
+        }
+
+        /// <summary>
+        /// Gets the sticker data.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public StickerData Data
+        {
+            get
+            {
+                return _data;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Add Sticker APIs to manage sticker information

Using Sticker library, a sticker application can provide sticker information to applications that want to read the sticker information as the standard specification.
StickerProvider APIs are used when sticker application creates/updates/deletes sticker information.
StickerConsumer APIs are used when application that use stored sticker search for sticker information.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: [TCSACR-481](https://code.sec.samsung.net/jira/browse/TCSACR-481)

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
