### PR TITLE
[MachineLearning.Train] Remove dot at the end of enum value description

### DIFF
--- a/src/Tizen.MachineLearning.Train/Tizen.MachineLearning.Train/Commons.cs
+++ b/src/Tizen.MachineLearning.Train/Tizen.MachineLearning.Train/Commons.cs
@@ -50,7 +50,7 @@ namespace Tizen.MachineLearning.Train
         /// </summary>
         Layer = 1,
         /// <summary>
-        /// Model summary weight information that layer has.
+        /// Model summary weight information that layer has
         /// </summary>
         Tensor = 2
     }
@@ -66,11 +66,11 @@ namespace Tizen.MachineLearning.Train
         /// </summary>
         Bin = 0,
         /// <summary>
-        /// Ini format file stores model configurations.
+        /// Ini format file stores model configurations
         /// </summary>
         Ini = 1,
         /// <summary>
-        /// Ini with bin format file stores configurations with parameters required for inference and training.
+        /// Ini with bin format file stores configurations with parameters required for inference and training
         /// </summary>
         IniWithBin = 2
     }


### PR DESCRIPTION
[MachineLearning.Train] Remove dot at the end of enum value description
- Remove dot at the end of enum value description

Signed-off-by: hyunil park <hyunil46.park@samsung.com>