### PR TITLE
[NUI] Fix MenuItem to add TextLabel and Icon always

### DIFF
--- a/src/Tizen.NUI.Components/Controls/MenuItem.cs
+++ b/src/Tizen.NUI.Components/Controls/MenuItem.cs
@@ -29,8 +29,6 @@ namespace Tizen.NUI.Components
     {
         private bool selectedAgain = false;
 
-        private bool styleApplied = false;
-
         /// <summary>
         /// Creates a new instance of MenuItem.
         /// </summary>
@@ -64,31 +62,6 @@ namespace Tizen.NUI.Components
             }
 
             base.Dispose(type);
-        }
-
-        /// <summary>
-        /// Applies style to MenuItem.
-        /// </summary>
-        /// <param name="viewStyle">The style to apply.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void ApplyStyle(ViewStyle viewStyle)
-        {
-            styleApplied = false;
-
-            base.ApplyStyle(viewStyle);
-
-            styleApplied = true;
-
-            //Calculate position based on Achor's position.
-            LayoutItems();
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void OnRelayout(Vector2 size, RelayoutContainer container)
-        {
-            base.OnRelayout(size, container);
-            LayoutItems();
         }
 
         /// <inheritdoc/>
@@ -173,53 +146,6 @@ namespace Tizen.NUI.Components
                 }
 
                 base.OnControlStateChanged(controlStateChangedInfo);
-            }
-        }
-
-        /// <inheritdoc/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void LayoutItems()
-        {
-            if (styleApplied == false)
-            {
-                return;
-            }
-
-            bool isEmptyIcon = false;
-            bool isEmptyText = false;
-
-            if (String.IsNullOrEmpty(Icon.ResourceUrl))
-            {
-                isEmptyIcon = true;
-            }
-
-            if (String.IsNullOrEmpty(TextLabel.Text))
-            {
-                isEmptyText = true;
-            }
-
-            if (isEmptyIcon)
-            {
-                if (Children.Contains(Icon))
-                {
-                    Remove(Icon);
-                }
-            }
-            else if (Children.Contains(Icon) == false)
-            {
-                Add(Icon);
-            }
-
-            if (isEmptyText)
-            {
-                if (Children.Contains(TextLabel))
-                {
-                    Remove(TextLabel);
-                }
-            }
-            else if (Children.Contains(TextLabel) == false)
-            {
-                Add(TextLabel);
             }
         }
 

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -770,7 +770,6 @@ namespace Tizen.NUI.Components
                 },
                 Icon = new ImageViewStyle()
                 {
-                    Size = new Size(32, 32),
                     Color = new Selector<Color>()
                     {
                         Normal = new Color("#090E21"),


### PR DESCRIPTION
Previously, MenuItem added TextLabel and Icon only if their properties
were set properly.
e.g. Icon is added only if IconURL is set properly.

Now, MenuItem adds TextLabel and Icon regardless of their properties
like Button does.
Because TextLabel and Icon are MenuItem's default feature so they
should always be added to MenuItem.

Icon's default size in theme is removed until Button has a proper way
to support default Icon size.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
