### PR TITLE
[NUI] Fix to invoke ValueChanged event when changing the value to Key

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -230,7 +230,7 @@ namespace Tizen.NUI.Components
                 {
                     WidthResizePolicy = ResizePolicyType.Fixed,
                     HeightResizePolicy = ResizePolicyType.Fixed,
-		    AccessibilityHidden = true,
+                    AccessibilityHidden = true,
                 };
                 this.Add(lowIndicatorImage);
             }

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -177,7 +177,23 @@ namespace Tizen.NUI.Components
 
                 if (newValue != null)
                 {
-                    instance.curValue = (float)newValue;
+                    float value = (float)newValue;
+                    if (value < instance.minValue)
+                    {
+                        instance.curValue = instance.minValue;
+                    }
+                    else if (value > instance.maxValue)
+                    {
+                        instance.curValue = instance.maxValue;
+                    }
+                    else
+                    {
+                        instance.curValue = value;
+                    }
+
+                    instance.sliderValueChangedHandler?.Invoke(instance, new SliderValueChangedEventArgs {
+                        CurrentValue = instance.curValue
+                        });
                     if (Accessibility.Accessibility.IsEnabled && instance.IsHighlighted)
                     {
                         instance.EmitAccessibilityEvent(AccessibilityPropertyChangeEvent.Value);
@@ -1460,16 +1476,13 @@ namespace Tizen.NUI.Components
                             isPressed = true;
                             if (IsDiscrete)
                             {
-                                float value = CurrentValue - discreteValue;
-                                CurrentValue = value < MinValue ? MinValue : value;
+                                float value = curValue - discreteValue;
+                                CurrentValue = value;
                             }
                             else
                             {
                                 CurrentValue -= 1;
                             }
-                            sliderValueChangedHandler?.Invoke(this, new SliderValueChangedEventArgs {
-                                CurrentValue = curValue
-                                });
                         }
                         return true; // Consumed
                     }
@@ -1484,16 +1497,13 @@ namespace Tizen.NUI.Components
                             isPressed = true;
                             if (IsDiscrete)
                             {
-                                float value = CurrentValue + discreteValue;
-                                CurrentValue = value > MaxValue ? MaxValue : value;
+                                float value = curValue + discreteValue;
+                                CurrentValue = value;
                             }
                             else
                             {
                                 CurrentValue += 1;
                             }
-                            sliderValueChangedHandler?.Invoke(this, new SliderValueChangedEventArgs {
-                                CurrentValue = curValue
-                                });
                         }
                         return true; // Consumed
                     }
@@ -1621,10 +1631,6 @@ namespace Tizen.NUI.Components
             if (current >= MinValue && current <= MaxValue)
             {
                 CurrentValue = current;
-                if (sliderValueChangedHandler != null)
-                {
-                    sliderValueChangedHandler(this, new SliderValueChangedEventArgs { CurrentValue = current });
-                }
                 return true;
             }
 
@@ -1762,13 +1768,6 @@ namespace Tizen.NUI.Components
             {
                 this.CurrentValue = CalculateDiscreteValue(this.CurrentValue);
             }
-
-            if (sliderValueChangedHandler != null)
-            {
-                SliderValueChangedEventArgs args = new SliderValueChangedEventArgs();
-                args.CurrentValue = this.CurrentValue;
-                sliderValueChangedHandler(this, args);
-            }
         }
 
         private bool OnTouchEventForTrack(object source, TouchEventArgs e)
@@ -1780,7 +1779,7 @@ namespace Tizen.NUI.Components
 
             if (this.FocusableInTouch == false && editMode == false)
             {
-                isFocused = false;   
+                isFocused = false;
             }
 
             PointStateType state = e.Touch.GetState(0);
@@ -1855,13 +1854,6 @@ namespace Tizen.NUI.Components
                 if (IsDiscrete)
                 {
                     this.CurrentValue = CalculateDiscreteValue(this.CurrentValue);
-                }
-
-                if (null != sliderValueChangedHandler)
-                {
-                    SliderValueChangedEventArgs args = new SliderValueChangedEventArgs();
-                    args.CurrentValue = this.CurrentValue;
-                    sliderValueChangedHandler(this, args);
                 }
             }
         }

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1435,6 +1435,7 @@ namespace Tizen.NUI.Components
                 recoverIndicator = FocusManager.Instance.FocusIndicator;
                 FocusManager.Instance.FocusIndicator = editModeIndicator;
             }
+            UpdateState(true, isPressed);
             return true;
         }
 
@@ -1466,6 +1467,9 @@ namespace Tizen.NUI.Components
                             {
                                 CurrentValue -= 1;
                             }
+                            sliderValueChangedHandler?.Invoke(this, new SliderValueChangedEventArgs {
+                                CurrentValue = curValue
+                                });
                         }
                         return true; // Consumed
                     }
@@ -1487,6 +1491,9 @@ namespace Tizen.NUI.Components
                             {
                                 CurrentValue += 1;
                             }
+                            sliderValueChangedHandler?.Invoke(this, new SliderValueChangedEventArgs {
+                                CurrentValue = curValue
+                                });
                         }
                         return true; // Consumed
                     }
@@ -1771,6 +1778,11 @@ namespace Tizen.NUI.Components
                 return false;
             }
 
+            if (this.FocusableInTouch == false && editMode == false)
+            {
+                isFocused = false;   
+            }
+
             PointStateType state = e.Touch.GetState(0);
             if (state == PointStateType.Down)
             {
@@ -1807,6 +1819,11 @@ namespace Tizen.NUI.Components
 
         private bool OnTouchEventForThumb(object source, TouchEventArgs e)
         {
+            if (this.FocusableInTouch == false && editMode == false)
+            {
+                isFocused = false;   
+            }
+
             PointStateType state = e.Touch.GetState(0);
             if (state == PointStateType.Down)
             {


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- Until now, `ValueChanged` event emits on Touch / Mouse moving.
- Update to invoke the event when the thumb moves
 with not only touch event but also key event.

### API Changes ###
- N/A