### PR TITLE
[NUI] Add GrabTouchAfterLeave to ViewStyle and fix ViewStyle apply bug.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -62,6 +62,8 @@ namespace Tizen.NUI.BaseComponents
         private Selector<Rectangle> backgroundImageBorderSelector;
         private Selector<Color> colorSelector;
         private VisualTransformPolicyType? cornerRadiusPolicy;
+        private bool? grabTouchAfterLeave;
+
 
         static ViewStyle() { }
 
@@ -508,6 +510,18 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool SolidNull { get; set; } = false;
+
+
+        /// <summary>
+        /// Whether the view grab all touches even if touch leaves its boundary.
+        /// The view that is touched down receives all touch events until it is touched up.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool? GrabTouchAfterLeave
+        {
+            get => (bool?)GetValue(GrabTouchAfterLeaveProperty);
+            set => SetValue(GrabTouchAfterLeaveProperty, value);
+        }
 
         /// <summary>
         /// HashSet of dirty properties. Internal use only.

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -427,5 +427,14 @@ namespace Tizen.NUI.BaseComponents
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).themeChangeSensitive = (bool?)newValue,
             defaultValueCreator: (bindable) => ((ViewStyle)bindable).themeChangeSensitive
         );
+
+        /// <summary> Bindable property of GrabTouchAfterLeaveProperty. Please do not open it. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty GrabTouchAfterLeaveProperty = BindableProperty.Create(nameof(GrabTouchAfterLeave), typeof(bool?), typeof(ViewStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).grabTouchAfterLeave = (bool?)newValue,
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).grabTouchAfterLeave
+        );
+
+
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -126,13 +126,14 @@ namespace Tizen.NUI.BaseComponents
             backgroundExtraData = uiControl.backgroundExtraData == null ? null : new BackgroundExtraData(uiControl.backgroundExtraData);
         }
 
-        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : this(cPtr, cMemoryOwn, shown)
+        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : this(cPtr, cMemoryOwn, null, shown)
         {
-            InitializeStyle(viewStyle);
         }
 
-        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : base(cPtr, cMemoryOwn)
+        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(cPtr, cMemoryOwn)
         {
+            InitializeStyle(viewStyle);
+
             if (HasBody())
             {
                 PositionUsesPivotPoint = false;
@@ -150,7 +151,6 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetVisible(false);
             }
-
         }
 
         internal View(ViewImpl implementation, bool shown = true) : this(Interop.View.NewViewInternal(ViewImpl.getCPtr(implementation)), true)

--- a/src/Tizen.NUI/src/public/Theme/IThemeCreator.cs
+++ b/src/Tizen.NUI/src/public/Theme/IThemeCreator.cs
@@ -14,10 +14,15 @@
  * limitations under the License.
  *
  */
+using System.ComponentModel;
 
 namespace Tizen.NUI
 {
-    internal interface IThemeCreator
+    /// <summary>
+    /// It is an interface that creates a theme.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IThemeCreator
     {
         Theme Create();
     }

--- a/src/Tizen.NUI/src/public/Theme/Theme.cs
+++ b/src/Tizen.NUI/src/public/Theme/Theme.cs
@@ -274,11 +274,11 @@ namespace Tizen.NUI
 
             do
             {
-                if (currentType.Equals(typeof(View))) break;
-                resultStyle = GetStyle(currentType.FullName);
+                var currentStyle = GetStyle(currentType.FullName);
+                resultStyle = (resultStyle == null) ? currentStyle : currentStyle?.Merge(resultStyle) ?? resultStyle;
                 currentType = currentType.BaseType;
             }
-            while (resultStyle == null && currentType != null);
+            while (currentType != null);
 
             return resultStyle;
         }

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -348,7 +348,13 @@ namespace Tizen.NUI
 #endif
         }
 
-        internal static void AddPackageTheme(IThemeCreator themeCreator)
+        /// <summary>
+        /// Add default theme. The default theme is applied to the entire application.
+        /// If userTheme is applied through ThemeManager.ApplyTheme(userTheme), defaultTheme and userTheme are merged and applied.
+        /// </summary>
+        /// <param name="themeCreator">The interface that creates a theme.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AddPackageTheme(IThemeCreator themeCreator)
         {
             if (packages.Contains(themeCreator))
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DefaultViewStyleChangeSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DefaultViewStyleChangeSample.cs
@@ -1,0 +1,90 @@
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+using Tizen.NUI.Events;
+
+
+namespace Tizen.NUI.Samples
+{
+    public class DefaultViewStyleChangeSample : IExample
+    {
+        private View root;
+        public class MyDefaultTheme : IThemeCreator
+        {
+            public Theme Create()
+            {
+                Theme theme = new Theme();
+                theme.AddStyle("Tizen.NUI.BaseComponents.View",  new ViewStyle()
+                {
+                    Size = new Size(250, 250),
+                    GrabTouchAfterLeave = true,
+                });
+                return theme;
+            }
+        }
+
+        public void Activate()
+        {
+            Window window = NUIApplication.GetDefaultWindow();
+            root = new View();
+
+            // Add defaultTheme applied to application.
+            ThemeManager.AddPackageTheme(new MyDefaultTheme());
+
+            var textLabel = new TextLabel
+            {
+                Size = new Size(500, 200),
+                MultiLine = true,
+            };
+
+            // greenView is created with the size 250x250 and GrabTouchAfterLeave=true defined in defaultTheme.
+            var greenView = new View()
+            {
+                Position = new Position(50, 120),
+                BackgroundColor = Color.Green,
+            };
+            textLabel.Text ="greenView GrabTouchAfterLeave : "+greenView.GrabTouchAfterLeave;
+
+            greenView.TouchEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"greenView {e.Touch.GetState(0)}\n");
+                return true;
+            };
+
+            // If userTheme is applied, it is merged with defaultTheme.
+            Theme userTheme = new Theme();
+            userTheme.AddStyle("Tizen.NUI.BaseComponents.View",  new ViewStyle()
+            {
+                Size = new Size(500, 500),
+            });
+            ThemeManager.ApplyTheme(userTheme);
+
+            // BlueView is created with size 500x500 defined in userTheme and GrabTouchAfterLeave=true defined in defaultTheme.
+            var blueView = new ImageView
+            {
+                Position = new Position(10, 100),
+                BackgroundColor = Color.Blue,
+            };
+            textLabel.Text +="\nblueView GrabTouchAfterLeave : "+blueView.GrabTouchAfterLeave;
+            blueView.TouchEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"blueView {e.Touch.GetState(0)}\n");
+                return true;
+            };
+
+            blueView.Add(greenView);
+            root.Add(textLabel);
+            root.Add(blueView);
+            window.Add(root);
+        }
+
+        public void Deactivate()
+        {
+            if (root != null)
+            {
+                NUIApplication.GetDefaultWindow().Remove(root);
+                root.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Add GrabTouchAfterLeave property to ViewStyle.

2. View does not apply ViewStyle. Fix this bug.
   Change the constructor so that defaultViewStyle is applied.
```C#
    internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : this(cPtr, cMemoryOwn, null, shown)
    {
    }

    internal View(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(cPtr, cMemoryOwn)
    {
        InitializeStyle(viewStyle);
        ...
    }
```

3. Resolves a bug where Views such as ImageView or TextLable did not receive the style of the base View.
   Allows ViewStyles to be merged according to the hierarchy.
```C#
   public ViewStyle GetStyle(Type viewType)
   {
       var currentType = viewType ?? throw new ArgumentNullException(nameof(viewType));
       ViewStyle resultStyle = null;
       do
       {
           var currentStyle = GetStyle(currentType.FullName);
           resultStyle = (resultStyle == null) ? currentStyle : currentStyle?.Merge(resultStyle) ?? resultStyle;
           currentType = currentType.BaseType;
       }
       while (currentType != null);
       return resultStyle;
        }
```

4. Change IThemeCreator and AddPackageTheme to public so that the default theme of the application can be added.
   If you want to change the application default theme, do as follows
```C#
   public class MyDefaultTheme : IThemeCreator
   {
       public Theme Create()
       {
          Theme theme = new Theme();
           theme.AddStyle("Tizen.NUI.BaseComponents.View",  new ViewStyle()
           {
                GrabTouchAfterLeave = true,
           });
           return theme;
       }
   }

   public void Activate()
   {
        ThemeManager.AddPackageTheme(new MyDefaultTheme());

        View viewA = new View(); // A newly created View is created with GrabTouchAfterLeave=true property.

        // Even if a new user theme is applied, it is maintained without overriding the default theme because it is merged with the default theme.
       Theme theme = new Theme();
       theme.AddStyle("Tizen.NUI.BaseComponents.View",  new ViewStyle()
       {
          Size = new Size(600, 600),
       });
       ThemeManager.ApplyTheme(theme);

       View viewB = new View(); // A newly created View is created with 600,600 size and GrabTouchAfterLeave=true properties.
   }
```
