### PR TITLE
[NUI] Fix FlexLayout size calculation issue caused by typo

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -672,8 +672,8 @@ namespace Tizen.NUI
 
             childLayout?.Measure(childWidthMeasureSpec, childHeightMeasureSpec);
 
-            measureSize.width = (childLayout == null) ? 0 : MeasuredWidth.Size.AsRoundedValue();
-            measureSize.height = (childLayout == null) ? 0 : MeasuredHeight.Size.AsRoundedValue();
+            measureSize.width = (childLayout == null) ? 0 : childLayout.MeasuredWidth.Size.AsRoundedValue();
+            measureSize.height = (childLayout == null) ? 0 : childLayout.MeasuredHeight.Size.AsRoundedValue();
         }
 
         void InsertChild(LayoutItem child)


### PR DESCRIPTION
Fix typo in FlexLayout size calculation logic.

This typo was caused by https://github.com/Samsung/TizenFX/pull/4032

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
