### PR TITLE
[Applications.Common] Fix OnLowMememory

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -219,14 +219,17 @@ namespace Tizen.Applications
         protected virtual void OnLowMemory(LowMemoryEventArgs e)
         {
             LowMemory?.Invoke(this, e);
-            double interval = new Random().Next(10 * 1000);
-            if (interval <= 0)
-                interval = 10 * 1000;
+            if (e.LowMemoryStatus == LowMemoryStatus.SoftWarning || e.LowMemoryStatus == LowMemoryStatus.HardWarning)
+            {
+                double interval = new Random().Next(10 * 1000);
+                if (interval <= 0)
+                    interval = 10 * 1000;
 
-            sTimer = new System.Timers.Timer(interval);
-            sTimer.Elapsed += OnTimedEvent;
-            sTimer.AutoReset = false;
-            sTimer.Enabled = true;
+                sTimer = new System.Timers.Timer(interval);
+                sTimer.Elapsed += OnTimedEvent;
+                sTimer.AutoReset = false;
+                sTimer.Enabled = true;
+            }
         }
 
         private static void OnTimedEvent(Object source, ElapsedEventArgs e)


### PR DESCRIPTION
This PR adds if conditions for registering the GC timer.
If the LowMemoryStatus of the LowMemoryEventArgs of the OnLowMemory is
SoftWarning or HardWarning, the timer will be registered.

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>