### PR TITLE
[NUI][XamlBuild] Fix build error when calling ExitXaml() if XamlOptimization set as 0.

### DIFF
--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
@@ -368,7 +368,15 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 initcomp.Statements.Add(new CodeMethodInvokeExpression(
                     new CodeTypeReferenceExpression(new CodeTypeReference($"global::{typeof(Extensions).FullName}")),
                     "LoadFromXaml", new CodeThisReferenceExpression(), new CodeTypeOfExpression(declType.Name)));
-			}
+
+                var exitXamlComp = new CodeMemberMethod()
+                {
+                    Name = "ExitXaml",
+                    CustomAttributes = { GeneratedCodeAttrDecl },
+                    Attributes = MemberAttributes.Assembly | MemberAttributes.Final
+                };
+                declType.Members.Add(exitXamlComp);
+            }
             else
 			{
                 var loadExaml_invoke = new CodeMethodInvokeExpression(

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
@@ -448,7 +448,8 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             var exitXamlComp = new CodeMemberMethod()
             {
                 Name = "ExitXaml",
-                CustomAttributes = { GeneratedCodeAttrDecl }
+                CustomAttributes = { GeneratedCodeAttrDecl },
+                Attributes = MemberAttributes.Assembly | MemberAttributes.Final
             };
 
             exitXamlComp.Statements.Add(new CodeMethodInvokeExpression(new CodeMethodReferenceExpression()


### PR DESCRIPTION
### Description of Change ###
**Sync from API10.**

This issue was reported by VD, If XamlOptimization set as 0, call ExitXaml would throw the exception : Error CS0103 The name 'ExitXaml' does not exist in the current context.

The reason:
Because the option 0 will not generate the method ExitXaml, so it will cause the build error.

Solution:
Generate an empty 'ExitXaml' method in the *.g.cs file.

After modification:
[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Tizen.NUI.Xaml.Build.Tasks.XamlG", "4.0.0.0")]
internal void ExitXaml() {
}

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
