### PR TITLE
[NUI] Use IsSet replace changedPropertiesSet

### DIFF
--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -94,14 +94,10 @@ namespace Tizen.NUI.Binding
                 {
                     nameToBindableProperty2.TryGetValue(keyValuePair.Key, out var bindableProperty);
 
-                    if (null != bindableProperty && (ChangedPropertiesSet.Contains(bindableProperty) || other.ChangedPropertiesSet.Contains(bindableProperty)))
+                    if (null != bindableProperty && other.IsSet(bindableProperty))
                     {
                         object value = other.GetValue(bindableProperty);
-
-                        if (null != value)
-                        {
-                            InternalSetValue(keyValuePair.Value, value);
-                        }
+                        InternalSetValue(keyValuePair.Value, value);
                     }
                 }
             }
@@ -323,42 +319,19 @@ namespace Tizen.NUI.Binding
                     throw new ArgumentNullException(nameof(property));
                 }
 
+                object oldvalue = null;
                 BindablePropertyContext context = GetOrCreateContext(property);
                 if (null != context)
                 {
                     context.Attributes |= BindableContextAttributes.IsManuallySet;
-                }
-                object oldvalue = null;
-                if (null == property.DefaultValueCreator)
-                {
                     oldvalue = context.Value;
                     context.Value = value;
-                }
-                else
-                {
-                    oldvalue = property.DefaultValueCreator.Invoke(this);
                 }
 
                 property.PropertyChanged?.Invoke(this, oldvalue, value);
 
                 OnPropertyChanged(property.PropertyName);
                 OnPropertyChangedWithData(property);
-            }
-
-            ChangedPropertiesSet.Add(property);
-        }
-
-        private HashSet<BindableProperty> changedPropertiesSet;
-        private HashSet<BindableProperty> ChangedPropertiesSet
-        {
-            get
-            {
-                if (null == changedPropertiesSet)
-                {
-                    changedPropertiesSet = new HashSet<BindableProperty>();
-                }
-
-                return changedPropertiesSet;
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Use IsSet to replace changedPropertiesSet

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
