### PR TITLE
[NUI] Add DispatchTouchEvents

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -71,6 +71,7 @@ namespace Tizen.NUI.BaseComponents
         private Size2D internalSize2D = null;
         private int layoutCount = 0;
         private ControlState propagatableControlStates = ControlState.All;
+        private bool dispatchTouchEvents = true;
 
         static View()
         {
@@ -3348,6 +3349,43 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(DispatchKeyEventsProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the status of whether touch events can be dispatched.
+        /// If a View's DispatchTouchEvents is set to false, then it's can not will receive touch and parents will not receive a touch event signal either.
+        /// This works without adding a TouchEvent callback in the View.
+        /// <note>
+        /// If the <see cref="Tizen.NUI.BaseComponents.View.Sensitive"/> is a property that determines whether or not to be hittable, then this property prevents the propagation of the hit touch event.
+        /// </note>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DispatchTouchEvents
+        {
+            get
+            {
+                return dispatchTouchEvents;
+            }
+            set
+            {
+                if (dispatchTouchEvents != value)
+                {
+                    dispatchTouchEvents = value;
+                    if (dispatchTouchEvents == false)
+                    {
+                        TouchEvent += OnDispatchTouchEvent;
+                    }
+                    else
+                    {
+                        TouchEvent -= OnDispatchTouchEvent;
+                    }
+                }
+            }
+        }
+
+        private bool OnDispatchTouchEvent(object source, View.TouchEventArgs e)
+        {
+            return true;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -962,6 +962,12 @@ namespace Tizen.NUI.BaseComponents
                 return true;
             }
 
+            if (DispatchTouchEvents == false)
+            {
+                NUILog.Debug("If DispatchTouchEvents is false, it can not dispatch.");
+                return true;
+            }
+
             TouchEventArgs e = new TouchEventArgs();
 
             e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This determines whether touch events are emitted or not.

If DispatchTouchEvents is set to false
The View will not receive a TouchEvent and its parents will not receive the TouchEvent.

This works without adding a TouchEvent callback in the View.



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
