### PR TITLE
[NUI] PropertyValue.EqualTo()

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyValue.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyValue.cs
@@ -78,6 +78,14 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Assign")]
             public static extern global::System.IntPtr PropertyValueAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_EqualTo")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_NotEqualTo")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Value")]
             public static extern void DeletePropertyValue(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Common/PropertyValue.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyValue.cs
@@ -244,6 +244,39 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Determines whether the ProperyValue has equal value with the current ProperyValue.
+        /// </summary>
+        /// <remarks>
+        /// Equal only if same type.
+        /// PropertyArray and PropertyMap don't have EqaulTo method. In that case, always return false.
+        /// EqualTo API consider absolute/relative error internally.
+        /// </remarks>
+        /// <param name="rhs">The ProperyValue to compare with the current ProperyValue.</param>
+        /// <returns>true if the specified ProperyValue is equal to the current ProperyValue; otherwise, false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool EqualTo(PropertyValue rhs)
+        {
+            bool ret = Interop.PropertyValue.EqualTo(SwigCPtr, PropertyValue.getCPtr(rhs));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Determines whether the ProperyValue doesn't have equal value with the current ProperyValue.
+        /// </summary>
+        /// <remarks>
+        /// Same as !EqualTo(rhs);
+        /// </remarks>
+        /// <param name="rhs">The ProperyValue to compare with the current ProperyValue.</param>
+        /// <returns>true if the specified ProperyValue is not equal to the current ProperyValue; otherwise, false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool NotEqualTo(PropertyValue rhs)
+        {
+            bool ret = Interop.PropertyValue.NotEqualTo(SwigCPtr, PropertyValue.getCPtr(rhs));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
 
         /// <summary>
         /// Hidden API (Inhouse API).

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSPropertyValue.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSPropertyValue.cs
@@ -1,0 +1,231 @@
+﻿using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Common/PropertyValue")]
+    public class PropertyValueTest
+    {
+        private const string tag = "NUITEST";
+        private string path;
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for PropertyValue.EqualTo")]
+        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void EqualTo_INT_VALUE()
+        {
+            /* TEST CODE */
+            int expectValue = 3;
+            PropertyValue v1 = new PropertyValue(expectValue);
+            PropertyValue v2 = new PropertyValue(expectValue);
+
+            int getValue = 0;
+            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have integer value");
+            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have integer value");
+            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+
+            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+
+            v1.Dispose();
+            v2.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for PropertyValue.EqualTo")]
+        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void EqualTo_FLOAT_VALUE()
+        {
+            /* TEST CODE */
+            float expectValue = 3.0f;
+            PropertyValue v1 = new PropertyValue(expectValue);
+            PropertyValue v2 = new PropertyValue(expectValue);
+
+            float getValue = 0;
+            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have float value");
+            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have float value");
+            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+
+            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+
+            v1.Dispose();
+            v2.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for PropertyValue.EqualTo")]
+        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void EqualTo_BOOL_VALUE()
+        {
+            /* TEST CODE */
+            bool expectValue = true;
+            PropertyValue v1 = new PropertyValue(expectValue);
+            PropertyValue v2 = new PropertyValue(expectValue);
+
+            bool getValue = false;
+            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have float value");
+            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have float value");
+            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+
+            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+
+            v1.Dispose();
+            v2.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for PropertyValue.EqualTo")]
+        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void EqualTo_STRING_VALUE()
+        {
+            /* TEST CODE */
+            string expectValue = "Hello, World!";
+            PropertyValue v1 = new PropertyValue(expectValue);
+            PropertyValue v2 = new PropertyValue("Hello, World!");
+
+            string getValue = "";
+            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have string value");
+            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have string value");
+            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+
+            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+
+            v1.Dispose();
+            v2.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for PropertyValue.EqualTo")]
+        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void EqualTo_VECTOR2_VALUE()
+        {
+            /* TEST CODE */
+            Vector2 expectValue = new Vector2(1.0f, 2.0f);
+            PropertyValue v1 = new PropertyValue(expectValue);
+            PropertyValue v2 = new PropertyValue(expectValue);
+            PropertyValue v3 = new PropertyValue(new Vector2(1.0f, 2.0f));
+
+            Vector2 getValue = new Vector2();
+            Assert.AreEqual(true, v1.Get(getValue), "v1 should have Vector2 value");
+            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+            Assert.AreEqual(true, v2.Get(getValue), "v2 should have Vector2 value");
+            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+            Assert.AreEqual(true, v3.Get(getValue), "v3 should have Vector2 value");
+            Assert.AreEqual(expectValue, getValue, "v3 should have expected value");
+
+            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+            Assert.AreEqual(true, v1.EqualTo(v3), "v1 and v3 should have same value");
+            Assert.AreEqual(true, v2.EqualTo(v3), "v2 and v3 should have same value");
+
+            v1.Dispose();
+            v2.Dispose();
+            v3.Dispose();
+            
+            expectValue.Dispose();
+            getValue.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for PropertyValue.EqualTo")]
+        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void EqualTo_VECTOR4_VALUE()
+        {
+            /* TEST CODE */
+            Vector4 expectValue = new Vector4(1.0f, 2.0f, 3.0f, 4.0f);
+            PropertyValue v1 = new PropertyValue(expectValue);
+            PropertyValue v2 = new PropertyValue(expectValue);
+            PropertyValue v3 = new PropertyValue(new Vector4(1.0f, 2.0f, 3.0f, 4.0f));
+
+            Vector4 getValue = new Vector4();
+            Assert.AreEqual(true, v1.Get(getValue), "v1 should have Vector4 value");
+            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+            Assert.AreEqual(true, v2.Get(getValue), "v2 should have Vector4 value");
+            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+            Assert.AreEqual(true, v3.Get(getValue), "v3 should have Vector4 value");
+            Assert.AreEqual(expectValue, getValue, "v3 should have expected value");
+
+            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+            Assert.AreEqual(true, v1.EqualTo(v3), "v1 and v3 should have same value");
+            Assert.AreEqual(true, v2.EqualTo(v3), "v2 and v3 should have same value");
+
+            v1.Dispose();
+            v2.Dispose();
+            v3.Dispose();
+
+            expectValue.Dispose();
+            getValue.Dispose();
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Set value test for PropertyValue.NotEqualTo")]
+        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.NotEqualTo")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void NotEqualTo_INT_VALUE()
+        {
+            /* TEST CODE */
+            int expectValue1 = 3;
+            int expectValue2 = expectValue1 + 1;
+            PropertyValue v1 = new PropertyValue(expectValue1);
+            PropertyValue v2 = new PropertyValue(expectValue2);
+
+            int getValue = 0;
+            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have integer value");
+            Assert.AreEqual(expectValue1, getValue, "v1 should have expected1 value");
+            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have integer value");
+            Assert.AreEqual(expectValue2, getValue, "v2 should have expected2 value");
+
+            Assert.AreEqual(false, v1.EqualTo(v2), "v1 and v2 should not have same value");
+            Assert.AreEqual(true, v1.NotEqualTo(v2), "v1 and v2 should not have same value");
+
+            v1.Dispose();
+            v2.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Add operation to compare the value of PropertyValue.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
