### PR TITLE
[NUI][AT-SPI] Window: add highlight signal

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowAccessibilityHighlightSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowAccessibilityHighlightSignal.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WindowAccessibilityHighlightSignal
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal")]
+            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Empty")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef signalType);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_GetConnectionCount")]
+            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef signalType);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Connect")]
+            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef callback);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_Disconnect")]
+            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef callback);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Accessibility_Highlight_Signal_delete")]
+            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef signalType);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Window/WindowAccessibilityHighlightEvent.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowAccessibilityHighlightEvent.cs
@@ -1,0 +1,70 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal class WindowAccessibilityHighlightEvent : Disposable
+    {
+        internal WindowAccessibilityHighlightEvent(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        public WindowAccessibilityHighlightEvent(Window window) : this(Interop.WindowAccessibilityHighlightSignal.GetSignal(Window.getCPtr(window)), false)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WindowAccessibilityHighlightSignal.DeleteSignal(swigCPtr);
+        }
+
+        public bool Empty()
+        {
+            bool ret = Interop.WindowAccessibilityHighlightSignal.Empty(SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public uint GetConnectionCount()
+        {
+            uint ret = Interop.WindowAccessibilityHighlightSignal.GetConnectionCount(SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowAccessibilityHighlightSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowAccessibilityHighlightSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -1224,6 +1224,79 @@ namespace Tizen.NUI
             }
         }
 
+        /// <summary>
+        /// AccessibilityHighlightArgs
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public class AccessibilityHighlightEventArgs : EventArgs
+        {
+            private bool accessibilityHighlight;
+            /// <summary>
+            /// accessibilityHighlight
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public bool AccessibilityHighlight
+            {
+                get => accessibilityHighlight;
+                set
+                {
+                    accessibilityHighlight = value;
+                }
+            }
+        }
 
+        private void OnAccessibilityHighlight(IntPtr window, bool highlight)
+        {
+            if (window == global::System.IntPtr.Zero)
+            {
+                NUILog.Error("[ERR] OnAccessibilityHighlight() window is null");
+                return;
+            }
+
+            AccessibilityHighlightEventArgs e = new AccessibilityHighlightEventArgs();
+            e.AccessibilityHighlight = highlight;
+            if (AccessibilityHighlightEventHandler != null)
+            {
+                AccessibilityHighlightEventHandler.Invoke(this, e);
+            }
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate void AccessibilityHighlightEventCallbackType(IntPtr window, bool highlight);
+        private AccessibilityHighlightEventCallbackType AccessibilityHighlightEventCallback;
+        private event EventHandler<AccessibilityHighlightEventArgs> AccessibilityHighlightEventHandler;
+        private WindowAccessibilityHighlightEvent AccessibilityHighlightEventSignal;
+
+        /// <summary>
+        /// Emits the event when the window needs to grab or clear highlight.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<AccessibilityHighlightEventArgs> AccessibilityHighlight
+        {
+            add
+            {
+                if (AccessibilityHighlightEventHandler == null)
+                {
+                    AccessibilityHighlightEventCallback = OnAccessibilityHighlight;
+                    AccessibilityHighlightEventSignal = new WindowAccessibilityHighlightEvent(this);
+                    AccessibilityHighlightEventSignal.Connect(AccessibilityHighlightEventCallback);
+                }
+                AccessibilityHighlightEventHandler += value;
+            }
+            remove
+            {
+                AccessibilityHighlightEventHandler -= value;
+                if (AccessibilityHighlightEventHandler == null)
+                {
+                    if (AccessibilityHighlightEventSignal != null)
+                    {
+                        if (AccessibilityHighlightEventSignal.Empty() == false)
+                        {
+                            AccessibilityHighlightEventSignal.Disconnect(AccessibilityHighlightEventCallback);
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AtspiSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AtspiSample.cs
@@ -42,6 +42,13 @@ namespace Tizen.NUI.Samples
                 Tizen.Log.Error("NUITEST", "Cannot set to false\n");
                 return;
             }
+
+            window.AccessibilityHighlight += OnWindowAccessibilityHighlight;
+        }
+
+        private void OnWindowAccessibilityHighlight(object sender, Window.AccessibilityHighlightEventArgs e)
+        {
+            Tizen.Log.Info("NUITEST", "Accessibility Highlight: " + e.AccessibilityHighlight + "\n");
         }
 
         public void Deactivate()


### PR DESCRIPTION
The Window will highlight itself on NUI side.
The GrabHighlight emits the Highlight signal.

This signal will be used for changing window border color or others
to indicate the NUI window is selected on the multi-window environment.
This is NOT used for the screen-reader.

Dependency:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/273682/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/273683/