### PR TITLE
[NUI][TCSACR-483] Remove Slider deprecated events and eventArgs

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -86,12 +86,9 @@ namespace Tizen.NUI.Components
 
         private PanGestureDetector panGestureDetector = null;
         private float currentSlidedOffset;
-        private EventHandler<ValueChangedArgs> valueChangedHandler;
-        private EventHandler<SlidingFinishedArgs> slidingFinishedHandler;
         private EventHandler<SliderValueChangedEventArgs> sliderValueChangedHandler;
         private EventHandler<SliderSlidingStartedEventArgs> sliderSlidingStartedHandler;
         private EventHandler<SliderSlidingFinishedEventArgs> sliderSlidingFinishedHandler;
-        private EventHandler<StateChangedArgs> stateChangedHandler;
 
         bool isFocused = false;
         bool isPressed = false;
@@ -357,13 +354,6 @@ namespace Tizen.NUI.Components
                 if (isValueShown)
                 {
                     valueIndicatorImage.Hide();
-                }
-
-                if (null != slidingFinishedHandler)
-                {
-                    SlidingFinishedArgs args = new SlidingFinishedArgs();
-                    args.CurrentValue = curValue;
-                    slidingFinishedHandler(this, args);
                 }
 
                 if (null != sliderSlidingFinishedHandler)

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -224,40 +224,6 @@ namespace Tizen.NUI.Components
         /// <summary>
         /// The value changed event handler.
         /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API8; Will be removed in API10. Please use ValueChanged event instead.")]
-        public event EventHandler<ValueChangedArgs> ValueChangedEvent
-        {
-            add
-            {
-                valueChangedHandler += value;
-            }
-            remove
-            {
-                valueChangedHandler -= value;
-            }
-        }
-
-        /// <summary>
-        /// The sliding finished event handler.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SlidingFinished event instead.")]
-        public event EventHandler<SlidingFinishedArgs> SlidingFinishedEvent
-        {
-            add
-            {
-                slidingFinishedHandler += value;
-            }
-            remove
-            {
-                slidingFinishedHandler -= value;
-            }
-        }
-
-        /// <summary>
-        /// The value changed event handler.
-        /// </summary>
         /// <since_tizen> 8 </since_tizen>
         public event EventHandler<SliderValueChangedEventArgs> ValueChanged
         {
@@ -300,23 +266,6 @@ namespace Tizen.NUI.Components
             remove
             {
                 sliderSlidingFinishedHandler -= value;
-            }
-        }
-
-        /// <summary>
-        /// The state changed event handler.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API8; Will be removed in API10. Please use View.ControlStateChangedEvent")]
-        public event EventHandler<StateChangedArgs> StateChangedEvent
-        {
-            add
-            {
-                stateChangedHandler += value;
-            }
-            remove
-            {
-                stateChangedHandler -= value;
             }
         }
 
@@ -1698,13 +1647,6 @@ namespace Tizen.NUI.Components
                 this.CurrentValue = CalculateDiscreteValue(this.CurrentValue);
             }
 
-            if (valueChangedHandler != null)
-            {
-                ValueChangedArgs args = new ValueChangedArgs();
-                args.CurrentValue = this.CurrentValue;
-                valueChangedHandler(this, args);
-            }
-
             if (sliderValueChangedHandler != null)
             {
                 SliderValueChangedEventArgs args = new SliderValueChangedEventArgs();
@@ -1731,12 +1673,6 @@ namespace Tizen.NUI.Components
                 Vector2 pos = e.Touch.GetLocalPosition(0);
                 CalculateCurrentValueByTouch(pos);
                 UpdateValue();
-                if (null != slidingFinishedHandler)
-                {
-                    SlidingFinishedArgs args = new SlidingFinishedArgs();
-                    args.CurrentValue = curValue;
-                    slidingFinishedHandler(this, args);
-                }
 
                 if (null != sliderSlidingFinishedHandler)
                 {
@@ -1790,13 +1726,6 @@ namespace Tizen.NUI.Components
                     this.CurrentValue = CalculateDiscreteValue(this.CurrentValue);
                 }
 
-                if (null != valueChangedHandler)
-                {
-                    ValueChangedArgs args = new ValueChangedArgs();
-                    args.CurrentValue = this.CurrentValue;
-                    valueChangedHandler(this, args);
-                }
-
                 if (null != sliderValueChangedHandler)
                 {
                     SliderValueChangedEventArgs args = new SliderValueChangedEventArgs();
@@ -1827,46 +1756,18 @@ namespace Tizen.NUI.Components
             if(!IsEnabled) // Disabled
             {
                 ControlState = ControlState.Disabled;
-
-                if (stateChangedHandler != null)
-                {
-                    StateChangedArgs args = new StateChangedArgs();
-                    args.CurrentState = (ControlStates)ControlStates.Disabled;
-                    stateChangedHandler(this, args);
-                }
             }
             else if (!isFocused && !isPressed)
             {
                 ControlState = ControlState.Normal;
-
-                if (stateChangedHandler != null)
-                {
-                    StateChangedArgs args = new StateChangedArgs();
-                    args.CurrentState = (ControlStates)ControlStates.Normal;
-                    stateChangedHandler(this, args);
-                }
             }
             else if (isPressed)
             {
                 ControlState = ControlState.Pressed;
-
-                if (stateChangedHandler != null)
-                {
-                    StateChangedArgs args = new StateChangedArgs();
-                    args.CurrentState = (ControlStates)ControlStates.Pressed;
-                    stateChangedHandler(this, args);
-                }
             }
             else if (!isPressed && isFocused)
             {
                 ControlState = ControlState.Focused;
-
-                if (stateChangedHandler != null)
-                {
-                    StateChangedArgs args = new StateChangedArgs();
-                    args.CurrentState = (ControlStates)ControlStates.Focused;
-                    stateChangedHandler(this, args);
-                }
             }
         }
 
@@ -1930,60 +1831,6 @@ namespace Tizen.NUI.Components
                     highIndicatorImage.Hide();
                 }
             }
-        }
-
-        /// <summary>
-        /// Value Changed event data.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderValueChangedEventArgs instead.")]
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
-        public class ValueChangedArgs : EventArgs
-        {
-            /// <summary>
-            /// Current value
-            /// </summary>
-            /// <since_tizen> 6 </since_tizen>
-            /// It will be removed in API10
-            [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
-            [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderValueChangedEventArgs.CurrentValue instead.")]
-            public float CurrentValue;
-        }
-
-        /// <summary>
-        /// Value Changed event data.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderSlidingFinishedEventArgs instead.")]
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
-        public class SlidingFinishedArgs : EventArgs
-        {
-            /// <summary>
-            /// Current value
-            /// </summary>
-            /// <since_tizen> 6 </since_tizen>
-            /// It will be removed in API10
-            [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
-            [Obsolete("Deprecated in API8; Will be removed in API10. Please use SliderSlidingFinishedEventArgs.CurrentValue instead.")]
-            public float CurrentValue;
-        }
-
-        /// <summary>
-        /// State Changed event data.
-        /// </summary>
-        /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated in API8; Will be removed in API10. Please use View.ControlStateChangedEventArgs")]
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
-        public class StateChangedArgs : EventArgs
-        {
-            /// <summary>
-            /// Current state
-            /// </summary>
-            /// <since_tizen> 6 </since_tizen>
-            /// It will be removed in API10
-            [global::System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
-            [Obsolete("Deprecated in API8; Will be removed in API10")]
-            public ControlStates CurrentState;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/Constants.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/Constants.cs
@@ -25,7 +25,7 @@ namespace Tizen.NUI.Components
     /// Enumeration for describing the states of the view.
     /// </summary>
     [FlagsAttribute]
-    // Please remove this enum when 'Tizen.NUI.BaseComponents.Button.StateChangedEventArgs' and 'Tizen.NUI.BaseComponents.Slider.StateChangedArgs' are removed.
+    // Please remove this enum when 'Tizen.NUI.BaseComponents.Button.StateChangedEventArgs' is removed.
     [Obsolete("This will be removed in API10. Please use Tizen.NUI.BaseComponents.ControlState instead!")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum ControlStates

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSSlider.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/testcase/Controls/TSSlider.cs
@@ -16,18 +16,6 @@ namespace Tizen.NUI.Components.Devel.Tests
         private const string tag = "NUITEST";
         private string image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "picture.png";
 
-        [Obsolete]
-        private EventHandler<Slider.ValueChangedArgs> OnValueChangedEvent()
-        {
-            return null;
-        }
-
-        [Obsolete]
-        private EventHandler<Slider.SlidingFinishedArgs> OnSlidingFinishedEvent()
-        {
-            return null;
-        }
-
         private EventHandler<SliderValueChangedEventArgs> OnValueChanged()
         {
             return null;
@@ -39,12 +27,6 @@ namespace Tizen.NUI.Components.Devel.Tests
         }
 
         private EventHandler<SliderSlidingFinishedEventArgs> OnSlidingFinished()
-        {
-            return null;
-        }
-
-        [Obsolete]
-        private EventHandler<Slider.StateChangedArgs> OnStateChangedEvent()
         {
             return null;
         }
@@ -324,62 +306,6 @@ namespace Tizen.NUI.Components.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("Slider ValueChangedEvent.")]
-        [Property("SPEC", "Tizen.NUI.Components.Slider.ValueChangedEvent A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("COVPARAM", "")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        [Obsolete]
-        public void SliderValueChangedEvent()
-        {
-            tlog.Debug(tag, $"SliderValueChangedEvent START");
-
-            var testingTarget = new Slider()
-            {
-                Direction = Slider.DirectionType.Vertical,
-                IsEnabled = true,
-            };
-            Assert.IsNotNull(testingTarget, "null handle");
-            Assert.IsInstanceOf<Slider>(testingTarget, "Should return Slider instance.");
-
-            testingTarget.ValueChangedEvent += OnValueChangedEvent();
-            testingTarget.ValueChangedEvent -= OnValueChangedEvent();
-
-            testingTarget.Dispose();
-            tlog.Debug(tag, $"SliderValueChangedEvent END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("Slider SlidingFinishedEvent.")]
-        [Property("SPEC", "Tizen.NUI.Components.Slider.SlidingFinishedEvent A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("COVPARAM", "")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        [Obsolete]
-        public void SliderSlidingFinishedEvent()
-        {
-            tlog.Debug(tag, $"SliderSlidingFinishedEvent START");
-
-            var testingTarget = new Slider()
-            {
-                Direction = Slider.DirectionType.Vertical,
-                IsEnabled = true,
-            };
-            Assert.IsNotNull(testingTarget, "null handle");
-            Assert.IsInstanceOf<Slider>(testingTarget, "Should return Slider instance.");
-
-            testingTarget.SlidingFinishedEvent += OnSlidingFinishedEvent();
-            testingTarget.SlidingFinishedEvent -= OnSlidingFinishedEvent();
-
-            testingTarget.Dispose();
-            tlog.Debug(tag, $"SliderValueChangedEvent END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
         [Description("SliderSlidingStartedEventArgs CurrentValue.")]
         [Property("SPEC", "Tizen.NUI.Components.Slider.OnKey A")]
         [Property("SPEC_URL", "-")]
@@ -482,34 +408,6 @@ namespace Tizen.NUI.Components.Devel.Tests
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"SliderSlidingFinished END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("Slider StateChangedEvent.")]
-        [Property("SPEC", "Tizen.NUI.Components.Slider.StateChangedEvent A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("COVPARAM", "")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        [Obsolete]
-        public void SliderStateChangedEvent()
-        {
-            tlog.Debug(tag, $"SliderStateChangedEvent START");
-
-            var testingTarget = new Slider()
-            {
-                Direction = Slider.DirectionType.Vertical,
-                IsEnabled = true,
-            };
-            Assert.IsNotNull(testingTarget, "null handle");
-            Assert.IsInstanceOf<Slider>(testingTarget, "Should return Slider instance.");
-
-            testingTarget.StateChangedEvent += OnStateChangedEvent();
-            testingTarget.StateChangedEvent -= OnStateChangedEvent();
-
-            testingTarget.Dispose();
-            tlog.Debug(tag, $"SliderStateChangedEvent END (OK)");
         }
 
         [Test]


### PR DESCRIPTION
Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- Remove some Slider events which have been deprecated since API level 8.


### API Changes ###
 - ACR:  TCSACR-483
   https://code.sec.samsung.net/jira/browse/TCSACR-483

  Removed :
  	public event EventHandler<ValueChangedArgs> ValueChangedEvent
  	public event EventHandler<SlidingFinishedArgs> SlidingFinishedEvent
  	public event EventHandler<StateChangedArgs> StateChangedEvent
  	public class ValueChangedArgs
  	public float ValueChangedArgs.CurrentValue
  	public class SlidingFinishedArgs
  	public float SlidingFinishedArgs.CurrentValue
  	public class StateChangedArgs
  	public ControlStates StateChangedArgs.CurrentState