### PR TITLE
[NUI] Fixed border behavior of windows launched at full size

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -207,11 +207,9 @@ namespace Tizen.NUI
                     realWindowSize.Width >= screenWidth && realWindowSize.Height >= screenHeight &&
                     IsMaximized() == false)
                 {
+                    WindowSize -= new Size2D((int)borderInterface.BorderLineThickness * 2, (int)(borderHeight + borderInterface.BorderLineThickness * 2));   
                     Maximize(true);
                     borderInterface.OnMaximize(true);
-                    ResizedEventArgs e = new ResizedEventArgs();
-                    e.WindowSize = WindowSize;
-                    OnBorderWindowResized(this, e);
                 }
                 else
                 {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
For windows launched in full size, we need to calibrate the window as much as the border size for Maximized to work well.

Otherwise, the border area will be located outsize of screen.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
