### PR TITLE
[Applications.Common] Use using to dispose ManualResetEvent handle

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/TizenSynchronizationContext.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/TizenSynchronizationContext.cs
@@ -67,27 +67,29 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public override void Send(SendOrPostCallback d, object state)
         {
-            var mre = new ManualResetEvent(false);
-            Exception err = null;
-            GSourceManager.Post(() =>
+            using (var mre = new ManualResetEvent(false))
             {
-                try
+                Exception err = null;
+                GSourceManager.Post(() =>
                 {
-                    d(state);
-                }
-                catch (Exception ex)
+                    try
+                    {
+                        d(state);
+                    }
+                    catch (Exception ex)
+                    {
+                        err = ex;
+                    }
+                    finally
+                    {
+                        mre.Set();
+                    }
+                });
+                mre.WaitOne();
+                if (err != null)
                 {
-                    err = ex;
+                    throw err;
                 }
-                finally
-                {
-                    mre.Set();
-                }
-            });
-            mre.WaitOne();
-            if (err != null)
-            {
-                throw err;
             }
         }
     }

--- a/src/Tizen.Applications.Common/Tizen.Applications/TizenUISynchronizationContext.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/TizenUISynchronizationContext.cs
@@ -69,27 +69,29 @@ namespace Tizen.Applications
         /// <since_tizen> 10 </since_tizen>
         public override void Send(SendOrPostCallback d, object state)
         {
-            var mre = new ManualResetEvent(false);
-            Exception err = null;
-            GSourceManager.Post(() =>
+            using (var mre = new ManualResetEvent(false))
             {
-                try
+                Exception err = null;
+                GSourceManager.Post(() =>
                 {
-                    d(state);
-                }
-                catch (Exception ex)
+                    try
+                    {
+                        d(state);
+                    }
+                    catch (Exception ex)
+                    {
+                        err = ex;
+                    }
+                    finally
+                    {
+                        mre.Set();
+                    }
+                }, true);
+                mre.WaitOne();
+                if (err != null)
                 {
-                    err = ex;
+                    throw err;
                 }
-                finally
-                {
-                    mre.Set();
-                }
-            }, true);
-            mre.WaitOne();
-            if (err != null)
-            {
-                throw err;
             }
         }
     }


### PR DESCRIPTION
To dispose ManualResetEvent handle after it is used, using is used.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
