### PR TITLE
[NUI] Fix not to use PROFILE_MOBILE

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -277,9 +277,7 @@ namespace Tizen.NUI.Components
             buttonIcon = CreateIcon();
             LayoutItems();
 
-#if PROFILE_MOBILE
             Feedback = true;
-#endif
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -140,8 +140,23 @@ namespace Tizen.NUI.Components
 
                 if (value)
                 {
-                    feedback = new Feedback();
-                    this.TouchEvent += OnTouchPlayFeedback;
+                    try
+                    {
+                        feedback = new Feedback();
+                        this.TouchEvent += OnTouchPlayFeedback;
+                    }
+                    catch (NotSupportedException e)
+                    {
+                        Log.Error("NUI", $"[ERROR] No support of Feedback: {e}");
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        Log.Error("NUI", $"[ERROR] Fail to initialize Feedback: {e}");
+                    }
+                    catch (NullReferenceException e)
+                    {
+                        Log.Error("NUI", $"[ERROR] Null reference error in Feedback: {e}");
+                    }
                 }
                 else
                 {

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -69,9 +69,8 @@ namespace Tizen.NUI.Components
             AccessibilityRole = Role.ToggleButton;
 
             IsSelectable = true;
-#if PROFILE_MOBILE
+
             Feedback = true;
-#endif
         }
 
         /// <summary>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SwitchSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SwitchSample.cs
@@ -225,9 +225,7 @@ namespace Tizen.NUI.Samples
                 utilitySwitch[i].ApplyStyle(utilitySt);
                 utilitySwitch[i].Size = new Size(96, 60);
                 utilitySwitch[i].Margin = new Extents(100, 0, 20, 0);
-#if PROFILE_MOBILE
                 utilitySwitch[i].Feedback = true;
-#endif
                 parentView[2].Add(utilitySwitch[i]);
             }
             for (i = 0; i < 4; i++)
@@ -235,9 +233,7 @@ namespace Tizen.NUI.Samples
                 familySwitch[i] = new Switch();
                 familySwitch[i].ApplyStyle(familySt);
                 familySwitch[i].Size = new Size(96, 60);
-#if PROFILE_MOBILE
                 familySwitch[i].Feedback = true;
-#endif
                 parentView[2].Add(familySwitch[i]);
             }
             for (i = 0; i < 4; i++)
@@ -245,9 +241,7 @@ namespace Tizen.NUI.Samples
                 foodSwitch[i] = new Switch();
                 foodSwitch[i].ApplyStyle(foodSt);
                 foodSwitch[i].Size = new Size(96, 60);
-#if PROFILE_MOBILE
                 foodSwitch[i].Feedback = true;
-#endif
                 parentView[2].Add(foodSwitch[i]);
             }
             for (i = 0; i < 4; i++)
@@ -255,9 +249,7 @@ namespace Tizen.NUI.Samples
                 kitchenSwitch[i] = new Switch();
                 kitchenSwitch[i].ApplyStyle(kitchenSt);
                 kitchenSwitch[i].Size = new Size(96, 60);
-#if PROFILE_MOBILE
                 kitchenSwitch[i].Feedback = true;
-#endif
                 parentView[2].Add(kitchenSwitch[i]);
             }
 
@@ -267,9 +259,7 @@ namespace Tizen.NUI.Samples
                 utilitySwitch2[i] = new Switch();
                 utilitySwitch2[i].ApplyStyle(utilitySt);
                 utilitySwitch2[i].Size = new Size(96, 60);
-#if PROFILE_MOBILE
                 utilitySwitch2[i].Feedback = true;
-#endif
                 parentView[2].Add(utilitySwitch2[i]);
             }
             for (i = 0; i < 4; i++)
@@ -277,9 +267,7 @@ namespace Tizen.NUI.Samples
                 familySwitch2[i] = new Switch();
                 familySwitch2[i].ApplyStyle(familySt);
                 familySwitch2[i].Size = new Size(96, 60);
-#if PROFILE_MOBILE
                 familySwitch2[i].Feedback = true;
-#endif
                 parentView[2].Add(familySwitch2[i]);
             }
             for (i = 0; i < 4; i++)
@@ -287,9 +275,7 @@ namespace Tizen.NUI.Samples
                 foodSwitch2[i] = new Switch();
                 foodSwitch2[i].ApplyStyle(foodSt);
                 foodSwitch2[i].Size = new Size(96, 60);
-#if PROFILE_MOBILE
                 foodSwitch2[i].Feedback = true;
-#endif
                 parentView[2].Add(foodSwitch2[i]);
             }
             for (i = 0; i < 4; i++)
@@ -297,9 +283,7 @@ namespace Tizen.NUI.Samples
                 kitchenSwitch2[i] = new Switch();
                 kitchenSwitch2[i].ApplyStyle(kitchenSt);
                 kitchenSwitch2[i].Size = new Size(96, 60);
-#if PROFILE_MOBILE
                 kitchenSwitch2[i].Feedback = true;
-#endif
                 parentView[2].Add(kitchenSwitch2[i]);
             }
 

--- a/test/Tizen.NUI.StyleGuide/Examples/SwitchExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/SwitchExample.cs
@@ -111,9 +111,7 @@ namespace Tizen.NUI.StyleGuide
                 switchTest[i].ApplyStyle(styleTest);
                 switchTest[i].Size = new Size(200, 100);
                 switchTest[i].Margin = new Extents(10, 10, 10, 10);
-#if PROFILE_MOBILE
                 switchTest[i].Feedback = true;
-#endif
                 rootContent.Add(switchTest[i]);
             }
             switchTest[2].IsEnabled = false;


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix not to use PROFILE_MOBILE
- remove 'PROFILE_MOBILE` macro. (can cover all profiles)
- tested locally and checked to run normally on RPI4, TV, and Ubuntu.

### API Changes ###
none