### PR TITLE
[NUI] Use FocusChanged in BorderWindow because it fixed an issue with Emulator's FocusChanged.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -276,9 +276,7 @@ namespace Tizen.NUI
                 // Add a view to the border layer.
                 GetBorderWindowBottomLayer().Add(rootView);
 
-                // TODO after the emulator issue is resolved, use the FocusChanged event.
-                //FocusChanged += OnWindowFocusChanged;
-                InterceptTouchEvent += OnWindowInterceptTouched;
+                FocusChanged += OnWindowFocusChanged;
 
                 return true;
             }
@@ -289,25 +287,14 @@ namespace Tizen.NUI
             }
         }
 
-        private bool OnWindowInterceptTouched(object sender, Window.TouchEventArgs e)
+        private void OnWindowFocusChanged(object sender, Window.FocusChangedEventArgs e)
         {
-            if (e.Touch.GetState(0) == PointStateType.Down && IsMaximized() == false)
+            if (e.FocusGained == true && IsMaximized() == false)
             {
                 // Raises the window when the window is focused.
                 Raise();
             }
-            return false;
         }
-
-        // TODO after the emulator issue is resolved, use the FocusChanged event.
-        // private void OnWindowFocusChanged(object sender, Window.FocusChangedEventArgs e)
-        // {
-        //     if (e.FocusGained == true && IsMaximized() == false)
-        //     {
-        //         // Raises the window when the window is focused.
-        //         Raise();
-        //     }
-        // }
 
         /// Create the border UI.
         private bool CreateBorder()
@@ -541,7 +528,7 @@ namespace Tizen.NUI
         internal void DisposeBorder()
         {
             Resized -= OnBorderWindowResized;
-            InterceptTouchEvent -= OnWindowInterceptTouched;
+            FocusChanged -= OnWindowFocusChanged;
             borderInterface.Dispose();
             GetBorderWindowBottomLayer().Dispose();
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

[NUI] Use FocusChanged in BorderWindow because it fixed an issue with Emulator's FocusChanged.

refer https://github.com/Samsung/TizenFX/pull/4498


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
