### PR TITLE
[NUI] Add AllowOnlyOwnTouch property and SetDefaultAllowOnlyOwnTouch api

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -204,6 +204,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_CAPTURE_ALL_TOUCH_AFTER_START_get")]
             public static extern int CaptureAllTouchAfterStartGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_ALLOW_ONLY_OWN_TOUCH_get")]
+            public static extern int AllowOnlyOwnTouchGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_BLEND_EQUATION_get")]
             public static extern int BlendEquationGet();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -32,6 +32,7 @@ namespace Tizen.NUI.BaseComponents
         private static HashSet<BindableProperty> sizePropertyGroup = new HashSet<BindableProperty>();
         private static HashSet<BindableProperty> scalePropertyGroup = new HashSet<BindableProperty>();
         private static bool defaultGrabTouchAfterLeave = false;
+        private static bool defaultAllowOnlyOwnTouch = false;
 
         internal BackgroundExtraData backgroundExtraData;
 
@@ -154,6 +155,7 @@ namespace Tizen.NUI.BaseComponents
             }
 
             GrabTouchAfterLeave = defaultGrabTouchAfterLeave;
+            AllowOnlyOwnTouch = defaultAllowOnlyOwnTouch;
         }
 
         internal View(ViewImpl implementation, bool shown = true) : this(Interop.View.NewViewInternal(ViewImpl.getCPtr(implementation)), true)
@@ -205,6 +207,16 @@ namespace Tizen.NUI.BaseComponents
         public static void SetDefaultGrabTouchAfterLeave(bool enable)
         {
             defaultGrabTouchAfterLeave = enable;
+        }
+
+        /// <summary>
+        /// If set to true, the <see cref="AllowOnlyOwnTouch"/> property value is set to true when all Views are created.
+        /// </summary>
+        /// <param name="enable">Sets value of AllowOnlyOwnTouch property</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetDefaultAllowOnlyOwnTouch(bool enable)
+        {
+            defaultAllowOnlyOwnTouch = enable;
         }
 
         /// <summary>
@@ -2988,6 +3000,42 @@ namespace Tizen.NUI.BaseComponents
             {
                 var temp = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.CaptureAllTouchAfterStart, temp);
+                temp.Dispose();
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Whether the view will only receive own touch.
+        /// </summary>
+        /// <returns>true, if it only receives touches that started from itself.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllowOnlyOwnTouch
+        {
+            get
+            {
+                return (bool)GetValue(AllowOnlyOwnTouchProperty);
+            }
+            set
+            {
+                SetValue(AllowOnlyOwnTouchProperty, value);
+            }
+        }
+
+        private bool InternalAllowOnlyOwnTouch
+        {
+            get
+            {
+                bool temp = false;
+                var pValue = GetProperty(View.Property.AllowOnlyOwnTouch);
+                pValue.Get(out temp);
+                pValue.Dispose();
+                return temp;
+            }
+            set
+            {
+                var temp = new Tizen.NUI.PropertyValue(value);
+                SetProperty(View.Property.AllowOnlyOwnTouch, temp);
                 temp.Dispose();
                 NotifyPropertyChanged();
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2447,6 +2447,25 @@ namespace Tizen.NUI.BaseComponents
         });
 
         /// <summary>
+        /// AllowOnlyOwnTouchProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty AllowOnlyOwnTouchProperty = BindableProperty.Create(nameof(AllowOnlyOwnTouch), typeof(bool), typeof(View), false, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            if (newValue != null)
+            {
+                instance.InternalAllowOnlyOwnTouch = (bool)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            return instance.InternalAllowOnlyOwnTouch;
+        });
+
+
+        /// <summary>
         /// BlendEquationProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -249,6 +249,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int PADDING = Interop.ViewProperty.PaddingGet();
             internal static readonly int SHADOW = Interop.ViewProperty.ShadowGet();
             internal static readonly int CaptureAllTouchAfterStart = Interop.ActorProperty.CaptureAllTouchAfterStartGet();
+            internal static readonly int AllowOnlyOwnTouch = Interop.ActorProperty.AllowOnlyOwnTouchGet();
             internal static readonly int BlendEquation = Interop.ActorProperty.BlendEquationGet();
             internal static readonly int Culled = Interop.ActorProperty.CulledGet();
             internal static readonly int AccessibilityName = Interop.ViewProperty.AccessibilityNameGet();


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

1. If the AllowOnlyOwnTouch property is true, view will only receive touch events that started from itself.
```c#
  var view = new View()
  {
    AllowOnlyOwnTouch = true,
  }
```

2. Add SetDefaultAllowOnlyOwnTouch(bool enable) in View
```c#
   // If this is set to true, all views are created with AllowOnlyOwnTouch set to true.
   View.SetDefaultiAllowOnlyOwnTouch(true);
```

dependency
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/276632/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/276656/



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
