### PR TITLE
[MachineLearning.Inference] Change interop (#4168)

### DIFF
--- a/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
+++ b/src/Tizen.MachineLearning.Inference/Interop/Interop.Nnstreamer.cs
@@ -23,6 +23,8 @@ internal static partial class Interop
     internal static partial class Libraries
     {
         public const string Nnstreamer = "libcapi-nnstreamer.so.1";
+        public const string MlCommon = "libcapi-ml-common.so.1";
+        public const string MlSingle = "libcapi-ml-inference-single.so.1";
     }
 
     internal static partial class Pipeline
@@ -187,106 +189,106 @@ internal static partial class Interop
     internal static partial class SingleShot
     {
         /* int ml_single_open (ml_single_h *single, const char *model, const ml_tensors_info_h input_info, const ml_tensors_info_h output_info, ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_open", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_open", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError OpenSingle(out IntPtr single_handle, string model_path, IntPtr input_info, IntPtr output_info, NNFWType nn_type, HWType hw_type);
 
         /* int ml_single_close (ml_single_h single) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_close", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_close", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError CloseSingle(IntPtr single_handle);
 
         /* int ml_single_invoke (ml_single_h single, const ml_tensors_data_h input, ml_tensors_data_h *output) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_invoke", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_invoke", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError InvokeSingle(IntPtr single_handle, IntPtr input_data, out IntPtr output_data);
 
         /* int ml_single_invoke_dynamic (ml_single_h single, const ml_tensors_data_h input, const ml_tensors_info_h in_info, ml_tensors_data_h * output, ml_tensors_info_h * out_info) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_invoke_dynamic", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_invoke_dynamic", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError InvokeSingleDynamic(IntPtr single_handle, IntPtr input_data, IntPtr input_info, out IntPtr output_data, out IntPtr output_info);
 
         /* int ml_single_get_input_info (ml_single_h single, ml_tensors_info_h *info) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_get_input_info", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_get_input_info", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetInputTensorsInfo(IntPtr single_handle, out IntPtr input_info);
 
         /* int ml_single_get_output_info (ml_single_h single, ml_tensors_info_h *info) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_get_output_info", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_get_output_info", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetOutputTensorsInfo(IntPtr single_handle, out IntPtr output_info);
 
         /* int ml_single_set_input_info (ml_single_h single, const ml_tensors_info_h info) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_set_input_info", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_set_input_info", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetInputInfo(IntPtr single_handle, IntPtr in_handle);
 
         /* int ml_single_set_timeout (ml_single_h single, unsigned int timeout)*/
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_set_timeout", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_set_timeout", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetTimeout(IntPtr single_handle, int time_ms);
 
         /* int ml_single_set_property (ml_single_h single, const char *name, const char *value) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_set_property", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_set_property", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetValue(IntPtr single_handle, string name, string value);
 
         /* int ml_single_get_property (ml_single_h single, const char *name, char **value) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_single_get_property", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_single_get_property", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetValue(IntPtr single_handle, string name, out IntPtr value);
     }
 
     internal static partial class Util
     {
         /* int ml_tensors_info_create (ml_tensors_info_h *info) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_create", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_create", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError CreateTensorsInfo(out IntPtr info);
 
         /* int ml_tensors_info_destroy (ml_tensors_info_h info) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_destroy", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_destroy", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError DestroyTensorsInfo(IntPtr info);
 
         /* int ml_tensors_info_set_count (ml_tensors_info_h info, unsigned int count) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_set_count", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_set_count", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetTensorsCount(IntPtr info, int count);
 
         /* int ml_tensors_info_get_count (ml_tensors_info_h info, unsigned int *count) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_get_count", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_get_count", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetTensorsCount(IntPtr info, out int count);
 
         /* int ml_tensors_info_set_tensor_name (ml_tensors_info_h info, unsigned int index, const char *name) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_set_tensor_name", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_set_tensor_name", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetTensorName(IntPtr info, int index, string name);
 
         /* int ml_tensors_info_get_tensor_name (ml_tensors_info_h info, unsigned int index, char **name) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_get_tensor_name", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_get_tensor_name", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetTensorName(IntPtr info, int index, out string name);
 
         /* int ml_tensors_info_set_tensor_type (ml_tensors_info_h info, unsigned int index, const ml_tensor_type_e type) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_set_tensor_type", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_set_tensor_type", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetTensorType(IntPtr info, int index, TensorType type);
 
         /* int ml_tensors_info_get_tensor_type (ml_tensors_info_h info, unsigned int index, ml_tensor_type_e *type) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_get_tensor_type", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_get_tensor_type", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetTensorType(IntPtr info, int index, out TensorType type);
 
         /* int ml_tensors_info_set_tensor_dimension (ml_tensors_info_h info, unsigned int index, const ml_tensor_dimension dimension) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_set_tensor_dimension", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_set_tensor_dimension", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetTensorDimension(IntPtr info, int index, int[] dimension);
 
         /* int ml_tensors_info_get_tensor_dimension (ml_tensors_info_h info, unsigned int index, ml_tensor_dimension dimension) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_info_get_tensor_dimension", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_info_get_tensor_dimension", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetTensorDimension(IntPtr info, int index, [In, Out] uint[] dimension);
 
         /* int ml_tensors_data_create (const ml_tensors_info_h info, ml_tensors_data_h *data) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_data_create", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_data_create", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError CreateTensorsData(IntPtr info, out IntPtr data);
 
         /* int ml_tensors_data_destroy (ml_tensors_data_h data) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_data_destroy", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_data_destroy", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError DestroyTensorsData(IntPtr data);
 
         /* int ml_tensors_data_get_tensor_data (ml_tensors_data_h data, unsigned int index, void **raw_data, size_t *data_size) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_data_get_tensor_data", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_data_get_tensor_data", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError GetTensorData(IntPtr data, int index, out IntPtr raw_data, out int data_size);
 
         /* int ml_tensors_data_set_tensor_data (ml_tensors_data_h data, unsigned int index, const void *raw_data, const size_t data_size) */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_tensors_data_set_tensor_data", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlCommon, EntryPoint = "ml_tensors_data_set_tensor_data", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError SetTensorData(IntPtr data, int index, byte[] raw_data, int data_size);
 
         /* int ml_check_nnfw_availability (ml_nnfw_type_e nnfw, ml_nnfw_hw_e hw, bool *available); */
-        [DllImport(Libraries.Nnstreamer, EntryPoint = "ml_check_nnfw_availability", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.MlSingle, EntryPoint = "ml_check_nnfw_availability", CallingConvention = CallingConvention.Cdecl)]
         internal static extern NNStreamerError CheckNNFWAvailability(NNFWType nnfw, HWType hw, out bool available);
 
         internal static byte[] IntPtrToByteArray(IntPtr unmanagedByteArray, int size)


### PR DESCRIPTION
Fix dllimport lib since MachineLearning package separated as below:
 capi-nnstreamer -> capi-ml-common, capi-ml-inference-single and
capi-nnstreamer.

Signed-off-by: gichan <gichan2.jang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
