### PR TITLE
[NUI] Fix to invoke SelectedChanged when IsSelected is changed by setter

### DIFF
--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -32,8 +32,6 @@ namespace Tizen.NUI.Components
     {
         private SelectGroup itemGroup = null;
 
-        private bool invokeSelectedChanged = false;
-
         /// <summary>
         /// Item group which is used to manager all SelectButton in it.
         /// </summary>
@@ -147,18 +145,6 @@ namespace Tizen.NUI.Components
                 return false;
             }
 
-            if (key.State == Key.StateType.Up)
-            {
-                if (key.KeyPressedName == "Return")
-                {
-                    invokeSelectedChanged = true;
-                }
-            }
-            else
-            {
-                invokeSelectedChanged = false;
-            }
-
             return base.OnKey(key);
         }
 
@@ -185,17 +171,6 @@ namespace Tizen.NUI.Components
                 return false;
             }
 
-            PointStateType state = touch.GetState(0);
-            switch (state)
-            {
-                case PointStateType.Up:
-                    invokeSelectedChanged = true;
-                    break;
-                default:
-                    invokeSelectedChanged = false;
-                    break;
-            }
-
             return base.HandleControlStateOnTouch(touch);
         }
 
@@ -217,12 +192,6 @@ namespace Tizen.NUI.Components
                 if (Accessibility.Accessibility.IsEnabled && IsHighlighted)
                 {
                     EmitAccessibilityStateChangedEvent(AccessibilityState.Checked, info.CurrentState.Contains(ControlState.Selected));
-                }
-
-                // SelectedChanged is invoked when button or key is unpressed.
-                if (invokeSelectedChanged == false)
-                {
-                    return;
                 }
 
                 OnSelectedChanged();

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CheckBoxSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CheckBoxSample.cs
@@ -85,8 +85,14 @@ namespace Tizen.NUI.Samples
 
             for (int i = 0; i < num; i++)
             {
+                int index = i + 1;
+
                 //Create utility radio button.
                 utilityCheckBox[i] = new CheckBox();
+                utilityCheckBox[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Utility CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 var utilityStyle = utilityCheckBox[i].Style;
                 utilityStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -125,6 +131,10 @@ namespace Tizen.NUI.Samples
                 group[0].Add(utilityCheckBox[i]);
                 //Create family radio button.
                 familyCheckBox[i] = new CheckBox();
+                familyCheckBox[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Family CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 var familyStyle = familyCheckBox[i].Style;
                 familyStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -149,6 +159,10 @@ namespace Tizen.NUI.Samples
                 group[1].Add(familyCheckBox[i]);
                 //Create food radio button.
                 foodCheckBox[i] = new CheckBox();
+                foodCheckBox[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Food CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 var foodStyle = foodCheckBox[i].Style;
                 foodStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -173,6 +187,10 @@ namespace Tizen.NUI.Samples
                 group[2].Add(foodCheckBox[i]);
                 //Create kitchen radio button.
                 kitchenCheckBox[i] = new CheckBox();
+                kitchenCheckBox[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Kitchen CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 var kitchenStyle = kitchenCheckBox[i].Style;
                 kitchenStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -338,22 +356,40 @@ namespace Tizen.NUI.Samples
             };
             for (int i = 0; i < num; i++)
             {
+                int index = i + 1;
+
                 utilityCheckBox2[i] = new CheckBox(utilityStyle2);
+                utilityCheckBox2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Utility CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 utilityCheckBox2[i].Size = new Size(48, 48);
                 utilityCheckBox2[i].Margin = new Extents(76, 76, 25, 25);
                 group2[0].Add(utilityCheckBox2[i]);
 
                 familyCheckBox2[i] = new CheckBox(familyStyle2);
+                familyCheckBox2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Family CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 familyCheckBox2[i].Size = new Size(48, 48);
                 familyCheckBox2[i].Margin = new Extents(76, 76, 25, 25);
                 group2[1].Add(familyCheckBox2[i]);
 
                 foodCheckBox2[i] = new CheckBox(foodStyle2);
+                foodCheckBox2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Food CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 foodCheckBox2[i].Size = new Size(48, 48);
                 foodCheckBox2[i].Margin = new Extents(76, 76, 25, 25);
                 group2[2].Add(foodCheckBox2[i]);
 
                 kitchenCheckBox2[i] = new CheckBox(kitchenStyle2);
+                kitchenCheckBox2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Kitchen CheckBox's IsSelected is changed to {args.IsSelected}.");
+                };
                 kitchenCheckBox2[i].Size = new Size(48, 48);
                 kitchenCheckBox2[i].Margin = new Extents(76, 76, 25, 25);
                 group2[3].Add(kitchenCheckBox2[i]);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/MenuSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/MenuSample.cs
@@ -38,9 +38,28 @@ namespace Tizen.NUI.Samples
             navigator.Push(page);
 
             var menuItem = new MenuItem() { Text = "Menu" };
+            menuItem.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+            {
+                global::System.Console.WriteLine($"1st MenuItem's IsSelected is changed to {args.IsSelected}.");
+            };
+
             var menuItem2 = new MenuItem() { Text = "Menu2" };
+            menuItem2.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+            {
+                global::System.Console.WriteLine($"2nd MenuItem's IsSelected is changed to {args.IsSelected}.");
+            };
+
             var menuItem3 = new MenuItem() { Text = "Menu3" };
+            menuItem3.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+            {
+                global::System.Console.WriteLine($"3rd MenuItem's IsSelected is changed to {args.IsSelected}.");
+            };
+
             var menuItem4 = new MenuItem() { Text = "Menu4" };
+            menuItem4.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+            {
+                global::System.Console.WriteLine($"4th MenuItem's IsSelected is changed to {args.IsSelected}.");
+            };
 
             moreButton.Clicked += (object sender, ClickedEventArgs args) =>
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RadioButtonSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RadioButtonSample.cs
@@ -87,8 +87,14 @@ namespace Tizen.NUI.Samples
 
             for (int i = 0; i < num; i++)
             {
+                int index = i + 1;
+
                 // create utility radio button.
                 utilityRadioButton[i] = new RadioButton();
+                utilityRadioButton[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Utility RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 var utilityStyle = utilityRadioButton[i].Style;
                 utilityStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -112,6 +118,10 @@ namespace Tizen.NUI.Samples
 
                 // create family radio button.
                 familyRadioButton[i] = new RadioButton();
+                familyRadioButton[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Family RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 var familyStyle = familyRadioButton[i].Style;
                 familyStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -136,6 +146,10 @@ namespace Tizen.NUI.Samples
 
                 // create food radio button.
                 foodRadioButton[i] = new RadioButton();
+                foodRadioButton[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Food RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 var foodStyle = foodRadioButton[i].Style;
                 foodStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -160,6 +174,10 @@ namespace Tizen.NUI.Samples
 
                 // create kitchen radio button.
                 kitchenRadioButton[i] = new RadioButton();
+                kitchenRadioButton[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Left {index}th Kitchen RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 var kitchenStyle = kitchenRadioButton[i].Style;
                 kitchenStyle.Icon.Opacity = new Selector<float?>
                 {
@@ -307,19 +325,37 @@ namespace Tizen.NUI.Samples
             };
             for (int i = 0; i < num; i++)
             {
+                int index = i + 1;
+
                 utilityRadioButton2[i] = new RadioButton(utilityStyle2);
+                utilityRadioButton2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Utility RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 utilityRadioButton2[i].Size = new Size(48, 48);
                 group2[0].Add(utilityRadioButton2[i]);
 
                 familyRadioButton2[i] = new RadioButton(familyStyle2);
+                familyRadioButton2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Family RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 familyRadioButton2[i].Size = new Size(48, 48);
                 group2[1].Add(familyRadioButton2[i]);
 
                 foodRadioButton2[i] = new RadioButton(foodStyle2);
+                foodRadioButton2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Food RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 foodRadioButton2[i].Size = new Size(48, 48);
                 group2[2].Add(foodRadioButton2[i]);
 
                 kitchenRadioButton2[i] = new RadioButton(kitchenStyle2);
+                kitchenRadioButton2[i].SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                {
+                    global::System.Console.WriteLine($"Right {index}th Kitchen RadioButton's IsSelected is changed to {args.IsSelected}.");
+                };
                 kitchenRadioButton2[i].Size = new Size(48, 48);
                 group2[3].Add(kitchenRadioButton2[i]);
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TabViewSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TabViewSample.cs
@@ -29,6 +29,10 @@ namespace Tizen.NUI.Samples
             {
                 Text = "Tab#1"
             };
+            tabButton.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+            {
+                global::System.Console.WriteLine($"1st TabButton's IsSelected is changed to {args.IsSelected}.");
+            };
 
             content = new TextLabel()
             {
@@ -47,6 +51,10 @@ namespace Tizen.NUI.Samples
             {
                 Text = "Tab#2"
             };
+            tabButton2.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+            {
+                global::System.Console.WriteLine($"2nd TabButton's IsSelected is changed to {args.IsSelected}.");
+            };
 
             content2 = new TextLabel()
             {
@@ -64,6 +72,10 @@ namespace Tizen.NUI.Samples
             tabButton3 = new TabButton()
             {
                 Text = "Tab#3"
+            };
+            tabButton3.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+            {
+                global::System.Console.WriteLine($"3rd TabButton's IsSelected is changed to {args.IsSelected}.");
             };
 
             content3 = new TextLabel()
@@ -97,6 +109,12 @@ namespace Tizen.NUI.Samples
                     var newTabButton = new TabButton()
                     {
                         Text = "Tab#" + tabCount.ToString()
+                    };
+
+                    int curCount = tabCount;
+                    newTabButton.SelectedChanged += (object sender, SelectedChangedEventArgs args) =>
+                    {
+                        global::System.Console.WriteLine($"{curCount}th TabButton's IsSelected is changed to {args.IsSelected}.");
                     };
 
                     var newContent = new TextLabel()

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
@@ -18,10 +18,8 @@
   <ItemGroup>
     <Compile Remove="Samples\AnimatedVectorImageViewTest.cs" />
     <Compile Remove="Samples\ButtonSample.cs" />
-    <Compile Remove="Samples\CheckBoxSample.cs" />
     <Compile Remove="Samples\DropDownSample.cs" />
     <Compile Remove="Samples\PopupSample.cs" />
-    <Compile Remove="Samples\RadioButtonSample.cs" />
     <Compile Remove="Samples\ThemeResourceSample.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Previously, SelectedChanged was not invoked when IsSelected is changed
by IsSelected's setter.
e.g. checkBox.IsSelected = true;

The issue occurred due to the logic that checked mouse up and key up.

Now, the incorrect logic has been removed and SelectedChanged is invoked
when IsSelected is changed by ISelected's setter.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
