### PR TITLE
[NUI] Replace GetValueByDescription in TextLabel Alignment

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -174,7 +174,24 @@ namespace Tizen.NUI.BaseComponents
             {
                 NUILog.Error("HorizontalAlignment get error!");
             }
-            return temp.GetValueByDescription<HorizontalAlignment>();
+
+            if (System.String.IsNullOrEmpty(temp))
+            {
+                return HorizontalAlignment.Begin; // Return default value.
+            }
+
+            if (temp.Equals("BEGIN"))
+            {
+                return HorizontalAlignment.Begin;
+            }
+            else if (temp.Equals("CENTER"))
+            {
+                return HorizontalAlignment.Center;
+            }
+            else
+            {
+                return HorizontalAlignment.End;
+            }
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -195,7 +212,23 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Error("VerticalAlignment get error!");
             }
 
-            return temp.GetValueByDescription<VerticalAlignment>();
+            if (System.String.IsNullOrEmpty(temp))
+            {
+                return VerticalAlignment.Top; // Return default value.
+            }
+
+            if (temp.Equals("TOP"))
+            {
+                return VerticalAlignment.Top;
+            }
+            else if (temp.Equals("CENTER"))
+            {
+                return VerticalAlignment.Center;
+            }
+            else
+            {
+                return VerticalAlignment.Bottom;
+            }
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
Horizontal/VerticalAlignment of TextLabelBindableProperty calls
GetValueByDescription to convert DALi property to NUI property.

To improve performance, GetValueByDescription in TextLabel Alignment has
been replaced with string compare.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
