### PR TITLE
[NUI] Support Layout property by ViewStyle

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -338,54 +338,52 @@ namespace Tizen.NUI.Components
             Size2D cellPadding = String.IsNullOrEmpty(buttonText.Text) ? new Size2D(0, 0) : itemSpacing;
 #pragma warning restore CA2000
 
+            // If LayoutItems() is called by OnInitialize(), then layout would be null.
+            // Because layout is set by ApplyStyle() which is called after OnInitialize().
+            var layout = Layout as LinearLayout;
+            if (layout != null)
+            {
+                layout.HorizontalAlignment = itemHorizontalAlignment;
+                layout.VerticalAlignment = itemVerticalAlignment;
+                layout.CellPadding = cellPadding;
+            }
+
             if (IconRelativeOrientation == IconOrientation.Left)
             {
-                Layout = new LinearLayout()
+                if (layout != null)
                 {
-                    LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                    layout.LinearOrientation = LinearLayout.Orientation.Horizontal;
+                }
 
                 Add(buttonIcon);
                 Add(buttonText);
             }
             else if (IconRelativeOrientation == IconOrientation.Right)
             {
-                Layout = new LinearLayout()
+                if (layout != null)
                 {
-                    LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                    layout.LinearOrientation = LinearLayout.Orientation.Horizontal;
+                }
 
                 Add(buttonText);
                 Add(buttonIcon);
             }
             else if (IconRelativeOrientation == IconOrientation.Top)
             {
-                Layout = new LinearLayout()
+                if (layout != null)
                 {
-                    LinearOrientation = LinearLayout.Orientation.Vertical,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                    layout.LinearOrientation = LinearLayout.Orientation.Vertical;
+                }
 
                 Add(buttonIcon);
                 Add(buttonText);
             }
             else if (IconRelativeOrientation == IconOrientation.Bottom)
             {
-                Layout = new LinearLayout()
+                if (layout != null)
                 {
-                    LinearOrientation = LinearLayout.Orientation.Vertical,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                    layout.LinearOrientation = LinearLayout.Orientation.Vertical;
+                }
 
                 Add(buttonText);
                 Add(buttonIcon);

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -56,7 +56,14 @@ namespace Tizen.NUI.Components
                 {
                     TextColor = new Color("#FDFDFD"),
                     PixelSize = 24,
-                }
+                },
+                Layout = new LinearLayout()
+                {
+                    LinearOrientation = LinearLayout.Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    CellPadding = new Size2D(8, 8),
+                },
             });
 
             // CheckBox base style

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -63,6 +63,7 @@ namespace Tizen.NUI.BaseComponents
         private Selector<Rectangle> backgroundImageBorderSelector;
         private Selector<Color> colorSelector;
         private VisualTransformPolicyType? cornerRadiusPolicy;
+        private LayoutItem layout;
 
         static ViewStyle() { }
 
@@ -521,6 +522,16 @@ namespace Tizen.NUI.BaseComponents
         public bool SolidNull { get; set; } = false;
 
         /// <summary>
+        /// Layout to position the View's children.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public LayoutItem Layout
+        {
+            get => (LayoutItem)GetValue(LayoutProperty);
+            set => SetValue(LayoutProperty, value);
+        }
+
+        /// <summary>
         /// HashSet of dirty properties. Internal use only.
         /// </summary>
         internal HashSet<BindableProperty> DirtyProperties { get; private set; }
@@ -576,7 +587,14 @@ namespace Tizen.NUI.BaseComponents
 
                 if (destinationProperty != null)
                 {
-                    InternalSetValue(destinationProperty, sourceValue);
+                    if (sourceProperty.PropertyName.Equals("Layout") && (sourceValue is LayoutItem layout))
+                    {
+                        InternalSetValue(destinationProperty, layout.Clone());
+                    }
+                    else
+                    {
+                        InternalSetValue(destinationProperty, sourceValue);
+                    }
                 }
             }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -440,5 +440,13 @@ namespace Tizen.NUI.BaseComponents
             var buttonStyle = (ViewStyle)bindable;
             return buttonStyle.isEnabled;
         });
+
+        /// <summary> Bindable property of Layout.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty LayoutProperty = BindableProperty.Create(nameof(Layout), typeof(LayoutItem), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            ((ViewStyle)bindable).layout = (LayoutItem)newValue;
+        }, defaultValueCreator: (bindable) => ((ViewStyle)bindable).layout);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -3118,7 +3118,14 @@ namespace Tizen.NUI.BaseComponents
 
                 if (destinationProperty != null)
                 {
-                    InternalSetValue(destinationProperty, sourceValue);
+                    if (sourceProperty.PropertyName.Equals("Layout") && (sourceValue is LayoutItem layout))
+                    {
+                        InternalSetValue(destinationProperty, layout.Clone());
+                    }
+                    else
+                    {
+                        InternalSetValue(destinationProperty, sourceValue);
+                    }
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -14,6 +14,8 @@
  *
  */
 
+using System.ComponentModel;
+
 namespace Tizen.NUI
 {
     /// <summary>
@@ -28,6 +30,23 @@ namespace Tizen.NUI
         /// <since_tizen> 6 </since_tizen>
         public AbsoluteLayout()
         {
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override LayoutItem Clone()
+        {
+            var layout = new AbsoluteLayout();
+
+            foreach (var prop in layout.GetType().GetProperties())
+            {
+                if (prop.GetSetMethod() != null)
+                {
+                    prop.SetValue(layout, this.GetType().GetProperty(prop.Name).GetValue(this));
+                }
+            }
+
+            return layout;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -629,6 +629,23 @@ namespace Tizen.NUI
             Absolute
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override LayoutItem Clone()
+        {
+            var layout = new FlexLayout();
+
+            foreach (var prop in layout.GetType().GetProperties())
+            {
+                if (prop.GetSetMethod() != null)
+                {
+                    prop.SetValue(layout, this.GetType().GetProperty(prop.Name).GetValue(this));
+                }
+            }
+
+            return layout;
+        }
+
         private void measureChild(global::System.IntPtr childPtr, float width, int measureModeWidth, float height, int measureModeHeight, out MeasuredSize measureSize)
         {
             // We need to measure child layout

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -544,6 +544,23 @@ namespace Tizen.NUI
             /// <since_tizen> 8 </since_tizen>
             End = 2,
         }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override LayoutItem Clone()
+        {
+            var layout = new GridLayout();
+
+            foreach (var prop in layout.GetType().GetProperties())
+            {
+                if (prop.GetSetMethod() != null)
+                {
+                    prop.SetValue(layout, this.GetType().GetProperty(prop.Name).GetValue(this));
+                }
+            }
+
+            return layout;
+        }
     }
 
     // Extension Method of GridLayout.Alignment.

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -417,7 +417,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return Owner.SuggestedMinimumWidth;
+                return (Owner != null) ? Owner.SuggestedMinimumWidth : new LayoutLength(0);
             }
         }
 
@@ -430,7 +430,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return Owner.SuggestedMinimumHeight;
+                return (Owner != null) ? Owner.SuggestedMinimumHeight : new LayoutLength(0);
             }
         }
 
@@ -662,6 +662,25 @@ namespace Tizen.NUI
                     parent?.ChangeLayoutChildOrder(this, order);
                 }
             }
+        }
+
+        /// <summary>
+        /// Creates a cloned LayoutItem.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual LayoutItem Clone()
+        {
+            var layout = new LayoutItem();
+
+            foreach (var prop in layout.GetType().GetProperties())
+            {
+                if (prop.GetSetMethod() != null)
+                {
+                    prop.SetValue(layout, this.GetType().GetProperty(prop.Name).GetValue(this));
+                }
+            }
+
+            return layout;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -209,6 +209,23 @@ namespace Tizen.NUI
         {
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override LayoutItem Clone()
+        {
+            var layout = new LinearLayout();
+
+            foreach (var prop in layout.GetType().GetProperties())
+            {
+                if (prop.GetSetMethod() != null)
+                {
+                    prop.SetValue(layout, this.GetType().GetProperty(prop.Name).GetValue(this));
+                }
+            }
+
+            return layout;
+        }
+
         /// <summary>
         /// Measure the layout and its content to determine the measured width and the measured height.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
@@ -337,6 +337,23 @@ namespace Tizen.NUI
         public static void SetFillVertical(View view, bool value) => SetAttachedValue(view, FillVerticalProperty, value);
 
         /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override LayoutItem Clone()
+        {
+            var layout = new RelativeLayout();
+
+            foreach (var prop in layout.GetType().GetProperties())
+            {
+                if (prop.GetSetMethod() != null)
+                {
+                    prop.SetValue(layout, this.GetType().GetProperty(prop.Name).GetValue(this));
+                }
+            }
+
+            return layout;
+        }
+
+        /// <inheritdoc/>
         /// <since_tizen> 9 </since_tizen>
         protected override void OnMeasure(MeasureSpecification widthMeasureSpec, MeasureSpecification heightMeasureSpec)
         {


### PR DESCRIPTION
To separate GUI code from Control logic code, Layout property is
supported by ViewStyle.

Now, Layout property can be set in Theme cs file.

In this PR, Tizen.NUI.Components.Button's Theme supports Layout
property.

After applying this PR, all other Controls' Themes can support Layout
property.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
