### PR TITLE
[NUI] Fix the mismatch between the selected state and clicked event.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -157,7 +157,10 @@ namespace Tizen.NUI.Components
                     return true;
                 case PointStateType.Up:
                     {
-                        bool clicked = isPressed && IsEnabled;
+                        if (!isPressed)
+                        {
+                            return false;
+                        }
 
                         isPressed = false;
 
@@ -172,11 +175,8 @@ namespace Tizen.NUI.Components
                             UpdateState();
                         }
 
-                        if (clicked)
-                        {
-                            ClickedEventArgs eventArgs = new ClickedEventArgs();
-                            OnClickedInternal(eventArgs);
-                        }
+                        ClickedEventArgs eventArgs = new ClickedEventArgs();
+                        OnClickedInternal(eventArgs);
 
                         return true;
                     }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Fix the mismatch between the selected state and clicked event.
Changes the selected state when the clicked event is called.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
