### PR TITLE
[NUI][TCSACR-482] Make PrimaryCursorPosition property public

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1727,9 +1727,13 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Specify primary cursor (caret) position in text control.
+        /// PrimaryCursorPosition property.<br />
+        /// Specify the position of the primary cursor (caret) in text control.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <remarks>
+        /// If the value set is out of range (negative or greater than or equal the number of characters in Text) then the PrimaryCursorPosition is moved to the end of Text (the number of characters in Text).
+        /// </remarks>
+        /// <since_tizen> 10 </since_tizen>
         public int PrimaryCursorPosition
         {
             get

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -1861,9 +1861,13 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Specify primary cursor (caret) position in text control.
+        /// PrimaryCursorPosition property.<br />
+        /// Specify the position of the primary cursor (caret) in text control.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        /// <remarks>
+        /// If the value set is out of range (negative or greater than or equal the number of characters in Text) then the PrimaryCursorPosition is moved to the end of Text (the number of characters in Text).
+        /// </remarks>
+        /// <since_tizen> 10 </since_tizen>
         public int PrimaryCursorPosition
         {
             get

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextEditor.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextEditor.cs
@@ -626,7 +626,7 @@ namespace Tizen.NUI.Devel.Tests
         [Property("SPEC", "Tizen.NUI.TextEditor.PrimaryCursorPosition A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "CONSTR")]
-        [Property("AUTHOR", "bowon.ryu@samsung.com")]
+        [Property("AUTHOR", "s.sabah@samsung.com")]
         public void TextEditorPrimaryCursorPosition()
         {
             tlog.Debug(tag, $"TextEditorPrimaryCursorPosition START");
@@ -635,13 +635,36 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
             Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
 
-            testingTarget.Text = "0123456789";
-            testingTarget.PrimaryCursorPosition = 5;
-            Assert.AreEqual(5, testingTarget.PrimaryCursorPosition, "Should be equal!");
+            testingTarget.Text ="Hello World!";
+            int textLen = testingTarget.Text.Length;
+
+            int expectedValue = textLen;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = 5;
+            testingTarget.PrimaryCursorPosition = expectedValue;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = 0;
+            testingTarget.PrimaryCursorPosition = expectedValue;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = textLen ;
+            testingTarget.PrimaryCursorPosition = textLen + 1;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = 6;
+            testingTarget.PrimaryCursorPosition = expectedValue;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = textLen ;
+            testingTarget.PrimaryCursorPosition = -1;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"TextEditorPrimaryCursorPosition END (OK)");
         }
+
 
         [Test]
         [Category("P1")]

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextField.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextField.cs
@@ -2280,13 +2280,14 @@ namespace Tizen.NUI.Devel.Tests
             tlog.Debug(tag, $"TextFieldEnableEditing END (OK)");
         }
 
+
         [Test]
         [Category("P1")]
         [Description("TextField PrimaryCursorPosition.")]
         [Property("SPEC", "Tizen.NUI.TextField.PrimaryCursorPosition A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "CONSTR")]
-        [Property("AUTHOR", "bowon.ryu@samsung.com")]
+        [Property("AUTHOR", "s.sabah@samsung.com")]
         public void TextFieldPrimaryCursorPosition()
         {
             tlog.Debug(tag, $"TextFieldPrimaryCursorPosition START");
@@ -2295,9 +2296,31 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextField");
             Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
 
-            testingTarget.Text = "0123456789";
-            testingTarget.PrimaryCursorPosition = 5;
-            Assert.AreEqual(5, testingTarget.PrimaryCursorPosition, "Should be equal!");
+            testingTarget.Text ="Hello World!";
+            int textLen = testingTarget.Text.Length;
+
+            int expectedValue = textLen;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = 5;
+            testingTarget.PrimaryCursorPosition = expectedValue;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = 0;
+            testingTarget.PrimaryCursorPosition = expectedValue;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = textLen ;
+            testingTarget.PrimaryCursorPosition = textLen + 1;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = 6;
+            testingTarget.PrimaryCursorPosition = expectedValue;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
+
+            expectedValue = textLen ;
+            testingTarget.PrimaryCursorPosition = -1;
+            Assert.AreEqual(expectedValue, testingTarget.PrimaryCursorPosition, "Should be equal!");
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"TextFieldPrimaryCursorPosition END (OK)");


### PR DESCRIPTION
Signed-off-by: Shrouq Sabah s.sabah@samsung.com
### Description of Change ###

Public open API list
- TextField
    -  PrimaryCursorPosition{ get; set; }      // Property

- TextEditor
    -  PrimaryCursorPosition{ get; set; }    // Property

  
### API Changes ###
 
- ACR: TCSACR-482
- https://code.sec.samsung.net/jira/browse/TCSACR-482