### PR TITLE
[NUI] Delay old ResourceReady signal

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1229,6 +1229,11 @@ namespace Tizen.NUI.BaseComponents
         // Callback for View ResourceReady signal
         private void OnResourceReady(IntPtr data)
         {
+            if(!CheckResourceReady())
+            {
+                return;
+            }
+
             ResourceReadyEventArgs e = new ResourceReadyEventArgs();
             if (data != null)
             {
@@ -1551,8 +1556,20 @@ namespace Tizen.NUI.BaseComponents
             return base.GetNaturalSize();
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override bool CheckResourceReady()
+        {
+            // If we have some properties to be updated, this signal is old thing.
+            // We need to ignore current signal, and wait next.
+            return !(imagePropertyUpdateProcessAttachedFlag && imagePropertyUpdatedFlag);
+        }
+
         private void OnResourceLoaded(IntPtr view)
         {
+            if(!CheckResourceReady())
+            {
+                return;
+            }
             ResourceLoadedEventArgs e = new ResourceLoadedEventArgs();
             e.Status = (ResourceLoadingStatusType)Interop.View.GetVisualResourceStatus(this.SwigCPtr, Property.IMAGE);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -1074,6 +1074,11 @@ namespace Tizen.NUI.BaseComponents
 
         private void OnResourcesLoaded(IntPtr view)
         {
+            if(!CheckResourceReady())
+            {
+                return;
+            }
+
             if (resourcesLoadedEventHandler != null)
             {
                 resourcesLoadedEventHandler(this, null);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1556,6 +1556,12 @@ namespace Tizen.NUI.BaseComponents
             return false;
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual bool CheckResourceReady()
+        {
+            return true;
+        }
+
         private ViewSelectorData EnsureSelectorData()
         {
             if (themeData == null) themeData = new ThemeData();


### PR DESCRIPTION
Due to the LazyUpdate for ImageView's property,
sometimes ResourceReady signal comes even resource is not ready.

This patch make if we have some LazyUpdate properties, skip current signal
and wait next valid ResourceReady signal

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

