### PR TITLE
[NUI][AT-SPI] Fix AutomationId for BaseComponents

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -390,6 +390,9 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetAccessibilityDelegate")]
             public static extern IntPtr DaliAccessibilitySetAccessibilityDelegate(IntPtr arg1_accessibilityDelegate, int arg2_accessibilityDelegateSize);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetAccessibilityAttribute")]
+            public static extern void DaliAccessibilitySetAccessibilityAttribute(HandleRef arg1_control, string arg2_key, string arg3_value);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -61,6 +61,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected Dictionary<string, string> AccessibilityAttributes { get; } = new Dictionary<string, string>();
 
+        private void SetAccessibilityAttribute(string key, string value)
+        {
+            Interop.ControlDevel.DaliAccessibilitySetAccessibilityAttribute(SwigCPtr, key, value);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
         ///////////////////////////////////////////////////////////////////
         // ************************** Highlight ************************ //
         ///////////////////////////////////////////////////////////////////

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
@@ -160,7 +160,9 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 base.AutomationId = value;
-                AccessibilityAttributes["automationId"] = value;
+
+                // AccessibilityAttributes["automationId"] will not work for BaseComponents not backed by ViewWrapperImpl & NUIViewAccessible
+                SetAccessibilityAttribute("automationId", value);
             }
         }
     }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Due to an oversight in https://github.com/Samsung/TizenFX/pull/4389, the `automationId` attribute disappeared from the AT-SPI tree for some `View`s (notably, `BaseComponents`). This PR fixes this bug.

Three bindings for `AppendAccessibilityAttribute`, `RemoveAccessibilityAttribute` and `ClearAccessibilityAttributes` were recently removed. They were generally no longer necessary with the addition of `AccessibilityAttributes` to `View` (collected on demand by `NUIViewAccessible::GetAttributes`). However, some `View`s (those not backed by `ViewWrapperImpl`\*) use `Accessible` implementations other than `NUIViewAccessible`, e.g. `TextEditor` uses `TextEditorAccessible` or `WidgetView` uses `WidgetViewAccessible`, which are internal to other repositories and cannot call into C# to collect attributes, nor bindings for them can be created. For the one specific use case of `AutomationId`, a binding function needs to be restored.

Please note that `AccessibilityAttributes` is not the only C# API that won't work for `View`s that don't create a `ViewWrapperImpl`\* (and the `NUIViewAccessible` created by it, e.g. `BaseComponents` or Flux controls). Other APIs that will not work for such `View`s include:
* `AccessibilityGetName`, `AccessibilityGetDescription` etc.,
* `AccessibilityCalculateStates` etc.,
* `IAtspiSelection`, `IAtspiText`, `IAtspiValue` etc.

because the C++ implementations (from the respective `Accessible`-derived class) will be used instead (e.g. `ControlAccessible::GetAttributes`, `ControlAccessible::CalculateStates`, `TextEditorAccessible::InsertText` etc.).

\* Or potentially also `ViewImpl` if an [extra patch is applied](https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/277964/) (not necessary at the moment).

Merge together with:
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/277986/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
