### PR TITLE
[NUI] Allow BorderlineWidth without BackgroundColor setup.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1076,6 +1076,24 @@ namespace Tizen.NUI.BaseComponents
         {
             if (backgroundExtraData == null) return;
 
+            // ActionUpdateProperty works well only if BACKGROUND visual setup before.
+            // If view don't have BACKGROUND visual, we set transparent background color in default.
+            using(PropertyMap backgroundPropertyMap = new PropertyMap())
+            {
+                using(PropertyValue propertyValue = Object.GetProperty(SwigCPtr, Property.BACKGROUND))
+                {
+                    propertyValue?.Get(backgroundPropertyMap);
+                    if(backgroundPropertyMap.Empty())
+                    {
+                        // BACKGROUND visual doesn't exist.
+                        SetBackgroundColor(Color.Transparent);
+                        // SetBackgroundColor function apply borderline internally.
+                        // So we can just return now.
+                        return;
+                    }
+                }
+            }
+
             var borderlineWidthValue = new PropertyValue(backgroundExtraData.BorderlineWidth);
             var borderlineColorValue = backgroundExtraData.BorderlineColor == null ? new PropertyValue(Color.Black) : new PropertyValue(backgroundExtraData.BorderlineColor);
             var borderlineOffsetValue = new PropertyValue(backgroundExtraData.BorderlineOffset);


### PR DESCRIPTION
Previous code only allow to setup BorderlineWidth after set BackgroundColor,
or BackgroundImage.
But some case, user want to setup Borderline-only view.

This patch make BackgroundColor default as Translate
so user can setup borderlin only without setting Background.

Signed-off-by: Eunki Hong <h.pichulia@gmail.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
