### PR TITLE
[NUI] Fix typo in ScrollableBase

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1870,7 +1870,7 @@ namespace Tizen.NUI.Components
                         }
                         else if (right > visibleRectangleRight)
                         {
-                            ScrollTo(right - Size.Width - ContentContainer.ScreenPosition.Y, true);
+                            ScrollTo(right - Size.Width - ContentContainer.ScreenPosition.X, true);
                         }
                     }
                     else


### PR DESCRIPTION
Fix typo ScreenPosition.Y to ScreenPosition.X in #4238.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
