### PR TITLE
[NUI][AT-SPI] Picker blocks the "MoveOuted" event

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Picker.cs
+++ b/src/Tizen.NUI.Components/Controls/Picker.cs
@@ -406,6 +406,9 @@ namespace Tizen.NUI.Components
             ValueChangedEventArgs eventArgs =
                 new ValueChangedEventArgs(displayedValuesUpdate ? Int32.Parse(itemList[currentValue].Name) : Int32.Parse(itemList[currentValue].Text));
             ValueChanged?.Invoke(this, eventArgs);
+
+            //TODO: Make this work only if screen-reader is enabled
+            itemList[currentValue].GrabAccessibilityHighlight();
         }
 
         private void PageAdjust(float positionY)
@@ -509,6 +512,7 @@ namespace Tizen.NUI.Components
                 Name = idx.ToString(),
             };
 
+            temp.SetBlockMoveOutedEvent(true);
             itemList.Add(temp);
             pickerScroller.Add(temp);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -177,6 +177,10 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_SetHighlightActor")]
             public static extern void DaliAccessibilityAccessibleSetHighlightActor(global::System.Runtime.InteropServices.HandleRef arg1);
 
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetBlockMoveOutedEvent")]
+            public static extern global::System.IntPtr DaliAccessibilitySetBlockMoveOutedEvent(global::System.Runtime.InteropServices.HandleRef arg1, bool arg2);
+
             // SetAccessibilityConstructor
 
             // Keep this structure layout binary compatible with the respective C++ structure!

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -422,6 +422,17 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Blocks "MoveOuted" event.
+        /// </summary>
+        /// <param name="isBlockEvent">The flag pointing if object blocks event</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetBlockMoveOutedEvent(bool isBlockEvent)
+        {
+            Interop.ControlDevel.DaliAccessibilitySetBlockMoveOutedEvent(SwigCPtr, isBlockEvent);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
         ///////////////////////////////////////////////////////////////////
         // ************************** Bridge *************************** //
         ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
(1) The "MoveOuted" event makes screen-reader find next accessible
    and grab highlight for the found accessible.

(2) Picker should inform its changed value. It would make sense the
    newly changed item grabs the highlight.

There is a conflict between (1) and (2). So we would like to block
the "MoveOuted" event.

The following changes should be reflected first.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/271381/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/271379/