### PR TITLE
[NUI] Slider track make correct value.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -568,59 +568,93 @@ namespace Tizen.NUI.Components
             }
         }
 
-        private int BgTrackLength()
+        private int GetBgTrackLength()
         {
             int bgTrackLength = 0;
+
+            int lowIndicatorOffset = GetBgTrackLowIndicatorOffset();
+            int highIndicatorOffet = GetBgTrackHighIndicatorOffset();
+
+            if (direction == DirectionType.Horizontal)
+            {
+                bgTrackLength = this.Size2D.Width - lowIndicatorOffset - highIndicatorOffet;
+            }
+            else if (direction == DirectionType.Vertical)
+            {
+                bgTrackLength = this.Size2D.Height - lowIndicatorOffset - highIndicatorOffet;
+            }
+
+            return bgTrackLength;
+        }
+
+        /// <summary>
+        /// Get offset value of bgtrack's low indicator side.
+        /// </summary>
+        private int GetBgTrackLowIndicatorOffset()
+        {
+            int bgTrackLowIndicatorOffset = 0;
             IndicatorType type = CurrentIndicatorType();
 
             if (type == IndicatorType.None)
             {
                 if (direction == DirectionType.Horizontal)
                 {
-                    bgTrackLength = this.Size2D.Width - thumbImage.Size2D.Width;
+                    bgTrackLowIndicatorOffset = (int)(thumbImage.Size.Width * 0.5f);
                 }
                 else if (direction == DirectionType.Vertical)
                 {
-                    bgTrackLength = this.Size2D.Height - thumbImage.Size2D.Height;
+                    bgTrackLowIndicatorOffset = (int)(thumbImage.Size.Height * 0.5f);
                 }
             }
-            else if (type == IndicatorType.Image)
-            {// <lowIndicatorImage> <spaceBetweenTrackAndIndicator> <bgTrack> <spaceBetweenTrackAndIndicator> <highIndicatorImage>
-                Size lowIndicatorImageSize = LowIndicatorImageSize();
-                Size highIndicatorImageSize = HighIndicatorImageSize();
+            else if (type == IndicatorType.Image || type == IndicatorType.Text)
+            {// <lowIndicatorImage or Text> <spaceBetweenTrackAndIndicator> <bgTrack>
+                Size lowIndicatorSize = (type == IndicatorType.Image) ? LowIndicatorImageSize() : LowIndicatorTextSize();
                 int curSpace = (int)CurrentSpaceBetweenTrackAndIndicator();
                 if (direction == DirectionType.Horizontal)
                 {
-                    int lowIndicatorSpace = ((lowIndicatorImageSize.Width == 0) ? (0) : ((int)(curSpace + lowIndicatorImageSize.Width)));
-                    int highIndicatorSpace = ((highIndicatorImageSize.Width == 0) ? (0) : ((int)(curSpace + highIndicatorImageSize.Width)));
-                    bgTrackLength = this.Size2D.Width - lowIndicatorSpace - highIndicatorSpace;
+                    bgTrackLowIndicatorOffset = ((lowIndicatorSize.Width == 0) ? (0) : ((int)(curSpace + lowIndicatorSize.Width)));
                 }
                 else if (direction == DirectionType.Vertical)
                 {
-                    int lowIndicatorSpace = ((lowIndicatorImageSize.Height == 0) ? (0) : ((int)(curSpace + lowIndicatorImageSize.Height)));
-                    int highIndicatorSpace = ((highIndicatorImageSize.Height == 0) ? (0) : ((int)(curSpace + highIndicatorImageSize.Height)));
-                    bgTrackLength = this.Size2D.Height - lowIndicatorSpace - highIndicatorSpace;
+                    bgTrackLowIndicatorOffset = ((lowIndicatorSize.Height == 0) ? (0) : ((int)(curSpace + lowIndicatorSize.Height)));
                 }
             }
-            else if (type == IndicatorType.Text)
-            {// <lowIndicatorText> <spaceBetweenTrackAndIndicator> <bgTrack> <spaceBetweenTrackAndIndicator> <highIndicatorText>
-                Size lowIndicatorTextSize = LowIndicatorTextSize();
-                Size highIndicatorTextSize = HighIndicatorTextSize();
+            return bgTrackLowIndicatorOffset;
+        }
+
+        /// <summary>
+        /// Get offset value of bgtrack's high indicator side.
+        /// </summary>
+        private int GetBgTrackHighIndicatorOffset()
+        {
+            int bgTrackHighIndicatorOffset = 0;
+            IndicatorType type = CurrentIndicatorType();
+
+            if (type == IndicatorType.None)
+            {
+                if (direction == DirectionType.Horizontal)
+                {
+                    bgTrackHighIndicatorOffset = (int)(thumbImage.Size.Width * 0.5f);
+                }
+                else if (direction == DirectionType.Vertical)
+                {
+                    bgTrackHighIndicatorOffset = (int)(thumbImage.Size.Height * 0.5f);
+                }
+            }
+            else if (type == IndicatorType.Image || type == IndicatorType.Text)
+            {// <bgTrack> <spaceBetweenTrackAndIndicator> <highIndicatorImage or Text>
+                Size highIndicatorSize = (type == IndicatorType.Image) ? HighIndicatorImageSize() : HighIndicatorTextSize();
                 int curSpace = (int)CurrentSpaceBetweenTrackAndIndicator();
                 if (direction == DirectionType.Horizontal)
                 {
-                    int lowIndicatorSpace = ((lowIndicatorTextSize.Width == 0) ? (0) : ((int)(curSpace + lowIndicatorTextSize.Width)));
-                    int highIndicatorSpace = ((highIndicatorTextSize.Width == 0) ? (0) : ((int)(curSpace + highIndicatorTextSize.Width)));
-                    bgTrackLength = this.Size2D.Width - lowIndicatorSpace - highIndicatorSpace;
+                    bgTrackHighIndicatorOffset = ((highIndicatorSize.Width == 0) ? (0) : ((int)(curSpace + highIndicatorSize.Width)));
                 }
                 else if (direction == DirectionType.Vertical)
                 {
-                    int lowIndicatorSpace = ((lowIndicatorTextSize.Height == 0) ? (0) : ((int)(curSpace + lowIndicatorTextSize.Height)));
-                    int highIndicatorSpace = ((highIndicatorTextSize.Height == 0) ? (0) : ((int)(curSpace + highIndicatorTextSize.Height)));
-                    bgTrackLength = this.Size2D.Height - lowIndicatorSpace - highIndicatorSpace;
+                    bgTrackHighIndicatorOffset = ((highIndicatorSize.Height == 0) ? (0) : ((int)(curSpace + highIndicatorSize.Height)));
                 }
             }
-            return bgTrackLength;
+            return bgTrackHighIndicatorOffset;
         }
 
         private void UpdateLowIndicatorSize()
@@ -638,13 +672,39 @@ namespace Tizen.NUI.Components
             }
             else
             {
-                if (lowIndicatorImage != null && lowIndicatorImage != null && lowIndicatorImage.Size != null)
+                if (lowIndicatorImage != null && lowIndicatorImage.Size != null)
                 {
                     lowIndicatorImage.Size = lowIndicatorSize ?? (ViewStyle as SliderStyle)?.LowIndicatorImage.Size;
                 }
-                if (lowIndicatorText != null && lowIndicatorText != null && lowIndicatorText.Size != null)
+                if (lowIndicatorText != null && lowIndicatorText.Size != null)
                 {
                     lowIndicatorText.Size = lowIndicatorSize ?? (ViewStyle as SliderStyle)?.LowIndicator.Size;
+                }
+            }
+        }
+
+        private void UpdateHighIndicatorSize()
+        {
+            if (highIndicatorSize != null)
+            {
+                if (highIndicatorImage != null)
+                {
+                    highIndicatorImage.Size = highIndicatorSize;
+                }
+                if (highIndicatorText != null)
+                {
+                    highIndicatorText.Size = highIndicatorSize;
+                }
+            }
+            else
+            {
+                if (highIndicatorImage != null && highIndicatorImage.Size != null)
+                {
+                    highIndicatorImage.Size = highIndicatorSize ?? (ViewStyle as SliderStyle)?.HighIndicatorImage.Size;
+                }
+                if (highIndicatorText != null && highIndicatorText.Size != null)
+                {
+                    highIndicatorText.Size = highIndicatorSize ?? (ViewStyle as SliderStyle)?.HighIndicator.Size;
                 }
             }
         }
@@ -656,7 +716,7 @@ namespace Tizen.NUI.Components
                 return;
             }
             int curTrackThickness = (int)CurrentTrackThickness();
-            int bgTrackLength = BgTrackLength();
+            int bgTrackLength = GetBgTrackLength();
             if (direction == DirectionType.Horizontal)
             {
                 bgTrackImage.Size2D = new Size2D(bgTrackLength, curTrackThickness);
@@ -673,47 +733,17 @@ namespace Tizen.NUI.Components
             {
                 return;
             }
-            IndicatorType type = CurrentIndicatorType();
 
-            if (type == IndicatorType.None)
+            int lowIndicatorOffset = GetBgTrackLowIndicatorOffset();
+            int highIndicatorOffet = GetBgTrackHighIndicatorOffset();
+
+            if (direction == DirectionType.Horizontal)
             {
-                bgTrackImage.Position2D = new Position2D(0, 0);
+                bgTrackImage.Position2D = new Position2D((lowIndicatorOffset - highIndicatorOffet) / 2, 0);
             }
-            else if (type == IndicatorType.Image)
+            else if (direction == DirectionType.Vertical)
             {
-                Size lowIndicatorImageSize = LowIndicatorImageSize();
-                Size highIndicatorImageSize = HighIndicatorImageSize();
-                int curSpace = (int)CurrentSpaceBetweenTrackAndIndicator();
-                if (direction == DirectionType.Horizontal)
-                {
-                    int lowIndicatorSpace = ((lowIndicatorImageSize.Width == 0) ? (0) : ((int)(curSpace + lowIndicatorImageSize.Width)));
-                    int highIndicatorSpace = ((highIndicatorImageSize.Width == 0) ? (0) : ((int)(curSpace + highIndicatorImageSize.Width)));
-                    bgTrackImage.Position2D = new Position2D(lowIndicatorSpace - (lowIndicatorSpace + highIndicatorSpace) / 2, 0);
-                }
-                else if (direction == DirectionType.Vertical)
-                {
-                    int lowIndicatorSpace = ((lowIndicatorImageSize.Height == 0) ? (0) : ((int)(curSpace + lowIndicatorImageSize.Height)));
-                    int highIndicatorSpace = ((highIndicatorImageSize.Height == 0) ? (0) : ((int)(curSpace + highIndicatorImageSize.Height)));
-                    bgTrackImage.Position2D = new Position2D(0, lowIndicatorSpace - (lowIndicatorSpace + highIndicatorSpace) / 2);
-                }
-            }
-            else if (type == IndicatorType.Text)
-            {
-                Size lowIndicatorTextSize = LowIndicatorTextSize();
-                Size highIndicatorTextSize = HighIndicatorTextSize();
-                int curSpace = (int)CurrentSpaceBetweenTrackAndIndicator();
-                if (direction == DirectionType.Horizontal)
-                {
-                    int lowIndicatorSpace = ((lowIndicatorTextSize.Width == 0) ? (0) : ((int)(curSpace + lowIndicatorTextSize.Width)));
-                    int highIndicatorSpace = ((highIndicatorTextSize.Width == 0) ? (0) : ((int)(curSpace + highIndicatorTextSize.Width)));
-                    bgTrackImage.Position2D = new Position2D(lowIndicatorSpace - (lowIndicatorSpace + highIndicatorSpace) / 2, 0);
-                }
-                else if (direction == DirectionType.Vertical)
-                {
-                    int lowIndicatorSpace = ((lowIndicatorTextSize.Height == 0) ? (0) : ((int)(curSpace + lowIndicatorTextSize.Height)));
-                    int highIndicatorSpace = ((highIndicatorTextSize.Height == 0) ? (0) : ((int)(curSpace + highIndicatorTextSize.Height)));
-                    bgTrackImage.Position2D = new Position2D(0, -(lowIndicatorSpace - (lowIndicatorSpace + highIndicatorSpace) / 2));
-                }
+                bgTrackImage.Position2D = new Position2D(0, (highIndicatorOffet - lowIndicatorOffset) / 2);
             }
         }
 
@@ -739,7 +769,7 @@ namespace Tizen.NUI.Components
                 {
                     ratio = 1.0f - ratio;
                 }
-                float slidedTrackLength = (float)BgTrackLength() * ratio;
+                float slidedTrackLength = (float)GetBgTrackLength() * ratio;
                 slidedTrackImage.Size2D = new Size2D((int)(slidedTrackLength + round), (int)curTrackThickness); //Add const round to reach Math.Round function.
                 thumbImage.Position = new Position(slidedTrackImage.Size2D.Width, 0);
                 thumbImage.RaiseToTop();
@@ -751,7 +781,7 @@ namespace Tizen.NUI.Components
             }
             else if (direction == DirectionType.Vertical)
             {
-                float slidedTrackLength = (float)BgTrackLength() * ratio;
+                float slidedTrackLength = (float)GetBgTrackLength() * ratio;
                 slidedTrackImage.Size2D = new Size2D((int)curTrackThickness, (int)(slidedTrackLength + round)); //Add const round to reach Math.Round function.
                 thumbImage.Position = new Position(0, -slidedTrackImage.Size2D.Height);
                 thumbImage.RaiseToTop();

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1091,14 +1091,15 @@ namespace Tizen.NUI.Components
         {
             get
             {
-                return highIndicatorText?.Size;
+                return highIndicatorSize;
             }
             set
             {
-                if (null != highIndicatorText)
-                {
-                    highIndicatorText.Size = value;
-                }
+                highIndicatorSize = value;
+                UpdateHighIndicatorSize();
+                UpdateBgTrackSize();
+                UpdateBgTrackPosition();
+                UpdateValue();
             }
         }
 
@@ -1732,6 +1733,7 @@ namespace Tizen.NUI.Components
             UpdateBgTrackPosition();
             UpdateWarningTrackSize();
             UpdateLowIndicatorSize();
+            UpdateHighIndicatorSize();
             UpdateValue();
         }
 
@@ -1751,13 +1753,13 @@ namespace Tizen.NUI.Components
             {
                 this.CurrentValue = minValue;
             }
-            else if (currentSlidedOffset >= BgTrackLength())
+            else if (currentSlidedOffset >= GetBgTrackLength())
             {
                 this.CurrentValue = maxValue;
             }
             else
             {
-                int bgTrackLength = BgTrackLength();
+                int bgTrackLength = GetBgTrackLength();
                 if (bgTrackLength != 0)
                 {
                     this.CurrentValue = ((currentSlidedOffset / (float)bgTrackLength) * (float)(maxValue - minValue)) + minValue;
@@ -1837,14 +1839,14 @@ namespace Tizen.NUI.Components
 
         private void CalculateCurrentValueByTouch(Vector2 pos)
         {
-            int bgTrackLength = BgTrackLength();
+            int bgTrackLength = GetBgTrackLength();
             if (direction == DirectionType.Horizontal)
             {
-                currentSlidedOffset = pos.X;
+                currentSlidedOffset = pos.X - GetBgTrackLowIndicatorOffset();
             }
             else if (direction == DirectionType.Vertical)
             {
-                currentSlidedOffset = bgTrackLength - pos.Y;
+                currentSlidedOffset = this.Size2D.Height - pos.Y - GetBgTrackLowIndicatorOffset();
             }
 
             if (bgTrackLength != 0)


### PR DESCRIPTION
Due to the track touch didn't apply offset of track,
the track touch didn't make correct value.

This patch apply the offset of bg track to the touch position.
Now the positions become correct value.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
