### PR TITLE
[NUI] Propagate AutomationId value to DALi

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
@@ -98,6 +98,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_HIDDEN_get")]
             public static extern int AccessibilityHiddenGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_AUTOMATION_ID_get")]
+            public static extern int AutomationIdGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityProperties.cs
@@ -153,15 +153,5 @@ namespace Tizen.NUI.BaseComponents
                 NotifyPropertyChanged();
             }
         }
-
-        private string InternalAutomationId
-        {
-            get { return base.AutomationId; }
-            set
-            {
-                base.AutomationId = value;
-                AccessibilityAttributes["automationId"] = value;
-            }
-        }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2491,13 +2491,15 @@ namespace Tizen.NUI.BaseComponents
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             if (newValue != null)
             {
-                instance.InternalAutomationId = (string)newValue;
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)instance.SwigCPtr, View.Property.AutomationId, new Tizen.NUI.PropertyValue((string)newValue));
             }
         },
         defaultValueCreator: (bindable) =>
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
-            return instance.InternalAutomationId;
+            string temp = "";
+            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)instance.SwigCPtr, View.Property.AutomationId).Get(out temp);
+            return temp;
         });
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -259,6 +259,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int AccessibilityAttributes = Interop.ViewProperty.AccessibilityAttributesGet();
             internal static readonly int DispatchKeyEvents = Interop.ViewProperty.DispatchKeyEventsGet();
             internal static readonly int AccessibilityHidden = Interop.ViewProperty.AccessibilityHiddenGet();
+            internal static readonly int AutomationId = Interop.ViewProperty.AutomationIdGet();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Due to an oversight in https://github.com/Samsung/TizenFX/pull/4389, the `automationId` attribute disappeared from the AT-SPI tree for some `View`s, causing multiple regressions in Aurum tests. This PR fixes this bug.

The `"automationId"` key set in `AccessibilityAttributes` is ignored for controls not backed by a `NUIViewAccessible` (e.g. `BaseComponents`, `FluxView` etc.), because `NUIViewAccessible::GetAttributes` is never called for such controls. The value of `AutomationId` should be propagated to `dali-toolkit` instead, so that is it visible to `ControlAccessible::GetAttributes`, therefore having an effect for all types of `View`s (`NUIViewAccessible::GetAttributes` calls `ControlAccessible::GetAttributes` first, and then collects any additional attributes stored in `View.AccessibilityAttributes`).

Dependencies:
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/278352/ (merged)
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/278353/ (merged)


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
