### PR TITLE
[NUI][AT-SPI] text: add "GetRangeExtents" interface

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -389,6 +389,11 @@ namespace Tizen.NUI
                 public delegate uint AccessibilityGetInterfaces(IntPtr self);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityGetInterfaces GetInterfaces; // 36
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetRangeExtents(IntPtr self, int startOffset, int endOffset, int coordType);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetRangeExtents GetRangeExtents; // 37
             }
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityConstructor_NUI")]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -658,6 +658,12 @@ namespace Tizen.NUI.BaseComponents
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual Rectangle AccessibilityGetRangeExtents(int startOffset, int endOffset, AccessibilityCoordinateType coordType)
+        {
+            return new Rectangle(0, 0, 0, 0);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual bool AccessibilityCopyText(int startPosition, int endPosition)
         {
             return false;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -1456,4 +1456,23 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         Paragraph,
     }
+
+    /// <summary>
+    /// Accessibility coordinate type describing if coordinates are relative to screen or window
+    /// </summary>
+    /// <seealso cref="View.AccessibilityGetRangeExtents" />
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum AccessibilityCoordinateType
+    {
+        /// <summary>
+        /// Specifies xy coordinates relative to the screen.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Screen,
+        /// <summary>
+        /// Specifies xy coordinates relative to the component's top-level window.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Window,
+    }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
@@ -61,6 +61,11 @@ namespace Tizen.NUI.BaseComponents
             return Interop.ControlDevel.DaliAccessibilityNewRange(range.StartOffset, range.EndOffset, range.Content);
         }
 
+        private static IntPtr DuplicateAccessibilityRectangle(Rectangle rect)
+        {
+            return Interop.Rectangle.NewRectangle(rect.X, rect.Y, rect.Width, rect.Height);
+        }
+
         //
         // Accessible interface
         //
@@ -283,6 +288,7 @@ namespace Tizen.NUI.BaseComponents
 
             ad.GetCharacterCount = AccessibilityGetCharacterCountWrapper;
             ad.GetCursorOffset   = AccessibilityGetCursorOffsetWrapper;
+            ad.GetRangeExtents   = AccessibilityGetRangeExtentsWrapper;
             ad.GetSelection      = AccessibilityGetSelectionWrapper;
             ad.GetText           = AccessibilityGetTextWrapper;
             ad.GetTextAtOffset   = AccessibilityGetTextAtOffsetWrapper;
@@ -299,6 +305,13 @@ namespace Tizen.NUI.BaseComponents
         private static int AccessibilityGetCursorOffsetWrapper(IntPtr self)
         {
             return GetViewFromRefObject(self).AccessibilityGetCursorOffset();
+        }
+
+        private static IntPtr AccessibilityGetRangeExtentsWrapper(IntPtr self, int startOffset, int endOffset, int coordType)
+        {
+            using Rectangle rect = GetViewFromRefObject(self).AccessibilityGetRangeExtents(startOffset, endOffset, (AccessibilityCoordinateType)coordType);
+
+            return DuplicateAccessibilityRectangle(rect);
         }
 
         private static IntPtr AccessibilityGetSelectionWrapper(IntPtr self, int selectionNumber)


### PR DESCRIPTION
This interface will be used for getting MBR(Minimum Bounding Rectangle)
with following usage on the AT client side.

  cc = atspi_text_get_character_count(text, NULL);
  rect = atspi_text_get_range_extents(text, 0, cc, ATSPI_COORD_TYPE_WINDOW, NULL);

This patch depends on
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/271782/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/271761/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/271759/