### PR TITLE
[NUI][AT-SPI] Add indexable AccessibilitySuppressedEvents

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Picker.cs
+++ b/src/Tizen.NUI.Components/Controls/Picker.cs
@@ -526,7 +526,7 @@ namespace Tizen.NUI.Components
                 Name = idx.ToString(),
             };
 
-            temp.SetAccessibilityEventSuppressed(AccessibilityEvent.MovedOut, true);
+            temp.AccessibilitySuppressedEvents[AccessibilityEvent.MovedOut] = true;
             itemList.Add(temp);
             pickerScroller.Add(temp);
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -423,28 +423,15 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Gets a value indicating given accessibility event is suppressed.
+        /// Modifiable collection of suppressed AT-SPI events (D-Bus signals).
         /// </summary>
-        /// <param name="accessibilityEvent">The accessibility event</param>
-        /// <returns>True if given accessibility event is suppressed, otherwise false</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsAccessibilityEventSuppressed(AccessibilityEvent accessibilityEvent)
+        public AccessibilityEvents AccessibilitySuppressedEvents
         {
-            bool result = Interop.ControlDevel.DaliAccessibilityIsSuppressedEvent(SwigCPtr, (int)accessibilityEvent);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return result;
-        }
-
-        /// <summary>
-        /// Sets a suppressed value of given accessibility event.
-        /// </summary>
-        /// <param name="accessibilityEvent">The accessibility event</param>
-        /// <param name="isSuppressed">The value indicating given accessibility event is suppressed</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetAccessibilityEventSuppressed(AccessibilityEvent accessibilityEvent, bool isSuppressed)
-        {
-            Interop.ControlDevel.DaliAccessibilitySetSuppressedEvent(SwigCPtr, (int)accessibilityEvent, isSuppressed);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            get
+            {
+                return new AccessibilityEvents {Owner = this};
+            }
         }
 
         ///////////////////////////////////////////////////////////////////

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -569,7 +569,7 @@ namespace Tizen.NUI.BaseComponents
     };
 
     /// <summary>
-    /// A collection of AccessibilityStates
+    /// AccessibilityStates is a collection of AccessibilityState's
     /// </summary>
     /// <seealso cref="AccessibilityState"/>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -613,6 +613,7 @@ namespace Tizen.NUI.BaseComponents
     /// <summary>
     /// Enumeration of possible AT-SPI events.
     /// </summary>
+    /// <seealso cref="AccessibilityEvents"/>
     /// <remarks>
     /// Accessible can emit differty type of event.
     /// </remarks>
@@ -735,6 +736,35 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         WindowChanged           = 22,
     };
+
+    /// <summary>
+    /// AccessibilityEvents is a collection of AccessibilityEvent's
+    /// </summary>
+    /// <seealso cref="AccessibilityEvent"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AccessibilityEvents
+    {
+        // Target object for interop call
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal View Owner { get; set; }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool this[AccessibilityEvent accessibilityEvent]
+        {
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations", Justification = "SWIG boilerplate, no exceptions are expected")]
+            get
+            {
+                bool result = Interop.ControlDevel.DaliAccessibilityIsSuppressedEvent(Owner.SwigCPtr, (int)accessibilityEvent);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return result;
+            }
+            set
+            {
+                Interop.ControlDevel.DaliAccessibilitySetSuppressedEvent(Owner.SwigCPtr, (int)accessibilityEvent, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+    }
 
     /// <summary>
     /// Notify mode for AccessibilityStates.

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AtspiSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AtspiSample.cs
@@ -20,23 +20,23 @@ namespace Tizen.NUI.Samples
             text.WidthResizePolicy = ResizePolicyType.FillToParent;
             window.Add(text);
 
-            if (text.IsAccessibilityEventSuppressed(AccessibilityEvent.MovedOut))
+            if (text.AccessibilitySuppressedEvents[AccessibilityEvent.MovedOut])
             {
                 text.Text = "FAIL";
                 Tizen.Log.Error("NUITEST", "Default value shoud be false\n");
                 return;
             }
 
-            text.SetAccessibilityEventSuppressed(AccessibilityEvent.MovedOut, true);
-            if (!text.IsAccessibilityEventSuppressed(AccessibilityEvent.MovedOut))
+            text.AccessibilitySuppressedEvents[AccessibilityEvent.MovedOut] = true;
+            if (!text.AccessibilitySuppressedEvents[AccessibilityEvent.MovedOut])
             {
                 text.Text = "FAIL";
                 Tizen.Log.Error("NUITEST", "Cannot set to true\n");
                 return;
             }
 
-            text.SetAccessibilityEventSuppressed(AccessibilityEvent.MovedOut, false);
-            if (text.IsAccessibilityEventSuppressed(AccessibilityEvent.MovedOut))
+            text.AccessibilitySuppressedEvents[AccessibilityEvent.MovedOut] = false;
+            if (text.AccessibilitySuppressedEvents[AccessibilityEvent.MovedOut])
             {
                 text.Text = "FAIL";
                 Tizen.Log.Error("NUITEST", "Cannot set to false\n");


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This commit changes the syntax used to modify the collection of suppressed AT-SPI events (D-Bus signals) to match the indexing syntax used in DALi:

```c#
view.SetAccessibilityEventSuppressed(AccessibilityEvent.MovedOut, true); // old C# syntax
```

```c#
view.AccessibilitySuppressedEvents[AccessibilityEvent.MovedOut] = true; // new C# syntax
```

```c++
accessible->GetSuppressedEvents()[Accessibility::AtspiEvent::MOVED_OUT] = true; // C++ syntax
```

Interops are unchanged (i.e. there are no related DALi patches).

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
