### PR TITLE
[NUI] Add GetWindow() to View

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1334,6 +1334,29 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        internal Window GetWindow()
+        {
+            Window win = null;
+
+            Container temp = GetParent();
+            Container parent = temp;
+
+            while (parent != null)
+            {
+                temp = parent.GetParent();
+                if (temp == null) break;
+
+                parent = temp;
+            }
+
+            if (parent != null)
+            {
+                var rootLayer = parent as Layer;
+                win = rootLayer.GetWindow();
+            }
+
+            return win;
+        }
 
         private void DisConnectFromSignals()
         {

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -727,6 +727,11 @@ namespace Tizen.NUI
             }
         }
 
+        internal Window GetWindow()
+        {
+            return window;
+        }
+
         internal uint GetId()
         {
             uint ret = Interop.Actor.GetId(SwigCPtr);


### PR DESCRIPTION
In NUI, there are some codes which use default window although the codes
are related to other window.
e.g. layout transition codes are attached to the default window.

To resolve the above issue, View provides GetWindow() internally.
To make View provide GetWindow(), Layer also provides GetWindow().

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
