### PR TITLE
[NUI] Add VerticalAlignment in TextEditor

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -39,6 +39,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_HORIZONTAL_ALIGNMENT_get")]
             public static extern int HorizontalAlignmentGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_VERTICAL_ALIGNMENT_get")]
+            public static extern int VerticalAlignmentGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_SCROLL_THRESHOLD_get")]
             public static extern int ScrollThresholdGet();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
@@ -69,6 +69,12 @@ namespace Tizen.NUI.BaseComponents
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).horizontalAlignment = (HorizontalAlignment?)newValue,
             defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).horizontalAlignment);
 
+        /// <summary> The bindable property of VerticalAlignment. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment?), typeof(TextEditorStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).verticalAlignment = (VerticalAlignment?)newValue,
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).verticalAlignment);
+
         /// <summary> The bindable property of SecondaryCursorColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty SecondaryCursorColorProperty = BindableProperty.Create(nameof(SecondaryCursorColor), typeof(Vector4), typeof(TextEditorStyle), null,
@@ -258,6 +264,7 @@ namespace Tizen.NUI.BaseComponents
         });
 
         private HorizontalAlignment? horizontalAlignment;
+        private VerticalAlignment? verticalAlignment;
         private Vector4 secondaryCursorColor;
         private bool? enableCursorBlink;
         private float? cursorBlinkInterval;
@@ -321,6 +328,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (HorizontalAlignment?)GetValue(HorizontalAlignmentProperty);
             set => SetValue(HorizontalAlignmentProperty, value);
+        }
+
+        /// <summary>
+        /// The VerticalAlignment property.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VerticalAlignment? VerticalAlignment
+        {
+            get => (VerticalAlignment?)GetValue(VerticalAlignmentProperty);
+            set => SetValue(VerticalAlignmentProperty, value);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -328,6 +328,24 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The VerticalAlignment property.<br />
+        /// The line vertical alignment.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VerticalAlignment VerticalAlignment
+        {
+            get
+            {
+                return (VerticalAlignment)GetValue(VerticalAlignmentProperty);
+            }
+            set
+            {
+                SetValue(VerticalAlignmentProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The ScrollThreshold property.<br />
         /// Horizontal scrolling will occur if the cursor is this close to the control border.<br />
         /// </summary>
@@ -2525,6 +2543,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int FontStyle = Interop.TextEditor.FontStyleGet();
             internal static readonly int PointSize = Interop.TextEditor.PointSizeGet();
             internal static readonly int HorizontalAlignment = Interop.TextEditor.HorizontalAlignmentGet();
+            internal static readonly int VerticalAlignment = Interop.TextEditor.VerticalAlignmentGet();
             internal static readonly int ScrollThreshold = Interop.TextEditor.ScrollThresholdGet();
             internal static readonly int ScrollSpeed = Interop.TextEditor.ScrollSpeedGet();
             internal static readonly int PrimaryCursorColor = Interop.TextEditor.PrimaryCursorColorGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -132,6 +132,26 @@ namespace Tizen.NUI.BaseComponents
 
             return temp.GetValueByDescription<HorizontalAlignment>();
         }));
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment), typeof(TextEditor), VerticalAlignment.Bottom, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            string temp;
+            if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment).Get(out temp) == false)
+            {
+                NUILog.Error("VerticalAlignment get error!");
+            }
+
+            return temp.GetValueByDescription<VerticalAlignment>();
+        }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollThresholdProperty = BindableProperty.Create(nameof(ScrollThreshold), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextEditor.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextEditor.cs
@@ -229,5 +229,33 @@ namespace Tizen.NUI.Devel.Tests
             testingTarget.Dispose();
             tlog.Debug(tag, $"TextEditorCharacterSpacing END (OK)");
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextEditor VerticalAlignment.")]
+        [Property("SPEC", "Tizen.NUI.TextEditor.VerticalAlignment A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "CONSTR")]
+        [Property("AUTHOR", "bowon.ryu@samsung.com")]
+        public void TextEditorVerticalAlignment()
+        {
+            tlog.Debug(tag, $"TextEditorVerticalAlignment START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            testingTarget.VerticalAlignment = VerticalAlignment.Bottom;
+            Assert.AreEqual(VerticalAlignment.Bottom, testingTarget.VerticalAlignment, "Should be equal!");
+
+            testingTarget.VerticalAlignment = VerticalAlignment.Top;
+            Assert.AreEqual(VerticalAlignment.Top, testingTarget.VerticalAlignment, "Should be equal!");
+
+            testingTarget.VerticalAlignment = VerticalAlignment.Center;
+            Assert.AreEqual(VerticalAlignment.Center, testingTarget.VerticalAlignment, "Should be equal!");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"TextEditorVerticalAlignment END (OK)");
+        }
     }
 }


### PR DESCRIPTION
editor.VerticalAlignment = VerticalAlignment.Top;
editor.VerticalAlignment = VerticalAlignment.Center;
editor.VerticalAlignment = VerticalAlignment.Bottom;

dali patches:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/273039/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/273582/

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>