### PR TITLE
[NUI] Remove some potential of memory leak

### DIFF
--- a/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
@@ -176,9 +176,10 @@ namespace Tizen.NUI
         /// <since_tizen> 4 </since_tizen>
         public Animatable GetTarget()
         {
-            BaseHandle ret = Registry.GetManagedBaseHandleFromNativePtr(Interop.PropertyNotification.GetTarget(SwigCPtr));
+            //to fix memory leak issue, match the handle count with native side.
+            Animatable ret = this.GetInstanceSafely<Animatable>(Interop.PropertyNotification.GetTarget(SwigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret as Animatable;
+            return ret;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -79,8 +79,9 @@ namespace Tizen.NUI
                 return null;
             }
 
-            Window ret = Registry.GetManagedBaseHandleFromNativePtr(Interop.Window.Get(View.getCPtr(view))) as Window;
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            //to fix memory leak issue, match the handle count with native side.
+            Window ret = view.GetInstanceSafely<Window>(Interop.Window.Get(View.getCPtr(view)));
+            if (NDalicPINVOKE.SWIGPendingException.Pending)throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
@@ -1211,7 +1212,7 @@ namespace Tizen.NUI
             {
                 NUILog.Error("This device does not support surfaceless_context. So Window cannot be created. ");
             }
-            Window ret = Registry.GetManagedBaseHandleFromNativePtr(Interop.Window.GetParent(SwigCPtr)) as Window;
+            Window ret = this.GetInstanceSafely<Window>(Interop.Window.GetParent(SwigCPtr));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
Some Interop API required Delete pairwisely.
This is cause IntPtr have same role as Native size's BaseHandle.
It mean, they increase Native side reference count of BaseObject,
and should decrease the reference by delete it self.
But that IntPtr created in c++ side, so also should delete in c++ side.

Registry.cs use IntPtr as Key so, some API us it as wrong way.
If someone find matched value in Registry, it is just one of BaseHandle.
inputed IntPtr required to delete but some API didn't delete it!

This patch find that case, and make them remove well.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
