### PR TITLE
[NUI] Add manually set api10 20220530

### DIFF
--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -329,6 +329,7 @@ namespace Tizen.NUI.Binding
                     BindablePropertyContext context = GetOrCreateContext(property);
                     if (null != context)
                     {
+                        context.Attributes |= BindableContextAttributes.IsManuallySet;
                         oldvalue = context.Value;
                         context.Value = value;
                     }

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -54,7 +54,7 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object BindingContext
         {
-            get { return GetValue(BindingContextProperty) ?? inheritedContext; }
+            get { return inheritedContext ?? GetValue(BindingContextProperty); }
             set { SetValue(BindingContextProperty, value); }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Make context as manually set in SetValue function of BindableObject.
2. Revert first use own binding context changes.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
