### PR TITLE
[NUI] Make WidgetView not propagate touch event to the below

### DIFF
--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -883,6 +883,14 @@ namespace Tizen.NUI
             Interop.WidgetView.DeleteWidgetView(swigCPtr);
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override bool HandleControlStateOnTouch(Touch touch)
+        {
+            base.HandleControlStateOnTouch(touch);
+            return true; // Do not pass the touch event to the below.
+        }
+
         // Callback for WidgetView WidgetAdded signal
         private void OnWidgetAdded(IntPtr data)
         {


### PR DESCRIPTION
HandleControlStateOnTouch is overridden by WidgetView with return value
true not to propagate touch event to the below.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
