### PR TITLE
[NUI] Palette: Add an exception for 4ch(ARGB) image processing

### DIFF
--- a/src/Tizen.NUI/src/internal/Utility/ColorCutQuantizer.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ColorCutQuantizer.cs
@@ -610,7 +610,14 @@ namespace Tizen.NUI
                         for (int i = lowIndex; i <= highIndex; i++)
                         {
                             int color = colors[i];
-                            colors[i] = 255 << 24 | (color >> 8 & 0xff) << 16 | (color >> 16 & 0xff) << 8 | (color & 0xff);
+                            if ((color >> 24 & 0xff) == 255)
+                            {
+                                colors[i] = 255 << 24 | (color >> 8 & 0xff) << 16 | (color >> 16 & 0xff) << 8 | (color & 0xff);
+                            }
+                            else
+                            {
+                                colors[i] = (color >> 24 & 0xff) << 24 | (color >> 8 & 0xff) << 16 | (color >> 16 & 0xff) << 8 | (color & 0xff);
+                            }
                         }
 
                         break;
@@ -619,7 +626,14 @@ namespace Tizen.NUI
                         for (int i = lowIndex; i <= highIndex; i++)
                         {
                             int color = colors[i];
-                            colors[i] = 255 << 24 | (color & 0xff) << 16 | (color >> 8 & 0xff) << 8 | (color >> 16 & 0xff);
+                            if ((color >> 24 & 0xff) == 255)
+                            {
+                                colors[i] = 255 << 24 | (color & 0xff) << 16 | (color >> 8 & 0xff) << 8 | (color >> 16 & 0xff);
+                            }
+                            else
+                            {
+                                colors[i] = (color >> 24 & 0xff) << 24  | (color & 0xff) << 16 | (color >> 8 & 0xff) << 8 | (color >> 16 & 0xff);
+                            }
                         }
                         break;
                 }


### PR DESCRIPTION
### Description of Change ###
Fix crash issue when user want to analyze 4ch image


### API Changes ###
no API Changes