### PR TITLE
[NUI][AT-SPI] Introduce AtspiEvents

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Picker.cs
+++ b/src/Tizen.NUI.Components/Controls/Picker.cs
@@ -526,6 +526,7 @@ namespace Tizen.NUI.Components
                 Name = idx.ToString(),
             };
 
+            temp.SetAccessibilityEventSuppressed(AccessibilityEvent.MovedOut, true);
             itemList.Add(temp);
             pickerScroller.Add(temp);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -150,6 +150,14 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr DaliAccessibilityEmitTextCursorMovedEvent(global::System.Runtime.InteropServices.HandleRef arg1, int arg2_pos);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_IsSuppressedEvent")]
+            public static extern bool DaliAccessibilityIsSuppressedEvent(global::System.Runtime.InteropServices.HandleRef arg1, int accessibilityEvent);
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetSuppressedEvent")]
+            public static extern void DaliAccessibilitySetSuppressedEvent(global::System.Runtime.InteropServices.HandleRef arg1, int accessibilityEvent, bool isSuppressed);
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_new_Range")]
             public static extern global::System.IntPtr DaliAccessibilityNewRange(int arg1_start, int arg2_end, string arg3_content);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -422,6 +422,31 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Gets a value indicating given accessibility event is suppressed.
+        /// </summary>
+        /// <param name="accessibilityEvent">The accessibility event</param>
+        /// <returns>True if given accessibility event is suppressed, otherwise false</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsAccessibilityEventSuppressed(AccessibilityEvent accessibilityEvent)
+        {
+            bool result = Interop.ControlDevel.DaliAccessibilityIsSuppressedEvent(SwigCPtr, (int)accessibilityEvent);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return result;
+        }
+
+        /// <summary>
+        /// Sets a suppressed value of given accessibility event.
+        /// </summary>
+        /// <param name="accessibilityEvent">The accessibility event</param>
+        /// <param name="isSuppressed">The value indicating given accessibility event is suppressed</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetAccessibilityEventSuppressed(AccessibilityEvent accessibilityEvent, bool isSuppressed)
+        {
+            Interop.ControlDevel.DaliAccessibilitySetSuppressedEvent(SwigCPtr, (int)accessibilityEvent, isSuppressed);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
         ///////////////////////////////////////////////////////////////////
         // ************************** Bridge *************************** //
         ///////////////////////////////////////////////////////////////////

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -606,6 +606,132 @@ namespace Tizen.NUI.BaseComponents
     }
 
     /// <summary>
+    /// Enumeration of possible AT-SPI events.
+    /// </summary>
+    /// <remarks>
+    /// Accessible can emit differty type of event.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum AccessibilityEvent
+    {
+        /// <summary>
+        /// Property changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        PropertyChanged         = 0,
+        /// <summary>
+        /// Bounds changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        BoundsChanged           = 1,
+        /// <summary>
+        /// Link selected event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        LinkSelected            = 2,
+        /// <summary>
+        /// State changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        StateChanged            = 3,
+        /// <summary>
+        /// Children changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ChildrenChanged         = 4,
+        /// <summary>
+        /// Visible data changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        VisibleDataChanged      = 5,
+        /// <summary>
+        /// Selection changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        SelectionChanged        = 6,
+        /// <summary>
+        /// Model changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ModelChanged            = 7,
+        /// <summary>
+        /// Active descendant changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ActiveDescendantChanged = 8,
+        /// <summary>
+        /// Row inserted event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        RowInserted             = 9,
+        /// <summary>
+        /// Row reordered event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        RowReordered            = 10,
+        /// <summary>
+        /// Row deleted event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        RowDeleted              = 11,
+        /// <summary>
+        /// Column inserted event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ColumnInserted          = 12,
+        /// <summary>
+        /// Column reordered event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ColumnReordered         = 13,
+        /// <summary>
+        /// Column deleted event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ColumnDeleted           = 14,
+        /// <summary>
+        /// Text bounds changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        TextBoundsChanged       = 15,
+        /// <summary>
+        /// Text selection changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        TextSelectionChanged    = 16,
+        /// <summary>
+        /// Text changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        TextChanged             = 17,
+        /// <summary>
+        /// Text attributes changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        TextAttributesChanged   = 18,
+        /// <summary>
+        /// Text caret moved event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        TextCaretMoved          = 19,
+        /// <summary>
+        /// Attributes changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        AttributesChanged       = 20,
+        /// <summary>
+        /// Moved out event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        MovedOut                = 21,
+        /// <summary>
+        /// Window changed event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        WindowChanged           = 22,
+    };
+
+    /// <summary>
     /// Notify mode for AccessibilityStates.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AtspiSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AtspiSample.cs
@@ -1,0 +1,51 @@
+﻿
+using System;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Samples
+{
+    public class AtspiSample : IExample
+    {
+        public void Activate()
+        {
+            Window window = NUIApplication.GetDefaultWindow();
+            window.BackgroundColor = Color.White;
+
+            TextLabel text = new TextLabel("PASS");
+            text.HorizontalAlignment = HorizontalAlignment.Center;
+            text.VerticalAlignment = VerticalAlignment.Center;
+            text.TextColor = Color.Blue;
+            text.PointSize = 12.0f;
+            text.HeightResizePolicy = ResizePolicyType.FillToParent;
+            text.WidthResizePolicy = ResizePolicyType.FillToParent;
+            window.Add(text);
+
+            if (text.IsAccessibilityEventSuppressed(AccessibilityEvent.MovedOut))
+            {
+                text.Text = "FAIL";
+                Tizen.Log.Error("NUITEST", "Default value shoud be false\n");
+                return;
+            }
+
+            text.SetAccessibilityEventSuppressed(AccessibilityEvent.MovedOut, true);
+            if (!text.IsAccessibilityEventSuppressed(AccessibilityEvent.MovedOut))
+            {
+                text.Text = "FAIL";
+                Tizen.Log.Error("NUITEST", "Cannot set to true\n");
+                return;
+            }
+
+            text.SetAccessibilityEventSuppressed(AccessibilityEvent.MovedOut, false);
+            if (text.IsAccessibilityEventSuppressed(AccessibilityEvent.MovedOut))
+            {
+                text.Text = "FAIL";
+                Tizen.Log.Error("NUITEST", "Cannot set to false\n");
+                return;
+            }
+        }
+
+        public void Deactivate()
+        {
+        }
+    }
+}


### PR DESCRIPTION
The AtspiEvents can be used for the event mask to suppress
specific event.

This is the second version to provide AtspiEvents.
The first version is
https://github.com/Samsung/TizenFX/pull/4019

Dependency:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/272794/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/272184/