### PR TITLE
[NUI] Fix Window.Add and Remove to use Layer.Add and Remove directly

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -937,15 +937,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void Add(View view)
         {
-            Interop.Actor.Add(Layer.getCPtr(GetRootLayer()), View.getCPtr(view));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            this.GetRootLayer().AddViewToLayerList(view); // Maintain the children list in the Layer
-            if (null != view)
-            {
-                view.InternalParent = this.GetRootLayer();
-
-                this.GetRootLayer().LayoutCount += view.LayoutCount;
-            }
+            this.GetRootLayer().Add(view);
         }
 
         /// <summary>
@@ -955,14 +947,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void Remove(View view)
         {
-            Interop.Actor.Remove(Layer.getCPtr(GetRootLayer()), View.getCPtr(view));
-            this.GetRootLayer().RemoveViewFromLayerList(view); // Maintain the children list in the Layer
-            if (null != view)
-            {
-                view.InternalParent = null;
-
-                this.GetRootLayer().LayoutCount -= view.LayoutCount;
-            }
+            this.GetRootLayer().Remove(view);
         }
 
         /// <summary>


### PR DESCRIPTION
Previously, Window.Add and Remove did not use Layer.Add and Remove.
This caused LayoutCount was updated duplicately.
e.g.
- Calling window.Remove(view) twice decreases LayoutCount duplicately.
Moreover, users could not get ChildAdded and ChildRemoved events from
Window's RootLayer.

Now, Window.Add and Remove use Layer.Add and Remove directly.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
