### PR TITLE
[NUI] Rotary Event (Custom Wheel Type) improvement

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -391,12 +391,6 @@ namespace Tizen.NUI.BaseComponents
                     signal?.Connect(wheelEventCallback);
                 }
                 wheelEventHandler += value;
-
-                if (WindowWheelEventHandler == null)
-                {
-                    NUIApplication.GetDefaultWindow().WheelEvent += OnWindowWheelEvent;
-                }
-                WindowWheelEventHandler += value;
             }
 
             remove
@@ -413,12 +407,6 @@ namespace Tizen.NUI.BaseComponents
                             wheelEventCallback = null;
                         }
                     }
-                }
-
-                WindowWheelEventHandler -= value;
-                if (WindowWheelEventHandler == null)
-                {
-                    NUIApplication.GetDefaultWindow().WheelEvent -= OnWindowWheelEvent;
                 }
             }
         }
@@ -1366,22 +1354,6 @@ namespace Tizen.NUI.BaseComponents
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             public ControlState CurrentState { get; }
-        }
-
-        private EventHandlerWithReturnType<object, WheelEventArgs, bool> WindowWheelEventHandler;
-        private void OnWindowWheelEvent(object sender, Window.WheelEventArgs e)
-        {
-            if (e != null)
-            {
-                if (e.Wheel.Type == Wheel.WheelType.CustomWheel)
-                {
-                    var arg = new WheelEventArgs()
-                    {
-                        Wheel = e.Wheel,
-                    };
-                    WindowWheelEventHandler?.Invoke(this, arg);
-                }
-            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1321,14 +1321,6 @@ namespace Tizen.NUI.BaseComponents
                 wheelEventCallback = null;
             }
 
-            if (WindowWheelEventHandler != null)
-            {
-                NUILog.Debug($"[Dispose] WindowWheelEventHandler");
-
-                NUIApplication.GetDefaultWindow().WheelEvent -= OnWindowWheelEvent;
-                WindowWheelEventHandler = null;
-            }
-
             if (hoverEventCallback != null)
             {
                 NUILog.Debug($"[Dispose] hoverEventCallback");

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TouchGestureSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TouchGestureSample.cs
@@ -19,14 +19,43 @@ namespace Tizen.NUI.Samples
             Window window = NUIApplication.GetDefaultWindow();
             root = new View();
 
+            window.WheelEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"window WheelEvent!!!!{e.Wheel.Type}\n");
+            };
 
-           frontView = new View
+            frontView = new View
             {
                 Size = new Size(300, 300),
                 Position = new Position(150, 170),
                 BackgroundColor = new Color(1.0f, 0.0f, 0.0f, 1.0f),
+                Focusable = true,
+                FocusableInTouch = true,
             };
             frontView.TouchEvent += OnFrontTouchEvent;
+            frontView.WheelEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"frontView WheelEvent!!!!{e.Wheel.Type}\n");
+                if (e.Wheel.Type == Wheel.WheelType.CustomWheel)
+                {
+                       // rotary event
+                }
+                else if (e.Wheel.Type == Wheel.WheelType.MouseWheel)
+                {
+                      // mouse wheel event
+                }
+                return false;
+            };
+
+            var middleView = new View
+            {
+                Size = new Size(300, 300),
+                Position = new Position(110, 120),
+                BackgroundColor = new Color(0.0f, 1.0f, 0.0f, 1.0f),
+                Focusable = true,
+                FocusableInTouch = true,
+            };
+
 
             // The default the maximum allowed time is 500ms.
             // If you want to change this time, do as below.
@@ -47,8 +76,15 @@ namespace Tizen.NUI.Samples
                 Position = new Position(50, 70),
                 PointSize = 11,
                 BackgroundColor = new Color(1.0f, 1.0f, 0.0f, 1.0f),
+                Focusable = true,
+                FocusableInTouch = true,
             };
             backView.TouchEvent += OnBackTouchEvent;
+            backView.WheelEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"backView WheelEvent!!!!{e.Wheel.Type}\n");
+                return true;
+            };
 
             // The default the minimum holding time is 500ms.
             // If you want to change this time, do as below.
@@ -62,6 +98,7 @@ namespace Tizen.NUI.Samples
               Tizen.Log.Error("NUI", $"OnLongPress\n");
             };
 
+            backView.Add(middleView);
             backView.Add(frontView);
             root.Add(backView);
             window.Add(root);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Previously, Rotary Event(CustomWheel type) could always be received only on window.
So, If WheelEvent is registered in View, Rotary Event is first received from window and delivered to all Views that registered WheelEvent.

Now, We removed the part that the window receives and passes it to the View, and changed it so that the focused View can receive the event.
So, User can receive Rotary Event in focused View as well.
It is also possible to propagate events to the parent view.

If there is no focused View, the window will receive the event.

This only applies to Rotary Event(CustomWheel type).

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
