### PR TITLE
[NUI] Fix MarginProperty and PaddingProperty with Layout

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2100,35 +2100,11 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                // If View has a Layout then padding in stored in the base Layout class
-                if (Layout != null)
-                {
-                    return Layout.Padding;
-                }
-                else
-                {
-                    return (Extents)GetValue(PaddingProperty);
-                }
-                // Two return points to prevent creating a zeroed Extent native object before assignment
+                return (Extents)GetValue(PaddingProperty);
             }
             set
             {
-                Extents padding = value;
-                if (Layout != null)
-                {
-                    // Layout set so store Padding in LayoutItem instead of in View.
-                    // If View stores the Padding value then Legacy Size Negotiation will overwrite
-                    // the position and sizes measure in the Layouting.
-                    Layout.Padding = value;
-                    // If Layout is a LayoutItem then it could be a View that handles it's own padding.
-                    // Let the View keeps it's padding.  Still store Padding in Layout to reduce code paths.
-                    if (typeof(LayoutGroup).IsAssignableFrom(Layout.GetType())) // If a Layout container of some kind.
-                    {
-                        padding = new Extents(0, 0, 0, 0); // Reset value stored in View.
-                    }
-                }
-
-                SetValue(PaddingProperty, padding);
+                SetValue(PaddingProperty, value);
                 NotifyPropertyChanged();
             }
         }
@@ -2440,35 +2416,12 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                // If View has a Layout then margin is stored in Layout.
-                if (Layout != null)
-                {
-                    return Layout.Margin;
-                }
-                else
-                {
-                    // If Layout not set then return margin stored in View.
-                    return (Extents)GetValue(MarginProperty);
-                }
-                // Two return points to prevent creating a zeroed Extent native object before assignment
+                return (Extents)GetValue(MarginProperty);
             }
             set
             {
-                if (Layout != null)
-                {
-                    // Layout set so store Margin in LayoutItem instead of View.
-                    // If View stores the Margin too then the Legacy Size Negotiation will
-                    // overwrite the position and size values measured in the Layouting.
-                    Layout.Margin = value;
-                    SetValue(MarginProperty, new Extents(0, 0, 0, 0));
-                    layout?.RequestLayout();
-                }
-                else
-                {
-                    SetValue(MarginProperty, value);
-                }
+                SetValue(MarginProperty, value);
                 NotifyPropertyChanged();
-                layout?.RequestLayout();
             }
         }
 
@@ -2803,26 +2756,28 @@ namespace Tizen.NUI.BaseComponents
                     {
                         Extents margin = Margin;
                         Extents padding = Padding;
+                        bool setMargin = false;
+                        bool setPadding = false;
+
                         if (margin.Top != 0 || margin.Bottom != 0 || margin.Start != 0 || margin.End != 0)
                         {
                             // If View already has a margin set then store it in Layout instead.
                             value.Margin = margin;
                             SetValue(MarginProperty, new Extents(0, 0, 0, 0));
-                            NotifyPropertyChanged();
+                            setMargin = true;
                         }
 
                         if (padding.Top != 0 || padding.Bottom != 0 || padding.Start != 0 || padding.End != 0)
                         {
                             // If View already has a padding set then store it in Layout instead.
                             value.Padding = padding;
+                            SetValue(PaddingProperty, new Extents(0, 0, 0, 0));
+                            setPadding = true;
+                        }
 
-                            // If Layout is a LayoutItem then it could be a View that handles it's own padding.
-                            // Let the View keeps it's padding.  Still store Padding in Layout to reduce code paths.
-                            if (typeof(LayoutGroup).IsAssignableFrom(value.GetType()))
-                            {
-                                SetValue(PaddingProperty, new Extents(0, 0, 0, 0));
-                                NotifyPropertyChanged();
-                            }
+                        if (setMargin || setPadding)
+                        {
+                            NotifyPropertyChanged();
                         }
 
                         value.SetPositionByLayout = !excludeLayouting;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1570,22 +1570,50 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
                 if (newValue != null)
                 {
-                    var tmp = new PropertyValue((Extents)newValue);
-                    Object.SetProperty(view.SwigCPtr, View.Property.PADDING, tmp);
-                    tmp?.Dispose();
+                    if (view.Layout != null)
+                    {
+                        view.Layout.Padding = new Extents((Extents)newValue);
+                        if ((view.Padding.Start != 0) || (view.Padding.End != 0) || (view.Padding.Top != 0) || (view.Padding.Bottom != 0))
+                        {
+                            var tmp = new PropertyValue(new Extents(0, 0, 0, 0));
+                            Object.SetProperty(view.SwigCPtr, Property.PADDING, tmp);
+                            tmp?.Dispose();
+                        }
+                        view.Layout.RequestLayout();
+                    }
+                    else
+                    {
+                        var tmp = new PropertyValue((Extents)newValue);
+                        Object.SetProperty(view.SwigCPtr, Property.PADDING, tmp);
+                        tmp?.Dispose();
+                    }
                 }
             },
             defaultValueCreator: (bindable) =>
             {
                 var view = (View)bindable;
-                if (view.internalPadding == null)
+                if ((view.internalPadding == null) || (view.Layout != null))
                 {
-                    view.internalPadding = new Extents(view.OnPaddingChanged, 0, 0, 0, 0);
+                    ushort start = 0, end = 0, top = 0, bottom = 0;
+                    if (view.Layout != null)
+                    {
+                        if (view.Layout.Padding != null)
+                        {
+                            start = view.Layout.Padding.Start;
+                            end = view.Layout.Padding.End;
+                            top = view.Layout.Padding.Top;
+                            bottom = view.Layout.Padding.Bottom;
+                        }
+                    }
+                    view.internalPadding = new Extents(view.OnPaddingChanged, start, end, top, bottom);
                 }
 
-                var tmp = Object.GetProperty(view.SwigCPtr, Property.PADDING);
-                tmp?.Get(view.internalPadding);
-                tmp?.Dispose();
+                if (view.Layout == null)
+                {
+                    var tmp = Object.GetProperty(view.SwigCPtr, Property.PADDING);
+                    tmp?.Get(view.internalPadding);
+                    tmp?.Dispose();
+                }
 
                 return view.internalPadding;
             }
@@ -1784,21 +1812,51 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
                 if (newValue != null)
                 {
-                    var tmp = new PropertyValue((Extents)newValue);
-                    Object.SetProperty(view.SwigCPtr, Property.MARGIN, tmp);
-                    tmp?.Dispose();
+                    if (view.Layout != null)
+                    {
+                        view.Layout.Margin = new Extents((Extents)newValue);
+                        if ((view.Margin.Start != 0) || (view.Margin.End != 0) || (view.Margin.Top != 0) || (view.Margin.Bottom != 0))
+                        {
+                            var tmp = new PropertyValue(new Extents(0, 0, 0, 0));
+                            Object.SetProperty(view.SwigCPtr, Property.MARGIN, tmp);
+                            tmp?.Dispose();
+                        }
+                        view.Layout.RequestLayout();
+                    }
+                    else
+                    {
+                        var tmp = new PropertyValue((Extents)newValue);
+                        Object.SetProperty(view.SwigCPtr, Property.MARGIN, tmp);
+                        tmp?.Dispose();
+                    }
                 }
             },
             defaultValueCreator: (bindable) =>
             {
                 var view = (View)bindable;
-                if (view.internalMargin == null)
+                if ((view.internalMargin == null) || (view.Layout != null))
                 {
-                    view.internalMargin = new Extents(view.OnMarginChanged, 0, 0, 0, 0);
+                    ushort start = 0, end = 0, top = 0, bottom = 0;
+                    if (view.Layout != null)
+                    {
+                        if (view.Layout.Margin != null)
+                        {
+                            start = view.Layout.Margin.Start;
+                            end = view.Layout.Margin.End;
+                            top = view.Layout.Margin.Top;
+                            bottom = view.Layout.Margin.Bottom;
+                        }
+                    }
+                    view.internalMargin = new Extents(view.OnMarginChanged, start, end, top, bottom);
                 }
-                var tmp = Object.GetProperty(view.SwigCPtr, Property.MARGIN);
-                tmp?.Get(view.internalMargin);
-                tmp?.Dispose();
+
+                if (view.Layout == null)
+                {
+                    
+                    var tmp = Object.GetProperty(view.SwigCPtr, Property.MARGIN);
+                    tmp?.Get(view.internalMargin);
+                    tmp?.Dispose();
+                }
 
                 return view.internalMargin;
             }

--- a/test/Tizen.NUI.LayoutSamples/Tizen.NUI.LayoutSamples/ObjectView.cs
+++ b/test/Tizen.NUI.LayoutSamples/Tizen.NUI.LayoutSamples/ObjectView.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI.LayoutSamples
             {
                 if (base.Margin.EqualTo(value)) return;
 
-                base.Margin.CopyFrom(value);
+                base.Margin = new Extents(value);
                 MarginChanged?.Invoke(this, new MarginChangedEventArgs(base.Margin));
             }
         }
@@ -82,7 +82,7 @@ namespace Tizen.NUI.LayoutSamples
             {
                 if (base.Padding.EqualTo(value)) return;
 
-                base.Padding.CopyFrom(value);
+                base.Padding = new Extents(value);
                 PaddingChanged?.Invoke(this, new PaddingChangedEventArgs(base.Padding));
             }
         }


### PR DESCRIPTION
View.Margin and Padding refers View.Layout.Margin and Padding.

So if View.Margin and Padding are set with Layout, then
View.Layout.Margin and Padding are set and View.Margin and Padding
become Extents(0, 0, 0, 0).

Previously, the problem was that View.MarginProperty and PaddingProperty
did not support the above logic properly.

Now, to resolve the above issue, View.MarginProperty and PaddingProperty
support the above logic properly.
i.e. Setting View.MarginProperty and PaddingProperty with Layout set
     value to View.Layout.Margin and Padding and also set
     Extents(0, 0, 0, 0) to View.Margin and Padding.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
