### PR TITLE
[NUI] Add Null check in Slider Dispose

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1651,8 +1651,11 @@ namespace Tizen.NUI.Components
                 this.TouchEvent -= OnTouchEventForTrack;
 
                 recoverIndicator = null;
-                editModeIndicator.Dispose();
-                editModeIndicator = null;
+                if (editModeIndicator != null)
+                {
+                    editModeIndicator.Dispose();
+                    editModeIndicator = null;
+                }
             }
 
             base.Dispose(type);


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- 'editModeIndicator' of Slider class is not created all the time.
 So, added Null check for this variable when Dispose() is called.


### API Changes ###
- N/A