### PR TITLE
[NUI] Fix bug that PreMultipliedAlpha not applied to Visual

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -50,6 +50,7 @@ namespace Tizen.NUI.BaseComponents
             ImageVisualProperty.WrapModeU,
             ImageVisualProperty.WrapModeV,
             ImageVisualProperty.SynchronousLoading,
+            Visual.Property.PremultipliedAlpha,
             ImageVisualProperty.OrientationCorrection,
             NpatchImageVisualProperty.Border,
             NpatchImageVisualProperty.BorderOnly,

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -135,14 +135,33 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha, new Tizen.NUI.PropertyValue((bool)newValue));
+                if(imageView.imagePropertyUpdatedFlag)
+                {
+                    // If imageView Property still not send to the dali, Append cached property.
+                    imageView.UpdateImage(Visual.Property.PremultipliedAlpha, new PropertyValue((bool)newValue));
+                }
+                else
+                {
+                    // Else, we don't need to re-create view. Get value from current ImageView.
+                    Tizen.NUI.Object.SetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha, new Tizen.NUI.PropertyValue((bool)newValue));
+                }
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var imageView = (ImageView)bindable;
             bool temp = false;
-            Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha).Get(out temp);
+
+            if(imageView.imagePropertyUpdatedFlag)
+            {
+                // If imageView Property still not send to the dali, just get cached property.
+                imageView.GetCachedImageVisualProperty(Visual.Property.PremultipliedAlpha)?.Get(out temp);
+            }
+            else
+            {
+                // Else, PremultipliedAlpha may not setuped in cached property. Get value from current ImageView.
+                Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha).Get(out temp);
+            }
             return temp;
         }));
 

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSImageView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSImageView.cs
@@ -97,6 +97,29 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
+        [Description("internal API test in Ubuntu, ImageView.PreMultipliedAlpha")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.PreMultipliedAlpha")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void PreMultipliedAlpha_SET_GET_VALUE()
+        {
+            /* TEST CODE */
+            ImageView testView = new ImageView(image_path);
+
+            testView.PreMultipliedAlpha = true;
+
+            Assert.AreEqual(testView.PreMultipliedAlpha, true, "PreMultipliedAlpha is not updated");
+
+            testView.PreMultipliedAlpha = false;
+
+            Assert.AreEqual(testView.PreMultipliedAlpha, false, "PreMultipliedAlpha is not updated");
+
+            testView.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
         [Description("internal API test in Ubuntu, ImageView.CropToMask with AlphaMaskURL")]
         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.CropToMask")]
         [Property("SPEC_URL", "-")]


### PR DESCRIPTION
Due to the PreMultipliedAlpha property used
both ImageView and ImageVisual internally,
(+ This property don't required re-create new Visual)

We need to make some new way to send this changness
news into ImageVisual.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

