### PR TITLE
[NUI] Add maximum motion age of pan motion gesture

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -85,6 +85,7 @@ namespace Tizen.NUI.Components
         private float discreteValue = 0;
 
         private PanGestureDetector panGestureDetector = null;
+        private readonly uint panGestureMotionEventAge = 16; // TODO : Can't we get this value from system configure?
         private float currentSlidedOffset;
         private EventHandler<SliderValueChangedEventArgs> sliderValueChangedHandler;
         private EventHandler<SliderSlidingStartedEventArgs> sliderSlidingStartedHandler;
@@ -107,6 +108,7 @@ namespace Tizen.NUI.Components
 
             panGestureDetector = new PanGestureDetector();
             panGestureDetector.Attach(this);
+            panGestureDetector.SetMaximumMotionEventAge(panGestureMotionEventAge);
             panGestureDetector.Detected += OnPanGestureDetected;
 
             this.Layout = new LinearLayout()
@@ -403,6 +405,17 @@ namespace Tizen.NUI.Components
 
             if (e.PanGesture.State == Gesture.StateType.Finished)
             {
+                // Update as finished position value
+                if (direction == DirectionType.Horizontal)
+                {
+                    CalculateCurrentValueByGesture(e.PanGesture.Displacement.X);
+                }
+                else if (direction == DirectionType.Vertical)
+                {
+                    CalculateCurrentValueByGesture(-e.PanGesture.Displacement.Y);
+                }
+                UpdateValue();
+
                 if (isValueShown)
                 {
                     valueIndicatorImage.Hide();

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1749,26 +1749,21 @@ namespace Tizen.NUI.Components
         {
             currentSlidedOffset += offset;
 
-            if (currentSlidedOffset <= 0)
+            float resultValue = this.CurrentValue;
+
+            int bgTrackLength = GetBgTrackLength();
+            if (bgTrackLength != 0)
             {
-                this.CurrentValue = minValue;
-            }
-            else if (currentSlidedOffset >= GetBgTrackLength())
-            {
-                this.CurrentValue = maxValue;
-            }
-            else
-            {
-                int bgTrackLength = GetBgTrackLength();
-                if (bgTrackLength != 0)
-                {
-                    this.CurrentValue = ((currentSlidedOffset / (float)bgTrackLength) * (float)(maxValue - minValue)) + minValue;
-                }
+                resultValue = ((currentSlidedOffset / (float)bgTrackLength) * (float)(maxValue - minValue)) + minValue;
             }
 
             if (IsDiscrete)
             {
-                this.CurrentValue = CalculateDiscreteValue(this.CurrentValue);
+                this.CurrentValue = CalculateDiscreteValue(resultValue);
+            }
+            else
+            {
+                this.CurrentValue = resultValue;
             }
         }
 
@@ -1822,7 +1817,7 @@ namespace Tizen.NUI.Components
         {
             if (this.FocusableInTouch == false && editMode == false)
             {
-                isFocused = false;   
+                isFocused = false;
             }
 
             PointStateType state = e.Touch.GetState(0);
@@ -1851,11 +1846,15 @@ namespace Tizen.NUI.Components
 
             if (bgTrackLength != 0)
             {
-                this.CurrentValue = ((currentSlidedOffset / (float)bgTrackLength) * (maxValue - minValue)) + minValue;
+                float resultValue = ((currentSlidedOffset / (float)bgTrackLength) * (maxValue - minValue)) + minValue;
 
                 if (IsDiscrete)
                 {
-                    this.CurrentValue = CalculateDiscreteValue(this.CurrentValue);
+                    this.CurrentValue = CalculateDiscreteValue(resultValue);
+                }
+                else
+                {
+                    this.CurrentValue = resultValue;
                 }
             }
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
@@ -99,11 +99,17 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMaximumTouchesRequired")]
             public static extern void SetMaximumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_SetMaximumMotionEventAge")]
+            public static extern void SetMaximumMotionEventAge(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMinimumTouchesRequired")]
             public static extern uint GetMinimumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMaximumTouchesRequired")]
             public static extern uint GetMaximumTouchesRequired(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_GetMaximumMotionEventAge")]
+            public static extern uint GetMaximumMotionEventAge(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGestureDetector_AddAngle__SWIG_0")]
             public static extern void AddAngle(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -342,6 +342,18 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Set a maximum duration of motion event that is able to live on the pan gesture event queue.
+        /// If duration exceed it, the motion event is discarded.
+        /// </summary>
+        /// <param name="maximumAgeMilliSecond">Maximum age of motion events as milliseconds</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetMaximumMotionEventAge(uint maximumAgeMilliSecond)
+        {
+            Interop.PanGestureDetector.SetMaximumMotionEventAge(SwigCPtr, maximumAgeMilliSecond);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Retrieves the minimum number of touches required for the pan gesture to be detected.
         /// </summary>
         /// <returns>The minimum touches required</returns>
@@ -363,6 +375,18 @@ namespace Tizen.NUI
         public uint GetMaximumTouchesRequired()
         {
             uint ret = Interop.PanGestureDetector.GetMaximumTouchesRequired(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Retrieves the maximum age for the pan gesture motion as milliseconds.
+        /// </summary>
+        /// <returns>The maximum age of motion events as milliseconds</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint GetMaximumMotionEventAge()
+        {
+            uint ret = Interop.PanGestureDetector.GetMaximumMotionEventAge(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
When event spend so long time, a lot of events are queued.

Ecore cannot skip these event, so we make some heuristic
threshold of discard motion events on pan gesture.

Default age is UINT_MAX ms, (~= 49 days)

Currently, we make maximum age as hard-coded value
in NUI.Component.Slider.Internal

These patches are required to be merged :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/276378/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/276380/

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
