### PR TITLE
[NUI][XamlBuild] Fix issues of xamlbuild.

### DIFF
--- a/src/Tizen.NUI.Components/Properties/AssemblyInfo.cs
+++ b/src/Tizen.NUI.Components/Properties/AssemblyInfo.cs
@@ -2,7 +2,3 @@ using Tizen.NUI;
 
 // Xamarin.Forms.Loader.dll Xamarin.Forms.Xaml.XamlLoader.Load(object, string), kzu@microsoft.com
 [assembly: XmlnsDefinition("http://tizen.org/Tizen.NUI/2018/XAML", "Tizen.NUI.Components")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]

--- a/src/Tizen.NUI.Extension/Properties/AssemblyInfo.cs
+++ b/src/Tizen.NUI.Extension/Properties/AssemblyInfo.cs
@@ -2,7 +2,3 @@ using Tizen.NUI;
 
 // Xamarin.Forms.Loader.dll Xamarin.Forms.Xaml.XamlLoader.Load(object, string), kzu@microsoft.com
 [assembly: XmlnsDefinition("http://tizen.org/Tizen.NUI/2018/XAML", "Tizen.NUI.Extension")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/CompiledConverters/BindablePropertyConverter.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/CompiledConverters/BindablePropertyConverter.cs
@@ -57,7 +57,7 @@ namespace Tizen.NUI.Xaml.Core.XamlC
                         (   parent.XmlType.Name == "Trigger"
                          || parent.XmlType.Name == "DataTrigger"
                          || parent.XmlType.Name == "MultiTrigger"
-                         || parent.XmlType.Name == "Style")) {
+                         || parent.XmlType.Name == "XamlStyle")) {
                         var ttnode = (parent as ElementNode).Properties [new XmlName("", "TargetType")];
                         if (ttnode is ValueNode)
                             typeName = (ttnode as ValueNode).Value as string;

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/SetPropertiesVisitor.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/SetPropertiesVisitor.cs
@@ -475,7 +475,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             } else
                 yield return Create(Ldnull);
             yield return Instruction.Create(OpCodes.Newobj, module.ImportReference(ctorinforef));
-            yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.bindingNameSpace, "BindingExtension"), propertyName: "TypedBinding"));
+            yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.xamlNameSpace, "BindingExtension"), propertyName: "TypedBinding"));
         }
 
         static IList<Tuple<PropertyDefinition, string>> ParsePath(string path, TypeReference tSourceRef, IXmlLineInfo lineInfo, ModuleDefinition module)


### PR DESCRIPTION
### Description of Change ###
src/Tizen.NUI.XamlBuild/src/public/XamlBuild/SetPropertiesVisitor.cs
before:
yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.**bindingNameSpace**, "BindingExtension"), propertyName: "TypedBinding"));
after:
yield return Instruction.Create(OpCodes.Callvirt, module.ImportPropertySetterReference((NUIXamlCTask.bindingAssemblyName, NUIXamlCTask.**xamlNameSpace**, "BindingExtension"), propertyName: "TypedBinding"));

_BindingExtension 's name space is Tizen.NUI.Xaml, not Tizen.NUI.Binding, or will throw "error : Value cannot be null. (Parameter 'type')"_

=====================

src/Tizen.NUI.XamlBuild/src/public/XamlBuild/CompiledConverters/BindablePropertyConverter.cs
line 60:
               before:        || parent.XmlType.Name == "Style")) {
                  after:        || parent.XmlType.Name == "XamlStyle"))

We can test like below sample code:

     <TextLabel PointSize="18">
        <TextLabel.XamlStyle>
            <Binding Source="{x:Reference view1}" Path="Sensitive">
                <Binding.Converter>
                    <l:BoolToObjectConverter x:TypeArguments="XamlStyle">
                        <l:BoolToObjectConverter.TrueObject>
                            <XamlStyle TargetType="TextLabel">
                                <Setter Property="Text" Value="Indubitably!" />
                                <Setter Property="TextColor" Value="Green" />
                            </XamlStyle>
                        </l:BoolToObjectConverter.TrueObject>

                        <l:BoolToObjectConverter.FalseObject>
                            <XamlStyle TargetType="TextLabel">
                                <Setter Property="Text" Value="Maybe later" />
                                <Setter Property="TextColor" Value="Red" />
                            </XamlStyle>
                        </l:BoolToObjectConverter.FalseObject>
                    </l:BoolToObjectConverter>
                </Binding.Converter>
            </Binding>
        </TextLabel.XamlStyle>
    </TextLabel>

In this case, before modifying, will throw "Cannot convert "Text" into Tizen.NUI.Binding.BindableProperty"

==================

In  src/Tizen.NUI.Components/Properties/AssemblyInfo.cs  & src/Tizen.NUI.Extension/Properties/AssemblyInfo.cs
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
-[assembly: XmlnsDefinition("http://schemas.microsoft.com/winfx/2009/xaml", "System", AssemblyName = "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]

We can  test like below sample code:
<l:MyView >
    <l:MyView.Array>
        <x:Array Type="{x:Type x:String}">
            <x:String>AA</x:String>
            <x:String>BB</x:String>
        </x:Array>
    </l:MyView.Array>
</l:MyView>

Before modifying, if UseInjection,  find "type" from system first, if find it, will return, but the type is not attribute of Xaml, so in this case we will got the error :  "No property, bindable property, or event found for 'Type'"
 


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
