### PR TITLE
[NUI] Add Button ItemHorizontalAlignment and ItemVerticalAlignment

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -352,7 +352,8 @@ namespace Tizen.NUI.Components
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    LinearAlignment = itemAlignment,
+                    HorizontalAlignment = itemHorizontalAlignment,
+                    VerticalAlignment = itemVerticalAlignment,
                     CellPadding = cellPadding
                 };
 
@@ -364,7 +365,8 @@ namespace Tizen.NUI.Components
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    LinearAlignment = itemAlignment,
+                    HorizontalAlignment = itemHorizontalAlignment,
+                    VerticalAlignment = itemVerticalAlignment,
                     CellPadding = cellPadding
                 };
 
@@ -376,7 +378,8 @@ namespace Tizen.NUI.Components
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Vertical,
-                    LinearAlignment = itemAlignment,
+                    HorizontalAlignment = itemHorizontalAlignment,
+                    VerticalAlignment = itemVerticalAlignment,
                     CellPadding = cellPadding
                 };
 
@@ -388,7 +391,8 @@ namespace Tizen.NUI.Components
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Vertical,
-                    LinearAlignment = itemAlignment,
+                    HorizontalAlignment = itemHorizontalAlignment,
+                    VerticalAlignment = itemVerticalAlignment,
                     CellPadding = cellPadding
                 };
 

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -146,10 +146,69 @@ namespace Tizen.NUI.Components
             if (instance.itemAlignment != newAlignment)
             {
                 instance.itemAlignment = newAlignment;
+
+                switch (newAlignment)
+                {
+                    case LinearLayout.Alignment.Begin:
+                        instance.itemHorizontalAlignment = HorizontalAlignment.Begin;
+                        break;
+                    case LinearLayout.Alignment.End:
+                        instance.itemHorizontalAlignment = HorizontalAlignment.End;
+                        break;
+                    case LinearLayout.Alignment.CenterHorizontal:
+                        instance.itemHorizontalAlignment = HorizontalAlignment.Center;
+                        break;
+                    case LinearLayout.Alignment.Top:
+                        instance.itemVerticalAlignment = VerticalAlignment.Top;
+                        break;
+                    case LinearLayout.Alignment.Bottom:
+                        instance.itemVerticalAlignment = VerticalAlignment.Bottom;
+                        break;
+                    case LinearLayout.Alignment.CenterVertical:
+                        instance.itemVerticalAlignment = VerticalAlignment.Center;
+                        break;
+                    case LinearLayout.Alignment.Center:
+                        instance.itemHorizontalAlignment = HorizontalAlignment.Center;
+                        instance.itemVerticalAlignment = VerticalAlignment.Center;
+                        break;
+                    default:
+                        break;
+                }
+
                 instance.LayoutItems();
             }
         },
         defaultValueCreator: (bindable) => ((Button)bindable).itemAlignment);
+
+        /// <summary> The bindable property of ItemHorizontalAlignment. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly BindableProperty ItemHorizontalAlignmentProperty = BindableProperty.Create(nameof(ItemHorizontalAlignment), typeof(HorizontalAlignment), typeof(Button), HorizontalAlignment.Center, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Button)bindable;
+            var newHorizontalAlignment = (HorizontalAlignment)newValue;
+
+            if (instance.itemHorizontalAlignment != newHorizontalAlignment)
+            {
+                instance.itemHorizontalAlignment = newHorizontalAlignment;
+                instance.LayoutItems();
+            }
+        },
+        defaultValueCreator: (bindable) => ((Button)bindable).itemHorizontalAlignment);
+
+        /// <summary> The bindable property of ItemVerticalAlignment. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly BindableProperty ItemVerticalAlignmentProperty = BindableProperty.Create(nameof(ItemVerticalAlignment), typeof(VerticalAlignment), typeof(Button), VerticalAlignment.Center, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Button)bindable;
+            var newVerticalAlignment = (VerticalAlignment)newValue;
+
+            if (instance.itemVerticalAlignment != newVerticalAlignment)
+            {
+                instance.itemVerticalAlignment = newVerticalAlignment;
+                instance.LayoutItems();
+            }
+        },
+        defaultValueCreator: (bindable) => ((Button)bindable).itemVerticalAlignment);
 
         /// <summary> The bindable property of ItemSpacing. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -166,6 +225,8 @@ namespace Tizen.NUI.Components
         private bool isSelectable = false;
         private Size2D itemSpacing;
         private LinearLayout.Alignment itemAlignment = LinearLayout.Alignment.Center;
+        private HorizontalAlignment itemHorizontalAlignment = HorizontalAlignment.Center;
+        private VerticalAlignment itemVerticalAlignment = VerticalAlignment.Center;
 
         static Button() { }
 
@@ -817,6 +878,26 @@ namespace Tizen.NUI.Components
         {
             get => (LinearLayout.Alignment)GetValue(ItemAlignmentProperty);
             set => SetValue(ItemAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// The item (text or icon or both) horizontal alignment.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public HorizontalAlignment ItemHorizontalAlignment
+        {
+            get => (HorizontalAlignment)GetValue(ItemHorizontalAlignmentProperty);
+            set => SetValue(ItemHorizontalAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// The item (text or icon or both) vertical alignment.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VerticalAlignment ItemVerticalAlignment
+        {
+            get => (VerticalAlignment)GetValue(ItemVerticalAlignmentProperty);
+            set => SetValue(ItemVerticalAlignmentProperty, value);
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Style/ButtonStyle.cs
+++ b/src/Tizen.NUI.Components/Style/ButtonStyle.cs
@@ -91,8 +91,52 @@ namespace Tizen.NUI.Components
         internal static readonly BindableProperty ItemAlignmentProperty = BindableProperty.Create(nameof(ItemAlignment), typeof(LinearLayout.Alignment?), typeof(ButtonStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((ButtonStyle)bindable).itemAlignment = (LinearLayout.Alignment?)newValue;
+
+            switch (newValue)
+            {
+                case LinearLayout.Alignment.Begin:
+                    ((ButtonStyle)bindable).itemHorizontalAlignment = HorizontalAlignment.Begin;
+                    break;
+                case LinearLayout.Alignment.End:
+                    ((ButtonStyle)bindable).itemHorizontalAlignment = HorizontalAlignment.End;
+                    break;
+                case LinearLayout.Alignment.CenterHorizontal:
+                    ((ButtonStyle)bindable).itemHorizontalAlignment = HorizontalAlignment.Center;
+                    break;
+                case LinearLayout.Alignment.Top:
+                    ((ButtonStyle)bindable).itemVerticalAlignment = VerticalAlignment.Top;
+                    break;
+                case LinearLayout.Alignment.Bottom:
+                    ((ButtonStyle)bindable).itemVerticalAlignment = VerticalAlignment.Bottom;
+                    break;
+                case LinearLayout.Alignment.CenterVertical:
+                    ((ButtonStyle)bindable).itemVerticalAlignment = VerticalAlignment.Center;
+                    break;
+                case LinearLayout.Alignment.Center:
+                    ((ButtonStyle)bindable).itemHorizontalAlignment = HorizontalAlignment.Center;
+                    ((ButtonStyle)bindable).itemVerticalAlignment = VerticalAlignment.Center;
+                    break;
+                default:
+                    break;
+            }
         },
         defaultValueCreator: (bindable) => ((ButtonStyle)bindable).itemAlignment);
+
+        /// <summary> The bindable property of ItemHorizontalAlignment. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly BindableProperty ItemHorizontalAlignmentProperty = BindableProperty.Create(nameof(ItemHorizontalAlignment), typeof(HorizontalAlignment?), typeof(ButtonStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((ButtonStyle)bindable).itemHorizontalAlignment = (HorizontalAlignment?)newValue;
+        },
+        defaultValueCreator: (bindable) => ((ButtonStyle)bindable).itemHorizontalAlignment);
+
+        /// <summary> The bindable property of ItemVerticalAlignment. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly BindableProperty ItemVerticalAlignmentProperty = BindableProperty.Create(nameof(ItemVerticalAlignment), typeof(VerticalAlignment?), typeof(ButtonStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((ButtonStyle)bindable).itemVerticalAlignment = (VerticalAlignment?)newValue;
+        },
+        defaultValueCreator: (bindable) => ((ButtonStyle)bindable).itemVerticalAlignment);
 
         /// <summary> The bindable property of ItemSpacing. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -109,6 +153,8 @@ namespace Tizen.NUI.Components
         private Extents textPadding;
         private Size2D itemSpacing;
         private LinearLayout.Alignment? itemAlignment;
+        private HorizontalAlignment? itemHorizontalAlignment;
+        private VerticalAlignment? itemVerticalAlignment;
 
         static ButtonStyle() { }
 
@@ -220,6 +266,26 @@ namespace Tizen.NUI.Components
         {
             get => (LinearLayout.Alignment?)GetValue(ItemAlignmentProperty);
             set => SetValue(ItemAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// The item (text or icon or both) horizontal alignment.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public HorizontalAlignment? ItemHorizontalAlignment
+        {
+            get => (HorizontalAlignment?)GetValue(ItemHorizontalAlignmentProperty);
+            set => SetValue(ItemHorizontalAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// The item (text or icon or both) vertical alignment.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VerticalAlignment? ItemVerticalAlignment
+        {
+            get => (VerticalAlignment?)GetValue(ItemVerticalAlignmentProperty);
+            set => SetValue(ItemVerticalAlignmentProperty, value);
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -41,7 +41,8 @@ namespace Tizen.NUI.Components
             {
                 Size = new Size(339, 96),
                 CornerRadius = 28.0f,
-                ItemAlignment = LinearLayout.Alignment.Center,
+                ItemHorizontalAlignment = HorizontalAlignment.Center,
+                ItemVerticalAlignment = VerticalAlignment.Center,
                 BackgroundColor = new Selector<Color>()
                 {
                     Normal = new Color(0.039f, 0.055f, 0.29f, 1),
@@ -60,7 +61,8 @@ namespace Tizen.NUI.Components
             theme.AddStyleWithoutClone("Tizen.NUI.Components.CheckBox", new ButtonStyle()
             {
                 ItemSpacing = new Size2D(32, 32),
-                ItemAlignment = LinearLayout.Alignment.CenterVertical,
+                ItemHorizontalAlignment = HorizontalAlignment.Begin,
+                ItemVerticalAlignment = VerticalAlignment.Center,
                 Icon = new ImageViewStyle()
                 {
                     Size = new Size(36, 36),
@@ -152,7 +154,8 @@ namespace Tizen.NUI.Components
             theme.AddStyleWithoutClone("Tizen.NUI.Components.RadioButton", new ButtonStyle()
             {
                 ItemSpacing = new Size2D(32, 32),
-                ItemAlignment = LinearLayout.Alignment.CenterVertical,
+                ItemHorizontalAlignment = HorizontalAlignment.Begin,
+                ItemVerticalAlignment = VerticalAlignment.Center,
                 Icon = new ImageViewStyle()
                 {
                     Size = new Size(36, 36),
@@ -222,7 +225,8 @@ namespace Tizen.NUI.Components
             theme.AddStyleWithoutClone("Tizen.NUI.Components.Switch", new SwitchStyle()
             {
                 ItemSpacing = new Size2D(32, 32),
-                ItemAlignment = LinearLayout.Alignment.CenterVertical,
+                ItemHorizontalAlignment = HorizontalAlignment.Begin,
+                ItemVerticalAlignment = VerticalAlignment.Center,
                 Track = new ImageViewStyle()
                 {
                     Size = new Size(80, 40),


### PR DESCRIPTION
LinearLayout.LinearAlignment is deprecated, and HorizontalAlignment and
VerticalAlignment are added.

To replace Button.ItemAlignment, whose type is LinearAlignment,
ItemHorizontalAlignment and ItemVerticalAlignment are added.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
