### PR TITLE
[NUI][XamlBuild] Change XamlCTask / XamlGTask into NUIXamlCTask /  NUIXamlGTask.

### DIFF
--- a/pkg/Tizen.NET.API9/xamlbuild/Tizen.NUI.XamlBuild.targets
+++ b/pkg/Tizen.NET.API9/xamlbuild/Tizen.NUI.XamlBuild.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Tizen.NUI.Xaml.Build.Tasks.XamlGTask" AssemblyFile="$(MSBuildThisFileDirectory)Tizen.NUI.XamlBuild.dll" />
-	<UsingTask TaskName="Tizen.NUI.Xaml.Build.Tasks.XamlCTask" AssemblyFile="$(MSBuildThisFileDirectory)Tizen.NUI.XamlBuild.dll" />
+	<UsingTask TaskName="Tizen.NUI.Xaml.Build.Tasks.NUIXamlGTask" AssemblyFile="$(MSBuildThisFileDirectory)Tizen.NUI.XamlBuild.dll" />
+	<UsingTask TaskName="Tizen.NUI.Xaml.Build.Tasks.NUIXamlCTask" AssemblyFile="$(MSBuildThisFileDirectory)Tizen.NUI.XamlBuild.dll" />
 
 	<!-- XamlG -->
 	<Target Name="UpdateDesignTimeXaml" DependsOnTargets="XamlG"/>
@@ -20,14 +20,14 @@
 	</Target>
 
 	<Target Name="XamlG" BeforeTargets="BeforeCompile" DependsOnTargets="_FindXamlGFiles; PrepareResourceNames; AfterResolveReferences" Inputs="@(_XamlGInputs)" Outputs="@(_XamlGOutputs)">
-		<XamlGTask
+		<NUIXamlGTask
 			XamlFiles="@(_XamlGInputs)"
 			OutputFiles="@(_XamlGOutputs)"
 			Language="$(Language)"
 			AssemblyName="$(AssemblyName)"
 			ReferencePath="@(ReferencePath)"
 			XamlOptimization="$(XamlOptimization)"
-            AddXamlCompilationAttribute="True" />
+                        AddXamlCompilationAttribute="True" />
 		<ItemGroup>
 			<FileWrites Include="@(_XamlGOutputs)" />
 			<Compile Include="@(_XamlGOutputs)" />
@@ -43,7 +43,7 @@
 	</PropertyGroup>
 
 	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" >
-		<XamlCTask
+		<NUIXamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
 			OptimizeIL = "true"

--- a/src/Tizen.NUI.XamlBuild/src/public/EXamlBuild/EXamlSetPropertiesVisitor.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/EXamlBuild/EXamlSetPropertiesVisitor.cs
@@ -710,7 +710,7 @@ namespace Tizen.NUI.EXaml.Build.Tasks
             if (implicitOperator != null)
                 return true;
 
-            return valueInstance.GetType().InheritsFromOrImplements(module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindingBase")));
+            return valueInstance.GetType().InheritsFromOrImplements(module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindingBase")));
         }
 
         static void SetBinding(EXamlCreateObject parent, MemberReference bpRef, IElementNode elementNode, IXmlLineInfo iXmlLineInfo, EXamlContext context)

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/CreateObjectVisitor.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/CreateObjectVisitor.cs
@@ -81,7 +81,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
             //if this is a MarkupExtension that can be compiled directly, compile and returns the value
             var compiledMarkupExtensionName = typeref
-                .GetCustomAttribute(Module, (XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "ProvideCompiledAttribute"))
+                .GetCustomAttribute(Module, (NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "ProvideCompiledAttribute"))
                 ?.ConstructorArguments?[0].Value as string;
             Type compiledMarkupExtensionType;
             ICompiledMarkupExtension markupProvider;
@@ -325,9 +325,9 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                     Context.IL.Emit(OpCodes.Initobj, Module.ImportReference(typedef));
                 }
 
-                if (null != XamlCTask.BaseTypeDefiniation && typedef.InheritsFromOrImplements(XamlCTask.BaseTypeDefiniation))
+                if (null != NUIXamlCTask.BaseTypeDefiniation && typedef.InheritsFromOrImplements(NUIXamlCTask.BaseTypeDefiniation))
                 {
-                    var field = XamlCTask.BaseTypeDefiniation.Properties.SingleOrDefault(fd => fd.Name == "IsCreateByXaml");
+                    var field = NUIXamlCTask.BaseTypeDefiniation.Properties.SingleOrDefault(fd => fd.Name == "IsCreateByXaml");
                     if (field == null)
                         return;
 

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NUIXamlCTask.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NUIXamlCTask.cs
@@ -33,7 +33,7 @@ using static Mono.Cecil.Cil.OpCodes;
 namespace Tizen.NUI.Xaml.Build.Tasks
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class XamlCTask : XamlTask
+    public class NUIXamlCTask : XamlTask
     {
         bool hasCompiledXamlResources;
         public bool KeepXamlResources { get; set; }

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NUIXamlGTask.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NUIXamlGTask.cs
@@ -24,7 +24,7 @@ using Microsoft.Build.Utilities;
 namespace Tizen.NUI.Xaml.Build.Tasks
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class XamlGTask : Task
+    public class NUIXamlGTask : Task
     {
         [Required]
         public ITaskItem[] XamlFiles { get; set; }

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/SetNamescopesAndRegisterNamesVisitor.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/SetNamescopesAndRegisterNamesVisitor.cs
@@ -72,7 +72,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 namescopeVarDef = Context.Scopes[parentNode].Item1;
                 namesInNamescope = Context.Scopes[parentNode].Item2;
             }
-            if (setNameScope && Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference((XamlCTask.xamlAssemblyName, XamlCTask.bindingNameSpace, "BindableObject"))))
+            if (setNameScope && Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference((NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableObject"))))
                 SetNameScope(node, namescopeVarDef);
             Context.Scopes[node] = new Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
         }
@@ -81,7 +81,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
         {
             var namescopeVarDef = CreateNamescope();
             IList<string> namesInNamescope = new List<string>();
-            if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference((XamlCTask.xamlAssemblyName, XamlCTask.bindingNameSpace, "BindableObject"))))
+            if (Context.Variables[node].VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference((NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableObject"))))
                 SetNameScope(node, namescopeVarDef);
             Context.Scopes[node] = new System.Tuple<VariableDefinition, IList<string>>(namescopeVarDef, namesInNamescope);
         }
@@ -124,9 +124,9 @@ namespace Tizen.NUI.Xaml.Build.Tasks
         VariableDefinition CreateNamescope()
         {
             var module = Context.Body.Method.Module;
-            var vardef = new VariableDefinition(module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "NameScope")));
+            var vardef = new VariableDefinition(module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "NameScope")));
             Context.Body.Variables.Add(vardef);
-            Context.IL.Emit(OpCodes.Newobj, module.ImportCtorReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "NameScope"), parameterTypes: null));
+            Context.IL.Emit(OpCodes.Newobj, module.ImportCtorReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "NameScope"), parameterTypes: null));
             Context.IL.Emit(OpCodes.Stloc, vardef);
             return vardef;
         }
@@ -136,11 +136,11 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             var module = Context.Body.Method.Module;
             Context.IL.Emit(OpCodes.Ldloc, Context.Variables[node]);
             Context.IL.Emit(OpCodes.Ldloc, ns);
-            Context.IL.Emit(OpCodes.Call, module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "NameScope"),
+            Context.IL.Emit(OpCodes.Call, module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "NameScope"),
                                                                        methodName: "SetNameScope",
                                                                        parameterTypes: new[] {
-                                                                           (XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableObject"),
-                                                                           (XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "INameScope"),
+                                                                           (NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableObject"),
+                                                                           (NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "INameScope"),
                                                                        },
                                                                        isStatic: true));
         }
@@ -155,7 +155,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             Context.IL.Emit(OpCodes.Ldloc, namescopeVarDef);
             Context.IL.Emit(OpCodes.Ldstr, str);
             Context.IL.Emit(OpCodes.Ldloc, element);
-            Context.IL.Emit(OpCodes.Callvirt, module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "INameScope"),
+            Context.IL.Emit(OpCodes.Callvirt, module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "INameScope"),
                                                                            methodName: "RegisterName",
                                                                            parameterTypes: new[] {
                                                                                ("mscorlib", "System", "String"),
@@ -165,18 +165,18 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
         void SetStyleId(string str, VariableDefinition element)
         {
-            if (!element.VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "Element"))))
+            if (!element.VariableType.InheritsFromOrImplements(Context.Body.Method.Module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "Element"))))
                 return;
 
             var module = Context.Body.Method.Module;
 
             var nop = Instruction.Create(OpCodes.Nop);
             Context.IL.Emit(OpCodes.Ldloc, element);
-            Context.IL.Emit(OpCodes.Callvirt, module.ImportPropertyGetterReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "Element"), propertyName: "StyleId"));
+            Context.IL.Emit(OpCodes.Callvirt, module.ImportPropertyGetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "Element"), propertyName: "StyleId"));
             Context.IL.Emit(OpCodes.Brtrue, nop);
             Context.IL.Emit(OpCodes.Ldloc, element);
             Context.IL.Emit(OpCodes.Ldstr, str);
-            Context.IL.Emit(OpCodes.Callvirt, module.ImportPropertySetterReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "Element"), propertyName: "StyleId"));
+            Context.IL.Emit(OpCodes.Callvirt, module.ImportPropertySetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "Element"), propertyName: "StyleId"));
             Context.IL.Append(nop);
         }
     }

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/SetPropertiesVisitor.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/SetPropertiesVisitor.cs
@@ -335,7 +335,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             else if (vardefref.VariableDefinition.VariableType.ImplementsGenericInterface("Tizen.NUI.Xaml.IMarkupExtension`1",
                 out markupExtension, out genericArguments))
             {
-                var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(module, (XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "AcceptEmptyServiceProviderAttribute")) != null;
+                var acceptEmptyServiceProvider = vardefref.VariableDefinition.VariableType.GetCustomAttribute(module, (NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "AcceptEmptyServiceProviderAttribute")) != null;
                 if (vardefref.VariableDefinition.VariableType.FullName == "Tizen.NUI.Xaml.BindingExtension")
                     foreach (var instruction in CompileBindingPath(node, context, vardefref.VariableDefinition))
                         yield return instruction;
@@ -356,9 +356,9 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 yield return Instruction.Create(OpCodes.Callvirt, provideValue);
                 yield return Instruction.Create(OpCodes.Stloc, vardefref.VariableDefinition);
             }
-            else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference((XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "IMarkupExtension"))))
+            else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference((NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "IMarkupExtension"))))
             {
-                var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module, (XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "AcceptEmptyServiceProviderAttribute")) != null;
+                var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module, (NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "AcceptEmptyServiceProviderAttribute")) != null;
                 vardefref.VariableDefinition = new VariableDefinition(module.TypeSystem.Object);
                 yield return Create(Ldloc, context.Variables[node]);
                 if (acceptEmptyServiceProvider)
@@ -366,17 +366,17 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 else
                     foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
                         yield return instruction;
-                yield return Create(Callvirt, module.ImportMethodReference((XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "IMarkupExtension"),
+                yield return Create(Callvirt, module.ImportMethodReference((NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "IMarkupExtension"),
                                                                            methodName: "ProvideValue",
                                                                            parameterTypes: new[] { ("System.ComponentModel", "System", "IServiceProvider") }));
                 yield return Create(Stloc, vardefref.VariableDefinition);
             }
-            else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference((XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "IValueProvider"))))
+            else if (context.Variables[node].VariableType.ImplementsInterface(module.ImportReference((NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "IValueProvider"))))
             {
-                var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module, (XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "AcceptEmptyServiceProviderAttribute")) != null;
+                var acceptEmptyServiceProvider = context.Variables[node].VariableType.GetCustomAttribute(module, (NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "AcceptEmptyServiceProviderAttribute")) != null;
                 var valueProviderType = context.Variables[node].VariableType;
                 //If the IValueProvider has a ProvideCompiledAttribute that can be resolved, shortcut this
-                var compiledValueProviderName = valueProviderType?.GetCustomAttribute(module, (XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "ProvideCompiledAttribute"))?.ConstructorArguments?[0].Value as string;
+                var compiledValueProviderName = valueProviderType?.GetCustomAttribute(module, (NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "ProvideCompiledAttribute"))?.ConstructorArguments?[0].Value as string;
                 Type compiledValueProviderType;
                 if (compiledValueProviderName != null && (compiledValueProviderType = Type.GetType(compiledValueProviderName)) != null) {
                     var compiledValueProvider = Activator.CreateInstance(compiledValueProviderType);
@@ -398,7 +398,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 else
                     foreach (var instruction in node.PushServiceProvider(context, bpRef, propertyRef, propertyDeclaringTypeRef))
                         yield return instruction;
-                yield return Create(Callvirt, module.ImportMethodReference((XamlCTask.xamlAssemblyName, XamlCTask.xamlNameSpace, "IValueProvider"),
+                yield return Create(Callvirt, module.ImportMethodReference((NUIXamlCTask.xamlAssemblyName, NUIXamlCTask.xamlNameSpace, "IValueProvider"),
                                                                            methodName: "ProvideValue",
                                                                            parameterTypes: new[] { ("System.ComponentModel", "System", "IServiceProvider") }));
                 yield return Create(Stloc, vardefref.VariableDefinition);
@@ -450,7 +450,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             var actionRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Action`2")).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef }));
             var funcObjRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Func`2")).MakeGenericInstanceType(new [] { tSourceRef, module.TypeSystem.Object }));
             var tupleRef = module.ImportReference(module.ImportReference(("mscorlib", "System", "Tuple`2")).MakeGenericInstanceType(new [] { funcObjRef, module.TypeSystem.String}));
-            var typedBindingRef = module.ImportReference(module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "TypedBinding`2")).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef}));
+            var typedBindingRef = module.ImportReference(module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "TypedBinding`2")).MakeGenericInstanceType(new [] { tSourceRef, tPropertyRef}));
 
             var ctorInfo =  module.ImportReference(typedBindingRef.ResolveCached().Methods.FirstOrDefault(md => md.IsConstructor && !md.IsStatic && md.Parameters.Count == 3 ));
             var ctorinforef = ctorInfo.MakeGeneric(typedBindingRef, funcRef, actionRef, tupleRef);
@@ -469,7 +469,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             } else
                 yield return Create(Ldnull);
             yield return Instruction.Create(OpCodes.Newobj, module.ImportReference(ctorinforef));
-            yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindingExtension"), propertyName: "TypedBinding"));
+            yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindingExtension"), propertyName: "TypedBinding"));
         }
 
         static IList<Tuple<PropertyDefinition, string>> ParsePath(string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module)
@@ -1016,11 +1016,11 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             yield return Create(Ldloc, parent);
             yield return Create(Ldsfld, bpRef);
             yield return Create(Ldloc, context.Variables[elementNode]);
-            yield return Create(Callvirt, module.ImportPropertyGetterReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "DynamicResource"), propertyName: "Key"));
-            yield return Create(Callvirt, module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingInternalNameSpace, "IDynamicResourceHandler"),
+            yield return Create(Callvirt, module.ImportPropertyGetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "DynamicResource"), propertyName: "Key"));
+            yield return Create(Callvirt, module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingInternalNameSpace, "IDynamicResourceHandler"),
                                                                        methodName: "SetDynamicResource",
                                                                        parameterTypes: new[] {
-                                                                           (XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableProperty"),
+                                                                           (NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableProperty"),
                                                                            ("mscorlib", "System", "String"),
                                                                        }));
         }
@@ -1039,18 +1039,18 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             if (!context.Variables.TryGetValue(valueNode as IElementNode, out varValue))
                 return false;
 
-            var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindingBase")), module);
+            var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindingBase")), module);
             if (implicitOperator != null)
                 return true;
 
-            return varValue.VariableType.InheritsFromOrImplements(module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindingBase")));
+            return varValue.VariableType.InheritsFromOrImplements(module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindingBase")));
         }
 
         static IEnumerable<Instruction> SetBinding(VariableDefinition parent, FieldReference bpRef, IElementNode elementNode, IXmlLineInfo iXmlLineInfo, ILContext context)
         {
             var module = context.Body.Method.Module;
             var varValue = context.Variables [elementNode];
-            var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindingBase")), module);
+            var implicitOperator = varValue.VariableType.GetImplicitOperatorTo(module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindingBase")), module);
 
             //TODO: check if parent is a BP
             yield return Create(Ldloc, parent);
@@ -1059,11 +1059,11 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             if (implicitOperator != null) 
 //                IL_000f:  call !0 class [Tizen.NUI.Xaml.Core]Tizen.NUI.Xaml.OnPlatform`1<BindingBase>::op_Implicit(class [Tizen.NUI.Xaml.Core]Tizen.NUI.Xaml.OnPlatform`1<!0>)
                 yield return Create(Call, module.ImportReference(implicitOperator));
-            yield return Create(Callvirt, module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableObject"),
+            yield return Create(Callvirt, module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableObject"),
                                                                        methodName: "SetBinding",
                                                                        parameterTypes: new[] {
-                                                                           (XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableProperty"),
-                                                                           (XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindingBase"),
+                                                                           (NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableProperty"),
+                                                                           (NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindingBase"),
                                                                        }));
         }
 
@@ -1110,7 +1110,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             if (bpRef == null)
                 return false;
 
-            if (!parent.VariableType.InheritsFromOrImplements(module.ImportReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableObject"))))
+            if (!parent.VariableType.InheritsFromOrImplements(module.ImportReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableObject"))))
                 return false;
 
             propertyType = bpRef.GetBindablePropertyType(iXmlLineInfo, module);
@@ -1147,10 +1147,10 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 if (varType.IsValueType)
                     yield return Create(Box, varType);
             }
-            yield return Create(Callvirt, module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableObject"),
+            yield return Create(Callvirt, module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableObject"),
                                                                        methodName: "SetValue",
                                                                        parameterTypes: new[] {
-                                                                           (XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableProperty"),
+                                                                           (NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableProperty"),
                                                                            ("mscorlib", "System", "Object"),
                                                                        }));
         }
@@ -1163,9 +1163,9 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             return new[] {
                 Create(Ldloc, parent),
                 Create(Ldsfld, bpRef),
-                Create(Callvirt,  module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableObject"),
+                Create(Callvirt,  module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableObject"),
                                                                methodName: "GetValue",
-                                                               parameterTypes: new[] { (XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "BindableProperty") })),
+                                                               parameterTypes: new[] { (NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindableProperty") })),
             };
         }
 
@@ -1339,7 +1339,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             //is there a RD.Add() overrides that accepts this ?
             var nodeTypeRef = context.Variables[node].VariableType;
             var module = context.Body.Method.Module;
-            if (module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "ResourceDictionary"),
+            if (module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "ResourceDictionary"),
                                              methodName: "Add",
                                              parameterTypes: new[] { (nodeTypeRef.Scope.Name, nodeTypeRef.Namespace, nodeTypeRef.Name) }) != null)
                 return true;
@@ -1392,7 +1392,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 yield return Create(Ldloc, varDef);
                 if (varDef.VariableType.IsValueType)
                     yield return Create(Box, module.ImportReference(varDef.VariableType));
-                yield return Create(Callvirt, module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "ResourceDictionary"),
+                yield return Create(Callvirt, module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "ResourceDictionary"),
                                                                            methodName: "Add",
                                                                            parameterTypes: new[] {
                                                                                ("mscorlib", "System", "String"),
@@ -1403,7 +1403,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
 
             var nodeTypeRef = context.Variables[node].VariableType;
             yield return Create(Ldloc, context.Variables[node]);
-            yield return Create(Callvirt, module.ImportMethodReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "ResourceDictionary"),
+            yield return Create(Callvirt, module.ImportMethodReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "ResourceDictionary"),
                                                                        methodName: "Add",
                                                                        parameterTypes: new[] { (nodeTypeRef.Scope.Name, nodeTypeRef.Namespace, nodeTypeRef.Name) }));
             yield break;
@@ -1521,7 +1521,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                                                              classArguments: new[] { ("mscorlib", "System", "Object") },
                                                              paramCount: 2));
 
-            var setterRef = module.ImportPropertySetterReference((XamlCTask.bindingAssemblyName, XamlCTask.bindingNameSpace, "IDataTemplate"), propertyName: "LoadTemplate");
+            var setterRef = module.ImportPropertySetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "IDataTemplate"), propertyName: "LoadTemplate");
             parentContext.IL.Emit(OpCodes.Callvirt, setterRef);
 
             loadTemplate.Body.Optimize();

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
@@ -323,13 +323,13 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 IsPartial = true,
                 TypeAttributes = GetTypeAttributes(classModifier),
                 CustomAttributes = {
-                    new CodeAttributeDeclaration(new CodeTypeReference(XamlCTask.xamlNameSpace + ".XamlFilePathAttribute"),
+                    new CodeAttributeDeclaration(new CodeTypeReference(NUIXamlCTask.xamlNameSpace + ".XamlFilePathAttribute"),
                          new CodeAttributeArgument(new CodePrimitiveExpression(XamlFile))),
                 }
             };
             if (AddXamlCompilationAttribute)
                 declType.CustomAttributes.Add(
-                    new CodeAttributeDeclaration(new CodeTypeReference(XamlCTask.xamlNameSpace + ".XamlCompilationAttribute"),
+                    new CodeAttributeDeclaration(new CodeTypeReference(NUIXamlCTask.xamlNameSpace + ".XamlCompilationAttribute"),
                                                  new CodeAttributeArgument(new CodeSnippetExpression($"global::{typeof(XamlCompilationOptions).FullName}.Compile"))));
             if (HideFromIntellisense)
                 declType.CustomAttributes.Add(


### PR DESCRIPTION
### Description of Change ###
**Sync code from API10.**

This requirements comes from the build error:

The "ValidateOnly" parameter is not supported by the "XamlCTask" task loaded from assembly: Tizen.NUI.XamlBuild.

Because NUI XamlCTask makes Xamarin, which is already existed in Tizen, so change XamlCTask into NUIXamlCTask, to avoid confusing.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
