### PR TITLE
[NUI][Xaml] Fix issue that the Xaml element which has the created-in-csharp parent will not be disposed when exit xaml

### DIFF
--- a/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
+++ b/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
@@ -56,10 +56,11 @@ namespace Tizen.NUI.EXaml
                 {
                     var child = container.Children[i];
 
+                    DisposeXamlElements(child);
+
                     if (child.IsCreateByXaml)
                     {
                         child.Unparent();
-                        DisposeXamlElements(child);
                         child.Dispose();
                     }
                 }


### PR DESCRIPTION
### Description of Change ###
[NUI][Xaml] Fix issue that the Xaml element which has the created-in-csharp parent will not be disposed when exit xaml


### API Changes ###
none