### PR TITLE
[NUI][AT-SPI] Apply AccessibilityHidden for Scrollbar

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Scrollbar.cs
+++ b/src/Tizen.NUI.Components/Controls/Scrollbar.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -270,7 +270,8 @@ namespace Tizen.NUI.Components
             trackView = new View()
             {
                 PositionUsesPivotPoint = true,
-                BackgroundColor = new Color(1.0f, 1.0f, 1.0f, 0.15f)
+                BackgroundColor = new Color(1.0f, 1.0f, 1.0f, 0.15f),
+                AccessibilityHidden = true
             };
             Add(trackView);
 


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- AT-SPI2 tree shows Scrollbar, Control, and ImageView when Scrollbar
class is just created.
- `Control` is trackView in Scrollbar, but is not necessary for at-spi
tree. So, it can be hidden in the tree.
- Applied AccessibilityHidden property to a View.


### API Changes ###
- N/A
- 