### PR TITLE
[NUI] Add IsEnabled Property in View class for controling user interaction.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -186,6 +186,16 @@ namespace Tizen.NUI.Components
             return base.HandleControlStateOnTouch(touch);
         }
 
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnEnabled(bool enabled)
+        {
+            base.OnEnabled(enabled);
+            //Sensitive = false;
+            UpdateState();
+        }
+
         /// <summary>
         /// Update Button State.
         /// </summary>

--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -186,13 +186,11 @@ namespace Tizen.NUI.Components
             return base.HandleControlStateOnTouch(touch);
         }
 
-
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void OnEnabled(bool enabled)
         {
             base.OnEnabled(enabled);
-            //Sensitive = false;
             UpdateState();
         }
 

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -66,23 +66,8 @@ namespace Tizen.NUI.Components
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(Button), true, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var instance = (Button)bindable;
-            if (newValue != null)
-            {
-                bool newEnabled = (bool)newValue;
-                if (instance.isEnabled != newEnabled)
-                {
-                    instance.isEnabled = newEnabled;
-                    // FIXME : InsEnabled Property should not change other property value.
-                    instance.Sensitive = newEnabled;
-                    ((Control)instance).IsEnabled = newEnabled;
-                    instance.UpdateState();
-                }
-            }
-        },
-        defaultValueCreator: (bindable) => ((Button)bindable).isEnabled);
+        public static readonly BindableProperty IsEnabledProperty = View.IsEnabledProperty;
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(nameof(IsSelected), typeof(bool), typeof(Button), false, propertyChanged: (bindable, oldValue, newValue) =>
@@ -183,7 +168,6 @@ namespace Tizen.NUI.Components
         private IconOrientation? iconRelativeOrientation = IconOrientation.Left;
         private bool isSelected = false;
         private bool isSelectable = false;
-        private bool isEnabled = true;
         private Size2D itemSpacing;
         private LinearLayout.Alignment itemAlignment = LinearLayout.Alignment.Center;
 
@@ -786,13 +770,10 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public bool IsEnabled
         {
-            get
-            {
-                return (bool)GetValue(IsEnabledProperty);
-            }
+            get => base.IsEnabled;
             set
             {
-                SetValue(IsEnabledProperty, value);
+                base.IsEnabled = value;
             }
         }
 

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -764,7 +764,7 @@ namespace Tizen.NUI.Components
         /// Flag to decide enable or disable in Button.
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
-        public bool IsEnabled
+        public new bool IsEnabled
         {
             get => base.IsEnabled;
             set

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -66,10 +66,6 @@ namespace Tizen.NUI.Components
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IsEnabledProperty = View.IsEnabledProperty;
-
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(nameof(IsSelected), typeof(bool), typeof(Button), false, propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Button)bindable;

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -75,7 +75,9 @@ namespace Tizen.NUI.Components
                 if (instance.isEnabled != newEnabled)
                 {
                     instance.isEnabled = newEnabled;
+                    // FIXME : InsEnabled Property should not change other property value.
                     instance.Sensitive = newEnabled;
+                    ((Control)instance).IsEnabled = newEnabled;
                     instance.UpdateState();
                 }
             }

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -131,26 +131,6 @@ namespace Tizen.NUI.Components
             return instance.state;
         });
 
-        /// <summary>
-        /// IsEnabledProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(Progress), true, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var instance = (Progress)bindable;
-            if (newValue != null)
-            {
-                bool newEnabled = (bool)newValue;
-                if (instance.isEnabled != newEnabled)
-                {
-                    instance.isEnabled = newEnabled;
-                    instance.Sensitive = newEnabled;
-                    instance.UpdateStates();
-                }
-            }
-        },
-        defaultValueCreator: (bindable) => ((Progress)bindable).isEnabled);
-
         /// This needs to be considered more if public-open is necessary.
         private ProgressStatusType state = ProgressStatusType.Determinate;
 
@@ -165,7 +145,6 @@ namespace Tizen.NUI.Components
         private float currentValue = 0;
         private float bufferValue = 0;
         private Animation indeterminateAnimation = null;
-        bool isEnabled = true;
 
         static Progress() { }
         /// <summary>
@@ -490,22 +469,6 @@ namespace Tizen.NUI.Components
             }
         }
 
-        /// <summary>
-        /// Flag to decide enable or disable in Progress.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsEnabled
-        {
-            get
-            {
-                return (bool)GetValue(IsEnabledProperty);
-            }
-            set
-            {
-                SetValue(IsEnabledProperty, value);
-            }
-        }
-
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void OnInitialize()
@@ -779,6 +742,14 @@ namespace Tizen.NUI.Components
 
                 UpdateIndeterminateAnimation();
             }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnEnabled(bool enabled)
+        {
+            base.OnEnabled(enabled);
+            UpdateStates();
         }
 
         private void Initialize()

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 Samsung Electronics Co., Ltd.
+/* Copyright (c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
@@ -203,9 +203,16 @@ namespace Tizen.NUI.Components
         {
             MeasureChild();
             LayoutChild();
-
-            Sensitive = IsEnabled;
         }
+
+                /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnEnabled(bool enabled)
+        {
+            base.OnEnabled(enabled);
+            UpdateState();
+        }
+
 
 
         /// FIXME!! This has to be done in Element or View class.

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 Samsung Electronics Co., Ltd.
+/* Copyright (c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -141,7 +141,7 @@ namespace Tizen.NUI.Components
         /// Set enabled state false makes item untouchable and unfocusable.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public bool IsEnabled
+        public new bool IsEnabled
         {
             get => base.IsEnabled;
             set

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -30,20 +30,7 @@ namespace Tizen.NUI.Components
         /// Property of boolean Enable flag.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(RecyclerViewItem), true, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var instance = (RecyclerViewItem)bindable;
-            if (newValue != null)
-            {
-                bool newEnabled = (bool)newValue;
-                if (instance.isEnabled != newEnabled)
-                {
-                    instance.isEnabled = newEnabled;
-                    instance.UpdateState();
-                }
-            }
-        },
-        defaultValueCreator: (bindable) => ((RecyclerViewItem)bindable).isEnabled);
+        public static readonly BindableProperty IsEnabledProperty = View.IsEnabledProperty;
 
         /// <summary>
         /// Property of boolean Selected flag.
@@ -93,7 +80,6 @@ namespace Tizen.NUI.Components
 
         private bool isSelected = false;
         private bool isSelectable = true;
-        private bool isEnabled = true;
         private RecyclerViewItemStyle ItemStyle => ViewStyle as RecyclerViewItemStyle;
 
         static RecyclerViewItem() { }
@@ -157,8 +143,11 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 9 </since_tizen>
         public bool IsEnabled
         {
-            get => (bool)GetValue(IsEnabledProperty);
-            set => SetValue(IsEnabledProperty, value);
+            get => base.IsEnabled;
+            set
+            {
+                base.IsEnabled = value;
+            }
         }
 
         /// <summary>
@@ -262,7 +251,7 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Called when the control loses key input focus. 
+        /// Called when the control loses key input focus.
         /// Should be overridden by derived classes if they need to customize
         /// what happens when the focus is lost.
         /// </summary>
@@ -286,7 +275,7 @@ namespace Tizen.NUI.Components
             if (viewStyle != null)
             {
                 //Extension = RecyclerViewItemStyle.CreateExtension();
-                //FIXME : currently padding and margin are not applied by ApplyStyle automatically as missing binding features.               
+                //FIXME : currently padding and margin are not applied by ApplyStyle automatically as missing binding features.
                 Padding = new Extents(viewStyle.Padding);
                 Margin = new Extents(viewStyle.Margin);
             }

--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -95,7 +95,6 @@ namespace Tizen.NUI.Components
 
         bool isFocused = false;
         bool isPressed = false;
-        bool isEnabled = true;
 
         private void Initialize()
         {

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -190,26 +190,6 @@ namespace Tizen.NUI.Components
             }
         );
 
-        /// <summary>
-        /// IsEnabledProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool), typeof(Slider), true, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var instance = (Slider)bindable;
-            if (newValue != null)
-            {
-                bool newEnabled = (bool)newValue;
-                if (instance.isEnabled != newEnabled)
-                {
-                    instance.isEnabled = newEnabled;
-                    instance.Sensitive = newEnabled;
-                    instance.UpdateValue();
-                }
-            }
-        },
-        defaultValueCreator: (bindable) => ((Slider)bindable).isEnabled);
-
         static Slider() { }
 
         /// <summary>
@@ -1277,22 +1257,6 @@ namespace Tizen.NUI.Components
             }
         }
 
-        /// <summary>
-        /// Flag to decide enable or disable in Slider.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsEnabled
-        {
-            get
-            {
-                return (bool)GetValue(IsEnabledProperty);
-            }
-            set
-            {
-                SetValue(IsEnabledProperty, value);
-            }
-        }
-
         private Extents spaceBetweenTrackAndIndicator
         {
             get
@@ -1697,6 +1661,14 @@ namespace Tizen.NUI.Components
             UpdateBgTrackPosition();
             UpdateWarningTrackSize();
             UpdateLowIndicatorSize();
+            UpdateValue();
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnEnabled(bool enabled)
+        {
+            base.OnEnabled(enabled);
             UpdateValue();
         }
 

--- a/src/Tizen.NUI.Components/Style/ButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ButtonStyle.cs
@@ -53,18 +53,6 @@ namespace Tizen.NUI.Components
         });
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool?), typeof(ButtonStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var buttonStyle = (ButtonStyle)bindable;
-            buttonStyle.isEnabled = (bool?)newValue;
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var buttonStyle = (ButtonStyle)bindable;
-            return buttonStyle.isEnabled;
-        });
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty IconRelativeOrientationProperty = BindableProperty.Create(nameof(IconRelativeOrientation), typeof(Button.IconOrientation?), typeof(ButtonStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
             var buttonStyle = (ButtonStyle)bindable;
@@ -116,7 +104,6 @@ namespace Tizen.NUI.Components
 
         private bool? isSelectable;
         private bool? isSelected;
-        private bool? isEnabled;
         private Button.IconOrientation? iconRelativeOrientation;
         private Extents iconPadding;
         private Extents textPadding;
@@ -186,8 +173,11 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public bool? IsEnabled
         {
-            get => (bool?)GetValue(IsEnabledProperty);
-            set => SetValue(IsEnabledProperty, value);
+            get => (bool?)base.IsEnabled;
+            set
+            {
+                base.IsEnabled = value;
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Style/ButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ButtonStyle.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI.Components/Style/ButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ButtonStyle.cs
@@ -171,7 +171,7 @@ namespace Tizen.NUI.Components
         /// Flag to decide button can be selected or not.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
-        public bool? IsEnabled
+        public new bool? IsEnabled
         {
             get => (bool?)base.IsEnabled;
             set

--- a/src/Tizen.NUI.Components/Style/RecyclerViewItemStyle.cs
+++ b/src/Tizen.NUI.Components/Style/RecyclerViewItemStyle.cs
@@ -52,22 +52,9 @@ namespace Tizen.NUI.Components
             var RecyclerViewItemStyle = (RecyclerViewItemStyle)bindable;
             return RecyclerViewItemStyle.isSelected;
         });
-        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool?), typeof(RecyclerViewItemStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var RecyclerViewItemStyle = (RecyclerViewItemStyle)bindable;
-            RecyclerViewItemStyle.isEnabled = (bool?)newValue;
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var RecyclerViewItemStyle = (RecyclerViewItemStyle)bindable;
-            return RecyclerViewItemStyle.isEnabled;
-        });
 
         private bool? isSelectable;
         private bool? isSelected;
-        private bool? isEnabled;
 
         static RecyclerViewItemStyle() { }
 
@@ -106,16 +93,6 @@ namespace Tizen.NUI.Components
         {
             get => (bool?)GetValue(IsSelectedProperty);
             set => SetValue(IsSelectedProperty, value);
-        }
-
-        /// <summary>
-        /// Flag to decide RecyclerViewItem can be selected or not.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool? IsEnabled
-        {
-            get => (bool?)GetValue(IsEnabledProperty);
-            set => SetValue(IsEnabledProperty, value);
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Style/RecyclerViewItemStyle.cs
+++ b/src/Tizen.NUI.Components/Style/RecyclerViewItemStyle.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
@@ -218,6 +218,13 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsFocusableInTouch(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetEnabled")]
+            public static extern void SetEanbled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsEnabled")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSizeScalePolicy")]
             public static extern void SetSizeScalePolicy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
@@ -218,12 +218,12 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsFocusableInTouch(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetEnabled")]
-            public static extern void SetEanbled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetUserInteractionEnabled")]
+            public static extern void SetUserInteractionEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsEnabled")]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsUserInteractionEnabled")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+            public static extern bool IsUserInteractionEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSizeScalePolicy")]
             public static extern void SetSizeScalePolicy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
@@ -218,13 +218,6 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsFocusableInTouch(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetUserInteractionEnabled")]
-            public static extern void SetUserInteractionEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_IsUserInteractionEnabled")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool IsUserInteractionEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetSizeScalePolicy")]
             public static extern void SetSizeScalePolicy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -150,6 +150,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SENSITIVE_get")]
             public static extern int SensitiveGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ENABLED_get")]
+            public static extern int EnabledGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_LEAVE_REQUIRED_get")]
             public static extern int LeaveRequiredGet();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -150,8 +150,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_SENSITIVE_get")]
             public static extern int SensitiveGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_ENABLED_get")]
-            public static extern int EnabledGet();
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_USER_INTERACTION_ENABLED_get")]
+            public static extern int UserInteractionEnabledGet();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_LEAVE_REQUIRED_get")]
             public static extern int LeaveRequiredGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -53,6 +53,7 @@ namespace Tizen.NUI.BaseComponents
         private float? borderlineWidth;
         private Color borderlineColor;
         private float? borderlineOffset;
+        private bool? isEnabled;
 
         private Selector<ImageShadow> imageShadow;
         private Selector<Shadow> boxShadow;
@@ -496,6 +497,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (bool?)GetValue(ThemeChangeSensitiveProperty);
             set => SetValue(ThemeChangeSensitiveProperty, value);
+        }
+
+        /// <summary>
+        /// Flag to decide View can be enabled user interaction or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool? IsEnabled
+        {
+            get => (bool?)GetValue(IsEnabledProperty);
+            set => SetValue(IsEnabledProperty, value);
         }
 
 

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -427,5 +427,18 @@ namespace Tizen.NUI.BaseComponents
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).themeChangeSensitive = (bool?)newValue,
             defaultValueCreator: (bindable) => ((ViewStyle)bindable).themeChangeSensitive
         );
+
+        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var buttonStyle = (ViewStyle)bindable;
+            buttonStyle.isEnabled = (bool?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var buttonStyle = (ViewStyle)bindable;
+            return buttonStyle.isEnabled;
+        });
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1815,6 +1815,25 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Gets or sets the status of whether the view should be enabled user interactions.
+        /// If a View is made disabled, then user interactions including touch, focus, and actiavation is disabled.
+        /// </summary>
+        /// <since_tizen> tizen_next </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsEnabled
+        {
+            get
+            {
+                return (bool)GetValue(IsEnabledProperty);
+            }
+            set
+            {
+                SetValue(IsEnabledProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the status of whether the view should receive a notification when touch or hover motion events leave the boundary of the view.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019-2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2019-2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1174,8 +1174,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (newValue != null)
             {
-                newValue = view.OnEnabled((bool)newValue);
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.Enabled, new Tizen.NUI.PropertyValue((bool)newValue));
+                view.OnEnabled((bool)newValue);
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1174,15 +1174,15 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.Enabled, new Tizen.NUI.PropertyValue((bool)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.UserInteractionEnabled, new Tizen.NUI.PropertyValue((bool)newValue));
                 view.OnEnabled((bool)newValue);
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var view = (View)bindable;
-            bool temp = true;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.Enabled).Get(out temp);
+            bool temp = false;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.UserInteractionEnabled).Get(out temp);
             return temp;
         }));
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1166,6 +1166,27 @@ namespace Tizen.NUI.BaseComponents
         }));
 
         /// <summary>
+        /// IsEnabledProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(Sensitive), typeof(bool), typeof(View), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                newValue = view.OnEnabled((bool)newValue);
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.Enabled, new Tizen.NUI.PropertyValue((bool)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var view = (View)bindable;
+            bool temp = true;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.Enabled).Get(out temp);
+            return temp;
+        }));
+
+        /// <summary>
         /// DispatchKeyEventsProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -216,7 +216,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int WorldMatrix = Interop.ActorProperty.WorldMatrixGet();
             internal static readonly int NAME = Interop.ActorProperty.NameGet();
             internal static readonly int SENSITIVE = Interop.ActorProperty.SensitiveGet();
-            internal static readonly int Enabled = Interop.ActorProperty.EnabledGet();
+            internal static readonly int UserInteractionEnabled = Interop.ActorProperty.UserInteractionEnabledGet();
             internal static readonly int LeaveRequired = Interop.ActorProperty.LeaveRequiredGet();
             internal static readonly int InheritOrientation = Interop.ActorProperty.InheritOrientationGet();
             internal static readonly int InheritScale = Interop.ActorProperty.InheritScaleGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019-2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2019-2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -216,6 +216,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int WorldMatrix = Interop.ActorProperty.WorldMatrixGet();
             internal static readonly int NAME = Interop.ActorProperty.NameGet();
             internal static readonly int SENSITIVE = Interop.ActorProperty.SensitiveGet();
+            internal static readonly int Enabled = Interop.ActorProperty.EnabledGet();
             internal static readonly int LeaveRequired = Interop.ActorProperty.LeaveRequiredGet();
             internal static readonly int InheritOrientation = Interop.ActorProperty.InheritOrientationGet();
             internal static readonly int InheritScale = Interop.ActorProperty.InheritScaleGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1299,7 +1299,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
 
-        
         private void DisConnectFromSignals()
         {
             if (HasBody() == false)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1285,13 +1285,21 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnEnabled(bool enabled)
         {
-            if (enableControlState)
+            if (enabled)
             {
-                if (enabled)
+                if (State == View.States.Disabled)
+                {
+                    State = View.States.Normal;
+                }
+                if (enableControlState)
                 {
                     ControlState -= ControlState.Disabled;
                 }
-                else
+            }
+            else
+            {
+                State = View.States.Disabled;
+                if (enableControlState)
                 {
                     ControlState += ControlState.Disabled;
                 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1283,7 +1283,7 @@ namespace Tizen.NUI.BaseComponents
         /// Inherited view can override this method to implements enabled property changes.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool OnEnabled(bool enabled)
+        protected virtual void OnEnabled(bool enabled)
         {
             if (enableControlState)
             {
@@ -1296,7 +1296,6 @@ namespace Tizen.NUI.BaseComponents
                     ControlState += ControlState.Disabled;
                 }
             }
-            return enabled;
         }
 
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1278,6 +1278,29 @@ namespace Tizen.NUI.BaseComponents
             return false;
         }
 
+        /// <summary>
+        /// Internal callback of enabled property changes.
+        /// Inherited view can override this method to implements enabled property changes.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual bool OnEnabled(bool enabled)
+        {
+            if (enableControlState)
+            {
+                if (enabled)
+                {
+                    ControlState -= ControlState.Disabled;
+                }
+                else
+                {
+                    ControlState += ControlState.Disabled;
+                }
+            }
+            return enabled;
+        }
+
+
+        
         private void DisConnectFromSignals()
         {
             if (HasBody() == false)

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
@@ -1,0 +1,72 @@
+﻿using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI.Components;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/BaseComponents/View")]
+    public class ViewTest
+    {
+        private const string tag = "NUITEST";
+        private const int testSize = 100;
+        private const int testPosition = 100;
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Get default value test for View.IsEnabled")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.View.IsEnabled")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "sh10233.lee@samsung.com")]
+        public void IsEnabled_CHECK_DEFAULT_VALUE()
+        {
+            /* TEST CODE */
+            View testView = new View();
+            var isEnabled = testView.IsEnabled;
+
+            Assert.AreEqual(true, isEnabled, "View IsEnabled should be true by default");
+
+            testView.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for View.IsEnabled")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.View.IsEnabled")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "sh10233.lee@samsung.com")]
+        public void IsEnabled_SET_VALUE()
+        {
+            /* TEST CODE */
+            View testView = new View();
+            var isEnabled = testView.IsEnabled;
+
+            Assert.AreEqual(true, isEnabled, "View IsEnabled should be true by default");
+
+            testView.IsEnabled = false;
+
+            Assert.AreEqual(false, isEnabled, "View IsEnabled should be changed by set value");
+
+            testView.Dispose();
+        }
+
+    }
+}

--- a/test/Tizen.NUI.StyleGuide/Examples/ButtonExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/ButtonExample.cs
@@ -80,7 +80,6 @@ namespace Tizen.NUI.StyleGuide
                 Text = "Disabled",
                 IsEnabled = false,
             };
-            disabledButton.EnableFocus();
             disabledButton.Clicked += (object obj, ClickedEventArgs ev) =>
             {
                 // This event should not be recieved. button is disabled.
@@ -99,8 +98,8 @@ namespace Tizen.NUI.StyleGuide
                 Log.Info(this.GetType().Name, "Selected Button Clicked\n");
                 if (obj is Button button)
                 {
-                   disabledButton.IsEnabled = button.IsSelected;
-                   if (button.IsSelected)
+                    disabledButton.IsEnabled = button.IsSelected;
+                    if (button.IsSelected)
                     {
                         button.Text = "Selected";
                     }

--- a/test/Tizen.NUI.StyleGuide/Examples/ButtonExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/ButtonExample.cs
@@ -80,6 +80,7 @@ namespace Tizen.NUI.StyleGuide
                 Text = "Disabled",
                 IsEnabled = false,
             };
+            disabledButton.EnableFocus();
             disabledButton.Clicked += (object obj, ClickedEventArgs ev) =>
             {
                 // This event should not be recieved. button is disabled.
@@ -98,6 +99,7 @@ namespace Tizen.NUI.StyleGuide
                 Log.Info(this.GetType().Name, "Selected Button Clicked\n");
                 if (obj is Button button)
                 {
+                   disabledButton.IsEnabled = button.IsSelected;
                    if (button.IsSelected)
                     {
                         button.Text = "Selected";

--- a/test/Tizen.NUI.StyleGuide/Examples/ProgressExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/ProgressExample.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  */
-using System;
 using System.ComponentModel;
 using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
@@ -23,10 +22,10 @@ using Tizen.NUI.Components;
 namespace Tizen.NUI.StyleGuide
 {
     // IExample inehrited class will be automatically added in the main examples list.
-    internal class CheckBoxExample : ContentPage, IExample
+    internal class ProgressExample : ContentPage, IExample
     {
         private View rootContent;
-        private CheckBox checkBox, disabledCheckBox, selectedCheckBox;
+        private Tizen.NUI.Components.Progress bufferingProgress, disabledProgress, determinatedProgress, indeterminatedProgress;
 
         public void Activate()
         {
@@ -36,7 +35,7 @@ namespace Tizen.NUI.StyleGuide
         }
 
         /// Modify this method for adding other examples.
-        public CheckBoxExample() : base()
+        public ProgressExample() : base()
         {
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
@@ -44,7 +43,7 @@ namespace Tizen.NUI.StyleGuide
             // Navigator bar title is added here.
             AppBar = new AppBar()
             {
-                Title = "CheckBox Default Style",
+                Title = "Slider Default Style",
             };
 
             // Example root content view.
@@ -64,29 +63,41 @@ namespace Tizen.NUI.StyleGuide
             };
 
             // CheckBox examples.
-            checkBox = new CheckBox();
-            rootContent.Add(checkBox);
-
-            disabledCheckBox = new CheckBox()
+            bufferingProgress = new Progress()
             {
+                MinValue = 0,
+                MaxValue = 100,
+                BufferValue = 10,
+                ProgressState = Progress.ProgressStatusType.Buffering,
+            };
+            rootContent.Add(bufferingProgress);
+
+            determinatedProgress = new Progress()
+            {
+                MinValue = 0,
+                MaxValue = 100,
+                CurrentValue = 80,
+                ProgressState = Progress.ProgressStatusType.Determinate,
+            };
+            rootContent.Add(determinatedProgress);
+
+            indeterminatedProgress = new Progress()
+            {
+                MinValue = 0,
+                MaxValue = 100,
+                ProgressState = Progress.ProgressStatusType.Indeterminate,
+            };
+            rootContent.Add(indeterminatedProgress);
+
+
+            disabledProgress = new Progress()
+            {
+                MinValue = 0,
+                MaxValue = 100,
                 IsEnabled = false,
+                ProgressState = Progress.ProgressStatusType.Indeterminate,
             };
-            rootContent.Add(disabledCheckBox);
-
-            selectedCheckBox = new CheckBox()
-            {
-                IsSelected = true,
-            };
-            selectedCheckBox.Clicked += (object obj, ClickedEventArgs ev) =>
-            {
-                Log.Info(this.GetType().Name, "Selected CheckBox Clicked\n");
-                if (obj is CheckBox cb)
-                {
-                    disabledCheckBox.IsEnabled = !cb.IsSelected;
-                }
-            };
-            rootContent.Add(selectedCheckBox);
-
+            rootContent.Add(disabledProgress);
             Content = rootContent;
         }
     }

--- a/test/Tizen.NUI.StyleGuide/Examples/SliderExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/SliderExample.cs
@@ -23,10 +23,10 @@ using Tizen.NUI.Components;
 namespace Tizen.NUI.StyleGuide
 {
     // IExample inehrited class will be automatically added in the main examples list.
-    internal class CheckBoxExample : ContentPage, IExample
+    internal class SliderExample : ContentPage, IExample
     {
         private View rootContent;
-        private CheckBox checkBox, disabledCheckBox, selectedCheckBox;
+        private Slider slider, disabledSlider, completedSlider;
 
         public void Activate()
         {
@@ -36,7 +36,7 @@ namespace Tizen.NUI.StyleGuide
         }
 
         /// Modify this method for adding other examples.
-        public CheckBoxExample() : base()
+        public SliderExample() : base()
         {
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
@@ -44,7 +44,7 @@ namespace Tizen.NUI.StyleGuide
             // Navigator bar title is added here.
             AppBar = new AppBar()
             {
-                Title = "CheckBox Default Style",
+                Title = "Slider Default Style",
             };
 
             // Example root content view.
@@ -64,28 +64,28 @@ namespace Tizen.NUI.StyleGuide
             };
 
             // CheckBox examples.
-            checkBox = new CheckBox();
-            rootContent.Add(checkBox);
-
-            disabledCheckBox = new CheckBox()
+            slider = new Slider()
             {
+                MinValue = 0,
+                MaxValue = 100,
+            };
+            rootContent.Add(slider);
+
+            disabledSlider = new Slider()
+            {
+                MinValue = 0,
+                MaxValue = 100,
                 IsEnabled = false,
             };
-            rootContent.Add(disabledCheckBox);
+            rootContent.Add(disabledSlider);
 
-            selectedCheckBox = new CheckBox()
+            completedSlider = new Slider()
             {
-                IsSelected = true,
+                MinValue = 0,
+                MaxValue = 100,
+                CurrentValue = 100,
             };
-            selectedCheckBox.Clicked += (object obj, ClickedEventArgs ev) =>
-            {
-                Log.Info(this.GetType().Name, "Selected CheckBox Clicked\n");
-                if (obj is CheckBox cb)
-                {
-                    disabledCheckBox.IsEnabled = !cb.IsSelected;
-                }
-            };
-            rootContent.Add(selectedCheckBox);
+            rootContent.Add(completedSlider);
 
             Content = rootContent;
         }


### PR DESCRIPTION
NUI View object can disable touch by set Senstive, key focus by Focusable, and touch focus by FocusableInTouch property individually but we never had unified control property of disabling.

This work is pulling up IsEnabled property from to Button,
so every view object can handle Enable/Disable over the sestivity and  focusability
and automated handle of controlState.

Inherited class can override enabled action in OnEnabled() protected virtual method,
```
protected override bool OnEnabled(bool enabled)
{
   base.OnEnabled(enabled);
   /// Fill user class specific actions.
   
   /// you can changed enablity value here, but not recommanded.
   return enabled;
}
```

See also,
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/271115
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/271249



### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
