### PR TITLE
[NUI] Add API for consuming keyEvent in Widget

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetImpl.cs
@@ -78,6 +78,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_SetContentInfo")]
             public static extern void SetContentInfo(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_SetUsingKeyEvent")]
+            public static extern void SetUsingKeyEvent(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetImpl_SetImpl")]
             public static extern void SetImpl(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 

--- a/src/Tizen.NUI/src/internal/Widget/WidgetImpl.cs
+++ b/src/Tizen.NUI/src/internal/Widget/WidgetImpl.cs
@@ -274,7 +274,11 @@ namespace Tizen.NUI
             Interop.WidgetImpl.SetContentInfo(SwigCPtr, contentInfo);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
-
+        public void SetUsingKeyEvent(bool flag)
+        {
+            Interop.WidgetImpl.SetUsingKeyEvent(SwigCPtr, flag);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
         internal void SetImpl(SWIGTYPE_p_Dali__Widget__Impl impl)
         {
             Interop.WidgetImpl.SetImpl(SwigCPtr, SWIGTYPE_p_Dali__Widget__Impl.getCPtr(impl));

--- a/src/Tizen.NUI/src/public/Widget/Widget.cs
+++ b/src/Tizen.NUI/src/public/Widget/Widget.cs
@@ -82,6 +82,16 @@ namespace Tizen.NUI
             widgetImpl.SetContentInfo(contentInfo);
         }
 
+        /// <summary>
+        /// Set the flag that widget is using keyEvent
+        /// </summary>
+        /// <param name="flag"> The flag that widget is using keyEvent. </param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetUsingKeyEvent(bool flag)
+        {
+            widgetImpl.SetUsingKeyEvent(flag);
+        }
+
         internal System.IntPtr GetIntPtr()
         {
             return SwigCPtr.Handle;


### PR DESCRIPTION
When a widget consumes a keyEvent, the WidgetView must also consume that keyEvent.
the API called SetUsingKeyEvent() allows the WidgetApplication to set this flag.

i added related patches:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/271970/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/widget-viewer-dali/+/271972/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/271973/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
