### PR TITLE
[NUI] Fix MenuItem's size calculation logic like TabButton

### DIFF
--- a/src/Tizen.NUI.Components/Controls/MenuItem.cs
+++ b/src/Tizen.NUI.Components/Controls/MenuItem.cs
@@ -85,14 +85,6 @@ namespace Tizen.NUI.Components
 
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnRelayout(Vector2 size, RelayoutContainer container)
-        {
-            base.OnRelayout(size, container);
-            LayoutItems();
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool OnKey(Key key)
         {
             if ((IsEnabled == false) || (key == null))
@@ -120,6 +112,36 @@ namespace Tizen.NUI.Components
             }
 
             return ret;
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new string Text
+        {
+            get
+            {
+                return base.Text;
+            }
+            set
+            {
+                base.Text = value;
+                UpdateSizeAndSpacing();
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new string IconURL
+        {
+            get
+            {
+                return base.IconURL;
+            }
+            set
+            {
+                base.IconURL = value;
+                UpdateSizeAndSpacing();
+            }
         }
 
         /// <inheritdoc/>
@@ -180,6 +202,31 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void LayoutItems()
         {
+            UpdateSizeAndSpacing();
+        }
+
+        private void Initialize()
+        {
+            Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Begin,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+        }
+
+        /// <summary>
+        /// Initialize AT-SPI object.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void OnInitialize()
+        {
+            base.OnInitialize();
+            AccessibilityRole = Role.MenuItem;
+        }
+
+        private void UpdateSizeAndSpacing()
+        {
             if (styleApplied == false)
             {
                 return;
@@ -221,26 +268,6 @@ namespace Tizen.NUI.Components
             {
                 Add(TextLabel);
             }
-        }
-
-        private void Initialize()
-        {
-            Layout = new LinearLayout()
-            {
-                LinearOrientation = LinearLayout.Orientation.Horizontal,
-                HorizontalAlignment = HorizontalAlignment.Begin,
-                VerticalAlignment = VerticalAlignment.Center,
-            };
-        }
-
-        /// <summary>
-        /// Initialize AT-SPI object.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnInitialize()
-        {
-            base.OnInitialize();
-            AccessibilityRole = Role.MenuItem;
         }
     }
 }


### PR DESCRIPTION
Previously, MenuItem's size was not calculated immediately when
MenuItem.Text/IconURL is set.
So, the MenuItem's size was calculated in the next main loop.

Now, MenuItem's size is calculated immediately when
MenuItem.Text/IconURL is set.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
