### PR TITLE
[NUI][AT-SPI] Remove AccessibilityShouldReportZeroChildren()

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -46,15 +46,6 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Prevents from showing child widgets in AT-SPI tree.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool AccessibilityShouldReportZeroChildren()
-        {
-            return true;
-        }
-
-        /// <summary>
         /// The ButtonExtension instance that is injected by ButtonStyle.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -71,7 +62,7 @@ namespace Tizen.NUI.Components
             {
                 HorizontalAlignment = HorizontalAlignment.Center,
                 VerticalAlignment = VerticalAlignment.Center,
-                AccessibilityHighlightable = false,
+                AccessibilityHidden = true,
             };
         }
 
@@ -84,7 +75,7 @@ namespace Tizen.NUI.Components
         {
             return new ImageView()
             {
-                AccessibilityHighlightable = false
+                AccessibilityHidden = true,
             };
         }
 
@@ -102,7 +93,7 @@ namespace Tizen.NUI.Components
                 PivotPoint = NUI.PivotPoint.Center,
                 WidthResizePolicy = ResizePolicyType.FillToParent,
                 HeightResizePolicy = ResizePolicyType.FillToParent,
-                AccessibilityHighlightable = false
+                AccessibilityHidden = true,
             };
         }
 

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -512,15 +512,6 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Prevents from showing child widgets in AT-SPI tree.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool AccessibilityShouldReportZeroChildren()
-        {
-            return true;
-        }
-
-        /// <summary>
         /// Gets minimum value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -685,7 +676,7 @@ namespace Tizen.NUI.Components
                 {
                     indeterminateAnimation = new Animation(2000);
                 }
-                
+
                 float destination = (this.SizeWidth - indeterminateImage.SizeWidth);
 
                 KeyFrames keyFrames = new KeyFrames();
@@ -796,7 +787,8 @@ namespace Tizen.NUI.Components
                     HeightResizePolicy = ResizePolicyType.FillToParent,
                     PositionUsesPivotPoint = true,
                     ParentOrigin = NUI.ParentOrigin.TopLeft,
-                    PivotPoint = NUI.PivotPoint.TopLeft
+                    PivotPoint = NUI.PivotPoint.TopLeft,
+                    AccessibilityHidden = true,
                 };
                 Add(trackImage);
             }
@@ -812,7 +804,8 @@ namespace Tizen.NUI.Components
                     HeightResizePolicy = ResizePolicyType.FillToParent,
                     PositionUsesPivotPoint = true,
                     ParentOrigin = Tizen.NUI.ParentOrigin.TopLeft,
-                    PivotPoint = Tizen.NUI.PivotPoint.TopLeft
+                    PivotPoint = Tizen.NUI.PivotPoint.TopLeft,
+                    AccessibilityHidden = true,
                 };
                 Add(progressImage);
             }
@@ -828,7 +821,8 @@ namespace Tizen.NUI.Components
                     HeightResizePolicy = ResizePolicyType.FillToParent,
                     PositionUsesPivotPoint = true,
                     ParentOrigin = Tizen.NUI.ParentOrigin.TopLeft,
-                    PivotPoint = Tizen.NUI.PivotPoint.TopLeft
+                    PivotPoint = Tizen.NUI.PivotPoint.TopLeft,
+                    AccessibilityHidden = true,
                 };
                 Add(bufferImage);
                 bufferImage.Hide(); // At first, buffer image does not show.
@@ -842,7 +836,8 @@ namespace Tizen.NUI.Components
                 Size = new Size(16, 16),
                 PositionUsesPivotPoint = true,
                 ParentOrigin = Tizen.NUI.ParentOrigin.CenterLeft,
-                PivotPoint = Tizen.NUI.PivotPoint.CenterLeft
+                PivotPoint = Tizen.NUI.PivotPoint.CenterLeft,
+                AccessibilityHidden = true,
             };
             trackImage.Add(indeterminateImage);
             indeterminateImage.Hide();

--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -126,7 +126,8 @@ namespace Tizen.NUI.Components
                 slidedTrackImage = new ImageView()
                 {
                     WidthResizePolicy = ResizePolicyType.Fixed,
-                    HeightResizePolicy = ResizePolicyType.Fixed
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+                    AccessibilityHidden = true,
                 };
 
                 if (bgTrackImage != null)
@@ -145,7 +146,8 @@ namespace Tizen.NUI.Components
                 warningTrackImage = new ImageView()
                 {
                     WidthResizePolicy = ResizePolicyType.Fixed,
-                    HeightResizePolicy = ResizePolicyType.Fixed
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+                    AccessibilityHidden = true,
                 };
 
                 if (bgTrackImage != null)
@@ -174,7 +176,8 @@ namespace Tizen.NUI.Components
                 warningSlidedTrackImage = new ImageView()
                 {
                     WidthResizePolicy = ResizePolicyType.Fixed,
-                    HeightResizePolicy = ResizePolicyType.Fixed
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+                    AccessibilityHidden = true,
                 };
 
                 if (warningTrackImage != null)
@@ -193,7 +196,8 @@ namespace Tizen.NUI.Components
                 lowIndicatorText = new TextLabel()
                 {
                     WidthResizePolicy = ResizePolicyType.Fixed,
-                    HeightResizePolicy = ResizePolicyType.Fixed
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+                    AccessibilityHidden = true,
                 };
                 this.Add(lowIndicatorText);
             }
@@ -208,7 +212,8 @@ namespace Tizen.NUI.Components
                 highIndicatorText = new TextLabel()
                 {
                     WidthResizePolicy = ResizePolicyType.Fixed,
-                    HeightResizePolicy = ResizePolicyType.Fixed
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+                    AccessibilityHidden = true,
                 };
                 this.Add(highIndicatorText);
             }
@@ -226,7 +231,8 @@ namespace Tizen.NUI.Components
                     HeightResizePolicy = ResizePolicyType.Fixed,
                     ParentOrigin = Tizen.NUI.ParentOrigin.Center,
                     PivotPoint = Tizen.NUI.PivotPoint.Center,
-                    PositionUsesPivotPoint = true
+                    PositionUsesPivotPoint = true,
+                    AccessibilityHidden = true,
                 };
                 this.Add(bgTrackImage);
 
@@ -259,7 +265,8 @@ namespace Tizen.NUI.Components
                     ParentOrigin = NUI.ParentOrigin.Center,
                     PivotPoint = NUI.PivotPoint.Center,
                     PositionUsesPivotPoint = true,
-                    EnableControlState = true
+                    EnableControlState = true,
+                    AccessibilityHidden = true,
                 };
                 if (bgTrackImage != null)
                 {
@@ -283,6 +290,7 @@ namespace Tizen.NUI.Components
                     PivotPoint = Tizen.NUI.PivotPoint.Center,
                     WidthResizePolicy = ResizePolicyType.Fixed,
                     HeightResizePolicy = ResizePolicyType.Fixed,
+                    AccessibilityHidden = true,
                 };
                 if (valueIndicatorText != null)
                 {
@@ -303,7 +311,8 @@ namespace Tizen.NUI.Components
                 valueIndicatorText = new TextLabel()
                 {
                     WidthResizePolicy = ResizePolicyType.Fixed,
-                    HeightResizePolicy = ResizePolicyType.Fixed
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+                    AccessibilityHidden = true,
                 };
                 if (valueIndicatorImage != null)
                 {

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -913,7 +913,14 @@ namespace Tizen.NUI.Components
             }
             set
             {
-                if (null == lowIndicatorImage) lowIndicatorImage = new ImageView();
+                if (null == lowIndicatorImage)
+                {
+                    lowIndicatorImage = new ImageView
+                    {
+                        AccessibilityHidden = true,
+                    };
+                }
+
                 lowIndicatorImage.ResourceUrl = value;
             }
         }
@@ -942,7 +949,14 @@ namespace Tizen.NUI.Components
             }
             set
             {
-                if (null == highIndicatorImage) highIndicatorImage = new ImageView();
+                if (null == highIndicatorImage)
+                {
+                    highIndicatorImage = new ImageView
+                    {
+                        AccessibilityHidden = true,
+                    };
+                }
+
                 highIndicatorImage.ResourceUrl = value;
             }
         }
@@ -1415,6 +1429,7 @@ namespace Tizen.NUI.Components
                         BorderlineWidth = 6.0f,
                         BorderlineOffset = -1f,
                         BackgroundColor = new Color(0.2f, 0.2f, 0.2f, 0.4f),
+                        AccessibilityHidden = true,
                     };
                 }
                 recoverIndicator = FocusManager.Instance.FocusIndicator;
@@ -1549,15 +1564,6 @@ namespace Tizen.NUI.Components
             }
 
             EnableControlStatePropagation = true;
-        }
-
-        /// <summary>
-        /// Prevents from showing child widgets in AT-SPI tree.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override bool AccessibilityShouldReportZeroChildren()
-        {
-            return true;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -247,9 +247,9 @@ namespace Tizen.NUI
                 public AccessibilityGetActionName GetActionName; // 6
 
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                public delegate bool AccessibilityShouldReportZeroChildren(IntPtr self);
+                public delegate uint AccessibilityGetInterfaces(IntPtr self);
                 [EditorBrowsable(EditorBrowsableState.Never)]
-                public AccessibilityShouldReportZeroChildren ShouldReportZeroChildren; // 7
+                public AccessibilityGetInterfaces GetInterfaces; // 7
 
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                 public delegate double AccessibilityGetMinimum(IntPtr self);
@@ -392,14 +392,9 @@ namespace Tizen.NUI
                 public AccessibilityDeselectChild DeselectChild; // 35
 
                 [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-                public delegate uint AccessibilityGetInterfaces(IntPtr self);
-                [EditorBrowsable(EditorBrowsableState.Never)]
-                public AccessibilityGetInterfaces GetInterfaces; // 36
-
-                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
                 public delegate IntPtr AccessibilityGetRangeExtents(IntPtr self, int startOffset, int endOffset, int coordType);
                 [EditorBrowsable(EditorBrowsableState.Never)]
-                public AccessibilityGetRangeExtents GetRangeExtents; // 37
+                public AccessibilityGetRangeExtents GetRangeExtents; // 36
             }
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_DuplicateString")]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -563,12 +563,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual bool AccessibilityShouldReportZeroChildren()
-        {
-            return false;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual bool AccessibilityIsScrollable()
         {
             return false;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
@@ -416,7 +416,6 @@ namespace Tizen.NUI.BaseComponents
             var ad = Interop.ControlDevel.AccessibilityDelegate.Instance;
 
             ad.ScrollToChild            = AccessibilityScrollToChildWrapper;
-            ad.ShouldReportZeroChildren = AccessibilityShouldReportZeroChildrenWrapper;
         }
 
         private static bool AccessibilityScrollToChildWrapper(IntPtr self, IntPtr child)
@@ -424,11 +423,6 @@ namespace Tizen.NUI.BaseComponents
             View view = GetViewFromRefObject(self);
 
             return view.AccessibilityScrollToChild(view.GetInstanceSafely<View>(child));
-        }
-
-        private static bool AccessibilityShouldReportZeroChildrenWrapper(IntPtr self)
-        {
-            return GetViewFromRefObject(self).AccessibilityShouldReportZeroChildren();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This method originated as a hack to cut the AT-SPI tree at a specific node in the case of compound controls (i.e. composed of multiple views overlaid on top of each other), so that there is only one leaf node (instead of a subtree) for `Button`, `Slider`, `Progress` (cf. https://github.com/Samsung/TizenFX/pull/2852) etc. When the AT-SPI infrastructure was developed for DALi, there were no "compound controls" which would need to be handled this way, hence the addition of `AccessibilityShouldReportZeroChildren()` specifically for NUI controls.

However, the `AccessibilityHidden` property was introduced in January 2022 (https://github.com/Samsung/TizenFX/pull/3765) to allow for controlling which nodes should be removed from the AT-SPI tree, and has since become the recommended solution over `AccessibilityShouldReportZeroChildren()`, because the latter is less flexible ("all-or-nothing" approach) and itself requires a hack in dali-csharp-binder to make sure the highlight frame actor is never removed from the tree.

Dependencies (merge at the same time):
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/275067/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
