### PR TITLE
[NUI][XamlBuild] Support use root node inheirt nest type

### DIFF
--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
@@ -529,6 +529,10 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             Func<string, string> getNamespaceOfPrefix = null)
         {
             var type = xmlType.Name;
+            if (type.Contains("-"))
+            {
+                type = type.Replace('-', '.');
+            }
             var ns = GetClrNamespace(xmlType.NamespaceUri, xmlType.Name);
             if (ns != null)
                 type = $"{ns}.{type}";


### PR DESCRIPTION
### Description of Change ###
Support use root node inheirt nest type

Sample
xaml:
`<l:CustomForNestView-CustomView x:Class="Tizen.NUI.Examples.NestedTypeTestPage"`

c#:
`public partial class NestedTypeTestPage : CustomForNestView.CustomView`

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
