### PR TITLE
[NUI] fix AnimatedVectorImageView's current frame set defect

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
@@ -228,6 +228,7 @@ namespace Tizen.NUI.BaseComponents
                 innerCurrentFrame = value;
                 AnimationState = AnimationStates.Paused;
 
+                base.SetMinMaxFrame(0, IntegerMaxValue);
                 base.CurrentFrame = innerCurrentFrame;
 
                 NUILog.Debug($" [{GetId()}] innerCurrentFrame={innerCurrentFrame}) ]AnimatedVectorImageView END]");
@@ -604,6 +605,7 @@ namespace Tizen.NUI.BaseComponents
         }
 
         private AnimationStates CurrentAnimationState = AnimationStates.Stopped;
+        private const int IntegerMaxValue = 0x7FFFFFFF;
         #endregion Private
     }
 }


### PR DESCRIPTION
### Description of Change ###
[NUI] fix AnimatedVectorImageView's current frame set defect
- AnimatedVectorImageView is hidden API and used only for VD
- CurrentFrame should be possible to set at out of the min/max range
- The CSFS's setting icon should be white color outline when losing the focus => this is fixed

### API Changes ###
none