### PR TITLE
[NUI] Fix crash issue in widget

### DIFF
--- a/src/Tizen.NUI/src/internal/Widget/WidgetApplication.cs
+++ b/src/Tizen.NUI/src/internal/Widget/WidgetApplication.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI
     {
         private Dictionary<System.Type, string> widgetInfo;
         private List<Widget> widgetList = new List<Widget>();
-        private delegate System.IntPtr CreateWidgetFunctionDelegate(ref string widgetName);
+        private delegate System.IntPtr CreateWidgetFunctionDelegate(ref global::System.IntPtr widgetPtr);
         private List<CreateWidgetFunctionDelegate> createWidgetFunctionDelegateList = new List<CreateWidgetFunctionDelegate>();
 
         internal WidgetApplication(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
@@ -115,8 +115,9 @@ namespace Tizen.NUI
             }
         }
 
-        public static System.IntPtr WidgetCreateFunction(ref string widgetName)
+        public static System.IntPtr WidgetCreateFunction(ref global::System.IntPtr widgetPtr)
         {
+            string widgetName = System.Runtime.InteropServices.Marshal.PtrToStringAnsi(widgetPtr);
             if ((Instance as WidgetApplication) == null)
             {
                 return IntPtr.Zero;


### PR DESCRIPTION
As the widget passes a string to use the creation function, string types makes crash.
To avoid this problem, we use Intptr instead of string when widget sender its Id.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
