### PR TITLE
[NUI][Samples] Remove error message on Tizen.NUI.Samples

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliTableView.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliTableView.cs
@@ -288,7 +288,6 @@ namespace Tizen.NUI.Samples
 
             // Create an ImageView for the 9-patch border around the tile.
             ImageView borderImage = new ImageView();
-            borderImage.SetStyleName("DemoTileBorder");
             borderImage.ResourceUrl = CommonResource.GetDaliResourcePath() + "DaliDemo/item-background.9.png";
             borderImage.PositionUsesPivotPoint = true;
             borderImage.PivotPoint = PivotPoint.Center;

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/res/style/demo-theme.json
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/res/style/demo-theme.json
@@ -17,19 +17,6 @@
 {
   "styles":
   {
-    "ConfirmationPopup":{
-      "popupBackgroundImage":"{APPLICATION_RESOURCE_PATH}/images/00_popup_bg.9.png"
-    },
-
-    "CustomPopupStyle":{
-      "popupBackgroundImage":"{APPLICATION_RESOURCE_PATH}/images/popup.9.png",
-      "popupBackgroundBorder":[0,4,4,0],
-      "tailUpImage":"{APPLICATION_RESOURCE_PATH}/images/popup-tail-up.png",
-      "tailDownImage":"{APPLICATION_RESOURCE_PATH}/images/popup-tail-down.png",
-      "tailLeftImage":"{APPLICATION_RESOURCE_PATH}/images/popup-tail-left.png",
-      "tailRightImage":"{APPLICATION_RESOURCE_PATH}/images/popup-tail-right.png"
-    },
-
     "DemoTile":
     {
       "states":
@@ -41,7 +28,6 @@
           {
             "image":
             {
-              "url":"{APPLICATION_RESOURCE_PATH}/images/demo-tile-texture.9.png",
 // TILE_BACKGROUND_ALPHA
 // This shader takes a texture.
 // An alpha discard is performed.
@@ -79,7 +65,6 @@
           {
             "image":
             {
-              "url":"{APPLICATION_RESOURCE_PATH}/images/demo-tile-texture-focused.9.png",
 // TILE_BACKGROUND_ALPHA
 // This shader takes a texture.
 // An alpha discard is performed.
@@ -109,26 +94,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "FocusActor":
-    {
-      "visuals":
-      {
-        "image":
-        {
-          "url":"{APPLICATION_RESOURCE_PATH}/images/tile-focus.9.png"
-        }
-      }
-    },
-    "DemoTileBorder":
-    {
-      "visuals":
-      {
-        "image":
-        {
-          "url":"{APPLICATION_RESOURCE_PATH}/images/item-background.9.png" // TILE_BACKGROUND
         }
       }
     },
@@ -182,35 +147,6 @@
         "radius": 932,
         "units": "USER_SPACE",
         "stopColor": [[0.247,0.38,0.52,1.0],[0.055,0.18,0.286,1.0]]
-      }
-    },
-//
-// Simple Visuals Application Style section
-//
-    "MyControl":
-    {
-      "states":
-      {
-        "NORMAL":
-        {
-          "visuals":
-          {
-            "iconVisual":
-            {
-              "url":"{APPLICATION_RESOURCE_PATH}/images/application-icon-13.png"
-            }
-          }
-        },
-        "FOCUSED":
-        {
-          "visuals":
-          {
-            "iconVisual":
-            {
-              "url":"{APPLICATION_RESOURCE_PATH}/images/application-icon-83.png"
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
Due to the DaliDemo.cs is just copycat of dali-demo,
it's local environment is not matched with NUI.
So, `{APPLICATION_RESOURCE_PATH}` is not matched as
`Tizen.Applications.Application.Current.DirectoryInfo.Resource`.

Therefore, when we try to SetStyle with image url, we fail to find that image.
That's why Tizen.NUI.Samples show so many error messages.

So I remove that url in demo style file.

Signed-off-by: Eunki Hong <h.pichulia@gmail.com>