### PR TITLE
[NUI] Fix Svace issue not to do unnecessary null check in DefaultBorder

### DIFF
--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -673,10 +673,9 @@ namespace Tizen.NUI
             if (disposing)
             {
                 ClearWindowGesture();
-                if (BorderWindow != null)
-                {
-                    BorderWindow.InterceptTouchEvent -= OnWinInterceptedTouch;
-                }
+
+                BorderWindow.InterceptTouchEvent -= OnWinInterceptedTouch;
+
                 borderPanGestureDetector?.Dispose();
                 borderPinchGestureDetector?.Dispose();
                 backgroundColor?.Dispose();


### PR DESCRIPTION
Svace issue occurs because null check of BorderWindow is done after
BorderWindow is accessed in DefaultBorder.Dispose().

When close button in DefaultBorder is clicked, BorderWindow is disposed.
When BorderWindow is disposed, DisposeBorder() is called.
In DisposeBorder(), DefaultBorder is disposed.
When DefaultBorder is disposed, BorderWindow is under disposed but
BorderWindow is not set to be null yet.
Therefore, it is not necessary to do null check of BorderWindow in
DefaultBorder.Dispose() to resolve the Svace issue.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
