### PR TITLE
[NUI.Components] Fix issue of LowIndicatorImage & HighIndicatorImage could not shown normally

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -222,6 +222,40 @@ namespace Tizen.NUI.Components
             return highIndicatorText;
         }
 
+        private ImageView CreateLowIndicatorImage()
+        {
+            if (lowIndicatorImage == null)
+            {
+                lowIndicatorImage = new ImageView()
+                {
+                    WidthResizePolicy = ResizePolicyType.Fixed,
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+		    AccessibilityHidden = true,
+                };
+                this.Add(lowIndicatorImage);
+            }
+
+            return lowIndicatorImage;
+        }
+
+        private ImageView CreateHighIndicatorImage()
+        {
+            if (highIndicatorImage == null)
+            {
+                highIndicatorImage = new ImageView()
+                {
+                    WidthResizePolicy = ResizePolicyType.Fixed,
+                    HeightResizePolicy = ResizePolicyType.Fixed,
+					AccessibilityHidden = true,
+                };
+                this.Add(highIndicatorImage);
+            }
+
+            return highIndicatorImage;
+        }
+
+
+
         private ImageView CreateBackgroundTrack()
         {
             if (null == bgTrackImage)
@@ -282,7 +316,7 @@ namespace Tizen.NUI.Components
             return thumbImage;
         }
 
-        private ImageView CreateValueIndicator()
+        private ImageView CreateValueIndicatorImage()
         {
             if (valueIndicatorImage == null)
             {

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1533,6 +1533,16 @@ namespace Tizen.NUI.Components
                 CreateHighIndicatorText().ApplyStyle(sliderStyle.HighIndicator);
             }
 
+            if (null != sliderStyle?.LowIndicatorImage)
+            {
+                CreateLowIndicatorImage().ApplyStyle(sliderStyle.LowIndicatorImage);
+            }
+
+            if (null != sliderStyle?.HighIndicatorImage)
+            {
+                CreateHighIndicatorImage().ApplyStyle(sliderStyle.HighIndicatorImage);
+            }
+
             if (null != sliderStyle?.Track)
             {
                 CreateBackgroundTrack().ApplyStyle(sliderStyle.Track);
@@ -1550,7 +1560,7 @@ namespace Tizen.NUI.Components
 
             if (null != sliderStyle?.ValueIndicatorImage)
             {
-                CreateValueIndicator().ApplyStyle(sliderStyle.ValueIndicatorImage);
+                CreateValueIndicatorImage().ApplyStyle(sliderStyle.ValueIndicatorImage);
             }
 
             if (null != sliderStyle?.WarningTrack)


### PR DESCRIPTION
### Description of Change ###
Set LowIndicatorImageURL and HighIndicatorImageURL for slider, but could not be shown, because the ImageView was not be added , 

// in Slider.cs

public override void ApplyStyle(ViewStyle viewStyle)
{
	......
	
	if (null != sliderStyle?.LowIndicatorImage)
        {
            CreateLowIndicatorImage().ApplyStyle(sliderStyle.LowIndicatorImage);
        }

        if (null != sliderStyle?.HighIndicatorImage)
        {
            CreateHighIndicatorImage().ApplyStyle(sliderStyle.HighIndicatorImage);
        }
	
	......
}


// added in Slider.Internal.cs
private ImageView CreateLowIndicatorImage()
{
    if (lowIndicatorImage == null)
    {
        lowIndicatorImage = new ImageView()
        {
            WidthResizePolicy = ResizePolicyType.Fixed,
            HeightResizePolicy = ResizePolicyType.Fixed,
			AccessibilityHidden = true,
        };
        this.Add(lowIndicatorImage);
    }

    return lowIndicatorImage;
}

private ImageView CreateHighIndicatorImage()
{
	if (highIndicatorImage == null)
    {
        highIndicatorImage = new ImageView()
		{
			WidthResizePolicy = ResizePolicyType.Fixed,
            HeightResizePolicy = ResizePolicyType.Fixed,
			AccessibilityHidden = true,
        };
        this.Add(highIndicatorImage);
    }

    return highIndicatorImage;
}


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
