### PR TITLE
[NUI] Remove GetDescription() in TextLabelBindableProperty

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -161,11 +161,9 @@ namespace Tizen.NUI.BaseComponents
         public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment), typeof(TextLabel), HorizontalAlignment.Begin, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var textLabel = (TextLabel)bindable;
-            string valueToString = "";
             if (newValue != null)
             {
-                valueToString = ((HorizontalAlignment)newValue).GetDescription();
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment, new Tizen.NUI.PropertyValue(valueToString));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
@@ -183,11 +181,9 @@ namespace Tizen.NUI.BaseComponents
         public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment), typeof(TextLabel), VerticalAlignment.Bottom, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var textLabel = (TextLabel)bindable;
-            string valueToString = "";
             if (newValue != null)
             {
-                valueToString = ((VerticalAlignment)newValue).GetDescription();
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment, new Tizen.NUI.PropertyValue(valueToString));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>


### PR DESCRIPTION
remove GetDescription() for better performance.
and there is no need to convert string to enum.
because the HORIZONTAL_ALIGNMENT and VERTICAL_ALIGNMENT properties of DALi
can be set to an integer or string, and there is no burden if it is an integer(enum).

https://code.sec.samsung.net/confluence/pages/viewpage.action?pageId=269926545&focusedCommentId=269928026