### PR TITLE
[NUI] Fix IsEqual

### DIFF
--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -493,7 +493,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public bool IsEqual(BaseHandle rhs)
         {
-            if (disposed == true)
+            if (disposed == true || rhs == null || !rhs.HasBody())
             {
                 return false;
             }


### PR DESCRIPTION
### Description of Change ###
 I got a exception if rhs of IsEquals was disposed 
``` 
E/STDERR  (12260): Unhandled exception. System.ArgumentNullException: Exception of type 'System.ArgumentNullException' was thrown. (Parameter 'Dali::BaseHandle const & type is null Inner Exception: FATAL: Exception e is null, numExceptionsPending : 0')
E/STDERR  (12260):    at Tizen.NUI.BaseHandle.IsEqual(BaseHandle rhs) in Tizen.NUI.dll:token 0x6000dd6+0xa
E/STDERR  (12260):    at Tizen.NUI.BaseHandle.op_Equality(BaseHandle x, BaseHandle y) in Tizen.NUI.dll:token 0x6000dc6+0x29
```
 This PR fixes it

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
