### PR TITLE
[WebRTC] Add new DataChannel buffered amount APIs

### DIFF
--- a/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.DataChannel.cs
+++ b/src/Tizen.Multimedia.Remoting/Interop/Interop.WebRTC.DataChannel.cs
@@ -38,6 +38,9 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ClosedCallback(IntPtr dataChanndelHandle, IntPtr userData);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void BufferedAmountLowThresholdCallback(IntPtr dataChanndelHandle, IntPtr userData);
+
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_create_data_channel")]
         internal static extern WebRTCErrorCode Create(IntPtr handle, string label, SafeBundleHandle bundle, out IntPtr dataChanndelHandle);
@@ -56,6 +59,12 @@ internal static partial class Interop
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_get_data")]
         internal static extern WebRTCErrorCode GetData(IntPtr byteDataHandle, out IntPtr data, out ulong size);
+
+        [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_data_channel_get_buffered_amount")]
+        internal static extern WebRTCErrorCode GetBufferedAmount(IntPtr handle, out uint amount);
+
+        [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_data_channel_get_buffered_amount_low_threshold")]
+        internal static extern WebRTCErrorCode GetBufferedAmountLowThreshold(IntPtr handle, out uint threshold);
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_set_data_channel_cb")]
         internal static extern WebRTCErrorCode SetCreatedByPeerCb(IntPtr handle, CreatedCallback callback, IntPtr userData = default);
@@ -86,5 +95,12 @@ internal static partial class Interop
 
         [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_data_channel_unset_close_cb")]
         internal static extern WebRTCErrorCode UnsetClosedCb(IntPtr handle);
+
+        [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_data_channel_set_buffered_amount_low_cb")]
+        internal static extern WebRTCErrorCode SetBufferedAmountLowThresholdCb(IntPtr handle, uint threshold, BufferedAmountLowThresholdCallback callback,
+            IntPtr userData = default);
+
+        [DllImport(Libraries.WebRTC, EntryPoint = "webrtc_data_channel_unset_buffered_amount_low_cb")]
+        internal static extern WebRTCErrorCode UnsetBufferedAmountLowThresholdCb(IntPtr handle);
     }
 }

--- a/src/Tizen.Multimedia.Remoting/WebRTC/WebRTCDataChannel.cs
+++ b/src/Tizen.Multimedia.Remoting/WebRTC/WebRTCDataChannel.cs
@@ -114,6 +114,57 @@ namespace Tizen.Multimedia.Remoting
         public string Label { get; }
 
         /// <summary>
+        /// Gets the amount of buffered data.
+        /// </summary>
+        /// <value>The buffered amount in bytes.</value>
+        /// <since_tizen> 10 </since_tizen>
+        public uint BufferedAmount
+        {
+            get
+            {
+                ValidateNotDisposed();
+
+                NativeDataChannel.GetBufferedAmount(Handle, out uint amount).
+                    ThrowIfFailed("Failed to get buffered amount");
+
+                return amount;
+            }
+        }
+
+        private uint? _bufferThreshold;
+        /// <summary>
+        /// Gets or sets the threshold of data channel buffered amount.<br/>
+        /// If the amount of buffered data is lower than threshold value, <see cref="BufferedAmountLow"/> will be occurred.<br/>
+        /// The default value is 0, which means <see cref="BufferedAmountLow"/> is disabled and will not be raised.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public uint BufferedAmountLowThreshold
+        {
+            get
+            {
+                ValidateNotDisposed();
+
+                if (!_bufferThreshold.HasValue)
+                {
+                    NativeDataChannel.GetBufferedAmountLowThreshold(Handle, out uint threshold).
+                        ThrowIfFailed("Failed to get buffer threshold value");
+
+                    _bufferThreshold = threshold;
+                }
+
+                return _bufferThreshold.Value;
+            }
+            set
+            {
+                ValidateNotDisposed();
+
+                _bufferThreshold = value;
+
+                RegisterDataChannelBufferedAmountLowThresholdCallback();
+            }
+        }
+
+        /// <summary>
         /// Sends a string data across the data channel to the remote peer.
         /// </summary>
         /// <param name="data">The string data to send</param>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Add new DataChannel buffered amount APIs

User can set threshold value using `BufferedAmountLowThreshold` property and the amount of buffered data is lower than threshold value, `BufferedAmountLow` event will be raised.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - TCSACR-480
