### PR TITLE
[NUI] fix the defect that an wrong image is shown when async loading of the AnimatedVectorImageView

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DebugFileLogging.cs
+++ b/src/Tizen.NUI/src/internal/Common/DebugFileLogging.cs
@@ -56,7 +56,7 @@ namespace Tizen.NUI
         #endregion //Constructors
 
         #region Methods
-        [Conditional("NUI_DEBUG_ON")]
+        [Conditional("NUI_DISPOSE_DEBUG_ON")]
         internal void WriteLog(string log)
         {
             TimeSpan curr = DateTime.Now.TimeOfDay;

--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
@@ -103,7 +103,6 @@ namespace Tizen.NUI.BaseComponents
                 resourceUrl = (value == null) ? "" : value;
                 URL = resourceUrl;
                 isMinMaxFrameSet = minMaxSetTypes.NotSetByUser;
-                totalFrameNum = base.TotalFrame;
                 NUILog.Debug($" [{GetId()}] resourceUrl={resourceUrl}) ]AnimatedVectorImageView END]");
             }
             get => resourceUrl;
@@ -187,6 +186,11 @@ namespace Tizen.NUI.BaseComponents
             get => totalFrameNum;
         }
 
+        private int totalFrameNum
+        {
+            get => base.TotalFrame;
+        }
+
         /// <summary>
         /// CurrentFrame of animation.
         /// </summary>
@@ -220,15 +224,10 @@ namespace Tizen.NUI.BaseComponents
                 {
                     value = 0;
                 }
-                else if (value >= totalFrameNum)
-                {
-                    value = totalFrameNum - 1;
-                }
 
                 innerCurrentFrame = value;
                 AnimationState = AnimationStates.Paused;
 
-                base.SetMinMaxFrame(0, totalFrameNum - 1);
                 base.CurrentFrame = innerCurrentFrame;
 
                 NUILog.Debug($" [{GetId()}] innerCurrentFrame={innerCurrentFrame}) ]AnimatedVectorImageView END]");
@@ -318,18 +317,9 @@ namespace Tizen.NUI.BaseComponents
             maximumFrame = (maxFrame) > 0 ? maxFrame : 0;
             isMinMaxFrameSet = minMaxSetTypes.SetByMinAndMaxFrameMethod;
 
-            if (minimumFrame >= totalFrameNum)
-            {
-                minimumFrame = totalFrameNum - 1;
-            }
-
-            if (maximumFrame >= totalFrameNum)
-            {
-                maximumFrame = totalFrameNum - 1;
-            }
-
             if (minimumFrame > maximumFrame)
             {
+                NUILog.Debug($" [{GetId()}] minimumFrame:{minimumFrame} > maximumFrame:{maximumFrame}) ]AnimatedVectorImageView END]");
                 return;
             }
 
@@ -600,7 +590,6 @@ namespace Tizen.NUI.BaseComponents
         #region Private
         private string resourceUrl = null;
         private int repeatCnt = 0;
-        private int totalFrameNum = 0;
         private RepeatModes repeatMode = RepeatModes.Restart;
         private int minimumFrame = -1, maximumFrame = -1;
         private minMaxSetTypes isMinMaxFrameSet = minMaxSetTypes.NotSetByUser;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1569,7 +1569,7 @@ namespace Tizen.NUI.BaseComponents
             return themeData.selectorData ?? (themeData.selectorData = new ViewSelectorData());
         }
 
-        [Conditional("NUI_DEBUG_ON")]
+        [Conditional("NUI_DISPOSE_DEBUG_ON")]
         private void disposeDebugging(DisposeTypes type)
         {
             DebugFileLogging.Instance.WriteLog($"View.Dispose({type}) START");

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -656,7 +656,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal bool IsDisposeQueued => isDisposeQueued;
 
-        [Conditional("NUI_DEBUG_ON")]
+        [Conditional("NUI_DISPOSE_DEBUG_ON")]
         private void disposeDebuggingCtor()
         {
             DebugFileLogging.Instance.WriteLog($"type:{GetType()} copyNativeHandle:{swigCPtrCopy.Handle.ToString("X8")}");
@@ -673,7 +673,7 @@ namespace Tizen.NUI
             }
         }
 
-        [Conditional("NUI_DEBUG_ON")]
+        [Conditional("NUI_DISPOSE_DEBUG_ON")]
         private void disposeDebuggingDispose(DisposeTypes type)
         {
             DebugFileLogging.Instance.WriteLog($"swigCMemOwn:{swigCMemOwn} type:{GetType()} copyNativeHandle:{swigCPtrCopy.Handle.ToString("X8")} HasBody:{HasBody()}");


### PR DESCRIPTION
### Description of Change ###
[NUI] fix the defect that an wrong image is shown when async loading of the AnimatedVectorImageView
- AnimatedVectorImageView has been added as hidden APIs for GBM usage only.
- `TotalFrame` is NOT read sometimes when the async loading of the Lottie file takes long time.
- remove the part of using `TotalFrame` where `TotalFrame` is not read properly.
- done the test locally in GBM target.

### API Changes ###
none