### PR TITLE
[NUI][AT-SPI] Add to set AccessibilityName and Description in some components

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -441,7 +441,7 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// AccessibilityGetName.
+        /// Gets accessibility name.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override string AccessibilityGetName()
@@ -454,6 +454,15 @@ namespace Tizen.NUI.Components
             {
                 return Message;
             }
+        }
+
+        /// <summary>
+        /// Gets accessibility description.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override string AccessibilityGetDescription()
+        {
+            return Message;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI.Components
         private bool styleApplied = false;
 
         /// <summary>
-        /// Get accessibility name.
+        /// Gets accessibility name.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override string AccessibilityGetName()

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -383,7 +383,6 @@ namespace Tizen.NUI.Components
             internal set
             {
                 buttonText = value;
-                AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Label, buttonText.Text);
             }
         }
 

--- a/src/Tizen.NUI.Components/Controls/Navigation/AppBar.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/AppBar.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -536,6 +536,15 @@ namespace Tizen.NUI.Components
 
                 return defaultActionContent;
             }
+        }
+
+        /// <summary>
+        /// Gets accessibility name.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override string AccessibilityGetName()
+        {
+            return Title;
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
@@ -205,7 +205,6 @@ namespace Tizen.NUI.Components
             {
                 itemLabel = value;
                 layoutChanged = true;
-                AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Label, itemLabel.Text);
             }
         }
 
@@ -474,6 +473,15 @@ namespace Tizen.NUI.Components
             }
 
 
+        }
+
+        /// <summary>
+        /// Gets accessibility name.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override string AccessibilityGetName()
+        {
+            return itemLabel.Text;
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultLinearItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultLinearItem.cs
@@ -156,7 +156,6 @@ namespace Tizen.NUI.Components
             internal set
             {
                 itemLabel = value;
-                AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Label, itemLabel.Text);
             }
         }
 
@@ -210,7 +209,6 @@ namespace Tizen.NUI.Components
             internal set
             {
                 itemSubLabel = value;
-                AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Label, itemSubLabel.Text);
             }
         }
 
@@ -360,7 +358,7 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Get accessibility name.
+        /// Gets accessibility name.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override string AccessibilityGetName()


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- Some NUI Components have text parts and they need to be connected with
 Accessibillity features.
 (`AccessibilityName` and `AccessibiityDescription`)


### API Changes ###
- N/A