### PR TITLE
[NUI] Add GetLastKeyEvent and GetLastTouchEvent api for Window

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -290,6 +290,12 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsWindowRotating")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsWindowRotating(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetLastKeyEvent")]
+            public static extern global::System.IntPtr GetLastKeyEvent(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetLastTouchEvent")]
+            public static extern global::System.IntPtr GetLastTouchEvent(global::System.Runtime.InteropServices.HandleRef window);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1701,6 +1701,30 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets the last key event the window gets.
+        /// </summary>
+        /// <returns>The last key event the window gets.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Key GetLastKeyEvent()
+        {
+            Key ret = new Key(Interop.Window.GetLastKeyEvent(SwigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Gets the last touch event the window gets.
+        /// </summary>
+        /// <returns>The last touch event the window gets.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Touch GetLastTouchEvent()
+        {
+            Touch ret = new Touch(Interop.Window.GetLastTouchEvent(SwigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
         /// Add FrameUpdateCallback
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Add GetLastKeyEvent and GetLastTouchEvent api for Window.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None.

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
