### PR TITLE
[NUI] Add PropagatableControlStates Property for controlling ControlState propagation from parent.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -69,6 +69,7 @@ namespace Tizen.NUI.BaseComponents
         private Size internalSize = null;
         private Size2D internalSize2D = null;
         private int layoutCount = 0;
+        private ControlState propagatableControlStates = ControlState.All;
 
         static View()
         {
@@ -262,7 +263,72 @@ namespace Tizen.NUI.BaseComponents
                 {
                     foreach (View child in Children)
                     {
-                        child.ControlState = value;
+                        ControlState Allowed = child.PropagatableControlStates;
+                        if (Allowed.Contains(ControlState.All))
+                        {
+                            child.ControlState = value;
+                        }
+                        else
+                        {
+                            ControlState prevControlState = child.ControlState;
+                            ControlState newControlState = prevControlState;
+
+                            if (Allowed.Contains(ControlState.Normal) || Allowed.Contains(ControlState.Disabled))
+                            {
+                                newControlState = IsEnabled ? ControlState.Normal : ControlState.Disabled;
+                            }
+
+                            if (Allowed.Contains(ControlState.Selected))
+                            {
+                                if (value.Contains(ControlState.Selected))
+                                {
+                                    newControlState += ControlState.Selected;
+                                }
+                                else
+                                {
+                                    newControlState -= ControlState.Selected;
+                                }
+                            }
+
+                            if (Allowed.Contains(ControlState.Pressed))
+                            {
+                                if (value.Contains(ControlState.Pressed))
+                                {
+                                    newControlState += ControlState.Pressed;
+                                }
+                                else
+                                {
+                                    newControlState -= ControlState.Pressed;
+                                }
+                            }
+
+                            if (Allowed.Contains(ControlState.Focused))
+                            {
+                                if (value.Contains(ControlState.Focused))
+                                {
+                                    newControlState += ControlState.Focused;
+                                }
+                                else
+                                {
+                                    newControlState -= ControlState.Focused;
+                                }
+                            }
+
+                            if (Allowed.Contains(ControlState.Other))
+                            {
+                                if (value.Contains(ControlState.Other))
+                                {
+                                    newControlState += ControlState.Other;
+                                }
+                                else
+                                {
+                                    newControlState -= ControlState.Other;
+                                }
+                            }
+
+                            if (child.ControlState != newControlState)
+                            child.ControlState = newControlState;
+                        }
                     }
                 }
 
@@ -2938,6 +3004,33 @@ namespace Tizen.NUI.BaseComponents
                     child.EnableControlStatePropagation = value;
                 }
             }
+        }
+
+        /// <summary>
+        /// The ControlStates can propagate from the parent.
+        /// Listed ControlStates will be accepted propagation of the parent ControlState changes
+        /// if parent view EnableControlState is true.
+        /// <see cref="EnableControlState"/>.
+        /// Default is ControlState.All, so every ControlStates will be propagated from the parent.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ControlState PropagatableControlStates
+        {
+            get
+            {
+                return (ControlState)GetValue(PropagatableControlStatesProperty);
+            }
+            set
+            {
+                SetValue(PropagatableControlStatesProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        private ControlState InternalPropagatableControlStates
+        {
+            get => propagatableControlStates;
+            set => propagatableControlStates = value;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2429,6 +2429,24 @@ namespace Tizen.NUI.BaseComponents
         });
 
         /// <summary>
+        /// PropagatableControlStatesProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty PropagatableControlStatesProperty = BindableProperty.Create(nameof(PropagatableControlStates), typeof(ControlState), typeof(View), ControlState.All, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            if (newValue != null)
+            {
+                instance.InternalPropagatableControlStates = (ControlState)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            return instance.InternalPropagatableControlStates;
+        });
+
+        /// <summary>
         /// GrabTouchAfterLeaveProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/test/Tizen.NUI.StyleGuide/Examples/DefaultLinearItemExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/DefaultLinearItemExample.cs
@@ -42,7 +42,13 @@ namespace Tizen.NUI.StyleGuide
             };
             if (subText != null) item.SubText = subText;
             if (icon) item.Icon = new CheckBox();
-            if (extra) item.Extra = new RadioButton();
+            if (extra)
+            {
+                item.Extra = new RadioButton();
+                // This will makes RadioButton only propagatable Disabled and Pressed state from it's parent view.
+                // Selected, Focused, Other will work as standalone in RadioButton.
+                item.Extra.PropagatableControlStates = ControlState.Disabled + ControlState.Pressed;
+            }
             return item;
         }
 


### PR DESCRIPTION
Parent View can propagate ControlState by setting EnableControlStatePropagation(default is true),
but child view cannot control propgations.
we know that some child view want to block the propagations,
or want to propagate specific states only.

this new property PropagatableControlStates will give child view to decide which states will be propagated and which isn't from the parent view.

For examples,

```childView.PropagatableControlStates = ControlState.All;```
will allow every states to be propagated(which is by default.)

```childView.PropagatableControlStates = ControlState.Disabled;```
will allow only DIsabled states to be propagated, others will be standalone.

```item.Extra.PropagatableControlStates = ControlState.Create();```
will disallow every states to be propagated.

you can use + operator for more than two states to be propagatable.

```cihldView.PropagatableControlStates = ControlState.Disabled + ControlState.Pressed;```

you can use - for remove state on current PropatableControlStates, but default value All has high priority of others,
so you need to remove All firstly.


### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
