### PR TITLE
[NUI] Added API to know when border window starts moving and ends moving

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -219,6 +219,8 @@ namespace Tizen.NUI
 
                 Resized += OnBorderWindowResized;
 
+                Moved += OnBorderWindowMoved;
+
                 borderInterface.OnCreated(borderView);
 
                 // Increase the window size as much as the border area.
@@ -433,6 +435,13 @@ namespace Tizen.NUI
                     GetBorderWindowBottomLayer().LowerToBottom();
                 }
             }
+        }
+
+        // Called when the window position has changed.
+        private void OnBorderWindowMoved(object sender, WindowMovedEventArgs e)
+        {
+            Tizen.Log.Info("NUI", $"OnBorderWindowMoved {e.WindowPosition.X}, {e.WindowPosition.Y}\n");
+            borderInterface.OnMoved(e.WindowPosition.X, e.WindowPosition.X);
         }
 
 

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -420,6 +420,7 @@ namespace Tizen.NUI
                     }
                     else
                     {
+                        OnRequestMove();
                         BorderWindow.RequestMoveToServer();
                     }
                 }
@@ -780,6 +781,7 @@ namespace Tizen.NUI
                     }
                     else
                     {
+                        OnRequestMove();
                         BorderWindow.RequestMoveToServer();
                     }
                 }
@@ -829,6 +831,20 @@ namespace Tizen.NUI
             }
             UpdateIcons();
         }
+
+        /// <summary>
+        /// Called when requesting a move
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual void OnRequestMove() {}
+
+        /// <summary>
+        /// Called when the window is moved.
+        /// </summary>
+        /// <param name="x">The x of the moved window</param>
+        /// <param name="y">The y of the moved window</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual void OnMoved(int x, int y) {}
 
         /// <summary>
         /// Called when the window is maximized.

--- a/src/Tizen.NUI/src/public/Window/IBorderInterface.cs
+++ b/src/Tizen.NUI/src/public/Window/IBorderInterface.cs
@@ -109,18 +109,20 @@ namespace Tizen.NUI
         public void OnCreated(View borderView);
 
         /// <summary>
-        /// Called when requesting a resize
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void OnRequestResize();
-
-        /// <summary>
         /// Called when the window is resized.
         /// </summary>
         /// <param name="width">The width of the resized window</param>
         /// <param name="height">The height of the resized window</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void OnResized(int width, int height);
+
+        /// <summary>
+        /// Called when the window is moved.
+        /// </summary>
+        /// <param name="x">The x of the moved window</param>
+        /// <param name="y">The y of the moved window</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void OnMoved(int x, int y);
 
         /// <summary>
         /// Called when the window is maximized.


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
[NUI] Added API to know when border window starts moving and ends moving
```c#
public virtual void OnRequestMove() {}

public virtual void OnMoved(int x, int y) {}
```




### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
