### PR TITLE
[NUI] Make the velocity of slider as 1% at key event

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1467,23 +1467,26 @@ namespace Tizen.NUI.Components
 
             if (key.State == Key.StateType.Down)
             {
+                float valueDiff;
+                if (IsDiscrete)
+                {
+                    valueDiff = discreteValue;
+                }
+                else
+                {
+                    /// TODO : Currently we set the velocity of value as 1% hardly.
+                    /// Can we use AccessibilityGetMinimumIncrement?
+                    valueDiff = (maxValue - minValue) * 0.01f;
+                }
                 if ((direction == DirectionType.Horizontal && key.KeyPressedName == "Left") ||
                     (direction == DirectionType.Vertical && key.KeyPressedName == "Down"))
                 {
                     if (editMode)
                     {
-                        if (MinValue < CurrentValue)
+                        if (minValue < curValue)
                         {
                             isPressed = true;
-                            if (IsDiscrete)
-                            {
-                                float value = curValue - discreteValue;
-                                CurrentValue = value;
-                            }
-                            else
-                            {
-                                CurrentValue -= 1;
-                            }
+                            CurrentValue -= valueDiff;
                         }
                         return true; // Consumed
                     }
@@ -1493,18 +1496,10 @@ namespace Tizen.NUI.Components
                 {
                     if (editMode)
                     {
-                        if (MaxValue > CurrentValue)
+                        if (maxValue > curValue)
                         {
                             isPressed = true;
-                            if (IsDiscrete)
-                            {
-                                float value = curValue + discreteValue;
-                                CurrentValue = value;
-                            }
-                            else
-                            {
-                                CurrentValue += 1;
-                            }
+                            CurrentValue += valueDiff;
                         }
                         return true; // Consumed
                     }


### PR DESCRIPTION
Previous code can move only 1 units when we try to change value
by Key event.

This patch make the value moved for 1%. It will change as same rates
even min/max value difference is big, or small.

TODO : Currently, we make it as const value 1%.
Should we need to make this value as property?

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>