### PR TITLE
[NUI][XamlBuild] Set node as null when calling ExitXaml().

### DIFF
--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
@@ -410,7 +410,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 Provider.GenerateCodeFromCompileUnit(ccu, writer, new CodeGeneratorOptions());
         }
 
-        private static void GenerateMethodExitXaml(CodeTypeDeclaration declType)
+        private void GenerateMethodExitXaml(CodeTypeDeclaration declType)
         {
             var removeEventsComp = new CodeMemberMethod()
             {
@@ -440,6 +440,19 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 "DisposeXamlElements", new CodeThisReferenceExpression());
 
             exitXamlComp.Statements.Add(disposeXamlElements_invoke);
+
+            CodeAssignStatement eXamlDataAssign = new CodeAssignStatement(
+                    new CodeVariableReferenceExpression("eXamlData"), new CodeDefaultValueExpression(new CodeTypeReference(typeof(object))));
+
+            exitXamlComp.Statements.Add(eXamlDataAssign);
+
+            foreach (var namedField in NamedFields)
+            {
+                CodeAssignStatement assign = new CodeAssignStatement(
+                    new CodeVariableReferenceExpression(namedField.Name), new CodeDefaultValueExpression(namedField.Type));
+
+                exitXamlComp.Statements.Add(assign);
+            }
 
             declType.Members.Add(exitXamlComp);
         }


### PR DESCRIPTION
### Description of Change ###
This requirement comes from VD to avoid memory leaks.

After modification, all nodes generated by XAML will be automatically as null.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
