### PR TITLE
[NUI] Add UpdateProperty() api and revert "Fixed border behavior of windows launched at full size" patch

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -48,6 +48,11 @@ namespace Tizen.NUI
         private float borderHeight = 0;
         private int screenWidth = 0;
         private int screenHeight = 0;
+
+        // for config
+        private Size2D minSize = null;
+        private Size2D maxSize = null;
+        private BorderResizePolicyType borderResizePolicy = BorderResizePolicyType.Free;
         #endregion //Fields
 
         #region Constructors
@@ -120,6 +125,37 @@ namespace Tizen.NUI
         #endregion //Indexers
 
         #region Methods
+        
+        /// <summary>
+        /// Update BorderProperty
+        /// </summary>
+        internal void UpdateProperty()
+        {
+            if (borderInterface != null)
+            {
+                if (minSize != borderInterface.MinSize)
+                {
+                    using Size2D mimimumSize = new Size2D(borderInterface.MinSize.Width, borderInterface.MinSize.Height + (int)borderHeight);
+                    SetMimimumSize(mimimumSize);
+                    minSize = borderInterface.MinSize;
+                }
+                if (maxSize != borderInterface.MaxSize)
+                {
+                    using Size2D maximumSize = new Size2D(borderInterface.MaxSize.Width, borderInterface.MaxSize.Height + (int)borderHeight);
+                    SetMaximumSize(maximumSize);
+                    maxSize = borderInterface.MaxSize;
+                }
+                if (borderResizePolicy != borderInterface.ResizePolicy)
+                {
+                    AddAuxiliaryHint("wm.policy.win.resize_aspect_ratio", "0");
+                    borderResizePolicy = borderInterface.ResizePolicy;
+                    if (borderResizePolicy == BorderResizePolicyType.KeepRatio)
+                    {
+                        AddAuxiliaryHint("wm.policy.win.resize_aspect_ratio", "1");
+                    }
+                }
+            }
+        }
         /// <summary>
         /// Called when the border is closed.
         /// If the delegate is declared, the delegate is called, otherwise window is destroyed.
@@ -198,8 +234,8 @@ namespace Tizen.NUI
                 }
                 if (borderInterface.MaxSize != null)
                 {
-                    using Size2D maximuSize = new Size2D(borderInterface.MaxSize.Width, borderInterface.MaxSize.Height + (int)borderHeight);
-                    SetMaximumSize(maximuSize);
+                    using Size2D maximumSize = new Size2D(borderInterface.MaxSize.Width, borderInterface.MaxSize.Height + (int)borderHeight);
+                    SetMaximumSize(maximumSize);
                 }
 
                 // When running the app for the first time, if it runs in full size, do Maximize(true).
@@ -207,9 +243,11 @@ namespace Tizen.NUI
                     realWindowSize.Width >= screenWidth && realWindowSize.Height >= screenHeight &&
                     IsMaximized() == false)
                 {
-                    WindowSize -= new Size2D((int)borderInterface.BorderLineThickness * 2, (int)(borderHeight + borderInterface.BorderLineThickness * 2));   
                     Maximize(true);
                     borderInterface.OnMaximize(true);
+                    ResizedEventArgs e = new ResizedEventArgs();
+                    e.WindowSize = WindowSize;
+                    OnBorderWindowResized(this, e);
                 }
                 else
                 {

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -71,6 +71,10 @@ namespace Tizen.NUI
 
         private CurrentGesture currentGesture = CurrentGesture.None;
         private bool disposed = false;
+
+        private Size2D minSize;
+        private Size2D maxSize;
+        private Window.BorderResizePolicyType resizePolicy;
         #endregion //Fields
 
         #region Events
@@ -115,13 +119,35 @@ namespace Tizen.NUI
         /// The minimum size by which the window will small.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Size2D MinSize {get; set;}
+        public Size2D MinSize 
+        {
+            get
+            {
+                return minSize;
+            }
+            set
+            {
+                minSize = value;
+                BorderWindow?.UpdateProperty();
+            }
+        }
 
         /// <summary>
         /// The maximum size by which the window will big.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Size2D MaxSize {get; set;}
+        public Size2D MaxSize
+        {
+            get
+            {
+                return maxSize;
+            }
+            set
+            {
+                maxSize = value;
+                BorderWindow?.UpdateProperty();
+            }
+        }
 
         /// <summary>
         /// The window with borders added.
@@ -143,7 +169,18 @@ namespace Tizen.NUI
         /// Default value is BorderResizePolicyType.Free;
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Window.BorderResizePolicyType ResizePolicy {get; set;}
+        public Window.BorderResizePolicyType ResizePolicy
+        {
+            get
+            {
+                return resizePolicy;
+            }
+            set
+            {
+                resizePolicy = value;
+                BorderWindow?.UpdateProperty();
+            }
+        }
 
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

1. Make the Border property updatable.

For now, it only applies when set in the constructor.

Modify so that the property can be applied when the property is set again.

2. revert "https://github.com/Samsung/TizenFX/pull/4398"




### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
