### PR TITLE
[NUI][TEST] update collectionViewCustomItemTest to create dataTemplat…

### DIFF
--- a/test/NUITizenGallery/Examples/CollectionViewTest/CollectionViewCustomItemTestPage.xaml
+++ b/test/NUITizenGallery/Examples/CollectionViewTest/CollectionViewCustomItemTestPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage x:Class="NUITizenGallery.CollectionViewCustomItemTestPage"
   xmlns="http://tizen.org/Tizen.NUI/2018/XAML"
   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  xmlns:gallery="clr-namespace:NUITizenGallery;assembly=NUITizenGallery"
   WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
   HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
 
@@ -21,8 +22,14 @@
                           ItemsSource="{Binding TestSource}">
 
             <CollectionView.ItemsLayouter>
-                  <LinearLayouter />
+                <LinearLayouter />
             </CollectionView.ItemsLayouter>
+
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <gallery:CollectionViewCustomItem />
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
 
         </CollectionView>
         </ContentPage.Content>

--- a/test/NUITizenGallery/Examples/CollectionViewTest/CollectionViewCustomItemTestPage.xaml.cs
+++ b/test/NUITizenGallery/Examples/CollectionViewTest/CollectionViewCustomItemTestPage.xaml.cs
@@ -50,11 +50,12 @@ namespace NUITizenGallery
         {
             InitializeComponent();
             BindingContext = new TestSourceModel(50);
-
+            /*
             ColView.ItemTemplate = new DataTemplate(() =>
             {
                 return new CollectionViewCustomItem();;
             });
+            */
         }
 
         protected override void Dispose(DisposeTypes type)


### PR DESCRIPTION
collectionView DataTemplate need to be supported in xaml and cs code both,
but currently this code occurs critical nullptr crash in,
CreateDataTemplate.cs
```
            var content = globalDataList.LongStrings.Substring(indexRangeOfContent.Item1, indexRangeOfContent.Item2 - indexRangeOfContent.Item1 + 1);
```

please fix this issue.


### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
