### PR TITLE
[NUI] Fix GetProperty ambiguousmatch exception

### DIFF
--- a/src/Tizen.NUI/src/internal/EXaml/Operation/GatherProperty.cs
+++ b/src/Tizen.NUI/src/internal/EXaml/Operation/GatherProperty.cs
@@ -38,7 +38,23 @@ namespace Tizen.NUI.EXaml
         public void Do()
         {
             var type = globalDataList.GatheredTypes[typeIndex];
-            globalDataList.GatheredProperties.Add(type.GetProperty(propertyName));
+            PropertyInfo propertyInfo = null;
+            try
+            {
+                propertyInfo = type.GetProperty(propertyName);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                propertyInfo = type.GetProperty(propertyName, BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
+            }
+
+            if (null == propertyInfo)
+            {
+                throw new Exception($"Can't find property {propertyName} from type {type.FullName}");
+            }
+            globalDataList.GatheredProperties.Add(propertyInfo);
         }
 
         private int typeIndex;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Fix GetProperty ambiguousmatch exception

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
