### PR TITLE
[NUI] Fix CheckBox and Button.Icon sizes in theme

### DIFF
--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -52,10 +52,6 @@ namespace Tizen.NUI.Components
                     Selected = new Color(0.624f, 0.239f, 0.0f, 1),
                     Disabled = new Color(0.792f, 0.792f, 0.792f, 1),
                 },
-                Icon = new ImageViewStyle()
-                {
-                    Size = new Size(32, 32),
-                },
                 Text = new TextLabelStyle()
                 {
                     TextColor = new Color("#FDFDFD"),
@@ -66,7 +62,7 @@ namespace Tizen.NUI.Components
             // CheckBox base style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.CheckBox", new ButtonStyle()
             {
-                Size = new Size(48, 48),
+                ItemSpacing = new Size2D(16, 16),
                 ItemHorizontalAlignment = HorizontalAlignment.Center,
                 ItemVerticalAlignment = VerticalAlignment.Center,
                 Icon = new ImageViewStyle()


### PR DESCRIPTION
Since CheckBox.Text size can be increased, CheckBox size should not be
set in theme.
CheckBox.ItemSpacing is set to be 8px.
Since Button.Icon is able not to be set, Button.Icon size should not be
set in theme.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
