### PR TITLE
[NUI] Apply xaml loaded event for NUIApplication

### DIFF
--- a/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
@@ -162,6 +162,8 @@ namespace Tizen.NUI.Xaml
                         if (value is Element element)
                         {
                             element.IsCreateByXaml = true;
+                            element.LineNumber = node.LineNumber;
+                            element.LinePosition = node.LinePosition;
                         }
                     }
                 }
@@ -282,6 +284,8 @@ namespace Tizen.NUI.Xaml
                 if (ret is Element element)
                 {
                     element.IsCreateByXaml = true;
+                    element.LineNumber = (node as ElementNode)?.LineNumber ?? -1;
+                    element.LinePosition = (node as ElementNode)?.LinePosition ?? -1;
                 }
                 return ret;
             }
@@ -417,6 +421,8 @@ namespace Tizen.NUI.Xaml
                 if (value is Element element)
                 {
                     element.IsCreateByXaml = true;
+                    element.LineNumber = (node as ElementNode)?.LineNumber ?? -1;
+                    element.LinePosition = (node as ElementNode)?.LinePosition ?? -1;
                 }
             }
 

--- a/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/XamlLoader.cs
@@ -93,6 +93,7 @@ namespace Tizen.NUI.Xaml
                 if (string.IsNullOrEmpty(xaml))
                     throw new XamlParseException(string.Format("Can't get xaml from type {0}", callingType), new XmlLineInfo());
                 Load(view, xaml);
+                NUIApplication.CurrentLoadedXaml = callingType.FullName;
             }
             catch (XamlParseException e)
             {

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -43,7 +43,7 @@ namespace Tizen.NUI
         /// Xaml loaded delegate.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public delegate void XamlLoadedHandler(XamlLoadedEventArgs args);
+        public delegate void XamlLoadedHandler(string xamlName);
 
         static NUIApplication()
         {
@@ -255,7 +255,7 @@ namespace Tizen.NUI
                 if (currentLoadedXaml != value)
                 {
                     currentLoadedXaml = value;
-                    XamlLoaded?.Invoke(new XamlLoadedEventArgs(){XamlName = value});
+                    XamlLoaded?.Invoke(value);
                 }
             }
         }
@@ -554,14 +554,5 @@ namespace Tizen.NUI
 
         internal const string GlesCSharpBinder = NDalicPINVOKE.Lib;
         internal const string VulkanCSharpBinder = "libdali-csharp-binder-vk.so";
-    }
-
-    /// <summary>
-    /// Xaml loaded event args.
-    /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public class XamlLoadedEventArgs : EventArgs
-    {
-        public string XamlName {get; set;}
     }
 }

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -37,6 +37,13 @@ namespace Tizen.NUI
         /// The instance of ResourceManager.
         /// </summary>
         private static System.Resources.ResourceManager resourceManager = null;
+        private static string currentLoadedXaml = null;
+
+        /// <summary>
+        /// Xaml loaded delegate.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public delegate void XamlLoadedHandler(XamlLoadedEventArgs args);
 
         static NUIApplication()
         {
@@ -183,6 +190,12 @@ namespace Tizen.NUI
         public event EventHandler Paused;
 
         /// <summary>
+        /// Xaml loaded event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static event XamlLoadedHandler XamlLoaded;
+
+        /// <summary>
         /// Enumeration for deciding whether a NUI application window is opaque or transparent.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
@@ -227,6 +240,25 @@ namespace Tizen.NUI
             [EditorBrowsable(EditorBrowsableState.Never)]
             ThemeChangeSensitive = 1 << 1,
         };
+
+        /// <summary>
+        /// Current loaded xaml's full name.
+        /// </summary>
+        public static string CurrentLoadedXaml
+        {
+            get
+            {
+                return currentLoadedXaml;
+            }
+            set
+            {
+                if (currentLoadedXaml != value)
+                {
+                    currentLoadedXaml = value;
+                    XamlLoaded?.Invoke(new XamlLoadedEventArgs(){XamlName = value});
+                }
+            }
+        }
 
         /// <summary>
         /// ResourceManager to handle multilingual.
@@ -522,5 +554,14 @@ namespace Tizen.NUI
 
         internal const string GlesCSharpBinder = NDalicPINVOKE.Lib;
         internal const string VulkanCSharpBinder = "libdali-csharp-binder-vk.so";
+    }
+
+    /// <summary>
+    /// Xaml loaded event args.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class XamlLoadedEventArgs : EventArgs
+    {
+        public string XamlName {get; set;}
     }
 }

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -244,6 +244,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Current loaded xaml's full name.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static string CurrentLoadedXaml
         {
             get

--- a/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
+++ b/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
@@ -136,6 +136,12 @@ namespace Tizen.NUI.EXaml
                 reader.Dispose();
 
                 LoadEXaml.Load(view, xaml, out eXamlData);
+                var filePath = likelyResourcePath.Replace("\\", "/");
+                if (filePath.Contains("/"))
+                {
+                    var xamlName = filePath.Substring(filePath.LastIndexOf("/") + 1, filePath.LastIndexOf(".") - filePath.LastIndexOf("/") - 1);
+                    NUIApplication.CurrentLoadedXaml = xamlName;
+                }
             }
             else
             {

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -57,6 +57,12 @@ namespace Tizen.NUI.Binding
             set { SetValue(BindingContextProperty, value); }
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int LineNumber { get; set; } = -1;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int LinePosition { get; set; } = -1;
+
         void IDynamicResourceHandler.SetDynamicResource(BindableProperty property, string key)
         {
             SetDynamicResource(property, key, false);

--- a/src/Tizen.NUI/src/public/XamlBinding/Element.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Element.cs
@@ -222,6 +222,12 @@ namespace Tizen.NUI.Binding
             }
         }
 
+        /// <summary>
+        /// Gets the x:Name dictionary of the element.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Dictionary<string, object> XNames => (GetNameScope() as NameScope)?.XNames ?? null;
+
         void IElement.RemoveResourcesChangedListener(Action<object, ResourcesChangedEventArgs> onchanged)
         {
             if (changeHandlers == null)

--- a/src/Tizen.NUI/src/public/XamlBinding/Internals/NameScope.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Internals/NameScope.cs
@@ -85,5 +85,8 @@ namespace Tizen.NUI.Binding.Internals
             }
             bindable.SetValue(NameScopeProperty, value);
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Dictionary<string, object> XNames => names;
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Add XamlLoaded event for NUIApplication
2. Add Xaml line info for bindable object

These changes to make beholder more useful.
This patch include the changes of the following patches:
https://github.com/Samsung/TizenFX/pull/3790 (merged in DevelNUI)
https://github.com/Samsung/TizenFX/pull/3808 (merged in DevelNUI)
https://github.com/Samsung/TizenFX/pull/3824 (merged in DevelNUI)

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None (It won't affect previously function)

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
