### PR TITLE
[NUI] If window is in overlay mode, pass the hittest so that the lower layer can be hit.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/IBorderInterface.cs
+++ b/src/Tizen.NUI/src/public/Window/IBorderInterface.cs
@@ -136,5 +136,12 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void OnMinimize(bool isMinimized);
 
+        /// <summary>
+        /// Called when there is a change in overlay mode.
+        /// </summary>
+        /// <param name="enabled">If true, borderView has entered overlayMode.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void OnOverlayMode(bool enabled);
+
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


When in overlay mode, the border layer is raised to the top.

In this case, a touch is received from the border layer, and the touch event is not received from the lower root layer.

So let's pass the hittest of the border layer.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
