### PR TITLE
[NUI] Fix to change IsSelected when ControlState is changed

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -315,6 +315,16 @@ namespace Tizen.NUI.Components
             {
                 isPressed = statePressed;
             }
+
+            if (IsSelectable)
+            {
+                var stateSelected = controlStateChangedInfo.CurrentState.Contains(ControlState.Selected);
+
+                if (IsSelected != stateSelected)
+                {
+                    IsSelected = stateSelected;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
@@ -178,6 +178,16 @@ namespace Tizen.NUI.Components
             {
                 IsPressed = statePressed;
             }
+
+            if (IsSelectable)
+            {
+                var stateSelected = controlStateChangedInfo.CurrentState.Contains(ControlState.Selected);
+
+                if (IsSelected != stateSelected)
+                {
+                    IsSelected = stateSelected;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/SelectButton.cs
+++ b/src/Tizen.NUI.Components/Controls/SelectButton.cs
@@ -196,6 +196,11 @@ namespace Tizen.NUI.Components
 
                 OnSelectedChanged();
 
+                if (IsSelected != info.CurrentState.Contains(ControlState.Selected))
+                {
+                    IsSelected = info.CurrentState.Contains(ControlState.Selected);
+                }
+
                 if (SelectedChanged != null)
                 {
                     SelectedChangedEventArgs eventArgs = new SelectedChangedEventArgs();

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -349,18 +349,15 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void OnControlStateChanged(ControlStateChangedEventArgs controlStateChangedInfo)
         {
+            if (controlStateChangedInfo == null) throw new ArgumentNullException(nameof(controlStateChangedInfo));
             base.OnControlStateChanged(controlStateChangedInfo);
 
-            if (!IsSelectable)
+            if (IsSelectable)
             {
-                return;
-            }
-
-            bool previousSelected = controlStateChangedInfo.PreviousState.Contains(ControlState.Selected);
-
-            if (previousSelected != IsSelected)
-            {
-                OnSelect();
+                if (controlStateChangedInfo.PreviousState.Contains(ControlState.Selected) != controlStateChangedInfo.CurrentState.Contains(ControlState.Selected))
+                {
+                   OnSelect();
+                }
             }
         }
 

--- a/test/Tizen.NUI.StyleGuide/Examples/DefaultLinearItemExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/DefaultLinearItemExample.cs
@@ -41,7 +41,27 @@ namespace Tizen.NUI.StyleGuide
                 Text = text,
             };
             if (subText != null) item.SubText = subText;
-            if (icon) item.Icon = new CheckBox();
+            if (icon)
+            {
+                var check = new CheckBox();
+                check.SelectedChanged += (s, e) =>
+                {
+                    if (e.IsSelected)
+                    {
+                        Log.Info(this.GetType().Name, "CheckBox is Selected\n");
+                    }
+                    else
+                    {
+                        Log.Info(this.GetType().Name, "CheckBox is Unselected\n");
+                    }
+                };
+                // CheckBox does not process touch event by setting Sensitive false.
+                // So, when user touches CheckBox, the touch event is passed to item and item becomes selected/unselected.
+                // When item becomes selected/unselected, CheckBox becomes selected/unselected.
+                // Because item's ControlState is propagated to its children by default by setting item.EnableControlStatePropagation true.
+                check.Sensitive = false;
+                item.Icon = check;
+            }
             if (extra) item.Extra = new RadioButton();
             return item;
         }


### PR DESCRIPTION
Previously, IsSelected property was not changed when its ControlState
was changed between Normal and Selected.

Now, IsSelected property is also changed when ControlState is changed.
So, SelectedChanged event's IsSelected is synchronized with its look.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
