### PR TITLE
[NUI] Add SetFocusFinderRootView() and ResetFocusFinderRootView() api

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.FocusManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FocusManager.cs
@@ -92,6 +92,12 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_GetNearestFocusableActor")]
             public static extern global::System.IntPtr GetNearestFocusableActor(global::System.Runtime.InteropServices.HandleRef rootView, global::System.Runtime.InteropServices.HandleRef currentView,  int direction);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_SetFocusFinderRootActor")]
+            public static extern void SetFocusFinderRootView(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_KeyboardFocusManager_ResetFocusFinderRootActor")]
+            public static extern void ResetFocusFinderRootView(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_KeyboardFocusManager_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
         }

--- a/src/Tizen.NUI/src/public/Input/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/Input/FocusManager.cs
@@ -453,6 +453,29 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// Sets the root view to start moving focus when DefaultAlgorithm is enabled.
+        /// This will only look for focusable Views within that View tree when looking for the next focus.
+        /// </summary>
+        /// <param name="rootView">The root view in which to find the next focusable view.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetFocusFinderRootView(View rootView)
+        {
+            Interop.FocusManager.SetFocusFinderRootView(SwigCPtr, View.getCPtr(rootView));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Reset the root view that starts moving focus when DefaultAlgorithm is enabled.
+        /// When reset, the window becomes root.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ResetFocusFinderRootView()
+        {
+            Interop.FocusManager.ResetFocusFinderRootView(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
         internal static FocusManager Get()
         {
             FocusManager ret = new FocusManager(Interop.FocusManager.Get(), true);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

If you enable DefaultAlgorithm of FocusManager, you can automatically move the focus to the nearest View.

However, this is always root based on Window.

We want to change this root.

So I add two apis

1. SetFocusFinderRootView(View root)

  - This will only look for focusable Views within that View tree when looking for the next focus.

2. ResetFocusFinderRootView()

  - the root becomes the window again.

Dependency
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/274424/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/274422/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
