### PR TITLE
[NUI] Add RelativeLineHeight in TextLabel, TextEditor

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -117,6 +117,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_INPUT_LINE_SPACING_get")]
             public static extern int InputLineSpacingGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_RELATIVE_LINE_SIZE_get")]
+            public static extern int RelativeLineHeightGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_UNDERLINE_get")]
             public static extern int UnderlineGet();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -63,6 +63,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_LINE_SPACING_get")]
             public static extern int LineSpacingGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RELATIVE_LINE_SIZE_get")]
+            public static extern int RelativeLineHeightGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_UNDERLINE_get")]
             public static extern int UnderlineGet();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
@@ -263,6 +263,19 @@ namespace Tizen.NUI.BaseComponents
             return textEditorStyle.minLineSize;
         });
 
+        /// <summary> The bindable property of RelativeLineHeightProperty. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textEditorStyle = (TextEditorStyle)bindable;
+            textEditorStyle.relativeLineHeight = (float?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textEditorStyle = (TextEditorStyle)bindable;
+            return textEditorStyle.relativeLineHeight;
+        });
+
         private HorizontalAlignment? horizontalAlignment;
         private VerticalAlignment? verticalAlignment;
         private Vector4 secondaryCursorColor;
@@ -299,6 +312,7 @@ namespace Tizen.NUI.BaseComponents
         private bool? ellipsis;
         private float? lineSpacing;
         private float? minLineSize;
+        private float? relativeLineHeight;
 
         static TextEditorStyle() { }
 
@@ -673,6 +687,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (float?)GetValue(MinLineSizeProperty);
             set => SetValue(MinLineSizeProperty, value);
+        }
+
+        /// <summary>
+        /// the relative line height to be used.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float? RelativeLineHeight
+        {
+            get => (float?)GetValue(RelativeLineHeightProperty);
+            set => SetValue(RelativeLineHeightProperty, value);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
@@ -185,6 +185,18 @@ namespace Tizen.NUI.BaseComponents
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.lineSpacing;
         });
+        /// <summary> The bindable property of RelativeLineHeightProperty. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            textLabelStyle.relativeLineHeight = (float?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            return textLabelStyle.relativeLineHeight;
+        });
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -335,6 +347,7 @@ namespace Tizen.NUI.BaseComponents
         private int? autoScrollLoopCount;
         private float? autoScrollGap;
         private float? lineSpacing;
+        private float? relativeLineHeight;
         private string emboss;
         private Selector<float?> pixelSizeSelector;
         private bool? ellipsis;
@@ -457,6 +470,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (float?)GetValue(LineSpacingProperty);
             set => SetValue(LineSpacingProperty, value);
+        }
+
+        /// <summary>
+        /// the relative line height to be used.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float? RelativeLineHeight
+        {
+            get => (float?)GetValue(RelativeLineHeightProperty);
+            set => SetValue(RelativeLineHeightProperty, value);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -1057,6 +1057,24 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The relative height of the line (a factor that will be multiplied by text height). <br />
+        /// If the value is less than 1, the lines could to be overlapped.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float RelativeLineHeight
+        {
+            get
+            {
+                return (float)GetValue(RelativeLineHeightProperty);
+            }
+            set
+            {
+                SetValue(RelativeLineHeightProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The Underline property.<br />
         /// The default underline parameters.<br />
         /// The underline map contains the following keys :<br />
@@ -2570,6 +2588,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int InputPointSize = Interop.TextEditor.InputPointSizeGet();
             internal static readonly int LineSpacing = Interop.TextEditor.LineSpacingGet();
             internal static readonly int InputLineSpacing = Interop.TextEditor.InputLineSpacingGet();
+            internal static readonly int RelativeLineHeight = Interop.TextEditor.RelativeLineHeightGet();
             internal static readonly int UNDERLINE = Interop.TextEditor.UnderlineGet();
             internal static readonly int InputUnderline = Interop.TextEditor.InputUnderlineGet();
             internal static readonly int SHADOW = Interop.TextEditor.ShadowGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -577,6 +577,22 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing).Get(out temp);
             return temp;
         }));
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight, new Tizen.NUI.PropertyValue((float)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textEditor = (TextEditor)bindable;
+            float temp = 0.0f;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight).Get(out temp);
+            return temp;
+        }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineProperty = BindableProperty.Create(nameof(Underline), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -783,6 +783,24 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The relative height of the line (a factor that will be multiplied by text height). <br />
+        /// If the value is less than 1, the lines could to be overlapped.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float RelativeLineHeight
+        {
+            get
+            {
+                return (float)GetValue(RelativeLineHeightProperty);
+            }
+            set
+            {
+                SetValue(RelativeLineHeightProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The Underline property.<br />
         /// The default underline parameters.<br />
         /// The underline map contains the following keys :<br />
@@ -1588,6 +1606,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int AutoScrollLoopCount = Interop.TextLabel.AutoScrollLoopCountGet();
             internal static readonly int AutoScrollGap = Interop.TextLabel.AutoScrollGapGet();
             internal static readonly int LineSpacing = Interop.TextLabel.LineSpacingGet();
+            internal static readonly int RelativeLineHeight = Interop.TextLabel.RelativeLineHeightGet();
             internal static readonly int UNDERLINE = Interop.TextLabel.UnderlineGet();
             internal static readonly int SHADOW = Interop.TextLabel.ShadowGet();
             internal static readonly int EMBOSS = Interop.TextLabel.EmbossGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -328,6 +328,22 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.LineSpacing).Get(out temp);
             return temp;
         }));
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            if (newValue != null)
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight, new Tizen.NUI.PropertyValue((float)newValue));
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            float temp = 0.0f;
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight).Get(out temp);
+            return temp;
+        }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineProperty = BindableProperty.Create(nameof(Underline), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>


### PR DESCRIPTION
`RelativeLineHeight` is a factor that will be multiplied by text height.

```
// line height will be 2.0 times the text height
label.RelativeLineHeight = 2.0f;

// if the value is less than 1.0f, the lines could to be overlapped
// line height will be 0.5 times the text height
label.RelativeLineHeight = 0.5f;
```

* The dali-toolkit logic has already been merged.
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/274014/

