### PR TITLE
[NUI] Modify GetWidgetViewFromPtr to use ManagedBaseHandle

### DIFF
--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -755,7 +755,11 @@ namespace Tizen.NUI
 
         internal static WidgetView GetWidgetViewFromPtr(global::System.IntPtr cPtr)
         {
-            WidgetView ret = new WidgetView(cPtr, false);
+            if (cPtr == global::System.IntPtr.Zero)
+            {
+                return null;
+            }
+            WidgetView ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as WidgetView;
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
When WidgetView uses its callback, WidgetView gets a crash problem because of referencing object.
To avoid this problem, WidgetView uses ManageBadeHandle.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
