### PR TITLE
[NUI] Allows user to set the height of the top and bottom borders respectively

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -47,7 +47,7 @@ namespace Tizen.NUI
         private View bottomView = null;
         private bool isTop = false;
         private bool isBottom = false;
-        private uint borderHeight = 0;
+        private float borderHeight = 0;
         private int screenWidth = 0;
         private int screenHeight = 0;
         #endregion //Fields
@@ -188,8 +188,9 @@ namespace Tizen.NUI
                 borderInterface.OnCreated(borderView);
 
                 // Increase the window size as much as the border area.
-                if (isTop) borderHeight += borderInterface.BorderHeight;
-                if (isBottom) borderHeight += borderInterface.BorderHeight;
+                borderHeight = 0;
+                if (isTop) borderHeight += topView.SizeHeight;
+                if (isBottom) borderHeight += bottomView.SizeHeight;
 
                 // When running the app for the first time, if it runs in full size, do Maximize(true).
                 if (screenWidth != 0 && screenHeight != 0 &&
@@ -348,7 +349,7 @@ namespace Tizen.NUI
                 direction = BorderDirection.Top;
             }
             // check move
-            else if ((yPosition > WindowSize.Height) || (isTop == true && yPosition < borderInterface.BorderHeight))
+            else if ((yPosition > WindowSize.Height) || (isTop == true && yPosition < topView.SizeHeight))
             {
                 direction = BorderDirection.Move;
             }
@@ -408,6 +409,11 @@ namespace Tizen.NUI
 
             borderInterface.OnResized(resizeWidth, resizeHeight);
 
+             // reset borderHeight
+            borderHeight = 0;
+            if (isTop) borderHeight += topView.SizeHeight;
+            if (isBottom) borderHeight += bottomView.SizeHeight;
+
             if (borderInterface.OverlayMode == true && IsMaximized() == true)
             {
                 Interop.ActorInternal.SetSize(GetBorderWindowRootLayer().SwigCPtr, resizeWidth, resizeHeight);
@@ -421,7 +427,7 @@ namespace Tizen.NUI
             }
             else
             {
-                uint height = (isTop == true) ? borderInterface.BorderHeight : 0;
+                float height = (isTop == true) ? topView.SizeHeight : 0;
                 Interop.ActorInternal.SetSize(GetBorderWindowRootLayer().SwigCPtr, resizeWidth, resizeHeight);
                 Interop.ActorInternal.SetSize(GetBorderWindowBottomLayer().SwigCPtr, resizeWidth + borderInterface.BorderLineThickness * 2, resizeHeight + borderHeight + borderInterface.BorderLineThickness * 2);
                 Interop.ActorInternal.SetPosition(GetBorderWindowRootLayer().SwigCPtr, 0, height + borderInterface.BorderLineThickness);
@@ -465,7 +471,7 @@ namespace Tizen.NUI
                 Interop.Actor.SetAnchorPoint(borderWindowRootLayer.SwigCPtr, topCentor.SwigCPtr);
                 Interop.Actor.Add(rootLayer.SwigCPtr, borderWindowRootLayer.SwigCPtr);
                 Interop.ActorInternal.SetSize(borderWindowRootLayer.SwigCPtr, WindowSize.Width, WindowSize.Height - borderHeight - borderInterface.BorderLineThickness * 2);
-                uint height = (isTop == true) ? borderInterface.BorderHeight : 0;
+                float height = (isTop == true) ? topView.SizeHeight : 0;
                 Interop.ActorInternal.SetPosition(borderWindowRootLayer.SwigCPtr, 0, height + borderInterface.BorderLineThickness);
                 using PropertyValue propertyValue = new Tizen.NUI.PropertyValue((int)Tizen.NUI.ClippingModeType.ClipToBoundingBox);
                 Tizen.NUI.Object.SetProperty(borderWindowRootLayer.SwigCPtr, Tizen.NUI.BaseComponents.View.Property.ClippingMode, propertyValue);

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -42,7 +42,7 @@ namespace Tizen.NUI
         private static readonly string DarkRightCornerIcon = ResourcePath + "dark_rightCorner.png";
 
 
-        private const uint DefaultHeight = 50;
+        private const float DefaultHeight = 50;
         private const uint DefaultLineThickness = 5;
         private const uint DefaultTouchThickness = 20;
         private static readonly Color DefaultBackgroundColor = new Color(1, 1, 1, 0.3f);
@@ -106,9 +106,10 @@ namespace Tizen.NUI
 
         /// <summary>
         /// The height of the border.
+        /// This value is the initial value used when creating borders.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint BorderHeight {get; set;}
+        public float BorderHeight {get; set;}
 
         /// <summary>
         /// The minimum size by which the window will small.

--- a/src/Tizen.NUI/src/public/Window/IBorderInterface.cs
+++ b/src/Tizen.NUI/src/public/Window/IBorderInterface.cs
@@ -41,9 +41,10 @@ namespace Tizen.NUI
 
         /// <summary>
         /// The height of the border.
+        /// This value is the initial value used when creating borders.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint BorderHeight {get;}
+        public float BorderHeight {get;}
 
         /// <summary>
         /// The minimum size by which the window will small.


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
BorderHeight is the default setting.
After the initial height is set as the BorderHeight value, the user can set the height of the border as SizeHeight.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
