### PR TITLE
[NUI] Fix Navigator not to handle touch events

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -732,6 +732,17 @@ namespace Tizen.NUI.Components
             return defaultNavigator;
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override bool HitTest(Touch touch)
+        {
+            // Navigator itself is not required to handle touch events.
+            // If Navigator has a Page, then the Page handles touch events.
+            // If Navigator does not have a Page, then objects behind the
+            // Navigator handle touch events.
+            return false;
+        }
+
         /// <summary>
         /// Create Transitions between currentTopPage and newTopPage
         /// </summary>


### PR DESCRIPTION
Navigator is a container that manages Pages.
Page and its children handle touch events.
Therefore, Navigator itself is not required to handle touch events.

If Navigator has a Page, then the Page handles touch events.
If Navigator does not have a Page, then objects behind the Navigator
handle touch events.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
