### PR TITLE
[Applications.Common] Add Globalization-invariant mode check

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -142,9 +142,16 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         protected virtual void OnCreate()
         {
-            string locale = ULocale.GetDefaultLocale();
-            ChangeCurrentUICultureInfo(locale);
-            ChangeCurrentCultureInfo(locale);
+            if (!GlobalizationMode.Invariant)
+            {
+                string locale = ULocale.GetDefaultLocale();
+                ChangeCurrentUICultureInfo(locale);
+                ChangeCurrentCultureInfo(locale);
+            }
+            else
+            {
+                Log.Warn(LogTag, "Run in invariant mode");
+            }
 
             Created?.Invoke(this, EventArgs.Empty);
         }
@@ -213,7 +220,11 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         protected virtual void OnLocaleChanged(LocaleChangedEventArgs e)
         {
-            ChangeCurrentUICultureInfo(e.Locale);
+            if (!GlobalizationMode.Invariant)
+            {
+                ChangeCurrentUICultureInfo(e.Locale);
+            }
+
             LocaleChanged?.Invoke(this, e);
         }
 
@@ -225,7 +236,11 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         protected virtual void OnRegionFormatChanged(RegionFormatChangedEventArgs e)
         {
-            ChangeCurrentCultureInfo(e.Region);
+            if (!GlobalizationMode.Invariant)
+            {
+                ChangeCurrentCultureInfo(e.Region);
+            }
+
             RegionFormatChanged?.Invoke(this, e);
         }
 
@@ -394,6 +409,25 @@ namespace Tizen.Applications
             }
 
             return fallbackCultureInfo;
+        }
+    }
+
+    internal static class GlobalizationMode
+    {
+        private static int _invariant = -1;
+
+        internal static bool Invariant
+        {
+            get
+            {
+                if (_invariant == -1)
+                {
+                    string value = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
+                    _invariant = value != null ? (value.Equals("1") ? 1 : 0) : 0;
+                }
+
+                return _invariant != 0;
+            }
         }
     }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/CultureInfoHelper.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CultureInfoHelper.cs
@@ -30,7 +30,6 @@ namespace Tizen.Applications
         private static readonly Dictionary<string, string> _cultureNames = new Dictionary<string, string>();
         private static readonly object _lock = new object();
         private const string _pathCultureInfoXml = "/usr/share/dotnet.tizen/framework/i18n/CultureInfo.xml";
-        private static readonly CultureInfo _cultureInfo = new CultureInfo("en-US");
 
         public static void Initialize()
         {
@@ -86,7 +85,7 @@ namespace Tizen.Applications
                     Initialize();
                 }
 
-                if (_cultureNames.TryGetValue(locale.ToLower(_cultureInfo), out string cultureName))
+                if (_cultureNames.TryGetValue(locale.ToLowerInvariant(), out string cultureName))
                 {
                     return cultureName;
                 }


### PR DESCRIPTION
Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->

In globalization-invariant mode, creating a new CultureInfo() throws a CultureNotFoundException exception. 
If the process runs in invariant mode, the CoreApplication doesn't set CultureInfos. And, the CultureInfoHelper uses ToLowerInvaraint() instead of ToLower() with CultureInfo("en-US");

Issue: https://github.com/Samsung/TizenFX/issues/3994