### PR TITLE
[DO NOT REVIEW] [NUI] Add a HitTestResult event.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
@@ -43,6 +43,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ActorSignal")]
             public static extern void DeleteActorSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_HitTestResultSignal")]
+            public static extern global::System.IntPtr ActorHitTestResultSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptTouchSignal")]
             public static extern global::System.IntPtr ActorInterceptTouchSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -33,6 +33,8 @@ namespace Tizen.NUI.BaseComponents
         private WheelEventCallbackType wheelEventCallback;
         private EventHandlerWithReturnType<object, KeyEventArgs, bool> keyEventHandler;
         private KeyCallbackType keyCallback;
+        private EventHandlerWithReturnType<object, TouchEventArgs, bool> hitTestResultDataEventHandler;
+        private TouchDataCallbackType hitTestResultDataCallback;
         private EventHandlerWithReturnType<object, TouchEventArgs, bool> interceptTouchDataEventHandler;
         private TouchDataCallbackType interceptTouchDataCallback;
         private EventHandlerWithReturnType<object, TouchEventArgs, bool> touchDataEventHandler;
@@ -246,6 +248,38 @@ namespace Tizen.NUI.BaseComponents
                         if (signal?.Empty() == true)
                         {
                             onRelayoutEventCallback = null;
+                        }
+                    }
+                }
+            }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandlerWithReturnType<object, TouchEventArgs, bool> HitTestResult
+        {
+            add
+            {
+                if (hitTestResultDataEventHandler == null)
+                {
+                    hitTestResultDataCallback = OnHitTestResult;
+                    using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorHitTestResultSignal(SwigCPtr), false);
+                    signal?.Connect(hitTestResultDataCallback);
+                }
+                hitTestResultDataEventHandler += value;
+            }
+
+            remove
+            {
+                hitTestResultDataEventHandler -= value;
+                if (hitTestResultDataEventHandler == null)
+                {
+                    using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorHitTestResultSignal(SwigCPtr), false);
+                    if (signal?.Empty() == false)
+                    {
+                        signal?.Disconnect(hitTestResultDataCallback);
+                        if (signal?.Empty() == true)
+                        {
+                            hitTestResultDataCallback = null;
                         }
                     }
                 }
@@ -660,6 +694,14 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        internal TouchDataSignal HitTestResultSignal()
+        {
+            TouchDataSignal ret = new TouchDataSignal(Interop.ActorSignal.ActorHitTestResultSignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         internal TouchDataSignal InterceptTouchSignal()
         {
             TouchDataSignal ret = new TouchDataSignal(Interop.ActorSignal.ActorInterceptTouchSignal(SwigCPtr), false);
@@ -925,6 +967,23 @@ namespace Tizen.NUI.BaseComponents
             {
                 onRelayoutEventHandler(this, null);
             }
+        }
+
+        // Callback for View HitTestResultSignal
+        private bool OnHitTestResult(IntPtr view, IntPtr touchData)
+        {
+            bool hitted = true;
+
+            TouchEventArgs e = new TouchEventArgs();
+
+            e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);
+
+            if (hitTestResultDataEventHandler != null)
+            {
+                hitted = hitTestResultDataEventHandler(this, e);
+            }
+
+            return hitted;
         }
 
         // Callback for View TouchSignal

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1338,6 +1338,16 @@ namespace Tizen.NUI.BaseComponents
                 hoverEventCallback = null;
             }
 
+            if (hitTestResultDataCallback != null)
+            {
+                NUILog.Debug($"[Dispose] hitTestResultDataCallback");
+
+                using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorHitTestResultSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(hitTestResultDataCallback);
+                hitTestResultDataCallback = null;
+            }
+
+
             if (interceptTouchDataCallback != null)
             {
                 NUILog.Debug($"[Dispose] interceptTouchDataCallback");

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/EventPropagationSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/EventPropagationSample.cs
@@ -1,0 +1,177 @@
+
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace Tizen.NUI.Samples
+{
+  public class EventPropagationSample : IExample
+  {
+    class LogOutput : ScrollableBase
+    {
+        public LogOutput()
+        {
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            HideScrollbar = false;
+
+            ContentContainer.Layout = new LinearLayout
+            {
+                LinearOrientation = LinearLayout.Orientation.Vertical,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+        }
+
+        public void AddLog(string log)
+        {
+            Console.WriteLine($"{log}");
+            var txt = new TextLabel
+            {
+                Text = log
+            };
+
+            ContentContainer.Add(txt);
+            if (ContentContainer.Children.Count > 30)
+            {
+                var remove = ContentContainer.Children.GetRange(0, 10);
+                foreach (var child in remove)
+                {
+                    ContentContainer.Remove(child);
+                }
+            }
+            ElmSharp.EcoreMainloop.Post(() =>
+            {
+                ScrollTo((ContentContainer.Children.Count) * (txt.NaturalSize.Height), true);
+            });
+        }
+        public override View GetNextFocusableView(View currentFocusedView, View.FocusDirection direction, bool loopEnabled)
+        {
+            return null;
+        }
+    }
+
+    public View TargetView;
+    TapGestureDetector tap;
+
+    public void Activate()
+    {
+      Window window = NUIApplication.GetDefaultWindow();
+      TargetView = new View()
+      {
+        WidthResizePolicy = ResizePolicyType.FillToParent,
+        HeightResizePolicy = ResizePolicyType.FillToParent,
+        Layout = new LinearLayout()
+        {
+            LinearOrientation = LinearLayout.Orientation.Vertical,
+        },
+      };
+      window.Add(TargetView);
+
+      var log = new LogOutput();
+
+      TargetView.TouchEvent += (s, e) =>
+      {
+          if (e.Touch.GetState(0) == PointStateType.Down)
+          {
+              log.AddLog($"TouchEvent on Layout");
+          }
+          return false;
+      };
+
+      var margin = new View
+      {
+          SizeHeight = 50,
+          WidthResizePolicy = ResizePolicyType.FillToParent
+      };
+      TargetView.Add(margin);
+      var container = new View
+      {
+          WidthResizePolicy = ResizePolicyType.FillToParent,
+          SizeHeight = 400,
+          BackgroundColor = Color.Gray,
+          Layout = new AbsoluteLayout(),
+      };
+      container.TouchEvent += (s, e) =>
+      {
+          if (e.Touch.GetState(0) == PointStateType.Down)
+          {
+              log.AddLog($"TouchEvent on Gray");
+          }
+          return false;
+      };
+      TargetView.Add(container);
+
+      var layer = new Layer();
+      window.AddLayer(layer);
+      var overlayContainer = new View
+      {
+          WidthResizePolicy = ResizePolicyType.FillToParent,
+          SizeHeight = 150,
+          BackgroundColor = Color.Red,
+          Layout = new AbsoluteLayout(),
+      };
+
+      overlayContainer.HitTestResult += (s, e) =>
+      {
+          if (e.Touch.GetState(0) == PointStateType.Down)
+          {
+            log.AddLog($"HitTestResult");
+          }
+          return false;
+      };
+
+      overlayContainer.TouchEvent += (s, e) =>
+      {
+          if (e.Touch.GetState(0) == PointStateType.Down)
+          {
+              log.AddLog($"TouchEvent on Red");
+          }
+          return false;
+      };
+
+      var overlayContainer2 = new View
+      {
+          WidthResizePolicy = ResizePolicyType.FillToParent,
+          SizeHeight = 200,
+          BackgroundColor = Color.Yellow,
+          Layout = new AbsoluteLayout(),
+      };
+      tap = new TapGestureDetector();
+      tap.Detected += (s, e) =>
+      {
+          if (e.TapGesture.State == Gesture.StateType.Started)
+          {
+              log.AddLog($"Gesture Detected on Yellow");
+          }
+      };
+      tap.Attach(overlayContainer2);
+
+      overlayContainer2.TouchEvent += (s, e) =>
+      {
+          if (e.Touch.GetState(0) == PointStateType.Down)
+          {
+              log.AddLog($"TouchEvent on Yellow");
+          }
+          return false;
+      };
+
+      layer.Add(overlayContainer);
+      layer.Add(overlayContainer2);
+      overlayContainer2.Position = new Position(0, 150);
+
+      TargetView.RemovedFromWindow += (s, e) =>
+      {
+          window.RemoveLayer(layer);
+      };
+
+      TargetView.Add(log);
+    }
+
+    public void Deactivate()
+    {
+    }
+
+
+  }
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/HitTestResultSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/HitTestResultSample.cs
@@ -1,0 +1,189 @@
+
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace Tizen.NUI.Samples
+{
+  public class HitTestResultSample : IExample
+  {
+    class LogOutput : ScrollableBase
+    {
+        public LogOutput()
+        {
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            HideScrollbar = false;
+
+            ContentContainer.Layout = new LinearLayout
+            {
+                LinearOrientation = LinearLayout.Orientation.Vertical,
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+        }
+
+        public void AddLog(string log)
+        {
+            Console.WriteLine($"{log}");
+            var txt = new TextLabel
+            {
+                Text = log
+            };
+
+            ContentContainer.Add(txt);
+            if (ContentContainer.Children.Count > 30)
+            {
+                var remove = ContentContainer.Children.GetRange(0, 10);
+                foreach (var child in remove)
+                {
+                    ContentContainer.Remove(child);
+                }
+            }
+            ElmSharp.EcoreMainloop.Post(() =>
+            {
+                ScrollTo((ContentContainer.Children.Count) * (txt.NaturalSize.Height), true);
+            });
+        }
+        public override View GetNextFocusableView(View currentFocusedView, View.FocusDirection direction, bool loopEnabled)
+        {
+            return null;
+        }
+    }
+
+    View rootView;
+    bool hitTestResult = true;
+    public void Activate()
+    {
+        var log = new LogOutput();
+        Window window = NUIApplication.GetDefaultWindow();
+
+        rootView = new View()
+        {
+            WidthResizePolicy = ResizePolicyType.FillToParent,
+            HeightResizePolicy = ResizePolicyType.FillToParent,
+            Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Vertical,
+            },
+        };
+
+        View container = new View()
+        {
+            WidthResizePolicy = ResizePolicyType.FillToParent,
+            SizeHeight = 400,
+            Layout = new AbsoluteLayout(),
+        };
+
+        View blueView = new View()
+        {
+            Size = new Size(200, 100),
+            Position = new Position(75, 125),
+            BackgroundColor = Color.Blue,
+        };
+
+        blueView.HitTestResult += (o, e) =>
+        {
+            if (e.Touch.GetState(0) == PointStateType.Down)
+            {
+                if(hitTestResult == true)
+                {
+                    log.AddLog($"BlueView hittest hitted");
+                }
+                else
+                {
+                    log.AddLog($"BlueView hittest passed");
+                }
+            }
+            // If false is returned, the hit-test is continued.
+            // If true is returned, the current View is hit. Event propagation starts from the current View.
+            return hitTestResult;
+        };
+        blueView.TouchEvent += (s, e) =>
+        {
+            if (e.Touch.GetState(0) == PointStateType.Down)
+            {
+                log.AddLog($"TouchEvent on BlueView");
+            }
+            return false;
+        };
+
+        TapGestureDetector blueTap = new TapGestureDetector();
+        blueTap.Detected += (s, e) =>
+        {
+            if (e.TapGesture.State == Gesture.StateType.Started)
+            {
+                log.AddLog($"Gesture Detected on blueView");
+            }
+        };
+        blueTap.Attach(blueView);
+
+
+        View greenView = new View()
+        {
+            Size = new Size(300, 200),
+            Position = new Position(50, 100),
+            BackgroundColor = Color.Green,
+        };
+        greenView.TouchEvent += (s, e) =>
+        {
+            if (e.Touch.GetState(0) == PointStateType.Down)
+            {
+                log.AddLog($"TouchEvent on greenView");
+            }
+            return false;
+        };
+
+        TapGestureDetector greenTap = new TapGestureDetector();
+        greenTap.Detected += (s, e) =>
+        {
+            if (e.TapGesture.State == Gesture.StateType.Started)
+            {
+
+                log.AddLog($"Gesture Detected on greenView");
+            }
+        };
+        greenTap.Attach(greenView);
+
+
+
+        Button hitTestPass = new Button()
+        {
+            Text = "Blue HitTest Pass",
+        };
+        hitTestPass.Clicked += (o, e) => {
+            hitTestResult = false;
+        };
+
+        Button hitTestHit = new Button()
+        {
+            Text = "Blue HitTest Hit",
+            Position = new Position(350, 0),
+        };
+        hitTestHit.Clicked += (o, e) => {
+            hitTestResult = true;
+        };
+
+        container.Add(greenView);
+        container.Add(blueView);
+        container.Add(hitTestPass);
+        container.Add(hitTestHit);
+
+        rootView.Add(container);
+        rootView.Add(log);
+        window.Add(rootView);
+
+    }
+
+    public void Deactivate()
+    {
+        if (rootView != null)
+        {
+            NUIApplication.GetDefaultWindow().Remove(rootView);
+            rootView.Dispose();
+        }
+    }
+
+
+  }
+}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
In the case of TouchEvent or Gesture, there is no way to propagate the event to the view below that is not related.

So, before sending an touch event, send an HitTestResult event to the view in the hit-test process to ask whether it will be hit or not.
If it returns false, it means that it will not be hit, and the hit-test continues to the next view.
If it returns true, it means that it was hit, and the event is called from the view as before, and the event is propagated to the parent.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
