### PR TITLE
[NUI] When hiding the overlaid border, the timer is also initialized.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -879,6 +879,9 @@ namespace Tizen.NUI
             if (BorderWindow != null && BorderWindow.IsMaximized())
             {
                 borderView?.Hide();
+                overlayTimer?.Stop();
+                overlayTimer?.Dispose();
+                overlayTimer = null;
                 return true;
             }
             return false;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
When hiding the overlaid border, the timer is also initialized.

If the timer is not initialized, the border will not be visible when OverlayBorderShoew is performed again while the timer is alive.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
