### PR TITLE
[NUI] Change Button, TimePicker 's Focusable property as true

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -193,6 +193,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 6 </since_tizen>
         public Button() : base()
         {
+            Focusable = true;
         }
 
         /// <summary>
@@ -202,6 +203,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Button(string style) : base(style)
         {
+            Focusable = true;
         }
 
         /// <summary>
@@ -211,6 +213,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 8 </since_tizen>
         public Button(ButtonStyle buttonStyle) : base(buttonStyle)
         {
+            Focusable = true;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -144,6 +144,32 @@ namespace Tizen.NUI.Components
                 NotifyPropertyChanged();
             }
         }
+
+        /// <summary>
+        /// for the case of ContentPage, it sets key focus on AppBar's NavigationContent
+        /// </summary>
+        protected internal override void RestoreKeyFocus()
+        {
+            if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            {
+                if (base.LastFocusedView)
+                {
+                    FocusManager.Instance.SetCurrentFocusView(this.LastFocusedView);
+                }
+                else
+                {
+                    if (AppBar != null && AppBar.NavigationContent != null && AppBar.NavigationContent.Focusable)
+                    {
+                        FocusManager.Instance.SetCurrentFocusView(AppBar.NavigationContent);
+                    }
+                    else
+                    {
+                        FocusManager.Instance.ClearFocus();
+                    }
+                }
+            }
+        }
+
         private View InternalContent
         {
             get

--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -228,7 +228,7 @@ namespace Tizen.NUI.Components
             {
                 if (page is DialogPage == false)
                 {
-                   topPage.SetVisible(false);
+                    topPage.SetVisible(false);
                 }
 
                 // Need to update Content of the new page
@@ -338,6 +338,20 @@ namespace Tizen.NUI.Components
             page.InvokeAppearing();
             curTop.InvokeDisappearing();
 
+            //test.
+            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            // {
+            //     curTop.LastFocusedView = FocusManager.Instance.GetCurrentFocusView();
+            //     if(page.LastFocusedView)
+            //     {
+            //         FocusManager.Instance.SetCurrentFocusView(page.LastFocusedView);
+            //     }
+            //     else
+            //     {
+            //         FocusManager.Instance.ClearFocus();
+            //     }
+            // }
+
             //TODO: The following transition codes will be replaced with view transition.
             InitializeAnimation();
 
@@ -368,6 +382,15 @@ namespace Tizen.NUI.Components
                     //Invoke Page events
                     page.InvokeAppeared();
                     NotifyAccessibilityStatesChangeOfPages(curTop, page);
+
+                    //test.
+                    // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+                    // {
+                    //     FocusManager.Instance.ClearFocus();
+                    //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+                    //     //FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+                    // }
+
                 };
                 newAnimation.Play();
             }
@@ -375,6 +398,14 @@ namespace Tizen.NUI.Components
             {
                 ShowContentOfPage(page);
             }
+
+            //test.
+            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            // {
+            //     FocusManager.Instance.ClearFocus();
+            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+            // }
         }
 
         /// <summary>
@@ -414,6 +445,20 @@ namespace Tizen.NUI.Components
             newTop.InvokeAppearing();
             curTop.InvokeDisappearing();
 
+            //test.
+            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            // {
+            //     curTop.LastFocusedView = FocusManager.Instance.GetCurrentFocusView();
+            //     if(newTop.LastFocusedView)
+            //     {
+            //         FocusManager.Instance.SetCurrentFocusView(newTop.LastFocusedView);
+            //     }
+            //     else
+            //     {
+            //         FocusManager.Instance.ClearFocus();
+            //     }
+            // }
+
             //TODO: The following transition codes will be replaced with view transition.
             InitializeAnimation();
 
@@ -448,6 +493,17 @@ namespace Tizen.NUI.Components
 
                     //Invoke Page events
                     newTop.InvokeAppeared();
+
+
+                    //test.
+                    // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+                    // {
+                    //     FocusManager.Instance.ClearFocus();
+                    //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+                    //     //FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+                    // }
+
+
                 };
                 newAnimation.Play();
             }
@@ -455,6 +511,23 @@ namespace Tizen.NUI.Components
             {
                 Remove(curTop);
             }
+
+            //test.
+            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            // {
+            //     if(newTop.LastFocusedView)
+            //     {
+            //         FocusManager.Instance.SetCurrentFocusView(newTop.LastFocusedView);
+            //     }
+            // }
+
+            // //test.
+            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            // {
+            //     FocusManager.Instance.ClearFocus();
+            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
+            // }
 
             return curTop;
         }
@@ -741,12 +814,12 @@ namespace Tizen.NUI.Components
             RetrieveTaggedViews(taggedViewsInCurrentTopPage, currentTopPage, true);
 
             List<KeyValuePair<View, View>> sameTaggedViewPair = new List<KeyValuePair<View, View>>();
-            foreach(View currentTopPageView in taggedViewsInCurrentTopPage)
+            foreach (View currentTopPageView in taggedViewsInCurrentTopPage)
             {
                 bool findPair = false;
-                foreach(View newTopPageView in taggedViewsInNewTopPage)
+                foreach (View newTopPageView in taggedViewsInNewTopPage)
                 {
-                    if((currentTopPageView.TransitionOptions != null) && (newTopPageView.TransitionOptions != null) &&
+                    if ((currentTopPageView.TransitionOptions != null) && (newTopPageView.TransitionOptions != null) &&
                         currentTopPageView.TransitionOptions?.TransitionTag == newTopPageView.TransitionOptions?.TransitionTag)
                     {
                         sameTaggedViewPair.Add(new KeyValuePair<View, View>(currentTopPageView, newTopPageView));
@@ -754,21 +827,21 @@ namespace Tizen.NUI.Components
                         break;
                     }
                 }
-                if(findPair)
+                if (findPair)
                 {
                     taggedViewsInNewTopPage.Remove(sameTaggedViewPair[sameTaggedViewPair.Count - 1].Value);
                 }
             }
-            foreach(KeyValuePair<View, View> pair in sameTaggedViewPair)
+            foreach (KeyValuePair<View, View> pair in sameTaggedViewPair)
             {
                 taggedViewsInCurrentTopPage.Remove(pair.Key);
             }
 
             TransitionSet newTransitionSet = new TransitionSet();
-            foreach(KeyValuePair<View, View> pair in sameTaggedViewPair)
+            foreach (KeyValuePair<View, View> pair in sameTaggedViewPair)
             {
                 TransitionItem pairTransition = transition.CreateTransition(pair.Key, pair.Value, pushTransition);
-                if(pair.Value.TransitionOptions?.TransitionWithChild ?? false)
+                if (pair.Value.TransitionOptions?.TransitionWithChild ?? false)
                 {
                     pairTransition.TransitionWithChild = true;
                 }
@@ -777,11 +850,11 @@ namespace Tizen.NUI.Components
 
             newTransitionSet.Finished += (object sender, EventArgs e) =>
             {
-                if(newTopPage.Layout != null)
+                if (newTopPage.Layout != null)
                 {
                     newTopPage.Layout.RequestLayout();
                 }
-                if(currentTopPage.Layout != null)
+                if (currentTopPage.Layout != null)
                 {
                     currentTopPage.Layout.RequestLayout();
                 }

--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -338,19 +338,7 @@ namespace Tizen.NUI.Components
             page.InvokeAppearing();
             curTop.InvokeDisappearing();
 
-            //test.
-            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
-            // {
-            //     curTop.LastFocusedView = FocusManager.Instance.GetCurrentFocusView();
-            //     if(page.LastFocusedView)
-            //     {
-            //         FocusManager.Instance.SetCurrentFocusView(page.LastFocusedView);
-            //     }
-            //     else
-            //     {
-            //         FocusManager.Instance.ClearFocus();
-            //     }
-            // }
+            curTop.SaveKeyFocus();
 
             //TODO: The following transition codes will be replaced with view transition.
             InitializeAnimation();
@@ -383,29 +371,15 @@ namespace Tizen.NUI.Components
                     page.InvokeAppeared();
                     NotifyAccessibilityStatesChangeOfPages(curTop, page);
 
-                    //test.
-                    // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
-                    // {
-                    //     FocusManager.Instance.ClearFocus();
-                    //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-                    //     //FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-                    // }
-
+                    page.RestoreKeyFocus();
                 };
                 newAnimation.Play();
             }
             else
             {
                 ShowContentOfPage(page);
+                page.RestoreKeyFocus();
             }
-
-            //test.
-            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
-            // {
-            //     FocusManager.Instance.ClearFocus();
-            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-            // }
         }
 
         /// <summary>
@@ -444,20 +418,7 @@ namespace Tizen.NUI.Components
             //Invoke Page events
             newTop.InvokeAppearing();
             curTop.InvokeDisappearing();
-
-            //test.
-            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
-            // {
-            //     curTop.LastFocusedView = FocusManager.Instance.GetCurrentFocusView();
-            //     if(newTop.LastFocusedView)
-            //     {
-            //         FocusManager.Instance.SetCurrentFocusView(newTop.LastFocusedView);
-            //     }
-            //     else
-            //     {
-            //         FocusManager.Instance.ClearFocus();
-            //     }
-            // }
+            curTop.SaveKeyFocus();
 
             //TODO: The following transition codes will be replaced with view transition.
             InitializeAnimation();
@@ -494,16 +455,7 @@ namespace Tizen.NUI.Components
                     //Invoke Page events
                     newTop.InvokeAppeared();
 
-
-                    //test.
-                    // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
-                    // {
-                    //     FocusManager.Instance.ClearFocus();
-                    //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-                    //     //FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-                    // }
-
-
+                    newTop.RestoreKeyFocus();
                 };
                 newAnimation.Play();
             }
@@ -511,23 +463,6 @@ namespace Tizen.NUI.Components
             {
                 Remove(curTop);
             }
-
-            //test.
-            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
-            // {
-            //     if(newTop.LastFocusedView)
-            //     {
-            //         FocusManager.Instance.SetCurrentFocusView(newTop.LastFocusedView);
-            //     }
-            // }
-
-            // //test.
-            // if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
-            // {
-            //     FocusManager.Instance.ClearFocus();
-            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-            //     FocusManager.Instance.MoveFocus(View.FocusDirection.Down);
-            // }
 
             return curTop;
         }

--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -94,6 +94,8 @@ namespace Tizen.NUI.Components
             return instance.InternalDisappearingTransition;
         });
 
+        internal BaseComponents.View LastFocusedView = null;
+
         private Navigator navigator = null;
 
         // Default transition is Fade.

--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -94,7 +94,7 @@ namespace Tizen.NUI.Components
             return instance.InternalDisappearingTransition;
         });
 
-        internal BaseComponents.View LastFocusedView = null;
+        protected internal BaseComponents.View LastFocusedView = null;
 
         private Navigator navigator = null;
 
@@ -232,5 +232,69 @@ namespace Tizen.NUI.Components
         {
             Disappeared?.Invoke(this, new PageDisappearedEventArgs());
         }
+
+        /// <summary>
+        /// works only when DefaultAlgorithm is enabled.
+        /// to save the currentl focused View when disappeared.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal virtual void SaveKeyFocus()
+        {
+            if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            {
+                var currentFocusedView = FocusManager.Instance.GetCurrentFocusView();
+                if (currentFocusedView)
+                {
+                    var findChild = this.FindDescendantByID(currentFocusedView.ID);
+                    if (findChild)
+                    {
+                        this.LastFocusedView = findChild;
+                        return;
+                    }
+                }
+                this.LastFocusedView = null;
+            }
+        }
+
+        /// <summary>
+        /// works only when DefaultAlgorithm is enabled.
+        /// to set key focused View when showing.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal virtual void RestoreKeyFocus()
+        {
+            if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
+            {
+                if (this.LastFocusedView)
+                {
+                    FocusManager.Instance.SetCurrentFocusView(this.LastFocusedView);
+                }
+                else
+                {
+                    var temp = new Tizen.NUI.BaseComponents.View()
+                    {
+                        Size = new Size(0.1f, 0.1f, 0.0f),
+                        Position = new Position(0, 0, 0),
+                        Focusable = true,
+                    };
+                    this.Add(temp);
+                    temp.LowerToBottom();
+                    FocusManager.Instance.SetCurrentFocusView(temp);
+                    var focused = FocusManager.Instance.GetNearestFocusableActor(this, temp, Tizen.NUI.BaseComponents.View.FocusDirection.Down);
+                    if (focused)
+                    {
+                        FocusManager.Instance.SetCurrentFocusView(focused);
+                    }
+                    else
+                    {
+                        FocusManager.Instance.ClearFocus();
+                    }
+                    temp.Unparent();
+                    temp.Dispose();
+                }
+            }
+
+        }
+
     }
 }

--- a/src/Tizen.NUI.Components/Controls/TimePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/TimePicker.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI.Components
         /// TimeChangedEventArgs default constructor.
         /// <param name="time">time value of TimePicker.</param>
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]   
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TimeChangedEventArgs(DateTime time)
         {
             Time = time;
@@ -106,6 +106,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 9 </since_tizen>
         public TimePicker()
         {
+            SetKeyboardNavigationSupport(true);
         }
 
         /// <summary>
@@ -115,6 +116,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 9 </since_tizen>
         public TimePicker(string style) : base(style)
         {
+            SetKeyboardNavigationSupport(true);
         }
 
         /// <summary>
@@ -124,6 +126,7 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 9 </since_tizen>
         public TimePicker(TimePickerStyle timePickerStyle) : base(timePickerStyle)
         {
+            SetKeyboardNavigationSupport(true);
         }
 
         /// <summary>
@@ -194,7 +197,7 @@ namespace Tizen.NUI.Components
                         else hourPicker.CurrentValue = currentTime.Hour - 12;
                         ampmPicker.CurrentValue = 2;
                     }
-                    else 
+                    else
                     {
                         isAm = true;
                         if (currentTime.Hour == 0) hourPicker.CurrentValue = 12;
@@ -243,7 +246,7 @@ namespace Tizen.NUI.Components
                     hourPicker.MaxValue = 23;
                     hourPicker.CurrentValue = currentTime.Hour;
                 }
-                else 
+                else
                 {
                     hourPicker.MinValue = 1;
                     hourPicker.MaxValue = 12;
@@ -271,6 +274,7 @@ namespace Tizen.NUI.Components
             {
                 MinValue = 1,
                 MaxValue = 12,
+                Focusable = true,
             };
             hourPicker.ValueChanged += OnHourValueChanged;
 
@@ -278,6 +282,7 @@ namespace Tizen.NUI.Components
             {
                 MinValue = 0,
                 MaxValue = 59,
+                Focusable = true,
             };
             minutePicker.ValueChanged += OnMinuteValueChanged;
 
@@ -285,6 +290,7 @@ namespace Tizen.NUI.Components
             {
                 MinValue = 1,
                 MaxValue = 2,
+                Focusable = true,
             };
             ampmPicker.ValueChanged += OnAmpmValueChanged;
 
@@ -321,7 +327,7 @@ namespace Tizen.NUI.Components
             //Apply CellPadding.
             if (timePickerStyle?.CellPadding != null && Layout != null)
                 ((LinearLayout)Layout).CellPadding = new Size2D(timePickerStyle.CellPadding.Width, timePickerStyle.CellPadding.Height);
-            
+
             //Apply Internal Pickers style.
             if (timePickerStyle?.Pickers != null && hourPicker != null && minutePicker != null && ampmPicker != null)
             {
@@ -330,7 +336,57 @@ namespace Tizen.NUI.Components
                 ampmPicker.ApplyStyle(timePickerStyle.Pickers);
             }
         }
-                
+
+        /// <summary>
+        /// ToDo : only key navigation is enabled, but value editing is not yet added. for example, after enter key and up/down key the value need be changed.
+        /// </summary>
+        /// <param name="currentFocusedView"></param>
+        /// <param name="direction"></param>
+        /// <param name="loopEnabled"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override View GetNextFocusableView(View currentFocusedView, View.FocusDirection direction, bool loopEnabled)
+        {
+            if (currentFocusedView == hourPicker)
+            {
+                if (direction == View.FocusDirection.Right)
+                {
+                    return minutePicker;
+                }
+                else if (direction == View.FocusDirection.Left)
+                {
+                    return null;
+                }
+            }
+            else if (currentFocusedView == minutePicker)
+            {
+                if (direction == View.FocusDirection.Right)
+                {
+                    return ampmPicker;
+                }
+                else if (direction == View.FocusDirection.Left)
+                {
+                    return hourPicker;
+                }
+            }
+            else if (currentFocusedView == ampmPicker)
+            {
+                if (direction == View.FocusDirection.Right)
+                {
+                    return null;
+                }
+                else if (direction == View.FocusDirection.Left)
+                {
+                    return minutePicker;
+                }
+            }
+
+            Tizen.Log.Fatal("NUITEST", $"type={currentFocusedView.GetType()}, direction={direction}");
+
+            return null;
+        }
+
+
         [SuppressMessage("Microsoft.Reliability",
                          "CA2000:DisposeObjectsBeforeLosingScope",
                          Justification = "The CellPadding will be dispose when the time picker disposed")]
@@ -338,7 +394,8 @@ namespace Tizen.NUI.Components
         {
             HeightSpecification = LayoutParamPolicies.MatchParent;
 
-            Layout = new LinearLayout() { 
+            Layout = new LinearLayout()
+            {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
             };
             Console.WriteLine("initialize");
@@ -363,12 +420,12 @@ namespace Tizen.NUI.Components
 
             if (!is24HourView)
             {
-                if (isAm) 
+                if (isAm)
                 {
                     if (e.Value == 12) ChangeTime(0, 0, true);
                     else ChangeTime(e.Value, 0, true);
                 }
-                else 
+                else
                 {
                     if (e.Value == 12) ChangeTime(12, 0, true);
                     else ChangeTime(e.Value + 12, 0, true);
@@ -376,12 +433,12 @@ namespace Tizen.NUI.Components
             }
             else
                 ChangeTime(e.Value, 0, true);
-            
+
             OnTimeChanged();
         }
 
         private void OnMinuteValueChanged(object sender, ValueChangedEventArgs e)
-        { 
+        {
             if (currentTime.Minute == e.Value) return;
 
             ChangeTime(0, e.Value, false);
@@ -390,7 +447,7 @@ namespace Tizen.NUI.Components
         }
 
         private void OnAmpmValueChanged(object sender, ValueChangedEventArgs e)
-        { 
+        {
             if ((isAm && e.Value == 1) || (!isAm && e.Value == 2)) return;
 
             if (e.Value == 1)
@@ -400,7 +457,7 @@ namespace Tizen.NUI.Components
 
                 isAm = true;
             }
-            else 
+            else
             { //PM
                 if (currentTime.Hour == 0) ChangeTime(12, 0, true);
                 else ChangeTime(currentTime.Hour + 12, 0, true);
@@ -412,7 +469,7 @@ namespace Tizen.NUI.Components
         }
 
         private void OnTimeChanged()
-        { 
+        {
             TimeChangedEventArgs eventArgs = new TimeChangedEventArgs(currentTime);
             TimeChanged?.Invoke(this, eventArgs);
         }
@@ -429,10 +486,11 @@ namespace Tizen.NUI.Components
             String timePattern = timeFormatInfo.ShortTimePattern;
             String[] timePatternArray = timePattern.Split(' ', ':');
 
-            foreach (String format in timePatternArray) {
-                if (format.IndexOf("H") != -1|| format.IndexOf("h") != -1)  Add(hourPicker);
+            foreach (String format in timePatternArray)
+            {
+                if (format.IndexOf("H") != -1 || format.IndexOf("h") != -1) Add(hourPicker);
                 else if (format.IndexOf("M") != -1 || format.IndexOf("m") != -1) Add(minutePicker);
-                else if (format.IndexOf("t") != -1) 
+                else if (format.IndexOf("t") != -1)
                 {
                     is24HourView = false;
                     ampmForceSet = false;
@@ -448,7 +506,7 @@ namespace Tizen.NUI.Components
             //FIXME: There is no localeChanged Event for Component now
             //       AMPM text has to update when system locale changed.
             CultureInfo info = CultureInfo.CurrentCulture;
-            ampmText = new string[] {info.DateTimeFormat.AMDesignator, info.DateTimeFormat.PMDesignator};
+            ampmText = new string[] { info.DateTimeFormat.AMDesignator, info.DateTimeFormat.PMDesignator };
             ampmPicker.DisplayedValues = new ReadOnlyCollection<string>(ampmText);
         }
     }

--- a/src/Tizen.NUI/src/public/Input/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/Input/FocusManager.cs
@@ -72,6 +72,8 @@ namespace Tizen.NUI
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void FocusedViewEnterKeyEventCallback2(IntPtr view);
 
+        private View internalFocusIndicator = null;
+
         /// <summary>
         /// PreFocusChange will be triggered before the focus is going to be changed.<br />
         /// The FocusManager makes the best guess for which view to focus towards the given direction, but applications might want to change that.<br />
@@ -474,14 +476,15 @@ namespace Tizen.NUI
         {
             Interop.FocusManager.SetFocusIndicatorActor(SwigCPtr, View.getCPtr(indicator));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            internalFocusIndicator = indicator;
         }
 
         internal View GetFocusIndicatorView()
         {
             //to fix memory leak issue, match the handle count with native side.
             IntPtr cPtr = Interop.FocusManager.GetFocusIndicatorActor(SwigCPtr);
-            View ret = this.GetInstanceSafely<View>(cPtr);
-            return ret;
+            internalFocusIndicator = this.GetInstanceSafely<View>(cPtr);
+            return internalFocusIndicator;
         }
 
         internal PreFocusChangeSignal PreFocusChangeSignal()

--- a/test/Tizen.NUI.StyleGuide/Examples/ButtonExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/ButtonExample.cs
@@ -28,11 +28,11 @@ namespace Tizen.NUI.StyleGuide
         private Window window;
         public void Activate()
         {
-           Log.Info(this.GetType().Name, $"@@@ this.GetType().Name={this.GetType().Name}, Activate()\n");
+           Log.Info(this.GetType().Name, $"this.GetType().Name={this.GetType().Name}, Activate()\n");
         }
         public void Deactivate()
         {
-            Log.Info(this.GetType().Name, $"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()\n");
+            Log.Info(this.GetType().Name, $"this.GetType().Name={this.GetType().Name}, Deactivate()\n");
             window = null;
         }
 
@@ -71,7 +71,6 @@ namespace Tizen.NUI.StyleGuide
             {
                 Text = "Enabled"
             };
-            enabledButton.EnableFocus();
             enabledButton.Clicked += (object obj, ClickedEventArgs ev) =>
             {
                 Log.Info(this.GetType().Name, "Enabled Button Clicked\n");
@@ -96,7 +95,6 @@ namespace Tizen.NUI.StyleGuide
                 Text = "Unselected",
                 IsSelectable = true,
             };
-            selectableButton.EnableFocus();
             selectableButton.Clicked += (object obj, ClickedEventArgs ev) =>
             {
                 Log.Info(this.GetType().Name, "Selected Button Clicked\n");

--- a/test/Tizen.NUI.StyleGuide/Examples/PickerExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/PickerExample.cs
@@ -1,0 +1,101 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace Tizen.NUI.StyleGuide
+{
+    // IExample inehrited class will be automatically added in the main examples list.
+    internal class PickerExample : ContentPage, IExample
+    {
+        private Window window;
+        private View rootContent;
+        private TimePicker timePicker;
+        private TextLabel label;
+        private Button button;
+
+        public void Activate()
+        {
+        }
+        public void Deactivate()
+        {
+            window = null;
+        }
+
+        /// Modify this method for adding other examples.
+        public PickerExample() : base()
+        {
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+
+            // Navigator bar title is added here.
+            AppBar = new AppBar()
+            {
+                Title = "Picker Default Style",
+            };
+
+            // Example root content view.
+            // you can decorate, add children on this view.
+            rootContent = new View()
+            {
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+
+                Layout = new LinearLayout()
+                {
+                    LinearOrientation = LinearLayout.Orientation.Vertical,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    CellPadding = new Size2D(10, 20),
+                },
+            };
+
+            // Picker style examples.
+            timePicker = new TimePicker()
+            {
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                Time = DateTime.Now
+            };
+            rootContent.Add(timePicker);
+
+
+            label = new TextLabel
+            {
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                Text = $"Time: {timePicker.Time.ToString()}"
+            };
+            rootContent.Add(label);
+
+            button = new Tizen.NUI.Components.Button
+            {
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                Text = "set time"
+            };
+            rootContent.Add(button);
+
+            button.Clicked += (s, e) =>
+            {
+                label.Text = $"Time: {timePicker.Time.ToString()}";
+            };
+
+            Content = rootContent;
+        }
+    }
+}

--- a/test/Tizen.NUI.StyleGuide/Examples/ScrollableBase/ScrollableBaseDirectionExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/ScrollableBase/ScrollableBaseDirectionExample.cs
@@ -81,7 +81,6 @@ namespace Tizen.NUI.StyleGuide
                 colorView.WidthSpecification = (isHorizontal? 200 : LayoutParamPolicies.MatchParent);
                 colorView.HeightSpecification = (isHorizontal? LayoutParamPolicies.MatchParent : 200);
                 colorView.BackgroundColor = new Color((float)rnd.Next(256)/256f, (float)rnd.Next(256)/256f, (float)rnd.Next(256)/256f, 1);
-                colorView.EnableFocus();
                 scrollView.Add(colorView);
             }
 

--- a/test/Tizen.NUI.StyleGuide/Examples/ScrollableBase/ScrollableBaseExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/ScrollableBase/ScrollableBaseExample.cs
@@ -31,11 +31,11 @@ namespace Tizen.NUI.StyleGuide
         private List<DirectionOption> directionMenu;
         public void Activate()
         {
-            Log.Info(this.GetType().Name, $"@@@ this.GetType().Name={this.GetType().Name}, Activate()\n");
+            Log.Info(this.GetType().Name, $"this.GetType().Name={this.GetType().Name}, Activate()\n");
         }
         public void Deactivate()
         {
-            Log.Info(this.GetType().Name, $"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()\n");
+            Log.Info(this.GetType().Name, $"this.GetType().Name={this.GetType().Name}, Deactivate()\n");
             window = null;
             directionMenu = null;
         }
@@ -73,7 +73,6 @@ namespace Tizen.NUI.StyleGuide
                     };
                     item.Label.SetBinding(TextLabel.TextProperty, "Direction");
                     item.Label.HorizontalAlignment = HorizontalAlignment.Begin;
-                    item.EnableFocus();
                     return item;
                 }),
                 ScrollingDirection = ScrollableBase.Direction.Vertical,
@@ -88,7 +87,6 @@ namespace Tizen.NUI.StyleGuide
                     Page scrollDirPage = new ScrollableBaseDirectionExample(directionItem.Direction);
                     window = NUIApplication.GetDefaultWindow();
                     window.GetDefaultNavigator().Push(scrollDirPage);
-                    FocusableExtension.SetFocusOnPage(scrollDirPage);
                 }
                 directionListView.SelectedItem = null;
             };


### PR DESCRIPTION
### Description of Change ###
0. https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/272165/ 가 반영되어야 합니다.
1. Button class : 생성자에 Focusable=ture 추가 했습니다. (user 가 사용할때 key focus 를 그대로 사용 가능)
2. ContentPage class : RestoreKeyFocus() 재정의, SaveKeyFocus() 는 Page 것을 그대로 사용, AppBar 가 있으면 최초에 show 될 때 AppBar 에 key focus 주도록 했습니다.
3. Navigator class : Push(), Pop() 에 대해서 SaveKeyFocus(), RestoreKeyFocus() 를 추가했습니다. vs code 의 ctrl+shift+i 단축키로 auto intendation 맞췄습니다.
4. Page class : protected internal virtual 로 SaveKeyFocus(), RestoreKeyFocus() 를 추가 했습니다. default algorithm enabled 시에만 동작하고, Page 의 derived class (예: ContentPage) 에서 상황에 맞게 재정의 할 수 있도록 했습니다.
5. TimePicker class : GetNextFocusableView 를 재정의하여 내부 콤포넌트들의 key navigation 이 가능하게 했습니다. vs code 의 ctrl+shift+i 단축키로 auto intendation 맞췄습니다.
6. FocusManager class : internalFocusIndicator 를 추가하여, user 가 설정한 focus indicator 의 레퍼런스를 유지했습니다. (GC 되서 갑자기 사라지는 문제 방지)
7. ButtonExample.cs : Button, TimePicker 를 우선 Focusable=true 로 만들어서, extension method 인 EnableFocus() 를 제거 하였습니다. 
8. PickerExample : TimePicker 를 추가했고, 다른 콤포넌트들도 계속 추가 예정 입니다.
9. StyleGuide.cs : extension method 인 EnableFocus() 를 제거하였고, DefaultAlgorithm 을 테스트 하기 위해 enabled 했습니다. 
    NUI.Components 중에 필요한 것은 Focusable=true 로 하기로 정했고, BaseComponents 들은 default Focusable=false 를 유지하기로 정했습니다. 
	따라서, BaseComponents 들에 대해서는 Focusable=true; 를 명시적으로 해 줘야 합니다.


### API Changes ###
none