### PR TITLE
[NUI]Fix ResourcesDictionary & BindingContext issues

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -308,12 +308,9 @@ namespace Tizen.NUI
 
         public delegate void resChangeCb(object sender, ResourcesChangedEventArgs e);
 
-        internal event EventHandler<ResourcesChangedEventArgs> XamlResourceChanged;
-
         internal override void OnResourcesChanged(object sender, ResourcesChangedEventArgs e)
         {
             base.OnResourcesChanged(sender, e);
-            XamlResourceChanged?.Invoke(sender, e);
         }
 
         public ResourceDictionary XamlResources
@@ -358,6 +355,9 @@ namespace Tizen.NUI
 
         internal override void OnParentResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)
         {
+            if (values == null)
+                return;
+
             if (!((IResourcesProvider)this).IsResourcesCreated || XamlResources.Count == 0)
             {
                 base.OnParentResourcesChanged(values);
@@ -373,7 +373,8 @@ namespace Tizen.NUI
                 if (innerKeys.Add(value.Key))
                     changedResources.Add(value);
             }
-            OnResourcesChanged(changedResources);
+            if (changedResources.Count != 0)
+                OnResourcesChanged(changedResources);
         }
 
         internal Application(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)

--- a/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,11 +161,6 @@ namespace Tizen.NUI.Xaml
                         }
                         if (value is Element element)
                         {
-                            if (null != Application.Current)
-                            {
-                                Application.Current.XamlResourceChanged += element.OnResourcesChanged;
-                            }
-
                             element.IsCreateByXaml = true;
                             element.LineNumber = node.LineNumber;
                             element.LinePosition = node.LinePosition;
@@ -288,11 +283,6 @@ namespace Tizen.NUI.Xaml
                 object ret = Activator.CreateInstance(nodeType, BindingFlags.CreateInstance | BindingFlags.Public | BindingFlags.Instance | BindingFlags.OptionalParamBinding, null, arguments, CultureInfo.CurrentCulture);
                 if (ret is Element element)
                 {
-                    if (null != Application.Current)
-                    {
-                        Application.Current.XamlResourceChanged += element.OnResourcesChanged;
-                    }
-
                     element.IsCreateByXaml = true;
                     element.LineNumber = (node as ElementNode)?.LineNumber ?? -1;
                     element.LinePosition = (node as ElementNode)?.LinePosition ?? -1;
@@ -430,11 +420,6 @@ namespace Tizen.NUI.Xaml
                 value = Activator.CreateInstance(nodeType);
                 if (value is Element element)
                 {
-                    if (null != Application.Current)
-                    {
-                        Application.Current.XamlResourceChanged += element.OnResourcesChanged;
-                    }
-
                     element.IsCreateByXaml = true;
                     element.LineNumber = (node as ElementNode)?.LineNumber ?? -1;
                     element.LinePosition = (node as ElementNode)?.LinePosition ?? -1;

--- a/src/Tizen.NUI/src/internal/Xaml/IResourcesLoader.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/IResourcesLoader.cs
@@ -1,5 +1,5 @@
-﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,6 @@ namespace Tizen.NUI
     internal interface IResourcesLoader
     {
         T CreateFromResource<T>(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo) where T : new();
-        string GetResource(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo);
+        string GetResource(string resourcePath, Assembly assembly, object target, IXmlLineInfo lineInfo);
     }
 }

--- a/src/Tizen.NUI/src/internal/Xaml/ResourcesLoader.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/ResourcesLoader.cs
@@ -1,5 +1,5 @@
-﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,16 @@ namespace Tizen.NUI.Xaml
     {
         public T CreateFromResource<T>(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo) where T : new()
         {
-            var alternateResource = ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), resourcePath);
+            var rd = new T();
+            var resourceLoadingResponse = ResourceLoader.ResourceProvider?.Invoke(new ResourceLoader.ResourceLoadingQuery
+            {
+                AssemblyName = assembly.GetName(),
+                ResourcePath = resourcePath,
+                Instance = rd
+            });
+            var alternateResource = resourceLoadingResponse?.ResourceContent;
             if (alternateResource != null)
             {
-                var rd = new T();
                 rd.LoadFromXaml(alternateResource);
                 return rd;
             }
@@ -46,16 +52,20 @@ namespace Tizen.NUI.Xaml
                     throw new XamlParseException($"No resource found for '{resourceId}'.", lineInfo);
                 using (var reader = new StreamReader(stream))
                 {
-                    var rd = new T();
                     rd.LoadFromXaml(reader.ReadToEnd());
                     return rd;
                 }
             }
         }
 
-        public string GetResource(string resourcePath, Assembly assembly, IXmlLineInfo lineInfo)
+        public string GetResource(string resourcePath, Assembly assembly, object target, IXmlLineInfo lineInfo)
         {
-            var alternateResource = ResourceLoader.ResourceProvider?.Invoke(assembly.GetName(), resourcePath);
+            var resourceLoadingResponse = ResourceLoader.ResourceProvider?.Invoke(new ResourceLoader.ResourceLoadingQuery {
+                AssemblyName = assembly.GetName(),
+                ResourcePath = resourcePath,
+                Instance = target
+            });
+            var alternateResource = resourceLoadingResponse?.ResourceContent;
             if (alternateResource != null)
                 return alternateResource;
 

--- a/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,11 +130,13 @@ namespace Tizen.NUI.Xaml
 
                     var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, null), ret, (IXmlNamespaceResolver)reader);
                     XamlParser.ParseXaml(rootnode, reader);
+                    var doNotThrow = ResourceLoader.ExceptionHandler != null || Internals.XamlLoader.DoNotThrowOnExceptions;
+                    void ehandler(Exception e) => ResourceLoader.ExceptionHandler?.Invoke((e, path));
                     Visit(rootnode, new HydrationContext
                     {
                         RootElement = ret,
 #pragma warning disable 0618
-                        ExceptionHandler = ResourceLoader.ExceptionHandler ?? (Internals.XamlLoader.DoNotThrowOnExceptions ? e => { } : (Action<Exception>)null)
+                        ExceptionHandler = doNotThrow ? ehandler : (Action<Exception>)null
 #pragma warning restore 0618
                     });
                     break;
@@ -178,11 +180,13 @@ namespace Tizen.NUI.Xaml
 
                     var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, null), view, (IXmlNamespaceResolver)reader);
                     XamlParser.ParseXaml(rootnode, reader);
+                    var doNotThrow = ResourceLoader.ExceptionHandler != null || Internals.XamlLoader.DoNotThrowOnExceptions;
+                    void ehandler(Exception e) => ResourceLoader.ExceptionHandler?.Invoke((e, XamlFilePathAttribute.GetFilePathForObject(view)));
                     Visit(rootnode, new HydrationContext
                     {
                         RootElement = view,
 #pragma warning disable 0618
-                        ExceptionHandler = ResourceLoader.ExceptionHandler ?? (Internals.XamlLoader.DoNotThrowOnExceptions ? e => { } : (Action<Exception>)null)
+                        ExceptionHandler = doNotThrow ? ehandler : (Action<Exception>)null
 #pragma warning restore 0618
                     });
                     break;

--- a/src/Tizen.NUI/src/internal/XamlBinding/Internals/ResourceLoader.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/Internals/ResourceLoader.cs
@@ -1,5 +1,5 @@
-﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,29 +23,39 @@ namespace Tizen.NUI.Binding.Internals
 {
     internal static class ResourceLoader
     {
-        static Func<AssemblyName, string, string> resourceProvider = (asmName, path) =>
-        {
-            if (typeof(Theme).Assembly.GetName().FullName != asmName.FullName)
+        static Func<ResourceLoadingQuery, ResourceLoadingResponse> _resourceProvider = (resourceLoadingQuery) => {
+            if (typeof(Theme).Assembly.GetName().FullName != resourceLoadingQuery.AssemblyName.FullName)
             {
                 string resource = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
-                path = resource + path;
+                resourceLoadingQuery.ResourcePath = resource + resourceLoadingQuery.ResourcePath;
             }
 
-            string ret = File.ReadAllText(path);
-            return ret;
+            string ret = File.ReadAllText(resourceLoadingQuery.ResourcePath);
+            return new ResourceLoadingResponse { ResourceContent = ret };
         };
-
-        //takes a resource path, returns string content
-        public static Func<AssemblyName, string, string> ResourceProvider
+        public static Func<ResourceLoadingQuery, ResourceLoadingResponse> ResourceProvider
         {
-            get => resourceProvider;
+            get => _resourceProvider;
             internal set
             {
-                DesignMode.IsDesignModeEnabled = true;
-                resourceProvider = value;
+                DesignMode.IsDesignModeEnabled = value != null;
+                _resourceProvider = value;
             }
         }
 
-        internal static Action<Exception> ExceptionHandler { get; set; }
+        internal static Action<(Exception exception, string filepath)> ExceptionHandler { get; set; }
+
+        public class ResourceLoadingQuery
+        {
+            public AssemblyName AssemblyName { get; set; }
+            public string ResourcePath { get; set; }
+            public object Instance { get; set; }
+        }
+
+        public class ResourceLoadingResponse
+        {
+            public string ResourceContent { get; set; }
+            public bool UseDesignProperties { get; set; }
+        }
     }
 }

--- a/src/Tizen.NUI/src/internal/XamlBinding/MergedStyle.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/MergedStyle.cs
@@ -36,7 +36,14 @@ namespace Tizen.NUI.Binding
         public IStyle Style
         {
             get { return style; }
-            set { SetStyle(ImplicitStyle, ClassStyles, value); }
+            set
+            {
+                if (style == value)
+                    return;
+                if (value != null && !value.TargetType.IsAssignableFrom(TargetType))
+                    NUILog.Error($"Style TargetType {value.TargetType.FullName} is not compatible with element target type {TargetType}");
+                SetStyle(ImplicitStyle, ClassStyles, value);
+            }
         }
 
         public IList<string> StyleClass
@@ -47,7 +54,7 @@ namespace Tizen.NUI.Binding
                 if (styleClass == value)
                     return;
 
-                if (styleClass != null && classStyles != null)
+                if (styleClass != null && classStyleProperties != null)
                     foreach (var classStyleProperty in classStyleProperties)
                         Target.RemoveDynamicResource(classStyleProperty);
 

--- a/src/Tizen.NUI/src/internal/XamlBinding/ResourcesExtensions.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/ResourcesExtensions.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,13 @@ namespace Tizen.NUI.Binding
                     if (ve.XamlResources != null)
                     {
                         foreach (KeyValuePair<string, object> res in ve.XamlResources.MergedResources)
-                            if (!resources.ContainsKey(res.Key))
-                                resources.Add(res.Key, res.Value);
+                        {
+                            // If a MergedDictionary value is overridden for a DynamicResource, 
+                            // it comes out later in the enumeration of MergedResources
+                            // TryGetValue ensures we pull the up-to-date value for the key
+                            if (!resources.ContainsKey(res.Key) && ve.XamlResources.TryGetValue(res.Key, out object value))
+                                resources.Add(res.Key, value);
+                        }
                     }
                 }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -284,30 +284,6 @@ namespace Tizen.NUI.BaseComponents
                     Layout.SetPositionByLayout = !value;
                     Layout.RequestLayout();
                 }
-            }
-        }
-
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsResourcesCreated
-        {
-            get
-            {
-                return Application.Current.IsResourcesCreated;
-            }
-        }
-
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ResourceDictionary XamlResources
-        {
-            get
-            {
-                return Application.Current.XamlResources;
-            }
-            set
-            {
-                Application.Current.XamlResources = value;
             }
         }
 
@@ -2633,19 +2609,6 @@ namespace Tizen.NUI.BaseComponents
                 temp.Dispose();
                 NotifyPropertyChanged();
                 layout?.RequestLayout();
-            }
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public XamlStyle XamlStyle
-        {
-            get
-            {
-                return (XamlStyle)GetValue(XamlStyleProperty);
-            }
-            set
-            {
-                SetValue(XamlStyleProperty, value);
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1888,12 +1888,6 @@ namespace Tizen.NUI.BaseComponents
         });
 
         /// <summary>
-        /// XamlStyleProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty XamlStyleProperty = BindableProperty.Create(nameof(XamlStyle), typeof(XamlStyle), typeof(View), default(XamlStyle), propertyChanged: (bindable, oldvalue, newvalue) => ((View)bindable).MergedStyle.Style = (XamlStyle)newvalue);
-
-        /// <summary>
         /// EnableControlState property
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1,5 +1,5 @@
-﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,7 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using Tizen.NUI.Binding;
 
 namespace Tizen.NUI.BaseComponents
 {
@@ -30,21 +26,8 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class View
     {
-        private MergedStyle mergedStyle = null;
         internal string styleName;
 
-        internal MergedStyle MergedStyle
-        {
-            get
-            {
-                if (null == mergedStyle)
-                {
-                    mergedStyle = new MergedStyle(GetType(), this);
-                }
-
-                return mergedStyle;
-            }
-        }
         internal virtual LayoutItem CreateDefaultLayout()
         {
             return new AbsoluteLayout();
@@ -1034,8 +1017,7 @@ namespace Tizen.NUI.BaseComponents
             child.InternalParent = null;
             LayoutCount -= child.LayoutCount;
 
-            RemoveChildBindableObject(child);
-
+            OnChildRemoved(child);
             if (ChildRemoved != null)
             {
                 ChildRemovedEventArgs e = new ChildRemovedEventArgs

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -1,5 +1,5 @@
-﻿/*
- * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,6 +158,7 @@ namespace Tizen.NUI.BaseComponents
                 if (NDalicPINVOKE.SWIGPendingException.Pending)
                     throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 Children.Add(child);
+                OnChildAdded(child);
 
                 if (ChildAdded != null)
                 {
@@ -167,8 +168,6 @@ namespace Tizen.NUI.BaseComponents
                     };
                     ChildAdded(this, e);
                 }
-
-                AddChildBindableObject(child);
             }
         }
 

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -608,11 +608,6 @@ namespace Tizen.NUI
             }
 
             disposed = true;
-
-            if (null != Application.Current)
-            {
-                Application.Current.XamlResourceChanged -= OnResourcesChanged;
-            }
             DebugFileLogging.Instance.WriteLog($"BaseHandle.Dispose({type}) END");
             DebugFileLogging.Instance.WriteLog($"=============================");
             NUILog.Debug($"BaseHandle.Dispose({type}) END");

--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
 using Tizen.NUI.Binding.Internals;
 
 namespace Tizen.NUI
@@ -28,14 +29,74 @@ namespace Tizen.NUI
     /// added to them.
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
-    public abstract class Container : Animatable
+    public abstract class Container : Animatable, IResourcesProvider
     {
+        /// <summary> XamlStyleProperty </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty XamlStyleProperty = BindableProperty.Create(nameof(XamlStyle), typeof(XamlStyle), typeof(Container), default(XamlStyle), propertyChanged: (bindable, oldvalue, newvalue) => ((View)bindable).MergedStyle.Style = (XamlStyle)newvalue);
+
         internal BaseHandle InternalParent;
         private List<View> childViews = new List<View>();
+        private MergedStyle mergedStyle = null;
+        ResourceDictionary _resources;
+        bool IResourcesProvider.IsResourcesCreated => _resources != null;
 
         internal Container(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
             // No un-managed data hence no need to store a native ptr
+        }
+
+        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ResourceDictionary XamlResources
+        {
+            get
+            {
+                if (_resources != null)
+                    return _resources;
+                _resources = new ResourceDictionary();
+                ((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
+                return _resources;
+            }
+            set
+            {
+                if (_resources == value)
+                    return;
+                OnPropertyChanging();
+                if (_resources != null)
+                    ((IResourceDictionary)_resources).ValuesChanged -= OnResourcesChanged;
+                _resources = value;
+                OnResourcesChanged(value);
+                if (_resources != null)
+                    ((IResourceDictionary)_resources).ValuesChanged += OnResourcesChanged;
+                OnPropertyChanged();
+            }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public XamlStyle XamlStyle
+        {
+            get
+            {
+                return (XamlStyle)GetValue(XamlStyleProperty);
+            }
+            set
+            {
+                SetValue(XamlStyleProperty, value);
+            }
+        }
+
+        internal MergedStyle MergedStyle
+        {
+            get
+            {
+                if (null == mergedStyle)
+                {
+                    mergedStyle = new MergedStyle(GetType(), this);
+                }
+
+                return mergedStyle;
+            }
         }
 
         /// <summary>
@@ -213,6 +274,55 @@ namespace Tizen.NUI
         public abstract UInt32 GetChildCount();
 
         internal abstract View FindCurrentChildById(uint id);
+
+        internal override void OnParentResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)
+        {
+            if (values == null)
+                return;
+
+            if (!((IResourcesProvider)this).IsResourcesCreated || XamlResources.Count == 0)
+            {
+                base.OnParentResourcesChanged(values);
+                return;
+            }
+
+            var innerKeys = new HashSet<string>();
+            var changedResources = new List<KeyValuePair<string, object>>();
+            foreach (KeyValuePair<string, object> c in XamlResources)
+                innerKeys.Add(c.Key);
+            foreach (KeyValuePair<string, object> value in values)
+            {
+                if (innerKeys.Add(value.Key))
+                    changedResources.Add(value);
+            }
+            if (changedResources.Count != 0)
+                OnResourcesChanged(changedResources);
+        }
+
+        /// <summary>
+        /// Invoked whenever the binding context of the element changes. Implement this method to add class handling for this event.
+        /// </summary>
+        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnBindingContextChanged()
+        {
+            var gotBindingContext = false;
+            object bc = null;
+
+            for (var index = 0; index < Children.Count; index++)
+            {
+                Element child = Children[index];
+
+                if (!gotBindingContext)
+                {
+                    bc = BindingContext;
+                    gotBindingContext = true;
+                }
+
+                SetChildInheritedBindingContext(child, bc);
+            }
+            base.OnBindingContextChanged();
+        }
 
         private void DisposeIncludeChildren()
         {

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -17,7 +17,6 @@
 using System;
 using Tizen.NUI.BaseComponents;
 using System.ComponentModel;
-using Tizen.NUI.Binding;
 
 namespace Tizen.NUI
 {
@@ -28,7 +27,6 @@ namespace Tizen.NUI
     public class Layer : Container
     {
         private Window window;
-
         private int layoutCount = 0;
 
         /// <summary>
@@ -260,20 +258,6 @@ namespace Tizen.NUI
             }
         }
 
-        /// This will be public opened in tizen_next after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ResourceDictionary XamlResources
-        {
-            get
-            {
-                return Application.Current.XamlResources;
-            }
-            set
-            {
-                Application.Current.XamlResources = value;
-            }
-        }
-
         /// <summary>
         /// Gets the Layer's ID
         /// Readonly
@@ -324,7 +308,7 @@ namespace Tizen.NUI
                 if (NDalicPINVOKE.SWIGPendingException.Pending)
                     throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 Children.Add(child);
-                BindableObject.SetInheritedBindingContext(child, this?.BindingContext);
+                OnChildAdded(child);
             }
         }
 
@@ -356,7 +340,7 @@ namespace Tizen.NUI
 
             Children.Remove(child);
             child.InternalParent = null;
-
+            OnChildRemoved(child);
             LayoutCount -= child.LayoutCount;
         }
 

--- a/src/Tizen.NUI/src/public/Xaml/XamlFilePathAttribute.cs
+++ b/src/Tizen.NUI/src/public/Xaml/XamlFilePathAttribute.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace Tizen.NUI.Xaml
@@ -28,10 +30,11 @@ namespace Tizen.NUI.Xaml
     {
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public XamlFilePathAttribute([CallerFilePath] string filePath = "")
-        {
-            // Unused parameter
-            _ = filePath;
-        }
+        public XamlFilePathAttribute([CallerFilePath] string filePath = "") => FilePath = filePath;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string FilePath { get; }
+
+        internal static string GetFilePathForObject(object view) => (view?.GetType().GetTypeInfo().GetCustomAttributes(typeof(XamlFilePathAttribute), false).FirstOrDefault() as XamlFilePathAttribute)?.FilePath;
     }
 }

--- a/src/Tizen.NUI/src/public/Xaml/XamlParseException.cs
+++ b/src/Tizen.NUI/src/public/Xaml/XamlParseException.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,11 @@ namespace Tizen.NUI.Xaml
             XmlInfo = xmlInfo;
         }
 
+        internal XamlParseException(string message, IServiceProvider serviceProvider, Exception innerException = null)
+            : this(message, GetLineInfo(serviceProvider), innerException)
+        {
+        }
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IXmlLineInfo XmlInfo { get; private set; }
@@ -87,5 +92,9 @@ namespace Tizen.NUI.Xaml
                 return message;
             return string.Format("Position {0}:{1}. {2}", xmlinfo.LineNumber, xmlinfo.LinePosition, message);
         }
+
+
+        static IXmlLineInfo GetLineInfo(IServiceProvider serviceProvider)
+            => (serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider) ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
     }
 }

--- a/src/Tizen.NUI/src/public/XamlBinding/Element.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Element.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -448,10 +448,7 @@ namespace Tizen.NUI.Binding
 
         internal virtual void OnParentResourcesChanged(object sender, ResourcesChangedEventArgs e)
         {
-            // if (e == ResourcesChangedEventArgs.StyleSheets)
-            // 	// ApplyStyleSheetsOnParentSet();
-            // else
-            // 	OnParentResourcesChanged(e.Values);
+            OnParentResourcesChanged(e.Values);
         }
 
         internal virtual void OnParentResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)
@@ -520,11 +517,6 @@ namespace Tizen.NUI.Binding
             object value;
             if (this.TryGetResource(key, out value))
                 OnResourceChanged(property, value);
-
-            if (null != Application.Current)
-            {
-                Application.Current.XamlResourceChanged += OnResourcesChanged;
-            }
         }
 
         internal event EventHandler ParentSet;

--- a/src/Tizen.NUI/src/public/XamlBinding/IValueConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/IValueConverter.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright(c) 2021 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Tizen.NUI/src/public/XamlBinding/ResourceDictionary.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/ResourceDictionary.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-
-using Tizen.NUI.Binding.Internals;
 using Tizen.NUI.Xaml;
 
 namespace Tizen.NUI.Binding


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Optimize codes of xaml parser.
2. Split resources from Application, each view can has its own resources. Previously only use application resources, it costs more time to lookup.
3. Migrate XamlStyle/XamlResources from View/Layer to Container. Previously both Layer and View have XamlStyle and XamlResources properties, it is redundant.
4. Optimize inherited binding context.
5. This change does not change the previous use.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
