### PR TITLE
[NUI][XamlBinding] Unifying the delimiter for TypeConverter.

### DIFF
--- a/src/Tizen.NUI/src/internal/XamlBinding/ExtentsTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/ExtentsTypeConverter.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 4)
                 {
                     return new Extents((ushort)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim()),
@@ -49,7 +49,7 @@ namespace Tizen.NUI.Binding
         public override string ConvertToString(object value)
         {
             Extents extents = (Extents)value;
-            return extents.Start.ToString() + " " + extents.End.ToString() + " " + extents.Top.ToString() + " " + extents.Bottom.ToString();
+            return extents.Start.ToString() + TypeConverter.UnifiedDelimiter + extents.End.ToString() + TypeConverter.UnifiedDelimiter + extents.Top.ToString() + TypeConverter.UnifiedDelimiter + extents.Bottom.ToString();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/XamlBinding/ListStringTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/ListStringTypeConverter.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI.Binding
             if (value == null)
                 return null;
 
-            return value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList();
+            return value.Split(new[] { TypeConverter.UnifiedDelimiter }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/XamlBinding/PositionTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/PositionTypeConverter.cs
@@ -73,7 +73,7 @@ namespace Tizen.NUI.Binding
                     }
                 }
 
-                parts = value.Split(',');
+                parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 3)
                 {
                     int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
@@ -99,7 +99,7 @@ namespace Tizen.NUI.Binding
             Position position = value as Position;
             if (null != position)
             {
-                return position.X.ToString() + " " + position.Y.ToString() + " " + position.Z.ToString();
+                return position.X.ToString() + TypeConverter.UnifiedDelimiter + position.Y.ToString() + TypeConverter.UnifiedDelimiter + position.Z.ToString();
             }
             else
             {
@@ -126,7 +126,7 @@ namespace Tizen.NUI.Binding
             Position2D position = value as Position2D;
             if (null != position)
             {
-                return position.X.ToString() + " " + position.Y.ToString();
+                return position.X.ToString() + TypeConverter.UnifiedDelimiter + position.Y.ToString();
             }
             else
             {

--- a/src/Tizen.NUI/src/internal/XamlBinding/RectangleTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/RectangleTypeConverter.cs
@@ -36,7 +36,7 @@ namespace Tizen.NUI.Binding
             if (value != null)
             {
                 double x, y, w, h;
-                string[] xywh = value.Split(',');
+                string[] xywh = value.Split(TypeConverter.UnifiedDelimiter);
                 if (xywh.Length == 4)
                 {
                     x = GraphicsTypeManager.Instance.ConvertScriptToPixel(xywh[0]);
@@ -57,7 +57,7 @@ namespace Tizen.NUI.Binding
             Rectangle rect = value as Rectangle;
             if (null != rect)
             {
-                return rect.X.ToString() + " " + rect.Y.ToString() + " " + rect.Width.ToString() + " " + rect.Height.ToString();
+                return rect.X.ToString() + TypeConverter.UnifiedDelimiter + rect.Y.ToString() + TypeConverter.UnifiedDelimiter + rect.Width.ToString() + TypeConverter.UnifiedDelimiter + rect.Height.ToString();
             }
             else
             {

--- a/src/Tizen.NUI/src/internal/XamlBinding/RotationTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/RotationTypeConverter.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI.Binding
             // Orientation="R:23, 0, 0, 1"
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 4)
                 {
                     bool useDefault = true;

--- a/src/Tizen.NUI/src/internal/XamlBinding/VectorTypeConverter.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/VectorTypeConverter.cs
@@ -50,7 +50,7 @@ namespace Tizen.NUI.Binding
 
         internal static Vector2 FromString(string value)
         {
-            var parts = value.Split(',');
+            var parts = value.Split(TypeConverter.UnifiedDelimiter);
 
             if (parts.Length == 2)
             {
@@ -69,7 +69,7 @@ namespace Tizen.NUI.Binding
         {
             if (null != value)
             {
-                return value.X.ToString() + " " + value.Y.ToString();
+                return value.X.ToString() + TypeConverter.UnifiedDelimiter + value.Y.ToString();
             }
             else
             {
@@ -88,7 +88,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 3)
                 {
                     return new Vector3(Single.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
@@ -120,7 +120,7 @@ namespace Tizen.NUI.Binding
             Vector3 vector = value as Vector3;
             if (null != vector)
             {
-                return vector.X.ToString() + " " + vector.Y.ToString() + " " + vector.Z.ToString();
+                return vector.X.ToString() + TypeConverter.UnifiedDelimiter + vector.Y.ToString() + TypeConverter.UnifiedDelimiter + vector.Z.ToString();
             }
             else
             {
@@ -139,7 +139,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 4)
                 {
                     return new Vector4(Single.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
@@ -181,7 +181,7 @@ namespace Tizen.NUI.Binding
             Vector4 vector = value as Vector4;
             if (null != vector)
             {
-                return vector.X.ToString() + " " + vector.Y.ToString() + " " + vector.Z.ToString() + " " + vector.W.ToString();
+                return vector.X.ToString() + TypeConverter.UnifiedDelimiter + vector.Y.ToString() + TypeConverter.UnifiedDelimiter + vector.Z.ToString() + TypeConverter.UnifiedDelimiter + vector.W.ToString();
             }
             else
             {
@@ -200,7 +200,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 2)
                 {
                     return new RelativeVector2(Single.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
@@ -223,7 +223,7 @@ namespace Tizen.NUI.Binding
             RelativeVector2 vector = value as RelativeVector2;
             if (null != vector)
             {
-                return vector.X.ToString() + " " + vector.Y.ToString();
+                return vector.X.ToString() + TypeConverter.UnifiedDelimiter + vector.Y.ToString();
             }
             else
             {
@@ -242,7 +242,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 3)
                 {
                     return new RelativeVector3(Single.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
@@ -274,7 +274,7 @@ namespace Tizen.NUI.Binding
             RelativeVector3 vector = value as RelativeVector3;
             if (null != vector)
             {
-                return vector.X.ToString() + " " + vector.Y.ToString() + " " + vector.Z.ToString();
+                return vector.X.ToString() + TypeConverter.UnifiedDelimiter + vector.Y.ToString() + TypeConverter.UnifiedDelimiter + vector.Z.ToString();
             }
             else
             {
@@ -293,7 +293,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 4)
                 {
                     return new RelativeVector4(Single.Parse(parts[0].Trim(), CultureInfo.InvariantCulture),
@@ -335,7 +335,7 @@ namespace Tizen.NUI.Binding
             RelativeVector4 vector = value as RelativeVector4;
             if (null != vector)
             {
-                return vector.X.ToString() + " " + vector.Y.ToString() + " " + vector.Z.ToString() + " " + vector.W.ToString();
+                return vector.X.ToString() + TypeConverter.UnifiedDelimiter + vector.Y.ToString() + TypeConverter.UnifiedDelimiter + vector.Z.ToString() + TypeConverter.UnifiedDelimiter + vector.W.ToString();
             }
             else
             {

--- a/src/Tizen.NUI/src/public/XamlBinding/ColorTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/ColorTypeConverter.cs
@@ -44,7 +44,7 @@ namespace Tizen.NUI.Binding
                     return FromHex(value);
                 }
 
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 1) //like Red or Color.Red
                 {
                     parts = value.Split('.');
@@ -159,7 +159,7 @@ namespace Tizen.NUI.Binding
             if (value != null)
             {
                 Color color = (Color)value;
-                return color.R.ToString() + " " + color.G.ToString() + " " + color.B.ToString() + " " + color.A.ToString();
+                return color.R.ToString() + TypeConverter.UnifiedDelimiter + color.G.ToString() + TypeConverter.UnifiedDelimiter + color.B.ToString() + TypeConverter.UnifiedDelimiter + color.A.ToString();
             }
             return "";
         }

--- a/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/SizeTypeConverter.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 3)
                 {
                     int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
@@ -63,7 +63,7 @@ namespace Tizen.NUI.Binding
             if (value != null)
             {
                 Size size = (Size)value;
-                return size.Width.ToString() + " " + size.Height.ToString() + " " + size.Depth.ToString();
+                return size.Width.ToString() + TypeConverter.UnifiedDelimiter + size.Height.ToString() + TypeConverter.UnifiedDelimiter + size.Depth.ToString();
             }
             return "";
         }
@@ -80,7 +80,7 @@ namespace Tizen.NUI.Binding
         {
             if (value != null)
             {
-                string[] parts = value.Split(',');
+                string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
                 if (parts.Length == 2)
                 {
                     int x = (int)GraphicsTypeManager.Instance.ConvertScriptToPixel(parts[0].Trim());
@@ -99,7 +99,7 @@ namespace Tizen.NUI.Binding
             if (value != null)
             {
                 Size2D size = (Size2D)value;
-                return size.Width.ToString() + " " + size.Height.ToString();
+                return size.Width.ToString() + TypeConverter.UnifiedDelimiter + size.Height.ToString();
             }
             return "";
         }

--- a/src/Tizen.NUI/src/public/XamlBinding/TypeConverter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/TypeConverter.cs
@@ -24,6 +24,8 @@ namespace Tizen.NUI.Binding
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class TypeConverter
     {
+        internal const char UnifiedDelimiter = ',';
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool CanConvertFrom(Type sourceType)


### PR DESCRIPTION
### Description of Change ###
This requirement comes from 'develop mode'

For TypeConverter, ConvertFromInvariantString() & ConvertToString() use ',' and ' ' as delimiter respectively.
SizeTypeConveter, for example:

        public override object ConvertFromInvariantString(string value)
        {
            ......
            string[] parts = value.Split(',');
            ......
        }

        public override string ConvertToString(object value)
        {
            ......
            return size.Width.ToString() + ' ' + size.Height.ToString() + ' ' + size.Depth.ToString();
			......
        }

Now we use ',' as delimiter, after modification:

	public override object ConvertFromInvariantString(string value)
        {
            ......
            string[] parts = value.Split(TypeConverter.UnifiedDelimiter);
            ......
        }

        public override string ConvertToString(object value)
        {
            ......
            return size.Width.ToString() + TypeConverter.UnifiedDelimiter + size.Height.ToString() + TypeConverter.UnifiedDelimiter + size.Depth.ToString();
            ......
        }


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
