### PR TITLE
[NUI] Add ActionForward event for Accessibility

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.AccessibilityManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.AccessibilityManager.cs
@@ -185,6 +185,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AccessibilityManager_ActionScrollSignal")]
             public static extern global::System.IntPtr AccessibilityManager_ActionScrollSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AccessibilityManager_ActionForwardSignal")]
+            public static extern global::System.IntPtr AccessibilityManager_ActionForwardSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_AccessibilityActionSignal_Empty")]
             public static extern bool AccessibilityActionSignal_Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
@@ -327,6 +327,17 @@ namespace Tizen.NUI.Accessibility
             }
             return false;
         }
+        
+        // Callback for AccessibilityManager ActionForwardSignal
+        private bool OnActionForward(IntPtr data)
+        {
+            if (_accessibilityManagerActionForwardEventHandler != null)
+            {
+                //here we send all data to user event handlers
+                return _accessibilityManagerActionForwardEventHandler(instance, null);
+            }
+            return false;
+        }
 
         // Callback for AccessibilityManager FocusChangedSignal
         private void OnFocusChanged(IntPtr view1, IntPtr view2)
@@ -1086,6 +1097,13 @@ namespace Tizen.NUI.Accessibility
         internal SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t ActionScrollSignal()
         {
             SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t ret = new SWIGTYPE_p_Dali__SignalT_bool_fDali__Toolkit__AccessibilityManager_R_Dali__TouchEvent_const_RF_t(Interop.AccessibilityManager.AccessibilityManager_ActionScrollSignal(swigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal AccessibilityActionSignal ActionForwardSignal()
+        {
+            AccessibilityActionSignal ret = new AccessibilityActionSignal(Interop.AccessibilityManager.AccessibilityManager_ActionForwardSignal(swigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManagerEvent.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManagerEvent.cs
@@ -148,6 +148,10 @@ namespace Tizen.NUI.Accessibility
         private EventHandlerWithReturnType<object, EventArgs, bool> _accessibilityManagerActionStartStopEventHandler;
         private ActionStartStopEventCallbackDelegate _accessibilityManagerActionStartStopEventCallbackDelegate;
 
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate bool ActionForwardEventCallbackDelegate(IntPtr accessibilityManager);
+        private EventHandlerWithReturnType<object, EventArgs, bool> _accessibilityManagerActionForwardEventHandler;
+        private ActionForwardEventCallbackDelegate _accessibilityManagerActionForwardEventCallbackDelegate;
         /*
             // To be replaced by a new event that takes Touch
             [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -978,6 +982,38 @@ namespace Tizen.NUI.Accessibility
                 if (_accessibilityManagerActionStartStopEventHandler == null && ActionStartStopSignal().Empty() == false)
                 {
                     this.ActionStartStopSignal().Disconnect(_accessibilityManagerActionStartStopEventCallbackDelegate);
+                }
+            }
+        }
+
+        /// <summary>
+        /// This is emitted when accessibility action is received to forward the event to the application (by one finger double tap and hold).
+        /// It is a kind of backdoor to bypass the normal behaviour.
+        /// </summary>
+        /// <returns> The signal to connect to </returns>
+        /// This is the only experimental API added to Tizen 6.0. (hidden as inhouse API.)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandlerWithReturnType<object, EventArgs, bool> ActionForward
+        {
+            add
+            {
+                // Restricted to only one listener
+                if (_accessibilityManagerActionForwardEventHandler == null)
+                {
+                    _accessibilityManagerActionForwardEventCallbackDelegate = new ActionForwardEventCallbackDelegate(OnActionForward);
+                    this.ActionForwardSignal().Connect(_accessibilityManagerActionForwardEventCallbackDelegate);
+                }
+
+                _accessibilityManagerActionForwardEventHandler += value;
+            }
+
+            remove
+            {
+                _accessibilityManagerActionForwardEventHandler -= value;
+
+                if (_accessibilityManagerActionForwardEventHandler == null && ActionForwardSignal().Empty() == false)
+                {
+                    this.ActionForwardSignal().Disconnect(_accessibilityManagerActionForwardEventCallbackDelegate);
                 }
             }
         }


### PR DESCRIPTION

Signed-off-by: Seoyeon Kim <seoyeon2.kim@samsung.com>

### Description of Change ###
- In Accessibility, One finger double tap and hold gesture is to pass
the event to the application.
- For the application, it can get the signal using
ActionForward event.

- Dependencies :
  https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/278951/
  https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/278952/
  https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/278953/


### API Changes ###
- N/A