### PR TITLE
[NUI] TextField and TextEditor have Focusable set to true.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -89,7 +89,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetVisible(false);
             }
-
+            Focusable = true;
             TextChanged += TextEditorTextChanged;
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -78,7 +78,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetVisible(false);
             }
-
+            Focusable = true;
             TextChanged += TextFieldTextChanged;
         }
 
@@ -88,7 +88,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetVisible(false);
             }
-
+            Focusable = true;
             TextChanged += TextFieldTextChanged;
         }
 


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
If Focusable is true, it can receive focus when moved by the keyboard

This is a fix patch to put back in because Focusable=true was removed in another patch.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
