### PR TITLE
Replace getting filename with a primitive way

### DIFF
--- a/src/Tizen.Log/Tizen/Log.cs
+++ b/src/Tizen.Log/Tizen/Log.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.ComponentModel;
 
@@ -120,8 +121,9 @@ namespace Tizen
             }
             else
             {
-                Uri f = new Uri("file://" + file);
-                Interop.Dlog.Print(priority, tag, "%s: %s(%d) > %s", Path.GetFileName(f.AbsolutePath), func, line, message);
+                string[] fileslice = file.Split(new char[] { '\\', '/' });
+                string filename = fileslice.Last();
+                Interop.Dlog.Print(priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
             }
         }
     }
@@ -226,8 +228,9 @@ namespace Tizen
             }
             else
             {
-                Uri f = new Uri("file://" + file);
-                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > %s", Path.GetFileName(f.AbsolutePath), func, line, message);
+                string[] fileslice = file.Split(new char[] { '\\', '/' });
+                string filename = fileslice.Last();
+                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
             }
         }
     }
@@ -333,8 +336,9 @@ namespace Tizen
             }
             else
             {
-                Uri f = new Uri("file://" + file);
-                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > [SECURE_LOG] %s", Path.GetFileName(f.AbsolutePath), func, line, message);
+                string[] fileslice = file.Split(new char[] { '\\', '/' });
+                string filename = fileslice.Last();
+                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
             }
 #endif
         }


### PR DESCRIPTION
This enhances speed up to 5x faster than using library functions when
it comes to a burst call.

Signed-off-by: Youngjae Cho <y0.cho@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
