### PR TITLE
[NUI] remove warning messages with refactoring collectionView bindableProperties

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -94,6 +94,7 @@ namespace Tizen.NUI.Components
             return instance.InternalDisappearingTransition;
         });
 
+        /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal BaseComponents.View LastFocusedView = null;
 

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -100,57 +100,6 @@ namespace Tizen.NUI.Components
                     return colView.selectionMode;
                 });
 
-        /// <summary>
-        /// Binding Property of items data source.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ItemsSourceProperty =
-            BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(CollectionView), null,
-                propertyChanged: (bindable, oldValue, newValue) =>
-                {
-                    var colView = (CollectionView)bindable;
-                    oldValue = colView.itemsSource;
-
-                    if (oldValue != null)
-                    {
-                        // Clearing old data!
-                        if (oldValue is INotifyCollectionChanged prevNotifyCollectionChanged)
-                        {
-                            prevNotifyCollectionChanged.CollectionChanged -= colView.CollectionChanged;
-                        }
-                        if (colView.selectedItem != null) colView.selectedItem = null;
-                        colView.selectedItems?.Clear();
-                    }
-
-                    colView.itemsSource = (IEnumerable)newValue;
-
-                    if (newValue == null)
-                    {
-                        colView.InternalItemSource?.Dispose();
-                        colView.InternalItemSource = null;
-                        colView.itemsLayouter?.Clear();
-                        colView.ClearCache();
-                        return;
-                    }
-                    if (newValue is INotifyCollectionChanged newNotifyCollectionChanged)
-                    {
-                        newNotifyCollectionChanged.CollectionChanged += colView.CollectionChanged;
-                    }
-
-                    colView.InternalItemSource?.Dispose();
-                    colView.InternalItemSource = ItemsSourceFactory.Create(colView);
-
-                    if (colView.itemsLayouter == null) return;
-
-                    colView.needInitalizeLayouter = true;
-                    colView.Init();
-                },
-                defaultValueCreator: (bindable) =>
-                {
-                    var colView = (CollectionView)bindable;
-                    return colView.itemsSource;
-                });
-
 
         private static readonly IList<object> selectEmpty = new List<object>(0);
         private DataTemplate itemTemplate = null;
@@ -167,8 +116,6 @@ namespace Tizen.NUI.Components
         private ItemSelectionMode selectionMode = ItemSelectionMode.None;
         private RecyclerViewItem header;
         private RecyclerViewItem footer;
-        private View focusedView;
-        private int prevFocusedDataIndex = 0;
         private List<RecyclerViewItem> recycleGroupHeaderCache { get; } = new List<RecyclerViewItem>();
         private List<RecyclerViewItem> recycleGroupFooterCache { get; } = new List<RecyclerViewItem>();
         private bool delayedScrollTo;
@@ -255,8 +202,53 @@ namespace Tizen.NUI.Components
         /// <since_tizen> 9 </since_tizen>
         public override IEnumerable ItemsSource
         {
-            get => (IEnumerable)GetValue(ItemsSourceProperty);
-            set => SetValue(ItemsSourceProperty, value);
+            get => (IEnumerable)GetValue(RecyclerView.ItemsSourceProperty);
+            set => SetValue(RecyclerView.ItemsSourceProperty, value);
+        }
+
+        internal override IEnumerable InternalItemsSource
+        {
+            get
+            {
+                return itemsSource;
+            }
+            set
+            {
+                if (itemsSource != null)
+                {
+                    // Clearing old data!
+                    if (itemsSource is INotifyCollectionChanged prevNotifyCollectionChanged)
+                    {
+                        prevNotifyCollectionChanged.CollectionChanged -= CollectionChanged;
+                    }
+                    if (selectedItem != null) selectedItem = null;
+                    selectedItems?.Clear();
+                }
+
+                itemsSource = (IEnumerable)value;
+
+                if (itemsSource == null)
+                {
+                    InternalItemSource?.Dispose();
+                    InternalItemSource = null;
+                    itemsLayouter?.Clear();
+                    ClearCache();
+                    return;
+                }
+                if (itemsSource is INotifyCollectionChanged newNotifyCollectionChanged)
+                {
+                    newNotifyCollectionChanged.CollectionChanged += CollectionChanged;
+                }
+
+                InternalItemSource?.Dispose();
+                InternalItemSource = ItemsSourceFactory.Create(this);
+
+                if (itemsLayouter == null) return;
+
+                needInitalizeLayouter = true;
+                Init();
+
+            }
         }
 
         /// <summary>
@@ -278,7 +270,7 @@ namespace Tizen.NUI.Components
                 NotifyPropertyChanged();
             }
         }
-        private DataTemplate InternalItemTemplate
+        internal override DataTemplate InternalItemTemplate
         {
             get
             {
@@ -317,7 +309,11 @@ namespace Tizen.NUI.Components
                 NotifyPropertyChanged();
             }
         }
-        private ItemsLayouter InternalItemsLayouter
+
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override ItemsLayouter InternalItemsLayouter
         {
             get
             {

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionViewBindableProperty.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionViewBindableProperty.cs
@@ -6,23 +6,6 @@ namespace Tizen.NUI.Components
 {
     public partial class CollectionView
     {
-        /// <summary>
-        /// ItemTemplateProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly new BindableProperty ItemTemplateProperty = BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(CollectionView), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var instance = (CollectionView)bindable;
-            if (newValue != null)
-            {
-                instance.InternalItemTemplate = newValue as DataTemplate;
-            }
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var instance = (CollectionView)bindable;
-            return instance.InternalItemTemplate;
-        });
 
         /// <summary>
         /// ItemsLayouterProperty

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI.Components
         /// Property of boolean Enable flag.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly BindableProperty IsEnabledProperty = View.IsEnabledProperty;
+        public new static readonly BindableProperty IsEnabledProperty = View.IsEnabledProperty;
 
         /// <summary>
         /// Property of boolean Selected flag.

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
@@ -88,7 +88,7 @@ namespace Tizen.NUI.Components
                 NotifyPropertyChanged();
             }
         }
-        private IEnumerable InternalItemsSource { get; set; }
+        internal virtual IEnumerable InternalItemsSource { get; set; }
 
         /// <summary>
         /// DataTemplate for items.
@@ -106,7 +106,7 @@ namespace Tizen.NUI.Components
                 NotifyPropertyChanged();
             }
         }
-        private DataTemplate InternalItemTemplate { get; set; }
+        internal virtual DataTemplate InternalItemTemplate { get; set; }
 
         /// <summary>
         /// Internal encapsulated items data source.
@@ -123,7 +123,7 @@ namespace Tizen.NUI.Components
         /// Internal Items Layouter.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected ItemsLayouter InternalItemsLayouter { get; set; }
+        protected virtual ItemsLayouter InternalItemsLayouter { get; set; }
 
         /// <summary>
         /// Max size of RecycleCache. Default is 50.
@@ -333,7 +333,7 @@ namespace Tizen.NUI.Components
             if (item == null) return;
             item.Index = -1;
             item.ParentItemsView = null;
-            item.BindingContext = null; 
+            item.BindingContext = null;
             item.IsPressed = false;
             item.IsSelected = false;
             item.IsEnabled = true;
@@ -412,7 +412,7 @@ namespace Tizen.NUI.Components
 
         /// <summary>
         /// On scroll event callback.
-        /// </summary>        
+        /// </summary>
         /// <since_tizen> 9 </since_tizen>
         protected virtual void OnScrolling(object source, ScrollEventArgs args)
         {


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->


fix buildwarnings in NUI Components.

_Controls/RecyclerView/Item/RecyclerViewItem.cs(33,49): warning CS0108: 'RecyclerViewItem.IsEnabledProperty' hides inherited member 'View.IsEnabledProperty'. Use the new keyword if hiding was intended. [/home/sh10233lee/dev/Branch/TizenFX/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj]_
=>
**add new key.**

_Controls/RecyclerView/CollectionView.cs(107,49): warning CS0108: 'CollectionView.ItemsSourceProperty' hides inherited member 'RecyclerView.ItemsSourceProperty'. Use the new keyword if hiding was intended. [/home/sh10233lee/dev/Branch/TizenFX/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj]_
=>
**remove ItemsSourceProperty and use RecyclerView's.
also change private internalItemsSource to internal virtual to override.**

_Controls/RecyclerView/CollectionView.cs(320,31): warning CS0108: 'CollectionView.InternalItemsLayouter' hides inherited member 'RecyclerView.InternalItemsLayouter'. Use the new keyword if hiding was intended. [/home/sh10233lee/dev/Branch/TizenFX/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj]_
=>
**remove ItemsLayouterProperty and use RecyclerView's.
also change private internalItemsLayouter to internal virtual to override.**

_Controls/RecyclerView/CollectionView.cs(170,22): warning CS0169: The field 'CollectionView.focusedView' is never used [/home/sh10233lee/dev/Branch/TizenFX/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj]
Controls/RecyclerView/CollectionView.cs(171,21): warning CS0414: The field 'CollectionView.prevFocusedDataIndex' is assigned but its value is never used [/home/sh10233lee/dev/Branch/TizenFX/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj]_
=>
**removed.**

_Controls/Navigation/Page.cs(98,48): warning CS1591: Missing XML comment for publicly visible type or member 'Page.LastFocusedView' [/home/sh10233lee/dev/Branch/TizenFX/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj]_
=>
**add inherit doc.**

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
