### PR TITLE
[NUI] Fix not to do NUI.Components preloading on TV target

### DIFF
--- a/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
@@ -29,9 +29,9 @@ namespace Tizen.NUI.Components
 
         public static void Preload()
         {
+#if ExternalThemeEnabled
             ThemeManager.AddPackageTheme(Instance);
 
-#if ExternalThemeEnabled
             if (string.IsNullOrEmpty(ExternalThemeManager.CurrentThemeId)) return;
 
             ThemeManager.LoadPlatformTheme(ExternalThemeManager.CurrentThemeId);

--- a/src/Tizen.NUI.Components/Tizen.NUI.Components.preload
+++ b/src/Tizen.NUI.Components/Tizen.NUI.Components.preload
@@ -3,4 +3,4 @@
 ## AssemblyName.dll TypeName.Preload()   ##
 ## The methods must not have parameters. ##
 ###########################################
-Tizen.NUI.Components.dll Tizen.NUI.Components.Control.Preload()
+Tizen.NUI.Components.dll Tizen.NUI.Components.DefaultThemeCreator.Preload()


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix not to do NUI.Components preloading on TV target
- NUI.Components preloading is not required in TV target because TV doesn't use NUI.Components.
- change Preload() method from Control class' to DefaultThemeCreator class'.
- tested in tv target and checked it works normally.

### API Changes ###
none