### PR TITLE
[NUI] Fix to disable ThemeManager in tv profile

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -486,7 +486,9 @@ namespace Tizen.NUI
         static public void Preload()
         {
             Interop.Application.PreInitialize();
+#if ExternalThemeEnabled
             ThemeManager.Preload();
+#endif
             IsPreload = true;
         }
 

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -53,7 +53,9 @@ namespace Tizen.NUI
 
         static ThemeManager()
         {
+#if ExternalThemeEnabled
             ExternalThemeManager.Initialize();
+#endif
             AddPackageTheme(DefaultThemeCreator.Instance);
         }
 


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix to disable ThemeManager in tv profile
- in some place, `ExternalThemeEnabled` macro has to be inserted to avoid appfw-tizen-theme so loading.

### API Changes ###
none