### PR TITLE
Add new internal APIs for UIThread model

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -322,7 +322,7 @@ namespace Tizen.Applications
             }
 
             var task = new TaskCompletionSource<T>();
-            GSourceManager.Post(() => { task.SetResult(runner()); }, true);
+            GSourceManager.Post(() => { task.SetResult(runner()); });
             return await task.Task.ConfigureAwait(false);
         }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -21,6 +21,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Timers;
 using Tizen.Applications.CoreBackend;
 
@@ -302,6 +303,27 @@ namespace Tizen.Applications
             }
 
             GSourceManager.Post(runner);
+        }
+
+        /// <summary>
+        /// Dispatches an asynchronous message to the main loop of the CoreTask.
+        /// </summary>
+        /// <typeparam name="T">The type of the result.</typeparam>
+        /// <param name="runner">The runner callback.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
+        /// <returns>A task with the result.</returns>
+        /// <since_tizen> 10 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public async Task<T> Post<T>(Func<T> runner)
+        {
+            if (runner == null)
+            {
+                throw new ArgumentNullException(nameof(runner));
+            }
+
+            var task = new TaskCompletionSource<T>();
+            GSourceManager.Post(() => { task.SetResult(runner()); }, true);
+            return await task.Task.ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
@@ -15,10 +15,8 @@
  */
 
 using System;
-using System.Collections.Concurrent;
 using System.ComponentModel;
-using System.Threading;
-using static Tizen.Applications.TizenSynchronizationContext;
+using System.Threading.Tasks;
 
 namespace Tizen.Applications
 {
@@ -120,7 +118,7 @@ namespace Tizen.Applications
         /// Dispatches an asynchronous message to the main loop of the CoreApplication.
         /// </summary>
         /// <param name="runner">The runner callback.</param>
-        /// /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
         /// <since_tizen> 10 </since_tizen>
         public void Post(Action runner)
         {
@@ -130,6 +128,27 @@ namespace Tizen.Applications
             }
 
             GSourceManager.Post(runner, true);
+        }
+
+        /// <summary>
+        /// Dispatches an asynchronous message to the main loop of the CoreApplication.
+        /// </summary>
+        /// <typeparam name="T">The type of the result. </typeparam>
+        /// <param name="runner">The runner callback.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
+        /// <returns>A task with the result</returns>
+        /// <since_tizen> 10 </since_tizen>
+
+        public async Task<T> Post<T>(Func<T> runner)
+        {
+            if (runner == null)
+            {
+                throw new ArgumentNullException(nameof(runner));
+            }
+
+            var task = new TaskCompletionSource<T>();
+            GSourceManager.Post(() => { task.SetResult(runner()); }, true);
+            return await task.Task.ConfigureAwait(false);
         }
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
@@ -136,7 +136,7 @@ namespace Tizen.Applications
         /// <typeparam name="T">The type of the result. </typeparam>
         /// <param name="runner">The runner callback.</param>
         /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
-        /// <returns>A task with the result</returns>
+        /// <returns>A task with the result.</returns>
         /// <since_tizen> 10 </since_tizen>
 
         public async Task<T> Post<T>(Func<T> runner)


### PR DESCRIPTION
Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
This request is for UIThread model. To get the result from the Post() method asynchronously, Post() methods are added.

Added [internal]:
 - async Task<T> CoreApplication.Post<T>(Func<T> runner);
 - async Task<T> CoreTask.Post<T>(Func<T> runner);