### PR TITLE
[NUI][AT-SPI] Remove SetAccessibilityConstructor()

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -463,7 +463,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.Dialog);
+            AccessibilityRole = Role.Dialog;
             AppendAccessibilityAttribute("sub-role", "Alert");
             Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
         }

--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -275,8 +275,8 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.PushButton);
 
+            AccessibilityRole = Role.PushButton;
             AccessibilityHighlightable = true;
             EnableControlStatePropagation = true;
 

--- a/src/Tizen.NUI.Components/Controls/CheckBox.cs
+++ b/src/Tizen.NUI.Components/Controls/CheckBox.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.CheckBox);
+            AccessibilityRole = Role.CheckBox;
             WidthSpecification = LayoutParamPolicies.WrapContent;
             HeightSpecification = LayoutParamPolicies.WrapContent;
         }

--- a/src/Tizen.NUI.Components/Controls/DatePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/DatePicker.cs
@@ -183,7 +183,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.DateEditor);
+            AccessibilityRole = Role.DateEditor;
 
             dayPicker = new Picker()
             {

--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -133,7 +133,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.Dialog);
+            AccessibilityRole = Role.Dialog;
             AppendAccessibilityAttribute("sub-role", "Alert");
             Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
         }

--- a/src/Tizen.NUI.Components/Controls/Loading.cs
+++ b/src/Tizen.NUI.Components/Controls/Loading.cs
@@ -226,7 +226,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.ProgressBar);
+            AccessibilityRole = Role.ProgressBar;
 
             imageVisual = new AnimatedImageVisual()
             {

--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -652,7 +652,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.PopupMenu);
+            AccessibilityRole = Role.PopupMenu;
             AppendAccessibilityAttribute("sub-role", "Alert");
         }
 

--- a/src/Tizen.NUI.Components/Controls/MenuItem.cs
+++ b/src/Tizen.NUI.Components/Controls/MenuItem.cs
@@ -244,7 +244,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.MenuItem);
+            AccessibilityRole = Role.MenuItem;
         }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/Navigation/AppBar.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/AppBar.cs
@@ -544,7 +544,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.TitleBar);
+            AccessibilityRole = Role.TitleBar;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -76,7 +76,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.PageTab);
+            AccessibilityRole = Role.PageTab;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -132,7 +132,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.PageTabList);
+            AccessibilityRole = Role.PageTabList;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using Tizen.NUI.Accessibility;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 
@@ -28,7 +29,7 @@ namespace Tizen.NUI.Components
     /// Pagination shows the number of pages available and the currently active page.
     /// </summary>
     /// <since_tizen> 8 </since_tizen>
-    public partial class Pagination : Control
+    public partial class Pagination : Control, IAtspiValue
     {
         /// <summary>The IndicatorSize bindable property.</summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -453,7 +454,7 @@ namespace Tizen.NUI.Components
         /// Minimum value.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMinimum()
+        double IAtspiValue.AccessibilityGetMinimum()
         {
             return 0.0;
         }
@@ -462,7 +463,7 @@ namespace Tizen.NUI.Components
         /// Current value.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetCurrent()
+        double IAtspiValue.AccessibilityGetCurrent()
         {
             return (double)SelectedIndex;
         }
@@ -471,7 +472,7 @@ namespace Tizen.NUI.Components
         /// Maximum value.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMaximum()
+        double IAtspiValue.AccessibilityGetMaximum()
         {
             return (double)IndicatorCount;
         }
@@ -480,7 +481,7 @@ namespace Tizen.NUI.Components
         /// Current value.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool AccessibilitySetCurrent(double value)
+        bool IAtspiValue.AccessibilitySetCurrent(double value)
         {
             int integerValue = (int)value;
 
@@ -497,7 +498,7 @@ namespace Tizen.NUI.Components
         /// Minimum increment.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMinimumIncrement()
+        double IAtspiValue.AccessibilityGetMinimumIncrement()
         {
             return 1.0;
         }
@@ -507,7 +508,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.ScrollBar, AccessibilityInterface.Value);
+            AccessibilityRole = Role.ScrollBar;
             AccessibilityHighlightable = true;
             AppendAccessibilityAttribute("style", "pagecontrolbyvalue");
 

--- a/src/Tizen.NUI.Components/Controls/Picker.cs
+++ b/src/Tizen.NUI.Components/Controls/Picker.cs
@@ -294,7 +294,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.List);
+            AccessibilityRole = Role.List;
 
             Initialize();
         }

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -782,7 +782,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.Dialog);
+            AccessibilityRole = Role.Dialog;
             AppendAccessibilityAttribute("sub-role", "Alert");
 
             container.Add(this);

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -14,11 +14,13 @@
  * limitations under the License.
  *
  */
+
 using System;
-using Tizen.NUI.BaseComponents;
-using Tizen.NUI.Binding;
 using System.ComponentModel;
 using System.Diagnostics;
+using Tizen.NUI.Accessibility;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Binding;
 
 namespace Tizen.NUI.Components
 {
@@ -26,7 +28,7 @@ namespace Tizen.NUI.Components
     /// The Progress class is used to show the ongoing status with a long narrow bar.
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
-    public partial class Progress : Control
+    public partial class Progress : Control, IAtspiValue
     {
         /// <summary>
         /// MaxValueProperty
@@ -474,7 +476,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.ProgressBar, AccessibilityInterface.Value);
+            AccessibilityRole = Role.ProgressBar;
             // create necessary components
             InitializeTrack();
             InitializeBuffer();
@@ -521,7 +523,7 @@ namespace Tizen.NUI.Components
         /// Gets minimum value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMinimum()
+        double IAtspiValue.AccessibilityGetMinimum()
         {
             if (this.ProgressState == Progress.ProgressStatusType.Determinate)
             {
@@ -537,7 +539,7 @@ namespace Tizen.NUI.Components
         /// Gets the current value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetCurrent()
+        double IAtspiValue.AccessibilityGetCurrent()
         {
             if (this.ProgressState == Progress.ProgressStatusType.Determinate)
             {
@@ -549,11 +551,17 @@ namespace Tizen.NUI.Components
             }
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool IAtspiValue.AccessibilitySetCurrent(double value)
+        {
+            return false;
+        }
+
         /// <summary>
         /// Gets maximum value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMaximum()
+        double IAtspiValue.AccessibilityGetMaximum()
         {
             if (this.ProgressState == Progress.ProgressStatusType.Determinate)
             {
@@ -563,6 +571,12 @@ namespace Tizen.NUI.Components
             {
                 return 0.0;
             }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        double IAtspiValue.AccessibilityGetMinimumIncrement()
+        {
+            return 0.0;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RadioButton.cs
+++ b/src/Tizen.NUI.Components/Controls/RadioButton.cs
@@ -61,7 +61,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.RadioButton);
+            AccessibilityRole = Role.RadioButton;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -848,7 +848,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.List);
+            AccessibilityRole = Role.List;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
@@ -191,7 +191,7 @@ namespace Tizen.NUI.Components
 
             AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Trait, "ViewItem");
 
-            SetAccessibilityConstructor(Role.ListItem);
+            AccessibilityRole = Role.ListItem;
             AccessibilityHighlightable = true;
         }
 

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -14,9 +14,11 @@
  * limitations under the License.
  *
  */
+
 using System;
-using Tizen.NUI.BaseComponents;
 using System.ComponentModel;
+using Tizen.NUI.Accessibility;
+using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 
 namespace Tizen.NUI.Components
@@ -64,7 +66,7 @@ namespace Tizen.NUI.Components
     /// A slider lets users select a value from a continuous or discrete range of values by moving the slider thumb.
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
-    public partial class Slider : Control
+    public partial class Slider : Control, IAtspiValue
     {
         /// <summary>
         /// SpaceBetweenTrackAndIndicatorProperty
@@ -1536,7 +1538,7 @@ namespace Tizen.NUI.Components
         /// Gets minimum value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMinimum()
+        double IAtspiValue.AccessibilityGetMinimum()
         {
             return (double)MinValue;
         }
@@ -1545,7 +1547,7 @@ namespace Tizen.NUI.Components
         /// Gets the current value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetCurrent()
+        double IAtspiValue.AccessibilityGetCurrent()
         {
             return (double)CurrentValue;
         }
@@ -1554,7 +1556,7 @@ namespace Tizen.NUI.Components
         /// Gets maximum value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMaximum()
+        double IAtspiValue.AccessibilityGetMaximum()
         {
             return (double)MaxValue;
         }
@@ -1563,7 +1565,7 @@ namespace Tizen.NUI.Components
         /// Sets the current value using Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool AccessibilitySetCurrent(double value)
+        bool IAtspiValue.AccessibilitySetCurrent(double value)
         {
             var current = (float)value;
 
@@ -1584,7 +1586,7 @@ namespace Tizen.NUI.Components
         /// Gets minimum increment for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override double AccessibilityGetMinimumIncrement()
+        double IAtspiValue.AccessibilityGetMinimumIncrement()
         {
             // FIXME
             return (MaxValue - MinValue) / 20.0;
@@ -1597,7 +1599,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.Slider, AccessibilityInterface.Value);
+            AccessibilityRole = Role.Slider;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.ToggleButton);
+            AccessibilityRole = Role.ToggleButton;
 
             IsSelectable = true;
 #if PROFILE_MOBILE

--- a/src/Tizen.NUI.Components/Controls/TabBar.cs
+++ b/src/Tizen.NUI.Components/Controls/TabBar.cs
@@ -99,7 +99,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.PageTabList);
+            AccessibilityRole = Role.PageTabList;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/TabButton.cs
+++ b/src/Tizen.NUI.Components/Controls/TabButton.cs
@@ -70,7 +70,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.PageTab);
+            AccessibilityRole = Role.PageTab;
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Controls/TabContent.cs
+++ b/src/Tizen.NUI.Components/Controls/TabContent.cs
@@ -59,7 +59,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.PageTabList);
+            AccessibilityRole = Role.PageTabList;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/TabView.cs
+++ b/src/Tizen.NUI.Components/Controls/TabView.cs
@@ -105,7 +105,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
 
-            SetAccessibilityConstructor(Role.PageTabList);
+            AccessibilityRole = Role.PageTabList;
         }
 
         private void InitTabBar()

--- a/src/Tizen.NUI.Components/Controls/TimePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/TimePicker.cs
@@ -268,7 +268,7 @@ namespace Tizen.NUI.Components
         public override void OnInitialize()
         {
             base.OnInitialize();
-            SetAccessibilityConstructor(Role.DateEditor);
+            AccessibilityRole = Role.DateEditor;
 
             hourPicker = new Picker()
             {

--- a/src/Tizen.NUI/src/public/Accessibility/IAtspiEditableText.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/IAtspiEditableText.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Accessibility
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IAtspiEditableText : IAtspiText
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityCopyText(int startPosition, int endPosition);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityCutText(int startPosition, int endPosition);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityInsertText(int startPosition, string text);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilitySetTextContents(string newContents);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityDeleteText(int startPosition, int endPosition);
+    }
+}

--- a/src/Tizen.NUI/src/public/Accessibility/IAtspiSelection.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/IAtspiSelection.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Accessibility
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IAtspiSelection
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetSelectedChildrenCount();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        View AccessibilityGetSelectedChild(int selectedChildIndex);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilitySelectChild(int childIndex);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityDeselectSelectedChild(int selectedChildIndex);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityIsChildSelected(int childIndex);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilitySelectAll();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityClearSelection();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityDeselectChild(int childIndex);
+    }
+}

--- a/src/Tizen.NUI/src/public/Accessibility/IAtspiText.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/IAtspiText.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Accessibility
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IAtspiText
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string AccessibilityGetText(int startOffset, int endOffset);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetCharacterCount();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetCursorOffset();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilitySetCursorOffset(int offset);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        AccessibilityRange AccessibilityGetTextAtOffset(int offset, AccessibilityTextBoundary boundary);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        AccessibilityRange AccessibilityGetSelection(int selectionNumber);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityRemoveSelection(int selectionNumber);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilitySetSelection(int selectionNumber, int startOffset, int endOffset);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Rectangle AccessibilityGetRangeExtents(int startOffset, int endOffset, AccessibilityCoordinateType coordType);
+    }
+}

--- a/src/Tizen.NUI/src/public/Accessibility/IAtspiValue.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/IAtspiValue.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Accessibility
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IAtspiValue
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        double AccessibilityGetMinimum();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        double AccessibilityGetCurrent();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        double AccessibilityGetMaximum();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilitySetCurrent(double value);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        double AccessibilityGetMinimumIncrement();
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -145,7 +145,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public virtual void OnInitialize()
         {
-            SetAccessibilityConstructor(Role.Unknown);
+            AccessibilityRole = Role.Unknown;
             AppendAccessibilityAttribute("class", this.GetType().Name);
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -477,22 +477,6 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        /// <summary>
-        /// Sets the specific constructor for creating accessibility structure with its role and interface.
-        /// </summary>
-        /// <remarks>
-        /// The method should be called inside OnInitialize method of all classes inheriting from View.
-        /// </remarks>
-        /// <param name="role">Accessibility role</param>
-        /// <param name="accessibilityInterface">Accessibility interface</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetAccessibilityConstructor(Role role, AccessibilityInterface accessibilityInterface = AccessibilityInterface.None)
-        {
-            // We have to store the interface flags until we remove SetAccessibilityConstructor and switch to native C# interfaces
-            AtspiInterfaceFlags = (1U << (int)accessibilityInterface);
-            AccessibilityRole = role;
-        }
-
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(bool disposing)
         {
@@ -598,175 +582,13 @@ namespace Tizen.NUI.BaseComponents
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual double AccessibilityGetMinimum()
-        {
-            return 0.0;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual double AccessibilityGetCurrent()
-        {
-            return 0.0;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual double AccessibilityGetMaximum()
-        {
-            return 0.0;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilitySetCurrent(double value)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual double AccessibilityGetMinimumIncrement()
-        {
-            return 0.0;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual bool AccessibilityIsScrollable()
         {
             return false;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual string AccessibilityGetText(int startOffset, int endOffset)
-        {
-            return "";
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual int AccessibilityGetCharacterCount()
-        {
-            return 0;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual int AccessibilityGetCursorOffset()
-        {
-            return 0;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilitySetCursorOffset(int offset)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual AccessibilityRange AccessibilityGetTextAtOffset(int offset, AccessibilityTextBoundary boundary)
-        {
-            return new AccessibilityRange();
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual AccessibilityRange AccessibilityGetSelection(int selectionNumber)
-        {
-            return new AccessibilityRange();
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityRemoveSelection(int selectionNumber)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilitySetSelection(int selectionNumber, int startOffset, int endOffset)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual Rectangle AccessibilityGetRangeExtents(int startOffset, int endOffset, AccessibilityCoordinateType coordType)
-        {
-            return new Rectangle(0, 0, 0, 0);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityCopyText(int startPosition, int endPosition)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityCutText(int startPosition, int endPosition)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityInsertText(int startPosition, string text)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilitySetTextContents(string newContents)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityDeleteText(int startPosition, int endPosition)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual bool AccessibilityScrollToChild(View child)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual int AccessibilityGetSelectedChildrenCount()
-        {
-            return 0;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual View AccessibilityGetSelectedChild(int selectedChildIndex)
-        {
-            return null;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilitySelectChild(int childIndex)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityDeselectSelectedChild(int selectedChildIndex)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityIsChildSelected(int childIndex)
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilitySelectAll()
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityClearSelection()
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityDeselectChild(int childIndex)
         {
             return false;
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI.BaseComponents
     /// </summary>
     // Values are from Dali::Accessibility::AtspiInterface
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public enum AccessibilityInterface
+    internal enum AccessibilityInterface
     {
         /// <summary>
         /// Common accessibility interface
@@ -39,6 +39,11 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         Value = 26,
+        /// <summary>
+        /// Accessibility interface which can store text
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Text = 25,
         /// <summary>
         /// Accessibility interface which can store editable texts
         /// </summary>
@@ -1537,7 +1542,7 @@ namespace Tizen.NUI.BaseComponents
     /// <summary>
     /// Accessibility text boundary is used in text controls.
     /// </summary>
-    /// <seealso cref="View.AccessibilityGetTextAtOffset" />
+    /// <seealso cref="Accessibility.IAtspiText.AccessibilityGetTextAtOffset" />
     /// <remarks>
     /// Currently, only AccessibilityTextBoundary.Character is supported.
     /// </remarks>
@@ -1586,7 +1591,7 @@ namespace Tizen.NUI.BaseComponents
     /// <summary>
     /// Accessibility coordinate type describing if coordinates are relative to screen or window
     /// </summary>
-    /// <seealso cref="View.AccessibilityGetRangeExtents" />
+    /// <seealso cref="Accessibility.IAtspiText.AccessibilityGetRangeExtents" />
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum AccessibilityCoordinateType
     {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This PR exposes AT-SPI interfaces as native C# interfaces (e.g. `public class Slider : IAtspiValue`) instead of an enumeration value that has to be passed to `SetAccessibilityConstructor` from `OnInitialize` (e.g. `SetAccessibilityConstructor(AccessibilityInterface.Value)`). Leveraging the native interfaces mechanism allows the C# compiler to check that:

1. The respective interface is declared when trying to implement its method (previously it was possible to override e.g. `AccessibilityGetMinimum` without actually declaring `Value` interface, which is a violation of object-oriented programming principles).

And, conversely, that:

2. All required methods are implemented when declaring a given interface (previously it was possible to declare e.g. `Value` interface and leave `AccessibleGetMinimum` unimplemented, which is also a violation of object-oriented programming principles).

`SetAccessibilityConstructor` is now entirely removed. It has never served the purpose that the name suggested, and the respective DALi function with the same name (which, contrary to NUI, actually had an `accessibilityConstructor` parameter) has recently been removed as well anyway.

Finally, it is now possible to declare more than one AT-SPI interface for any control (e.g. `public class MyControl : IAtspiText, IAtspiValue`).

This change is entirely contained within the TizenFX repository, i.e. it is not dependent on any DALi patches.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
