### PR TITLE
[NUI][AT-SPI] Store AccessibilityAttributes in NUI

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -472,7 +472,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             AccessibilityRole = Role.Dialog;
-            AppendAccessibilityAttribute("sub-role", "Alert");
+            AccessibilityAttributes["sub-role"] = "Alert";
             Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
         }
 

--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -134,7 +134,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             AccessibilityRole = Role.Dialog;
-            AppendAccessibilityAttribute("sub-role", "Alert");
+            AccessibilityAttributes["sub-role"] = "Alert";
             Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
         }
 

--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -697,7 +697,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             AccessibilityRole = Role.PopupMenu;
-            AppendAccessibilityAttribute("sub-role", "Alert");
+            AccessibilityAttributes["sub-role"] = "Alert";
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -512,7 +512,7 @@ namespace Tizen.NUI.Components
             base.OnInitialize();
             AccessibilityRole = Role.ScrollBar;
             AccessibilityHighlightable = true;
-            AppendAccessibilityAttribute("style", "pagecontrolbyvalue");
+            AccessibilityAttributes["style"] = "pagecontrolbyvalue";
 
             container = new View()
             {

--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -783,7 +783,7 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             AccessibilityRole = Role.Dialog;
-            AppendAccessibilityAttribute("sub-role", "Alert");
+            AccessibilityAttributes["sub-role"] = "Alert";
 
             container.Add(this);
             container.SetTouchConsumed(true);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -84,18 +84,6 @@ namespace Tizen.NUI
             public static extern void DaliToolkitDevelControlClearAccessibilityRelations(HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_AppendAccessibilityAttribute")]
-            public static extern void DaliToolkitDevelControlAppendAccessibilityAttribute(HandleRef arg1, string arg2, string arg3);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_RemoveAccessibilityAttribute")]
-            public static extern void DaliToolkitDevelControlRemoveAccessibilityAttribute(HandleRef arg1, string arg2);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ClearAccessibilityAttributes")]
-            public static extern void DaliToolkitDevelControlClearAccessibilityAttributes(HandleRef arg1);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityReadingInfoType2")]
             public static extern void DaliToolkitDevelControlSetAccessibilityReadingInfoTypes(HandleRef arg1, int arg2);
 
@@ -387,6 +375,14 @@ namespace Tizen.NUI
                 public delegate IntPtr AccessibilityGetRangeExtents(IntPtr self, int startOffset, int endOffset, int coordType);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityGetRangeExtents GetRangeExtents; // 36
+
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate void AccessibilityGetAttributesCallback(string key, string value, IntPtr userData);
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate void AccessibilityGetAttributes(IntPtr self, AccessibilityGetAttributesCallback callback, IntPtr userData);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetAttributes GetAttributes; // 37
             }
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_DuplicateString")]

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -146,7 +146,6 @@ namespace Tizen.NUI.BaseComponents
         public virtual void OnInitialize()
         {
             AccessibilityRole = Role.Unknown;
-            AppendAccessibilityAttribute("class", this.GetType().Name);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -56,40 +56,10 @@ namespace Tizen.NUI.BaseComponents
         ///////////////////////////////////////////////////////////////////
 
         /// <summary>
-        /// Adds or modifies the value matched with given key.
-        /// </summary>
-        /// <remarks>
-        /// Modification takes place if key was previously set.
-        /// </remarks>
-        /// <param name="key">The key to insert</param>
-        /// <param name="value">The value to insert</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void AppendAccessibilityAttribute(string key, string value)
-        {
-            Interop.ControlDevel.DaliToolkitDevelControlAppendAccessibilityAttribute(SwigCPtr, key, value);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// <summary>
-        /// Erases a key with its value from accessibility attributes.
-        /// </summary>
-        /// <param name="key">The key to remove</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void RemoveAccessibilityAttribute(string key)
-        {
-            Interop.ControlDevel.DaliToolkitDevelControlRemoveAccessibilityAttribute(SwigCPtr, key);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// <summary>
-        /// Clears accessibility attributes.
+        /// Dictionary of accessibility attributes (key-value pairs of strings).
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void ClearAccessibilityAttributes()
-        {
-            Interop.ControlDevel.DaliToolkitDevelControlClearAccessibilityAttributes(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
+        protected Dictionary<string, string> AccessibilityAttributes { get; } = new Dictionary<string, string>();
 
         ///////////////////////////////////////////////////////////////////
         // ************************** Highlight ************************ //

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
@@ -160,7 +160,7 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 base.AutomationId = value;
-                AppendAccessibilityAttribute("automationId", value);
+                AccessibilityAttributes["automationId"] = value;
             }
         }
     }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
@@ -87,6 +87,7 @@ namespace Tizen.NUI.BaseComponents
             var ad = Interop.ControlDevel.AccessibilityDelegate.Instance;
 
             ad.CalculateStates = AccessibilityCalculateStatesWrapper;
+            ad.GetAttributes   = AccessibilityGetAttributes; // Not a wrapper, entirely private implementation
             ad.GetDescription  = AccessibilityGetDescriptionWrapper;
             ad.GetInterfaces   = AccessibilityGetInterfaces; // Not a wrapper, entirely private implementation
             ad.GetName         = AccessibilityGetNameWrapper;
@@ -97,7 +98,7 @@ namespace Tizen.NUI.BaseComponents
             View view = GetViewFromRefObject(self);
             if (view == null)
                 return 0UL;
-            
+
             ulong bitMask = 0UL;
 
             lock (AccessibilityInitialStates)
@@ -108,6 +109,23 @@ namespace Tizen.NUI.BaseComponents
             }
 
             return bitMask;
+        }
+
+        private static void AccessibilityGetAttributes(IntPtr self, Interop.ControlDevel.AccessibilityDelegate.AccessibilityGetAttributesCallback callback, IntPtr userData)
+        {
+            var view = GetViewFromRefObject(self);
+            var attributes = view.AccessibilityAttributes;
+            var classKey = "class";
+
+            if (!attributes.ContainsKey(classKey))
+            {
+                attributes[classKey] = view.GetType().Name;
+            }
+
+            foreach (var attribute in attributes)
+            {
+                callback(attribute.Key, attribute.Value, userData);
+            }
         }
 
         private static IntPtr AccessibilityGetDescriptionWrapper(IntPtr self)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Having a modifiable attribute dictionary in NUI removes the performance penalty of having to go through interops on every modification. A new override for `GetAttributes` in `NUIViewAccessible` will now collect the attributes stored in NUI (through `AccessibilityDelegate.GetAttributes`). Moreover, the `class` attribute is now calculated lazily in order to reduce the creation cost of `View`.

Merge together with (ABI change):
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/277288/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
