### PR TITLE
[NUI] Fix scrollableBase focus issue.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1985,7 +1985,6 @@ namespace Tizen.NUI.Components
             if (focusDebugScrollableBase)
             {
                 global::System.Text.StringBuilder debugMessage = new global::System.Text.StringBuilder("=========================================================\n");
-                debugMessage.Append("=========================================================\n");
                 debugMessage.Append($"GetNextFocusableView On: {this}:{this.ID}\n");
                 debugMessage.Append($"----------------Current: {currentFocusedView}:{currentFocusedView?.ID}\n");
                 debugMessage.Append($"-------------------Next: {nextFocusedView}:{nextFocusedView?.ID}\n");
@@ -2046,8 +2045,8 @@ namespace Tizen.NUI.Components
                     {
                         if (currentPosition == maxScrollDistance)
                         {
-                            Debug.WriteLineIf(focusDebugScrollableBase, $"return forward : {nextFocusedView}:{nextFocusedView?.ID}");
-                            return nextFocusedView;
+                            Debug.WriteLineIf(focusDebugScrollableBase, $"return null, escape scrollableBase on forward");
+                            return null;
                         }
                         targetPosition += stepDistance;
                         targetPosition = targetPosition > maxScrollDistance ? maxScrollDistance : targetPosition;
@@ -2057,8 +2056,8 @@ namespace Tizen.NUI.Components
                     {
                         if (currentPosition == 0)
                         {
-                            Debug.WriteLineIf(focusDebugScrollableBase, $"return backward : {nextFocusedView}:{nextFocusedView?.ID}");
-                            return nextFocusedView;
+                            Debug.WriteLineIf(focusDebugScrollableBase, $"return null, escape scrollableBase on backward");
+                            return null;
                         }
                         targetPosition -= stepDistance;
                         targetPosition = targetPosition < 0 ? 0 : targetPosition;

--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1985,6 +1985,14 @@ namespace Tizen.NUI.Components
             bool backward = ((isHorizontal && direction == View.FocusDirection.Left) ||
                                 (!isHorizontal && direction == View.FocusDirection.Up));
 
+             // Reached end of scroll. move out focus from ScrollableBase.
+            if ((forward && maxScrollDistance - targetPosition < 0.1f) || (backward && targetPosition < 0.1f))
+            {
+                var next = FocusManager.Instance.GetNearestFocusableActor(this.Parent, this, direction);
+                Debug.WriteLineIf(focusDebugScrollableBase, $"Reached End of Scroll. Next focus target {next}:{next?.ID}");
+                return next;
+            }
+
             View nextFocusedView = FocusManager.Instance.GetNearestFocusableActor(this, currentFocusedView, direction);
 
             if (focusDebugScrollableBase)
@@ -2045,12 +2053,6 @@ namespace Tizen.NUI.Components
                 }
 
                 ScrollTo(targetPosition, true);
-
-                // Reached end of scroll. move focus to ScrollableBase.
-                if ((forward && targetPosition == maxScrollDistance) || (backward && targetPosition == 0))
-                {
-                    nextFocusedView = this;
-                }
 
                 Debug.WriteLineIf(focusDebugScrollableBase, $"ScrollTo :({targetPosition})");
             }

--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -2032,22 +2032,12 @@ namespace Tizen.NUI.Components
 
                 if (forward)
                 {
-                    if (targetPosition == maxScrollDistance)
-                    {
-                        Debug.WriteLineIf(focusDebugScrollableBase, $"return null, escape scrollableBase on forward");
-                        return null;
-                    }
                     targetPosition += stepDistance;
                     targetPosition = targetPosition > maxScrollDistance ? maxScrollDistance : targetPosition;
 
                 }
                 else if (backward)
                 {
-                    if (targetPosition == 0)
-                    {
-                        Debug.WriteLineIf(focusDebugScrollableBase, $"return null, escape scrollableBase on backward");
-                        return null;
-                    }
                     targetPosition -= stepDistance;
                     targetPosition = targetPosition < 0 ? 0 : targetPosition;
                 }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusAllChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusAllChildrenSample.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.Samples
         int SCROLLMAX = 50;
         public View root;
 
-        private string GetLabelText(View parent)
+        private string GetChildText(View parent)
         {
             if (parent != null)
             {
@@ -23,12 +23,23 @@ namespace Tizen.NUI.Samples
                     }
                 }
             }
-            else
-            {
-                return "";
-            }
 
             return "";
+        }
+
+        private string GetLabelText(int i)
+        {
+            switch (i)
+            {
+                case 0:
+                    return "[1st]";
+                case 1:
+                    return "[2nd]";
+                case 2:
+                    return "[3rd]";
+                default:
+                    return $"[{i+1}th]";
+            }
         }
 
         public void Activate()
@@ -67,13 +78,13 @@ namespace Tizen.NUI.Samples
                 if (e.Previous != null)
                 {
                     var prevView = e.Previous;
-                    prev = $"{prevView.Name}[{prevView.ID}]{GetLabelText(prevView)}";
+                    prev = $"{prevView.Name}[{prevView.ID}]{GetChildText(prevView)}";
                 }
 
                 if (e.Current != null)
                 {
                     var curView = e.Current;
-                    cur = $"{curView.Name}[{curView.ID}]{GetLabelText(curView)}";
+                    cur = $"{curView.Name}[{curView.ID}]{GetChildText(curView)}";
                 }
 
                 focusInfo.Text = $"Prev:{prev} Current:{cur}";
@@ -120,7 +131,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
+                    Text = GetLabelText(i),
                     PointSize = 20,
                 };
                 colorItem.Add(label);
@@ -191,7 +202,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
+                    Text = GetLabelText(i),
                     PointSize = 20,
                 };
                 colorItem.Add(label);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusAllChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusAllChildrenSample.cs
@@ -88,6 +88,7 @@ namespace Tizen.NUI.Samples
                 }
 
                 focusInfo.Text = $"Prev:{prev} Current:{cur}";
+                Console.WriteLine($"Focus Changed Prev:{prev} => Current:{cur}");
             };
 
             var top = new Button()

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusAllChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusAllChildrenSample.cs
@@ -11,6 +11,26 @@ namespace Tizen.NUI.Samples
         int SCROLLMAX = 50;
         public View root;
 
+        private string GetLabelText(View parent)
+        {
+            if (parent != null)
+            {
+                foreach(View child in parent.Children)
+                {
+                    if (child is TextLabel label)
+                    {
+                        return $"{label.Text}";
+                    }
+                }
+            }
+            else
+            {
+                return "";
+            }
+
+            return "";
+        }
+
         public void Activate()
         {
 
@@ -31,7 +51,33 @@ namespace Tizen.NUI.Samples
             };
             window.Add(root);
 
+            var focusInfo = new TextLabel()
+            {
+                BackgroundColor = Color.Yellow,
+                TextColor = Color.Red,
+                Text = "Prev:[N/A] Current:[N/A]"
+            };
+            root.Add(focusInfo);
+
             FocusManager.Instance.EnableDefaultAlgorithm(true);
+            FocusManager.Instance.FocusChanged += (object s, FocusManager.FocusChangedEventArgs e) =>
+            {
+                string prev = "[N/A]";
+                string cur = "[N/A]";
+                if (e.Previous != null)
+                {
+                    var prevView = e.Previous;
+                    prev = $"{prevView.Name}[{prevView.ID}]{GetLabelText(prevView)}";
+                }
+
+                if (e.Current != null)
+                {
+                    var curView = e.Current;
+                    cur = $"{curView.Name}[{curView.ID}]{GetLabelText(curView)}";
+                }
+
+                focusInfo.Text = $"Prev:{prev} Current:{cur}";
+            };
 
             var top = new Button()
             {
@@ -51,7 +97,7 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Vertical,
                     HorizontalAlignment = HorizontalAlignment.Center,
-                    CellPadding = new Size2D(10, 10),
+                    CellPadding = new Size2D(10, 30),
                 }
             };
             root.Add(verticalScrollView);
@@ -74,7 +120,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = $"[{i}]",
+                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
                     PointSize = 20,
                 };
                 colorItem.Add(label);
@@ -122,7 +168,7 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
                     VerticalAlignment = VerticalAlignment.Center,
-                    CellPadding = new Size2D(10, 10),
+                    CellPadding = new Size2D(30, 10),
                 }
             };
             horizontalLayout.Add(horizontalScrollView);
@@ -145,7 +191,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = $"[{i}]",
+                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
                     PointSize = 20,
                 };
                 colorItem.Add(label);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusNoneChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusNoneChildrenSample.cs
@@ -11,6 +11,26 @@ namespace Tizen.NUI.Samples
         int SCROLLMAX = 50;
         public View root;
 
+        private string GetLabelText(View parent)
+        {
+            if (parent != null)
+            {
+                foreach(View child in parent.Children)
+                {
+                    if (child is TextLabel label)
+                    {
+                        return $"{label.Text}";
+                    }
+                }
+            }
+            else
+            {
+                return "";
+            }
+
+            return "";
+        }
+
         public void Activate()
         {
 
@@ -31,7 +51,34 @@ namespace Tizen.NUI.Samples
             };
             window.Add(root);
 
+            var focusInfo = new TextLabel()
+            {
+                BackgroundColor = Color.Yellow,
+                TextColor = Color.Red,
+                //Focusable = true,
+                Text = "Prev:[N/A] Current:[N/A]"
+            };
+            root.Add(focusInfo);
+
             FocusManager.Instance.EnableDefaultAlgorithm(true);
+            FocusManager.Instance.FocusChanged += (object s, FocusManager.FocusChangedEventArgs e) =>
+            {
+                string prev = "[N/A]";
+                string cur = "[N/A]";
+                if (e.Previous != null)
+                {
+                    var prevView = e.Previous;
+                    prev = $"{prevView.Name}[{prevView.ID}]{GetLabelText(prevView)}";
+                }
+
+                if (e.Current != null)
+                {
+                    var curView = e.Current;
+                    cur = $"{curView.Name}[{curView.ID}]{GetLabelText(curView)}";
+                }
+
+                focusInfo.Text = $"Prev:{prev} Current:{cur}";
+            };
 
             var top = new Button()
             {
@@ -56,7 +103,7 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Vertical,
                     HorizontalAlignment = HorizontalAlignment.Center,
-                    CellPadding = new Size2D(10, 10),
+                    CellPadding = new Size2D(10, 30),
                 }
             };
             root.Add(verticalScrollView);
@@ -74,12 +121,14 @@ namespace Tizen.NUI.Samples
                         VerticalAlignment = VerticalAlignment.Center,
                         CellPadding = new Size2D(10, 10),
                     }
+
                 };
                 var label = new TextLabel()
                 {
-                    Text = $"[{i}]",
+                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
                     PointSize = 20,
                 };
+
                 colorItem.Add(label);
                 verticalScrollView.Add(colorItem);
             }
@@ -130,7 +179,7 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
                     VerticalAlignment = VerticalAlignment.Center,
-                    CellPadding = new Size2D(10, 10),
+                    CellPadding = new Size2D(30, 10),
                 }
             };
             horizontalLayout.Add(horizontalScrollView);
@@ -151,7 +200,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = $"[{i}]",
+                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
                     PointSize = 20,
                 };
                 colorItem.Add(label);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusNoneChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusNoneChildrenSample.cs
@@ -89,6 +89,7 @@ namespace Tizen.NUI.Samples
                 }
 
                 focusInfo.Text = $"Prev:{prev} Current:{cur}";
+                Console.WriteLine($"Focus Changed Prev:{prev} => Current:{cur}");
             };
 
             var top = new Button()

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusNoneChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusNoneChildrenSample.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.Samples
         int SCROLLMAX = 50;
         public View root;
 
-        private string GetLabelText(View parent)
+        private string GetChildText(View parent)
         {
             if (parent != null)
             {
@@ -23,12 +23,23 @@ namespace Tizen.NUI.Samples
                     }
                 }
             }
-            else
-            {
-                return "";
-            }
 
             return "";
+        }
+
+        private string GetLabelText(int i)
+        {
+            switch (i)
+            {
+                case 0:
+                    return "[1st]";
+                case 1:
+                    return "[2nd]";
+                case 2:
+                    return "[3rd]";
+                default:
+                    return $"[{i+1}th]";
+            }
         }
 
         public void Activate()
@@ -68,13 +79,13 @@ namespace Tizen.NUI.Samples
                 if (e.Previous != null)
                 {
                     var prevView = e.Previous;
-                    prev = $"{prevView.Name}[{prevView.ID}]{GetLabelText(prevView)}";
+                    prev = $"{prevView.Name}[{prevView.ID}]{GetChildText(prevView)}";
                 }
 
                 if (e.Current != null)
                 {
                     var curView = e.Current;
-                    cur = $"{curView.Name}[{curView.ID}]{GetLabelText(curView)}";
+                    cur = $"{curView.Name}[{curView.ID}]{GetChildText(curView)}";
                 }
 
                 focusInfo.Text = $"Prev:{prev} Current:{cur}";
@@ -125,7 +136,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
+                    Text = GetLabelText(i),
                     PointSize = 20,
                 };
 
@@ -200,7 +211,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
+                    Text = GetLabelText(i),
                     PointSize = 20,
                 };
                 colorItem.Add(label);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSparseChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSparseChildrenSample.cs
@@ -88,6 +88,7 @@ namespace Tizen.NUI.Samples
                 }
 
                 focusInfo.Text = $"Prev:{prev} Current:{cur}";
+                Console.WriteLine($"Focus Changed Prev:{prev} => Current:{cur}");
             };
 
             var top = new Button()

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSparseChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSparseChildrenSample.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.Samples
         int SCROLLMAX = 50;
         public View root;
 
-        private string GetLabelText(View parent)
+        private string GetChildText(View parent)
         {
             if (parent != null)
             {
@@ -23,12 +23,23 @@ namespace Tizen.NUI.Samples
                     }
                 }
             }
-            else
-            {
-                return "";
-            }
 
             return "";
+        }
+
+        private string GetLabelText(int i)
+        {
+            switch (i)
+            {
+                case 0:
+                    return "[1st]";
+                case 1:
+                    return "[2nd]";
+                case 2:
+                    return "[3rd]";
+                default:
+                    return $"[{i+1}th]";
+            }
         }
 
         public void Activate()
@@ -67,13 +78,13 @@ namespace Tizen.NUI.Samples
                 if (e.Previous != null)
                 {
                     var prevView = e.Previous;
-                    prev = $"{prevView.Name}[{prevView.ID}]{GetLabelText(prevView)}";
+                    prev = $"{prevView.Name}[{prevView.ID}]{GetChildText(prevView)}";
                 }
 
                 if (e.Current != null)
                 {
                     var curView = e.Current;
-                    cur = $"{curView.Name}[{curView.ID}]{GetLabelText(curView)}";
+                    cur = $"{curView.Name}[{curView.ID}]{GetChildText(curView)}";
                 }
 
                 focusInfo.Text = $"Prev:{prev} Current:{cur}";
@@ -123,7 +134,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
+                    Text = GetLabelText(i),
                     PointSize = 20,
                 };
 
@@ -204,7 +215,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
+                    Text = GetLabelText(i),
                     PointSize = 20,
                 };
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSparseChildrenSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSparseChildrenSample.cs
@@ -11,6 +11,26 @@ namespace Tizen.NUI.Samples
         int SCROLLMAX = 50;
         public View root;
 
+        private string GetLabelText(View parent)
+        {
+            if (parent != null)
+            {
+                foreach(View child in parent.Children)
+                {
+                    if (child is TextLabel label)
+                    {
+                        return $"{label.Text}";
+                    }
+                }
+            }
+            else
+            {
+                return "";
+            }
+
+            return "";
+        }
+
         public void Activate()
         {
 
@@ -31,7 +51,33 @@ namespace Tizen.NUI.Samples
             };
             window.Add(root);
 
+            var focusInfo = new TextLabel()
+            {
+                BackgroundColor = Color.Yellow,
+                TextColor = Color.Red,
+                Text = "Prev:[N/A] Current:[N/A]"
+            };
+            root.Add(focusInfo);
+
             FocusManager.Instance.EnableDefaultAlgorithm(true);
+            FocusManager.Instance.FocusChanged += (object s, FocusManager.FocusChangedEventArgs e) =>
+            {
+                string prev = "[N/A]";
+                string cur = "[N/A]";
+                if (e.Previous != null)
+                {
+                    var prevView = e.Previous;
+                    prev = $"{prevView.Name}[{prevView.ID}]{GetLabelText(prevView)}";
+                }
+
+                if (e.Current != null)
+                {
+                    var curView = e.Current;
+                    cur = $"{curView.Name}[{curView.ID}]{GetLabelText(curView)}";
+                }
+
+                focusInfo.Text = $"Prev:{prev} Current:{cur}";
+            };
 
             var top = new Button()
             {
@@ -56,7 +102,7 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Vertical,
                     HorizontalAlignment = HorizontalAlignment.Center,
-                    CellPadding = new Size2D(10, 10),
+                    CellPadding = new Size2D(10, 30),
                 }
             };
             root.Add(verticalScrollView);
@@ -77,7 +123,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = $"[{i}]",
+                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
                     PointSize = 20,
                 };
 
@@ -137,7 +183,7 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
                     VerticalAlignment = VerticalAlignment.Center,
-                    CellPadding = new Size2D(10, 10),
+                    CellPadding = new Size2D(30, 10),
                 }
             };
             horizontalLayout.Add(horizontalScrollView);
@@ -158,7 +204,7 @@ namespace Tizen.NUI.Samples
                 };
                 var label = new TextLabel()
                 {
-                    Text = $"[{i}]",
+                    Text = (i == 1)? "[1st]":(i == 2)? "[2nd]":$"[{i}th]",
                     PointSize = 20,
                 };
 


### PR DESCRIPTION
fix several issue on focus of scrollableBase.

1. fix wrong focus fallback when next focused children is invisble.
- if current focused object is children of scrollableBase,
  keep focus to current focused object.
- if current focused object is out of scrollableBase,
  to keep focus within the scrollableBase, set focus on scrollableBase.

2. fix wrong next focus returns on next find failed case.
   if next focus find is failed, we can move scroll when key can move
   foward and backward only not other directions.
   In other direction inputs, escape the scrollableBase.

3. fix wrong escape condition of EOS(end of scroll).
   we escape scrollableBase in EOS, but we need to reached EOS firstly,
   and escape scrollableBase on next key input to move out.

4. add conditional debugging log.

5. fix focus samples.
   add text label for notify prev/current focused object.
   fix title of items.
   make padding longer on items.


note: ScrollableFocusNoneChildrenSample will get crash without below csharp-binder patch
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/276171/



### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
