### PR TITLE
[Build] Add dali2-csharp-binder to BuildRequires

### DIFF
--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -30,6 +30,7 @@ BuildArch:   noarch
 AutoReqProv: no
 
 BuildRequires: dotnet-build-tools
+BuildRequires: pkgconfig(dali2-csharp-binder)
 Requires(post): /usr/bin/vconftool
 
 # BuildRequires for StructValidator

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -29,6 +29,7 @@ BuildArch:   noarch
 AutoReqProv: no
 
 BuildRequires: dotnet-build-tools
+BuildRequires: pkgconfig(dali2-csharp-binder)
 Requires(post): /usr/bin/vconftool
 
 # BuildRequires for StructValidator


### PR DESCRIPTION
To depend on the latest dali2-csharp-binder, dali2-csharp-binder is
added to BuildRequires in spec.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
