### PR TITLE
[NUI] Add CloseDelegate for closing the application by the border.

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -480,7 +480,7 @@ namespace Tizen.NUI
 
             if (borderEnabled)
             {
-                GetDefaultWindow().EnableBorder(borderInterface);
+                GetDefaultWindow().EnableBorder(borderInterface, new Window.BorderCloseDelegate(Exit));
             }
 
             Tizen.Tracer.End();

--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -59,6 +59,9 @@ namespace Tizen.NUI
         #endregion //Distructors
 
         #region Delegates
+        internal delegate void BorderCloseDelegate();
+        private BorderCloseDelegate borderCloseDelegate = null;
+
         #endregion //Delegates
 
         #region Events
@@ -84,7 +87,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// This enum is the policy when resizing the border window. 
+        /// This enum is the policy when resizing the border window.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public enum BorderResizePolicyType
@@ -120,14 +123,30 @@ namespace Tizen.NUI
 
         #region Methods
         /// <summary>
+        /// Called when the border is closed.
+        /// If the delegate is declared, the delegate is called, otherwise window is destroyed.
+        /// </summary>
+        internal void BorderDestroy()
+        {
+            if (borderCloseDelegate != null)
+            {
+                borderCloseDelegate();
+            }
+            else
+            {
+                Destroy();
+            }
+        }
+        /// <summary>
         /// Enable the border window with IBorderInterface.
         /// This adds a border area to the Window.
         /// The border's UI is configured using IBorderInterface.
         /// Users can reisze and move by touching the border area.
         /// </summary>
         /// <param name="borderInterface">The IBorderInterface.</param>
+        /// <param name="borderCloseDelegate">The BorderCloseDelegate. When close, this delegate is called.</param>
         /// <returns>Whether the border window is enabled</returns>
-        internal bool EnableBorder(IBorderInterface borderInterface = null)
+        internal bool EnableBorder(IBorderInterface borderInterface, BorderCloseDelegate borderCloseDelegate = null)
         {
             if (isBorderWindow == true)
             {
@@ -150,6 +169,7 @@ namespace Tizen.NUI
                 borderInterface = new DefaultBorder();
             }
             this.borderInterface = borderInterface;
+            this.borderCloseDelegate = borderCloseDelegate;
 
             GetDefaultLayer().Name = "OriginalRootLayer";
 
@@ -172,8 +192,8 @@ namespace Tizen.NUI
                 if (isBottom) borderHeight += borderInterface.BorderHeight;
 
                 // When running the app for the first time, if it runs in full size, do Maximize(true).
-                if (screenWidth != 0 && screenHeight != 0 && 
-                    realWindowSize.Width >= screenWidth && realWindowSize.Height >= screenHeight && 
+                if (screenWidth != 0 && screenHeight != 0 &&
+                    realWindowSize.Width >= screenWidth && realWindowSize.Height >= screenHeight &&
                     IsMaximized() == false)
                 {
                     Maximize(true);
@@ -196,7 +216,7 @@ namespace Tizen.NUI
                 // Add a view to the border layer.
                 GetBorderWindowBottomLayer().Add(rootView);
 
-                InterceptTouchEvent += (s, e) => 
+                InterceptTouchEvent += (s, e) =>
                 {
                     if (e.Touch.GetState(0) == PointStateType.Down && IsMaximized() == false)
                     {
@@ -232,7 +252,7 @@ namespace Tizen.NUI
                 HeightResizePolicy = ResizePolicyType.FillToParent,
                 BackgroundColor = Color.Transparent,
                 Layout = new LinearLayout() {
-                    LinearOrientation = LinearLayout.Orientation.Vertical, 
+                    LinearOrientation = LinearLayout.Orientation.Vertical,
                     LinearAlignment = LinearLayout.Alignment.Top
                 },
                 Padding = new Extents(padding, padding, padding, padding),

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -390,7 +390,7 @@ namespace Tizen.NUI
                 BorderWindow.RequestResizeToServer(Window.ResizeDirection.TopLeft);
               }
             }
-            return false;
+            return true;
         }
 
         /// <summary>
@@ -408,7 +408,7 @@ namespace Tizen.NUI
                 BorderWindow.RequestResizeToServer(Window.ResizeDirection.TopRight);
               }
             }
-            return false;
+            return true;
         }
 
 
@@ -427,7 +427,7 @@ namespace Tizen.NUI
                 BorderWindow.RequestResizeToServer(Window.ResizeDirection.BottomLeft);
               }
             }
-            return false;
+            return true;
         }
 
         /// <summary>
@@ -445,7 +445,7 @@ namespace Tizen.NUI
                 BorderWindow.RequestResizeToServer(Window.ResizeDirection.BottomRight);
               }
             }
-            return false;
+            return true;
         }
 
 
@@ -470,7 +470,7 @@ namespace Tizen.NUI
             {
                 MinimizeBorderWindow();
             }
-            return false;
+            return true;
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace Tizen.NUI
             {
                 MaximizeBorderWindow();
             }
-            return false;
+            return true;
         }
 
         /// <summary>
@@ -511,8 +511,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void CloseBorderWindow()
         {
-            BorderWindow.Destroy();
-            BorderWindow = null;
+            BorderWindow.BorderDestroy();
         }
 
         /// <summary>
@@ -521,15 +520,11 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnCloseIconTouched(object sender, View.TouchEventArgs e)
         {
-            if (e == null)
-            {
-                return false;
-            }
             if (e != null && e.Touch.GetState(0) == PointStateType.Up)
             {
                 CloseBorderWindow();
             }
-            return false;
+            return true;
         }
 
 
@@ -801,7 +796,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="isMaximized">If window is maximized or unmaximized.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual void OnMaximize(bool isMaximized) 
+        public virtual void OnMaximize(bool isMaximized)
         {
             UpdateIcons();
         }
@@ -882,6 +877,8 @@ namespace Tizen.NUI
                     BorderWindow.InterceptTouchEvent -= OnWinInterceptedTouch;
                 }
 
+                borderView?.Dispose();
+                windowView?.Dispose();
                 borderPanGestureDetector?.Dispose();
                 borderPinchGestureDetector?.Dispose();
                 backgroundColor?.Dispose();
@@ -892,8 +889,6 @@ namespace Tizen.NUI
                 rightCornerIcon?.Dispose();
                 timer?.Dispose();
                 overlayTimer?.Dispose();
-                windowView?.Dispose();
-                borderView?.Dispose();
             }
             disposed = true;
         }


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
When closing, it is necessary to distinguish between the application case and the window case.
So, in the case of Application, we add a delegate so that it can be properly closed through the delegate.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
