### PR TITLE
[NUI][XamlBuild] Set ExitXaml() as internal method.

### DIFF
--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
@@ -448,7 +448,8 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             var exitXamlComp = new CodeMemberMethod()
             {
                 Name = "ExitXaml",
-                CustomAttributes = { GeneratedCodeAttrDecl }
+                CustomAttributes = { GeneratedCodeAttrDecl },
+                Attributes = MemberAttributes.Assembly | MemberAttributes.Final
             };
 
             exitXamlComp.Statements.Add(new CodeMethodInvokeExpression(new CodeMethodReferenceExpression()


### PR DESCRIPTION
### Description of Change ###
**Sync from API10.**

This requirement comes from VD.

Before modification:
[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Tizen.NUI.Xaml.Build.Tasks.XamlG", "1.0.6.0")]
private void ExitXaml() {
......
}

After modification:
[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Tizen.NUI.Xaml.Build.Tasks.XamlG", "1.0.6.0")]
internal void ExitXaml() {
......
}


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
