### PR TITLE
[NUI] Set Padding to CheckBox and RadioButton based on the latest UX

### DIFF
--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -62,6 +62,7 @@ namespace Tizen.NUI.Components
             // CheckBox base style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.CheckBox", new ButtonStyle()
             {
+                Padding = new Extents(8, 8, 8, 8),
                 ItemSpacing = new Size2D(16, 16),
                 ItemHorizontalAlignment = HorizontalAlignment.Center,
                 ItemVerticalAlignment = VerticalAlignment.Center,
@@ -156,6 +157,7 @@ namespace Tizen.NUI.Components
             // RadioButton base style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.RadioButton", new ButtonStyle()
             {
+                Padding = new Extents(8, 8, 8, 8),
                 ItemSpacing = new Size2D(16, 16),
                 ItemHorizontalAlignment = HorizontalAlignment.Center,
                 ItemVerticalAlignment = VerticalAlignment.Center,
@@ -335,7 +337,7 @@ namespace Tizen.NUI.Components
             theme.AddStyleWithoutClone("Tizen.NUI.Components.DefaultLinearItem", new DefaultLinearItemStyle()
             {
                 SizeHeight = 64,
-                Padding = new Extents(20, 20, 0, 0),
+                Padding = new Extents(16, 16, 0, 0),
                 Margin = new Extents(0, 0, 0, 0),
                 Label = new TextLabelStyle()
                 {
@@ -367,11 +369,11 @@ namespace Tizen.NUI.Components
                 },
                 Icon = new ViewStyle()
                 {
-                    Margin = new Extents(0, 24, 0, 0)
+                    Margin = new Extents(0, 16, 0, 0)
                 },
                 Extra = new ViewStyle()
                 {
-                    Margin = new Extents(24, 0, 0, 0)
+                    Margin = new Extents(16, 0, 0, 0)
                 },
             });
 


### PR DESCRIPTION
CheckBox and RadioButton has Padding around the Icon based on the latest
UX.

Due to the Padding, CheckBox and RadioButton sizes are increased.
Since CheckBox and RadioButton's sizes are increased,
DefaultLinearItem's Padding and Margin are updated.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
