### PR TITLE
[Build] Enable aarch64 build for API8

### DIFF
--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -27,7 +27,6 @@ Source0:    %{name}-%{version}.tar.gz
 Source1:    %{name}.manifest
 
 BuildArch:   noarch
-ExcludeArch: aarch64
 AutoReqProv: no
 
 BuildRequires: dotnet-build-tools

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -26,7 +26,6 @@ Source0:    %{name}-%{version}.tar.gz
 Source1:    %{name}.manifest
 
 BuildArch:   noarch
-ExcludeArch: aarch64
 AutoReqProv: no
 
 BuildRequires: dotnet-build-tools


### PR DESCRIPTION
- Fix csapi-tizenfx.spec to enable aarch64 build