### PR TITLE
[NUI][AT-SPI] Remove interops for SetAccessibilityConstructor()

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -177,8 +177,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_SetHighlightActor")]
             public static extern void DaliAccessibilityAccessibleSetHighlightActor(global::System.Runtime.InteropServices.HandleRef arg1);
 
-            // SetAccessibilityConstructor
-
             // Keep this structure layout binary compatible with the respective C++ structure!
             [EditorBrowsable(EditorBrowsableState.Never)]
             [StructLayout(LayoutKind.Sequential)]
@@ -395,9 +393,6 @@ namespace Tizen.NUI
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityGetRangeExtents GetRangeExtents; // 37
             }
-
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityConstructor_NUI")]
-            public static extern void DaliToolkitDevelControlSetAccessibilityConstructor(HandleRef arg1_self, int arg2_role);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_DuplicateString")]
             public static extern IntPtr DaliAccessibilityDuplicateString(string arg);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -465,8 +465,7 @@ namespace Tizen.NUI.BaseComponents
         {
             // We have to store the interface flags until we remove SetAccessibilityConstructor and switch to native C# interfaces
             AtspiInterfaceFlags = (1U << (int)accessibilityInterface);
-            Interop.ControlDevel.DaliToolkitDevelControlSetAccessibilityConstructor(SwigCPtr, (int)role);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            AccessibilityRole = role;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

The method name `SetAccessibilityConstructor()` in NUI has always been misleading, because it actually never had an `accessibilityConstructor` parameter in the first place. With the recent addition of bindings for `Accessible::GetInterfaces()`, all NUI controls use the same `Accessible` implementation (`NUIViewAccessible`) anyway. However, as this method is currently used in many places, it is kept as a wrapper for setting `AccessibilityRole` (and interface flags) and will be removed if/when we decide to switch to AT-SPI interfaces as native C# interfaces. Then, all usages of `SetAccessibilityConstructor()` would be replaced by simply setting `AccessibilityRole` (and interface flags won't be needed).

Merge together with:
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/272010/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
