### PR TITLE
[NUI] Add UpdateProperty api for BorderWindow

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -133,6 +133,17 @@ namespace Tizen.NUI
         {
             if (borderInterface != null)
             {
+                float height = 0;
+                if (isTop) height += topView.SizeHeight;
+                if (isBottom) height += bottomView.SizeHeight;
+
+                if (height != borderHeight)
+                {
+                    float diff = height - borderHeight;
+                    borderHeight = height;
+                    WindowSize = new Size2D(WindowSize.Width, WindowSize.Height + (int)(diff));
+                }
+
                 if (minSize != borderInterface.MinSize)
                 {
                     using Size2D mimimumSize = new Size2D(borderInterface.MinSize.Width, borderInterface.MinSize.Height + (int)borderHeight);

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -119,7 +119,7 @@ namespace Tizen.NUI
         /// The minimum size by which the window will small.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Size2D MinSize 
+        public Size2D MinSize
         {
             get
             {
@@ -128,7 +128,7 @@ namespace Tizen.NUI
             set
             {
                 minSize = value;
-                BorderWindow?.UpdateProperty();
+                UpdateProperty();
             }
         }
 
@@ -145,7 +145,7 @@ namespace Tizen.NUI
             set
             {
                 maxSize = value;
-                BorderWindow?.UpdateProperty();
+                UpdateProperty();
             }
         }
 
@@ -178,8 +178,17 @@ namespace Tizen.NUI
             set
             {
                 resizePolicy = value;
-                BorderWindow?.UpdateProperty();
+                UpdateProperty();
             }
+        }
+
+        /// <summary>
+        /// Update properties
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void UpdateProperty()
+        {
+            BorderWindow?.UpdateProperty();
         }
 
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Changing the BorderView's SizeHeight should also change the Window size.

For this, we add an UpdateProperty() api.




### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
