### PR TITLE
[NUI] Fix Window.Dispose and Layer.LayoutCount

### DIFF
--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -763,15 +763,8 @@ namespace Tizen.NUI
 
                 if (window != null)
                 {
-                    if (value == 0)
-                    {
-                        window.LayoutController.LayoutCount = 0;
-                    }
-                    else
-                    {
-                        int diff = value - layoutCount;
-                        window.LayoutController.LayoutCount += diff;
-                    }
+                    int diff = value - layoutCount;
+                    window.LayoutController.LayoutCount += diff;
                 }
                 layoutCount = value;
             }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1743,13 +1743,6 @@ namespace Tizen.NUI
                     DisposeBorder();
                 }
 
-                if (rootLayer != null)
-                {
-                    rootLayer.Dispose();
-                }
-
-                localController?.Dispose();
-
                 foreach (var layer in childLayers)
                 {
                     if (layer != null)
@@ -1759,6 +1752,8 @@ namespace Tizen.NUI
                 }
 
                 childLayers.Clear();
+
+                localController?.Dispose();
             }
 
             this.DisconnectNativeSignals();


### PR DESCRIPTION
Since Layer.Dispose updates LayoutController.LayoutCount,
LayoutController.Dispose should be called after all layers' Dispose are
called in Window.Dispose.

When a layer's LayoutCount is set, it should update its
LayoutController.LayoutCount by the difference between new and current
LayoutCount.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
