### PR TITLE
[NUI] Apply SetFocusFinderRootView() to DialogPage only when DefaultAlgorithm Enabled

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -244,6 +244,11 @@ namespace Tizen.NUI.Components
         {
             if (FocusManager.Instance.IsDefaultAlgorithmEnabled())
             {
+                if (this is DialogPage)
+                {
+                    FocusManager.Instance.ResetFocusFinderRootView();
+                }
+
                 var currentFocusedView = FocusManager.Instance.GetCurrentFocusView();
                 if (currentFocusedView)
                 {
@@ -293,6 +298,11 @@ namespace Tizen.NUI.Components
                     }
                     temp.Unparent();
                     temp.Dispose();
+                }
+
+                if (this is DialogPage)
+                {
+                    FocusManager.Instance.SetFocusFinderRootView(this);
                 }
             }
 


### PR DESCRIPTION
### Description of Change ###
[NUI] Apply SetFocusFinderRootView() to DialogPage only when DefaultAlgorithm Enabled
- related to https://github.sec.samsung.net/dotnet/NUIBackend/issues/130#issuecomment-1494887


### API Changes ###
none