### PR TITLE
[NUI] set default value for AutoScroll in TextLabel

### DIFF
--- a/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
@@ -42,6 +42,9 @@ namespace Tizen.NUI
                 PixelSize = 24,
                 TextColor = new Color(0.04f, 0.05f, 0.13f, 1),
                 FontStyle = new PropertyMap().Add("weight", new PropertyValue("regular")),
+                AutoScrollLoopCount = 2,
+                AutoScrollGap = 50.0f,
+                AutoScrollSpeed = 80,
             });
 
             // TextField style.


### PR DESCRIPTION
NUI TextLabel no longer use dali-theme.
So set default values in NUI theme.
This values are the same as the values in prev dali-theme.

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>
