### PR TITLE
[NUI] application: remove unnecessary reference count increments

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -1266,7 +1266,18 @@ namespace Tizen.NUI
                 return window;
             }
 
-            window = (Registry.GetManagedBaseHandleFromNativePtr(Interop.Application.GetWindow(SwigCPtr)) as Window) ?? new Window(Interop.Application.GetWindow(SwigCPtr), true);
+            var nativeWindow = Interop.Application.GetWindow(SwigCPtr);
+            window = Registry.GetManagedBaseHandleFromNativePtr(nativeWindow) as Window;
+            if (window != null)
+            {
+                HandleRef CPtr = new HandleRef(this, nativeWindow);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new HandleRef(null, IntPtr.Zero);
+            }
+            else
+            {
+                window = new Window(nativeWindow, true);
+            }
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return window;
@@ -1302,7 +1313,7 @@ namespace Tizen.NUI
             List<Window> WindowList = new List<Window>();
             for (uint i = 0; i < ListSize; ++i)
             {
-                Window currWin = Registry.GetManagedBaseHandleFromNativePtr(Interop.Application.GetWindowsFromList(i)) as Window;
+                Window currWin = WindowList.GetInstanceSafely<Window>(Interop.Application.GetWindowsFromList(i));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 if (currWin != null)
                 {


### PR DESCRIPTION
The GetWindow increases reference count of the Dali Window.
So there was no chance to call the Window destructor.