### PR TITLE
[NUI] Add GrabTouchAfterLeave property to ViewStyle and Add SetDefaultStyle() api

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -62,6 +62,7 @@ namespace Tizen.NUI.BaseComponents
         private Selector<Rectangle> backgroundImageBorderSelector;
         private Selector<Color> colorSelector;
         private VisualTransformPolicyType? cornerRadiusPolicy;
+        private bool? grabTouchAfterLeave;
 
         static ViewStyle() { }
 
@@ -508,6 +509,17 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool SolidNull { get; set; } = false;
+
+        /// <summary>
+        /// Whether the view grab all touches even if touch leaves its boundary.
+        /// The view that is touched down receives all touch events until it is touched up.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool? GrabTouchAfterLeave
+        {
+            get => (bool?)GetValue(GrabTouchAfterLeaveProperty);
+            set => SetValue(GrabTouchAfterLeaveProperty, value);
+        }
 
         /// <summary>
         /// HashSet of dirty properties. Internal use only.

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -427,5 +427,12 @@ namespace Tizen.NUI.BaseComponents
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).themeChangeSensitive = (bool?)newValue,
             defaultValueCreator: (bindable) => ((ViewStyle)bindable).themeChangeSensitive
         );
+
+        /// <summary> Bindable property of GrabTouchAfterLeaveProperty. Please do not open it. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty GrabTouchAfterLeaveProperty = BindableProperty.Create(nameof(GrabTouchAfterLeave), typeof(bool?), typeof(ViewStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).grabTouchAfterLeave = (bool?)newValue,
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).grabTouchAfterLeave
+        );
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -67,6 +67,8 @@ namespace Tizen.NUI.BaseComponents
         private Size internalSize = null;
         private Size2D internalSize2D = null;
         private int layoutCount = 0;
+        private static ViewStyle defaultStyle = null;
+
 
         static View()
         {
@@ -126,13 +128,14 @@ namespace Tizen.NUI.BaseComponents
             backgroundExtraData = uiControl.backgroundExtraData == null ? null : new BackgroundExtraData(uiControl.backgroundExtraData);
         }
 
-        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : this(cPtr, cMemoryOwn, shown)
+        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : this(cPtr, cMemoryOwn, null, shown)
         {
-            InitializeStyle(viewStyle);
         }
 
-        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : base(cPtr, cMemoryOwn)
+        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(cPtr, cMemoryOwn)
         {
+            InitializeStyle(viewStyle);
+
             if (HasBody())
             {
                 PositionUsesPivotPoint = false;
@@ -193,6 +196,17 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool LayoutingDisabled { get; set; } = true;
+
+        /// <summary>
+        /// This can designate a style that is applied as a default when creating a View.
+        /// When creating a View, This default style is applied first, followed by the Theme and user ViewStyle.
+        /// </summary>
+        /// <param name="viewStyle">The ViewStyle to be applied when View is created</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetDefaultStyle(ViewStyle viewStyle)
+        {
+            defaultStyle = viewStyle;
+        }
 
         /// <summary>
         /// Deprecate. Please do not use this.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1426,6 +1426,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void InitializeStyle(ViewStyle style = null)
         {
+            ApplyStyle(defaultStyle);
+
             var initialStyle = ThemeManager.GetInitialStyleWithoutClone(GetType());
             if (style == null)
             {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DefaultStyleSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DefaultStyleSample.cs
@@ -1,0 +1,111 @@
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+using Tizen.NUI.Events;
+
+
+namespace Tizen.NUI.Samples
+{
+    public class DefaultStyleSample : IExample
+    {
+        private View root;
+
+        public void Activate()
+        {
+            Window window = NUIApplication.GetDefaultWindow();
+
+            View.SetDefaultStyle(new ViewStyle()
+            {
+                Size = new Size(400, 250),
+                GrabTouchAfterLeave = true,
+            });
+
+            root = new View
+            {
+                Layout = new AbsoluteLayout(),
+                WidthResizePolicy = ResizePolicyType.FillToParent,
+                HeightResizePolicy = ResizePolicyType.FillToParent,
+            };
+
+            var textLabel = new TextLabel
+            {
+                MultiLine = true,
+                BackgroundColor = Color.Grey,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+            };
+
+            // greenView is created with the size 250x250 and GrabTouchAfterLeave=true defined in default style.
+            var greenView = new View()
+            {
+                Position = new Position(50, 320),
+                BackgroundColor = Color.Green,
+            };
+            textLabel.Text ="greenView GrabTouchAfterLeave : "+greenView.GrabTouchAfterLeave;
+
+            greenView.TouchEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"greenView {e.Touch.GetState(0)}\n");
+                return true;
+            };
+
+            // If userTheme is applied, it is override defaultStyle.
+            Theme userTheme = new Theme();
+            userTheme.AddStyle("Tizen.NUI.BaseComponents.TextLabel",  new TextLabelStyle()
+            {
+                Size = new Size(500, 500),
+            });
+            ThemeManager.ApplyTheme(userTheme);
+
+            // BlueView is created with size 500x500 defined in userTheme and GrabTouchAfterLeave=true defined in defaultStyle.
+            var blueView = new TextLabel
+            (new TextLabelStyle
+            {
+                Text = "BlueView",
+            })
+            {
+                Position = new Position(10, 100),
+                BackgroundColor = Color.Blue,
+            };
+            textLabel.Text +="\nblueView GrabTouchAfterLeave : "+blueView.GrabTouchAfterLeave;
+            blueView.TouchEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"blueView {e.Touch.GetState(0)}\n");
+                return true;
+            };
+
+            // BlueView is created with size 100x100 defined in userStyle and GrabTouchAfterLeave=true defined in defaultStyle.
+            var redView = new TextLabel
+            (new TextLabelStyle
+            {
+                PixelSize = 24,
+                Size = new Size(100, 100),
+            })
+            {
+                Text = "RedView",
+                Position = new Position(50, 120),
+                BackgroundColor = Color.Red,
+            };
+            textLabel.Text +="\redView GrabTouchAfterLeave : "+redView.GrabTouchAfterLeave;
+            redView.TouchEvent += (s, e) =>
+            {
+                Tizen.Log.Error("NUI", $"redView {e.Touch.GetState(0)}\n");
+                return true;
+            };
+
+            greenView.Add(blueView);
+            blueView.Add(redView);
+            root.Add(textLabel);
+            root.Add(greenView);
+            window.Add(root);
+        }
+
+        public void Deactivate()
+        {
+            if (root != null)
+            {
+                NUIApplication.GetDefaultWindow().Remove(root);
+                root.Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Add GrabTouchAfterLeave property to ViewStyle.

2. Add SetDefaultStyle(ViewStyle style) api
   This can designate a style that is applied as a default when creating a View.
   When creating a View, it is applied first, followed by the Theme and user ViewStyle.
```C#
    View.SetDefaultStyle(new ViewStyle()
    {
        GrabTouchAfterLeave = true,
    });
```

3. View does not apply ViewStyle. Fix this bug.
   Change the constructor so that defaultViewStyle is applied.
```C#
    internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : this(cPtr, cMemoryOwn, null, shown)
    {
    }

    internal View(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(cPtr, cMemoryOwn)
    {
        InitializeStyle(viewStyle);
        ...
    }
```