### PR TITLE
[NUI] Add line geometry APIs

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -364,6 +364,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
+
+             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetLineSize")]
+            public static extern global::System.IntPtr GetLineSize(global::System.Runtime.InteropServices.HandleRef textEditorRef, uint number);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_GetLinePosition")]
+            public static extern global::System.IntPtr GetLinePosition(global::System.Runtime.InteropServices.HandleRef textEditorRef, uint number);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -326,6 +326,13 @@ namespace Tizen.NUI
             public static extern int StrikethroughGet();
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetLineSize")]
+            public static extern global::System.IntPtr GetLineSize(global::System.Runtime.InteropServices.HandleRef textFieldRef, uint number);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_GetLinePosition")]
+            public static extern global::System.IntPtr GetLinePosition(global::System.Runtime.InteropServices.HandleRef textFieldRef, uint number);
+
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -189,6 +189,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetLineSize")]
+            public static extern global::System.IntPtr GetLineSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, uint number);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetLinePosition")]
+            public static extern global::System.IntPtr GetLinePosition(global::System.Runtime.InteropServices.HandleRef textLabelRef, uint number);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
@@ -212,5 +212,137 @@ namespace Tizen.NUI.BaseComponents
             CheckSWIGPendingException();
             return list;
         }
+
+        /// <summary>
+        /// Get the rendered size of the line based on a requested value, zero-based. <br />
+        /// if a line contains characters with different directions, multiple sizes will be returned for each block of contiguous characters with the same direction. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="number">The number of the line to get the size for, zero-based.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<Size2D> GetLineSize(TextEditor textEditor, int number)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            ValidateRange(number, 0);
+
+            List<Size2D> list = GetSizeListFromNativeVector(Interop.TextEditor.GetLineSize(textEditor.SwigCPtr, (uint)number));
+            CheckSWIGPendingException();
+            return list;
+        }
+
+        /// <summary>
+        /// Get the rendered size of the line based on a requested value, zero-based. <br />
+        /// if a line contains characters with different directions, multiple sizes will be returned for each block of contiguous characters with the same direction. <br />
+        /// </summary>
+        /// <param name="textField">The textField control containing the text.</param>
+        /// <param name="number">The number of the line to get the size for, zero-based.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+         [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<Size2D> GetLineSize(TextField textField, int number)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            ValidateRange(number, 0);
+
+            List<Size2D> list = GetSizeListFromNativeVector(Interop.TextField.GetLineSize(textField.SwigCPtr, (uint)number));
+            CheckSWIGPendingException();
+            return list;
+        }
+
+        /// <summary>
+        /// Get the rendered size of the line based on a requested value, zero-based. <br />
+        /// if a line contains characters with different directions, multiple sizes will be returned for each block of contiguous characters with the same direction. <br />
+        /// </summary>
+        /// <param name="textLabel">The textLabel control containing the text.</param>
+        /// <param name="number">The number of the line to get the size for, zero-based.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+       [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<Size2D> GetLineSize(TextLabel textLabel, int number)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            ValidateRange(number, 0);
+
+            List<Size2D> list = GetSizeListFromNativeVector(Interop.TextLabel.GetLineSize(textLabel.SwigCPtr, (uint)number));
+            CheckSWIGPendingException();
+            return list;
+        }
+
+        /// <summary>
+        /// Get the rendered position of the line based on a requested value, zero-based. <br />
+        /// if a line contains characters with different directions, multiple positions will be returned for each block of contiguous characters with the same direction. <br />
+        /// </summary>
+        /// <param name="textEditor">The textEditor control containing the text.</param>
+        /// <param name="number">The number of the line to get the position for, zero-based.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+       [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<Position2D> GetLinePosition(TextEditor textEditor, int number)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            ValidateRange(number, 0);
+
+            List<Position2D> list = GetPositionListFromNativeVector(Interop.TextEditor.GetLinePosition(textEditor.SwigCPtr, (uint)number));
+            CheckSWIGPendingException();
+            return list;
+        }
+
+        /// <summary>
+        /// Get the rendered position of the line based on a requested value, zero-based. <br />
+        /// if a line contains characters with different directions, multiple positions will be returned for each block of contiguous characters with the same direction. <br />
+        /// </summary>
+        /// <param name="textField">The textField control containing the text.</param>
+        /// <param name="number">The number of the line to get the position for, zero-based.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<Position2D> GetLinePosition(TextField textField, int number)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            ValidateRange(number, 0);
+
+            List<Position2D> list = GetPositionListFromNativeVector(Interop.TextField.GetLinePosition(textField.SwigCPtr, (uint)number));
+            CheckSWIGPendingException();
+            return list;
+        }
+
+        /// <summary>
+        /// Get the rendered position of the line based on a requested value, zero-based. <br />
+        /// if a line contains characters with different directions, multiple positions will be returned for each block of contiguous characters with the same direction. <br />
+        /// </summary>
+        /// <param name="textLabel">The textLabel control containing the text.</param>
+        /// <param name="number">The number of the line to get the position for, zero-based.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<Position2D> GetLinePosition(TextLabel textLabel, int number)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            ValidateRange(number, 0);
+
+            List<Position2D> list = GetPositionListFromNativeVector(Interop.TextLabel.GetLinePosition(textLabel.SwigCPtr, (uint)number));
+            CheckSWIGPendingException();
+            return list;
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
@@ -28,12 +28,16 @@ namespace Tizen.NUI.BaseComponents
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class TextGeometry
     {
+        private static void ValidateIndex(int index)
+        {
+            if (index < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(index), "Value is less than zero");
+        }
+
         private static void ValidateRange(int start, int end)
         {
-            if (start < 0)
-                throw new global::System.ArgumentOutOfRangeException(nameof(start), "Value is less than zero");
-            if (end < 0)
-                throw new global::System.ArgumentOutOfRangeException(nameof(end), "Value is less than zero");
+            ValidateIndex(start);
+            ValidateIndex(end);             
         }
 
         private static List<Size2D> GetSizeListFromNativeVector(System.IntPtr ptr)
@@ -228,7 +232,7 @@ namespace Tizen.NUI.BaseComponents
                 throw new ArgumentNullException(null, "textEditor object is null");
             }
 
-            ValidateRange(number, 0);
+            ValidateIndex(number);
 
             List<Size2D> list = GetSizeListFromNativeVector(Interop.TextEditor.GetLineSize(textEditor.SwigCPtr, (uint)number));
             CheckSWIGPendingException();
@@ -250,7 +254,7 @@ namespace Tizen.NUI.BaseComponents
                 throw new ArgumentNullException(null, "textField object is null");
             }
 
-            ValidateRange(number, 0);
+            ValidateIndex(number);
 
             List<Size2D> list = GetSizeListFromNativeVector(Interop.TextField.GetLineSize(textField.SwigCPtr, (uint)number));
             CheckSWIGPendingException();
@@ -272,7 +276,7 @@ namespace Tizen.NUI.BaseComponents
                 throw new ArgumentNullException(null, "textLabel object is null");
             }
 
-            ValidateRange(number, 0);
+            ValidateIndex(number);
 
             List<Size2D> list = GetSizeListFromNativeVector(Interop.TextLabel.GetLineSize(textLabel.SwigCPtr, (uint)number));
             CheckSWIGPendingException();
@@ -338,7 +342,7 @@ namespace Tizen.NUI.BaseComponents
                 throw new ArgumentNullException(null, "textLabel object is null");
             }
 
-            ValidateRange(number, 0);
+            ValidateIndex(number);
 
             List<Position2D> list = GetPositionListFromNativeVector(Interop.TextLabel.GetLinePosition(textLabel.SwigCPtr, (uint)number));
             CheckSWIGPendingException();

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
@@ -44,7 +44,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
             Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
 
-            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0, 0);
             Assert.IsNotNull(actualSizeList, "Null object is detected!");
             Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
 
@@ -68,7 +68,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextField");
             Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
 
-            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0, 0);
             Assert.IsNotNull(actualSizeList, "Null object is detected!");
             Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
 
@@ -92,7 +92,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
             Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
 
-            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0, 0);
             Assert.IsNotNull(actualSizeList, "Null object is detected!");
             Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
 
@@ -116,7 +116,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
             Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
 
-            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0, 0);
             Assert.IsNotNull(actualPositionList, "Null object is detected!");
             Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
 
@@ -140,7 +140,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextField");
             Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
 
-            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0, 0);
             Assert.IsNotNull(actualPositionList, "Null object is detected!");
             Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
 
@@ -164,13 +164,155 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
             Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
 
-            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0, 0);
             Assert.IsNotNull(actualPositionList, "Null object is detected!");
             Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
 
             tlog.Debug(tag, $"GetTextPositionTextLabel END (OK)");
         }
 
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineSize on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineSizeTextEditor()
+        {
+            tlog.Debug(tag, $"GetLineSizeTextEditor START");
 
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualSizeList = TextGeometry.GetLineSize(testingTarget, 0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLineSizeTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineSize on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineSizeTextField()
+        {
+            tlog.Debug(tag, $"GetLineSizeTextField START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualSizeList = TextGeometry.GetLineSize(testingTarget, 0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLineSizeTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineSize on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineSizeTextLabel()
+        {
+            tlog.Debug(tag, $"GetLineSizeTextLabel START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualSizeList = TextGeometry.GetLineSize(testingTarget, 0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLineSizeTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLinePosition on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLinePosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLinePositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetLinePositionTextLabel START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualPositionList = TextGeometry.GetLinePosition(testingTarget, 0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLinePositionTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLinePosition on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLinePosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLinePositionTextField()
+        {
+            tlog.Debug(tag, $"GetLinePositionTextField START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualPositionList = TextGeometry.GetLinePosition(testingTarget, 0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLinePositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLinePosition on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLinePosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLinePositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetLinePositionTextEditor START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualPositionList = TextGeometry.GetLinePosition(testingTarget, 0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLinePositionTextEditor END (OK)");
+        }
     }
 }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
@@ -1,0 +1,176 @@
+﻿using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI.Components;
+using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/BaseComponents/TextGeometry")]
+    public class PublicTextGeometryTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextSize on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextSizeTextEditor()
+        {
+            tlog.Debug(tag, $"GetTextSizeTextEditor START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextSizeTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextSize on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextSizeTextField()
+        {
+            tlog.Debug(tag, $"GetTextSizeTextField START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextSizeTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextSize on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextSizeTextLabel()
+        {
+            tlog.Debug(tag, $"GetTextSizeTextLabel START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextSizeTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextPosition on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextPosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextPositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetTextPositionTextEditor START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextPositionTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextPosition on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextPosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextPositionTextField()
+        {
+            tlog.Debug(tag, $"GetTextPositionTextField START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextPositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextPosition on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextPosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextPositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetTextPositionTextLabel START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextPositionTextLabel END (OK)");
+        }
+
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
@@ -44,7 +44,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
             Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
 
-            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0, 0);
             Assert.IsNotNull(actualSizeList, "Null object is detected!");
             Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
 
@@ -68,7 +68,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextField");
             Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
 
-            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0, 0);
             Assert.IsNotNull(actualSizeList, "Null object is detected!");
             Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
 
@@ -92,7 +92,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
             Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
 
-            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0, 0);
             Assert.IsNotNull(actualSizeList, "Null object is detected!");
             Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
 
@@ -116,7 +116,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
             Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
 
-            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0, 0);
             Assert.IsNotNull(actualPositionList, "Null object is detected!");
             Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
 
@@ -140,7 +140,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextField");
             Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
 
-            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0, 0);
             Assert.IsNotNull(actualPositionList, "Null object is detected!");
             Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
 
@@ -164,13 +164,155 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
             Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
 
-            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0, 0);
             Assert.IsNotNull(actualPositionList, "Null object is detected!");
             Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
 
             tlog.Debug(tag, $"GetTextPositionTextLabel END (OK)");
         }
 
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineSize on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineSizeTextEditor()
+        {
+            tlog.Debug(tag, $"GetLineSizeTextEditor START");
 
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualSizeList = TextGeometry.GetLineSize(testingTarget, 0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLineSizeTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineSize on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineSizeTextField()
+        {
+            tlog.Debug(tag, $"GetLineSizeTextField START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualSizeList = TextGeometry.GetLineSize(testingTarget, 0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLineSizeTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineSize on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineSizeTextLabel()
+        {
+            tlog.Debug(tag, $"GetLineSizeTextLabel START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualSizeList = TextGeometry.GetLineSize(testingTarget, 0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLineSizeTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLinePosition on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLinePosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLinePositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetLinePositionTextLabel START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualPositionList = TextGeometry.GetLinePosition(testingTarget, 0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLinePositionTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLinePosition on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLinePosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLinePositionTextField()
+        {
+            tlog.Debug(tag, $"GetLinePositionTextField START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualPositionList = TextGeometry.GetLinePosition(testingTarget, 0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLinePositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLinePosition on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLinePosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLinePositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetLinePositionTextEditor START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualPositionList = TextGeometry.GetLinePosition(testingTarget, 0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetLinePositionTextEditor END (OK)");
+        }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
@@ -1,0 +1,176 @@
+﻿using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI.Components;
+using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/BaseComponents/TextGeometry")]
+    public class PublicTextGeometryTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextSize on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextSizeTextEditor()
+        {
+            tlog.Debug(tag, $"GetTextSizeTextEditor START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextSizeTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextSize on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextSizeTextField()
+        {
+            tlog.Debug(tag, $"GetTextSizeTextField START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextSizeTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextSize on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextSize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextSizeTextLabel()
+        {
+            tlog.Debug(tag, $"GetTextSizeTextLabel START");
+
+            int expectedSizeOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualSizeList = TextGeometry.GetTextSize(testingTarget, 0,0);
+            Assert.IsNotNull(actualSizeList, "Null object is detected!");
+            Assert.IsTrue(actualSizeList.Count == expectedSizeOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextSizeTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextPosition on TextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextPosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextPositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetTextPositionTextEditor START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextPositionTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextPosition on TextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextPosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextPositionTextField()
+        {
+            tlog.Debug(tag, $"GetTextPositionTextField START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextPositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextPosition on TextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextPosition M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextPositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetTextPositionTextLabel START");
+
+            int expectedPositionOfList = 0;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var actualPositionList = TextGeometry.GetTextPosition(testingTarget, 0,0);
+            Assert.IsNotNull(actualPositionList, "Null object is detected!");
+            Assert.IsTrue(actualPositionList.Count == expectedPositionOfList, "Should be true!");
+
+            tlog.Debug(tag, $"GetTextPositionTextLabel END (OK)");
+        }
+
+
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Retrieves the size and the position of a line. The below functions are added to the TextGeometry.cs file:
* GetLinePosition
* GetLineSize

### API Changes ###

Added:
  - public static List<Size2D> GetLineSize(TextLabel textLabel, int number) //Method
  - public static List<Size2D> GetLineSize(TextEditor textEditor, int number) //Method
  - public static List<Size2D> GetLineSize(TextField textField, int number) //Method
  - public static List<Position2D> GetLinePosition(TextEditor textEditor, int number) //Method
  - public static List<Position2D> GetLinePosition(TextField textField, int number) //Method
  - public static List<Position2D> GetLinePosition(TextLabel textLabel, int number) //Method

Depends on the following patches: 
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/278414
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/279260