### PR TITLE
[WebRTC] Add Looping API for MediaFileSource

### DIFF
--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.cs
@@ -113,6 +113,12 @@ internal static partial class Interop
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_file_source_set_path")]
         internal static extern WebRTCErrorCode SetFileSourcePath(IntPtr handle, uint sourceId, string path);
 
+        [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_file_source_set_looping")]
+        internal static extern WebRTCErrorCode SetFileSourceLooping(IntPtr handle, uint sourceId, bool looping);
+
+        [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_file_source_get_looping")]
+        internal static extern WebRTCErrorCode GetFileSourceLooping(IntPtr handle, uint sourceId, out bool looping);
+
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_media_source_get_transceiver_direction")]
         internal static extern WebRTCErrorCode GetTransceiverDirection(IntPtr handle, uint sourceId, MediaType type, out TransceiverDirection mode);
 

--- a/src/Tizen.Multimedia.Remoting/WebRTC/MediaFileSource.cs
+++ b/src/Tizen.Multimedia.Remoting/WebRTC/MediaFileSource.cs
@@ -46,6 +46,42 @@ namespace Tizen.Multimedia.Remoting
             _path = path ?? throw new ArgumentNullException(nameof(path), "path is null");
         }
 
+        /// <summary>
+        /// Gets or sets the looping mode of the file source.
+        /// </summary>
+        /// <value>
+        /// true if the transfer starts again from the beginning of the file source after reaching the end of the file; otherwise, false\n
+        /// The default value is false.
+        /// </value>
+        /// <exception cref="InvalidOperationException">MediaSource is not attached yet.</exception>
+        /// <exception cref="ObjectDisposedException">The WebRTC has already been disposed.</exception>
+        /// <since_tizen> 10 </since_tizen>
+        public bool Looping
+        {
+            get
+            {
+                if (!SourceId.HasValue)
+                {
+                    throw new InvalidOperationException("MediaSource is not attached yet. Call AddSource() first.");
+                }
+
+                NativeWebRTC.GetFileSourceLooping(WebRtc.Handle, SourceId.Value, out bool isLooping).
+                    ThrowIfFailed("Failed to get looping mode");
+
+                return isLooping;
+            }
+            set
+            {
+                if (!SourceId.HasValue)
+                {
+                    throw new InvalidOperationException("MediaSource is not attached yet. Call AddSource() first.");
+                }
+
+                NativeWebRTC.SetFileSourceLooping(WebRtc.Handle, SourceId.Value, value).
+                    ThrowIfFailed("Failed to set looping mode");
+            }
+        }
+
         internal override void OnAttached(WebRTC webRtc)
         {
             Debug.Assert(webRtc != null);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
If this API is set to true, the transfer starts again from the beginning of the file source after reaching the end of the file.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - TCSACR-
