### PR TITLE
[XamlBuild] Add XamlOptimization to use xaml/injection/examl

### DIFF
--- a/pkg/Tizen.NET.API9/xamlbuild/Tizen.NUI.XamlBuild.targets
+++ b/pkg/Tizen.NET.API9/xamlbuild/Tizen.NUI.XamlBuild.targets
@@ -26,6 +26,7 @@
 			Language="$(Language)"
 			AssemblyName="$(AssemblyName)"
 			ReferencePath="@(ReferencePath)"
+			XamlOptimization="$(XamlOptimization)"
             AddXamlCompilationAttribute="True" />
 		<ItemGroup>
 			<FileWrites Include="@(_XamlGOutputs)" />
@@ -50,6 +51,7 @@
 			DebugType = "$(DebugType)"
 			NeedDebug = "$(NeedDebug)"
 			UseInjection = "$(NeedInjection)"
+			XamlOptimization="$(XamlOptimization)"
 			KeepXamlResources = "$(XFKeepXamlResources)" />
 		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
 		<ItemGroup>

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlCTask.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlCTask.cs
@@ -47,6 +47,8 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
         public bool UseInjection { get; set; }
 
+        public int XamlOptimization { get; set; } = 2;
+
         public IAssemblyResolver DefaultAssemblyResolver { get; set; }
 
         public string Type { get; set; }
@@ -284,10 +286,16 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                             continue;
                         }
 
-                        bool currentRetOfType;
-                        IList<Exception> currentExceptionsOfType;
+                        bool currentRetOfType = false;
+                        IList<Exception> currentExceptionsOfType = null;
 
-                        if (UseInjection)
+                        if(UseInjection) XamlOptimization = 1;
+                        LoggingHelper.LogWarning($"XamlOptimization is {XamlOptimization}.");
+                        if (0 == XamlOptimization)
+                        {//Use Xaml
+                            currentRetOfType = true;
+                        }
+                        else if (1 == XamlOptimization)
                         {
                             currentRetOfType = DoInjection(typeDef, resource, out currentExceptionsOfType);
                         }

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGTask.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGTask.cs
@@ -36,6 +36,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
         public string AssemblyName { get; set; }
         public string DependencyPaths { get; set; }
         public string ReferencePath { get; set; }
+        public int XamlOptimization {get; set;} = 2;
         public bool AddXamlCompilationAttribute { get; set; }
         public bool PrintReferenceAssemblies { get; set; }
 
@@ -88,6 +89,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
                 var generator = new XamlGenerator(xamlFile, Language, AssemblyName, outputFile, ReferencePath, Log);
                 generator.AddXamlCompilationAttribute = AddXamlCompilationAttribute;
+                generator.XamlOptimization = XamlOptimization;
                 generator.ReferencePath = ReferencePath;
 
                 try {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Add XamlOptimization to use xaml/injection/examl. If this patch included in target, then NeedInjection can be replaced by XamlOptimization.

Usage:
\<XamlOptimization>0\</XamlOptimization>  //Use Xaml
\<XamlOptimization>1\</XamlOptimization> //Use Injection
\<XamlOptimization>2\</XamlOptimization> //Use EXaml.

Note: NeedInjection is still in maintain, but it will be deprecated later. Default we use EXaml, so XamlOptimization default is 2.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:  None (It won't affect previously function)

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
