### PR TITLE
[NUI] Temporarily use InterceptTouchEvent instead of FocusChanged.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -125,7 +125,7 @@ namespace Tizen.NUI
         #endregion //Indexers
 
         #region Methods
-        
+
         /// <summary>
         /// Update BorderProperty
         /// </summary>
@@ -263,7 +263,9 @@ namespace Tizen.NUI
                 // Add a view to the border layer.
                 GetBorderWindowBottomLayer().Add(rootView);
 
-                FocusChanged += OnWindowFocusChanged;
+                // TODO after the emulator issue is resolved, use the FocusChanged event.
+                //FocusChanged += OnWindowFocusChanged;
+                InterceptTouchEvent += OnWindowInterceptTouched;
 
                 return true;
             }
@@ -274,14 +276,25 @@ namespace Tizen.NUI
             }
         }
 
-        private void OnWindowFocusChanged(object sender, Window.FocusChangedEventArgs e)
+        private bool OnWindowInterceptTouched(object sender, Window.TouchEventArgs e)
         {
-            if (e.FocusGained == true && IsMaximized() == false)
+            if (e.Touch.GetState(0) == PointStateType.Down && IsMaximized() == false)
             {
                 // Raises the window when the window is focused.
                 Raise();
             }
+            return false;
         }
+
+        // TODO after the emulator issue is resolved, use the FocusChanged event.
+        // private void OnWindowFocusChanged(object sender, Window.FocusChangedEventArgs e)
+        // {
+        //     if (e.FocusGained == true && IsMaximized() == false)
+        //     {
+        //         // Raises the window when the window is focused.
+        //         Raise();
+        //     }
+        // }
 
         /// Create the border UI.
         private bool CreateBorder()
@@ -508,6 +521,7 @@ namespace Tizen.NUI
         internal void DisposeBorder()
         {
             Resized -= OnBorderWindowResized;
+            InterceptTouchEvent -= OnWindowInterceptTouched;
             borderInterface.Dispose();
             GetBorderWindowBottomLayer().Dispose();
         }
@@ -555,7 +569,7 @@ namespace Tizen.NUI
             {
                 overlayEnabled = enabled;
             }
-            
+
             protected override bool HitTest(Touch touch)
             {
                 // If borderView is in overlay mode, pass the hittest.


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->

Registering the FocusChanged event at the time of OnCreate only in the emulator causes a crash.

Temporarily use InterceptTouchEvents until emulator problem is fixed.

This is a patch that will be reverted back once the emulator fix is ​​complete.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
