### PR TITLE
[NUI] fix ScrollableBase focus moving bug on non-scrollable case

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1987,17 +1987,20 @@ namespace Tizen.NUI.Components
                              (!isHorizontal && direction == View.FocusDirection.Up) ||
                              (direction == View.FocusDirection.CounterClockwise));
 
+            View nextFocusedView = FocusManager.Instance.GetNearestFocusableActor(this, currentFocusedView, direction);
+
             // Move out focus from ScrollableBase.
             // FIXME: Forward, Backward is unimplemented other components.
-            if (direction == View.FocusDirection.Forward || direction == View.FocusDirection.Backward ||
-                (forward && maxScrollDistance - targetPosition < 0.1f) || (backward && targetPosition < 0.1f))
+            if (direction == View.FocusDirection.Forward ||
+                direction == View.FocusDirection.Backward ||
+                (nextFocusedView == null &&
+                ((forward && maxScrollDistance - targetPosition < 0.1f) ||
+                 (backward && targetPosition < 0.1f))))
             {
                 var next = FocusManager.Instance.GetNearestFocusableActor(this.Parent, this, direction);
                 Debug.WriteLineIf(focusDebugScrollableBase, $"Focus move [{direction}] out from ScrollableBase! Next focus target {next}:{next?.ID}");
                 return next;
             }
-
-            View nextFocusedView = FocusManager.Instance.GetNearestFocusableActor(this, currentFocusedView, direction);
 
             if (focusDebugScrollableBase)
             {


### PR DESCRIPTION
currently we do not check item can be moved focus to next candidate,
so when scrollableBase is non-scrollable,
it directly move next object not the item.

here I add to next focusable item existence.

note : this code makes unfocusable in none-focusable - non-scrollable case,
but not sure we can call normal behavior.
need to more discuss about this.


### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
