### PR TITLE
[NUI] Add underline span

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class BaseSpan
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseSpan_GetMarkupTagName")]
+            public static extern string GetMarkupTagName(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseSpan")]
+            public static extern void DeleteBaseSpan(global::System.Runtime.InteropServices.HandleRef refSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorBuilder.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorBuilder.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class ForegroundColorSpanBuilder
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpanBuilder_Initialize")]
+            public static extern global::System.IntPtr Initialize();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpanBuilder_Build")]
+            public static extern global::System.IntPtr Build(global::System.Runtime.InteropServices.HandleRef refBuilder);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpanBuilder_WithForegroundColor")]
+            public static extern global::System.IntPtr WithForegroundColor(global::System.Runtime.InteropServices.HandleRef refBuilder, global::System.Runtime.InteropServices.HandleRef argColor);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ForegroundColorSpanBuilder")]
+            public static extern void DeleteForegroundColorSpanBuilder(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class ForegroundColorSpan
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_foregroundcolor_get")]
+            public static extern global::System.IntPtr ForegroundColorGet(global::System.Runtime.InteropServices.HandleRef refForegroundColorSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_foregroundcolor_defined_get")]
+            public static extern bool ForegroundColorDefinedGet(global::System.Runtime.InteropServices.HandleRef refForegroundColorSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ForegroundColorSpan")]
+            public static extern void DeleteForegroundColorSpan(global::System.Runtime.InteropServices.HandleRef refForegroundColorSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Spannable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Spannable.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class Spannable
+        {
+            internal static partial class TextLabel
+            {
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextLabel_AttachSpan")]
+                public static extern global::System.IntPtr AttachSpan(global::System.Runtime.InteropServices.HandleRef textLabelRef, global::System.Runtime.InteropServices.HandleRef spanRef, uint start, uint end);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextLabel_DetachSpan")]
+                public static extern global::System.IntPtr DetachSpan(global::System.Runtime.InteropServices.HandleRef textLabelRef, global::System.Runtime.InteropServices.HandleRef spanRef);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextLabel_BuildSpannedText")]
+                public static extern global::System.IntPtr BuildSpannedText(global::System.Runtime.InteropServices.HandleRef textLabelRef);
+            }
+
+            internal static partial class TextField
+            {
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextField_AttachSpan")]
+                public static extern global::System.IntPtr AttachSpan(global::System.Runtime.InteropServices.HandleRef textFieldRef, global::System.Runtime.InteropServices.HandleRef spanRef, uint start, uint end);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextField_DetachSpan")]
+                public static extern global::System.IntPtr DetachSpan(global::System.Runtime.InteropServices.HandleRef textFieldRef, global::System.Runtime.InteropServices.HandleRef spanRef);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextField_BuildSpannedText")]
+                public static extern global::System.IntPtr BuildSpannedText(global::System.Runtime.InteropServices.HandleRef textFieldRef);
+            }
+
+            internal static partial class TextEditor
+            {
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextEditor_AttachSpan")]
+                public static extern global::System.IntPtr AttachSpan(global::System.Runtime.InteropServices.HandleRef textEditorRef, global::System.Runtime.InteropServices.HandleRef spanRef, uint start, uint end);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextEditor_DetachSpan")]
+                public static extern global::System.IntPtr DetachSpan(global::System.Runtime.InteropServices.HandleRef textEditorRef, global::System.Runtime.InteropServices.HandleRef spanRef);
+
+                [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_TextEditor_BuildSpannedText")]
+                public static extern global::System.IntPtr BuildSpannedText(global::System.Runtime.InteropServices.HandleRef textEditorRef);
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.UnderlineBuilder.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.UnderlineBuilder.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class UnderlineSpanBuilder
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpanBuilder_Initialize")]
+            public static extern global::System.IntPtr Initialize();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpanBuilder_Build")]
+            public static extern global::System.IntPtr Build(global::System.Runtime.InteropServices.HandleRef refBuilder);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpanBuilder_WithUnderlineType")]
+            public static extern global::System.IntPtr WithUnderlineType(global::System.Runtime.InteropServices.HandleRef refBuilder, int argType);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpanBuilder_WithUnderlineColor")]
+            public static extern global::System.IntPtr WithUnderlineColor(global::System.Runtime.InteropServices.HandleRef refBuilder, global::System.Runtime.InteropServices.HandleRef argColor);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpanBuilder_WithUnderlineHeight")]
+            public static extern global::System.IntPtr WithUnderlineHeight(global::System.Runtime.InteropServices.HandleRef refBuilder, float argHeight);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpanBuilder_WithUnderlineDashGap")]
+            public static extern global::System.IntPtr WithUnderlineDashGap(global::System.Runtime.InteropServices.HandleRef refBuilder, float argDashGap);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpanBuilder_WithUnderlineDashWidth")]
+            public static extern global::System.IntPtr WithUnderlineDashWidth(global::System.Runtime.InteropServices.HandleRef refBuilder, float argDashWidth);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_UnderlineSpanBuilder")]
+            public static extern void DeleteUnderlineSpanBuilder(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.UnderlineSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.UnderlineSpan.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class UnderlineSpan
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_type_get")]
+            public static extern int UnderlineTypeGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_type_defined_get")]
+            public static extern bool UnderlineTypeDefinedGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_color_get")]
+            public static extern global::System.IntPtr UnderlineColorGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_color_defined_get")]
+            public static extern bool UnderlineColorDefinedGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_height_get")]
+            public static extern float UnderlineHeightGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_height_defined_get")]
+            public static extern bool UnderlineHeightDefinedGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_dashgap_get")]
+            public static extern float UnderlineDashGapGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_dashgap_defined_get")]
+            public static extern bool UnderlineDashGapDefinedGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_dashwidth_get")]
+            public static extern float UnderlineDashWidthGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_UnderlineSpan_dashwidth_defined_get")]
+            public static extern bool UnderlineDashWidthDefinedGet(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_UnderlineSpan")]
+            public static extern void DeleteUnderlineSpan(global::System.Runtime.InteropServices.HandleRef refUnderlineSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spannable.cs
+++ b/src/Tizen.NUI/src/public/Text/Spannable.cs
@@ -1,0 +1,255 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Text
+{
+    /// <summary>
+    /// Spans are markup objects that can be attached to and detached from text.
+    /// They can be applied to whole paragraphs or to parts of the text.
+    /// The style is changed dynamically on parts of the text.
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class Spannable
+    {
+
+
+        private static void ValidateRange(int start, int end)
+        {
+            if (start < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(start), "Value is less than zero");
+            if (end < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(end), "Value is less than zero");
+        }
+
+        private static void CheckSWIGPendingException()
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Apply the given span on the given range of text.<br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        /// <param name="startIndex">The start index of the text to apply span (included)</param>
+        /// <param name="endIndex">The end index of the text  The end index to apply span (included)</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AttachSpan(TextLabel textLabel, BaseSpan span, int startIndex, int endIndex)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Interop.Spannable.TextLabel.AttachSpan(textLabel.SwigCPtr,span.SwigCPtr, (uint)startIndex, (uint)endIndex);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Un-apply the given SpanStyle on all ranges of text.<br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DetachSpan(TextLabel textLabel, BaseSpan span)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            Interop.Spannable.TextLabel.DetachSpan(textLabel.SwigCPtr,span.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Apply the attached style tags on text ranges.<br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BuildSpannedText(TextLabel textLabel)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            Interop.Spannable.TextLabel.BuildSpannedText(textLabel.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Apply the given span on the given range of text.<br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        /// <param name="startIndex">The start index of the text to apply span (included)</param>
+        /// <param name="endIndex">The end index of the text  The end index to apply span (included)</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AttachSpan(TextField textField, BaseSpan span, int startIndex, int endIndex)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Interop.Spannable.TextField.AttachSpan(textField.SwigCPtr,span.SwigCPtr, (uint)startIndex, (uint)endIndex);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Un-apply the given SpanStyle on all ranges of text.<br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DetachSpan(TextField textField, BaseSpan span)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            Interop.Spannable.TextField.DetachSpan(textField.SwigCPtr,span.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Apply the attached style tags on text ranges.<br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BuildSpannedText(TextField textField)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            Interop.Spannable.TextField.BuildSpannedText(textField.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Apply the given span on the given range of text.<br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        /// <param name="startIndex">The start index of the text to apply span (included)</param>
+        /// <param name="endIndex">The end index of the text  The end index to apply span (included)</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AttachSpan(TextEditor textEditor, BaseSpan span, int startIndex, int endIndex)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Interop.Spannable.TextEditor.AttachSpan(textEditor.SwigCPtr,span.SwigCPtr, (uint)startIndex, (uint)endIndex);
+            CheckSWIGPendingException();
+        }
+
+
+        /// <summary>
+        /// Un-apply the given SpanStyle on all ranges of text.<br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="span">TThe span of style to apply it on text from startIndex to endIndex</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DetachSpan(TextEditor textEditor, BaseSpan span)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            if (span == null)
+            {
+                throw new ArgumentNullException(null, "span object is null");
+            }
+
+            Interop.Spannable.TextEditor.DetachSpan(textEditor.SwigCPtr,span.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Apply the attached style tags on text ranges.<br />
+        /// </summary>
+        /// <param name="textEditor">The TextField control containing the text.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void BuildSpannedText(TextEditor textEditor)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            Interop.Spannable.TextEditor.BuildSpannedText(textEditor.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BaseSpan : Disposable, ISpan
+    {
+
+        internal BaseSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string GetMarkupTagName()
+        {
+            string ret =  Interop.BaseSpan.GetMarkupTagName(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.BaseSpan.DeleteBaseSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ForegroundColorSpan : BaseSpan
+    {
+
+        /// <summary>
+        /// Create foreground color span Set and set color for it.<br />
+        /// </summary>
+        /// <param name="color">The fore color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ForegroundColorSpan CreateWithForegroundColor(Color color)
+        {
+            return ForegroundColorSpanBuilder.Initialize().WithForegroundColor(color).Build();
+        }
+
+        internal ForegroundColorSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The fore-color in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color ForegroundColor
+        {
+            get
+            {
+                Color ret = new Color(Interop.ForegroundColorSpan.ForegroundColorGet(SwigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the fore color is defined in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ForegroundColorDefined
+        {
+            get
+            {
+                bool ret = Interop.ForegroundColorSpan.ForegroundColorDefinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.ForegroundColorSpan.DeleteForegroundColorSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpanBuilder.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpanBuilder.cs
@@ -1,0 +1,75 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ForegroundColorSpanBuilder : Disposable
+    {
+
+        /// <summary>
+        /// Creates a new ForegroundColorSpanBuilder object<br />
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ForegroundColorSpanBuilder Initialize( )
+        {
+            ForegroundColorSpanBuilder ret = new ForegroundColorSpanBuilder(Interop.ForegroundColorSpanBuilder.Initialize( ), true);
+            return ret;
+        }
+
+        internal ForegroundColorSpanBuilder(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Create an instance for color-span<br />
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ForegroundColorSpan Build( )
+        {
+            ForegroundColorSpan ret = new ForegroundColorSpan(Interop.ForegroundColorSpanBuilder.Build(SwigCPtr), true);
+            return ret;
+        }
+
+        /// <summary>
+        /// Set fore color for span<br />
+        /// </summary>
+        /// <param name="color">The fore color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ForegroundColorSpanBuilder WithForegroundColor(Color color)
+        {
+            ForegroundColorSpanBuilder ret = new ForegroundColorSpanBuilder(Interop.ForegroundColorSpanBuilder.WithForegroundColor(SwigCPtr,Vector4.getCPtr(color)), true);
+            return ret;
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.ForegroundColorSpanBuilder.DeleteForegroundColorSpanBuilder(swigCPtr);
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ISpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ISpan.cs
@@ -1,0 +1,27 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI.Binding;
+
+namespace Tizen.NUI.Text.Spans
+{
+    public interface ISpan
+    {
+        string GetMarkupTagName();
+    }
+}
+

--- a/src/Tizen.NUI/src/public/Text/Spans/UnderlineSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/UnderlineSpan.cs
@@ -1,0 +1,200 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class UnderlineSpan : BaseSpan
+    {
+
+        /// <summary>
+        /// Create underline span.<br />
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static UnderlineSpan CreateUnderline()
+        {
+            return UnderlineSpanBuilder.Initialize().Build();
+        }
+
+        internal UnderlineSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The underline type in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UnderlineType UnderlineType
+        {
+            get
+            {
+                UnderlineType ret =   (UnderlineType)Interop.UnderlineSpan.UnderlineTypeGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the underline type is defined in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool UnderlineTypeDefined
+        {
+            get
+            {
+                bool ret = Interop.UnderlineSpan.UnderlineTypeDefinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The underline color in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color UnderlineColor
+        {
+            get
+            {
+                Color ret = new Color(Interop.UnderlineSpan.UnderlineColorGet(SwigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the underline color is defined in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool UnderlineColorDefined
+        {
+            get
+            {
+                bool ret = Interop.UnderlineSpan.UnderlineColorDefinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The underline height in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float UnderlineHeight
+        {
+            get
+            {
+                float ret = Interop.UnderlineSpan.UnderlineHeightGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the underline height is defined in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool UnderlineHeightDefined
+        {
+            get
+            {
+                bool ret = Interop.UnderlineSpan.UnderlineHeightDefinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The dash-gap of dashed underline in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float UnderlineDashGap
+        {
+            get
+            {
+                float ret = Interop.UnderlineSpan.UnderlineDashGapGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the dash-gap of dashed underline is defined in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool UnderlineDashGapDefined
+        {
+            get
+            {
+                bool ret = Interop.UnderlineSpan.UnderlineDashGapDefinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The dash-width of dashed underline in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float UnderlineDashWidth
+        {
+            get
+            {
+                float ret = Interop.UnderlineSpan.UnderlineDashWidthGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the dash-width of dashed underline is defined in underline-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool UnderlineDashWidthDefined
+        {
+            get
+            {
+                bool ret = Interop.UnderlineSpan.UnderlineDashWidthDefinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.UnderlineSpan.DeleteUnderlineSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/UnderlineSpanBuilder.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/UnderlineSpanBuilder.cs
@@ -1,0 +1,123 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class UnderlineSpanBuilder : Disposable
+    {
+
+        /// <summary>
+        /// Creates a new UnderlineSpanBuilder object<br />
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static UnderlineSpanBuilder Initialize( )
+        {
+            UnderlineSpanBuilder ret = new UnderlineSpanBuilder(Interop.UnderlineSpanBuilder.Initialize( ), true);
+            return ret;
+        }
+
+        internal UnderlineSpanBuilder(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Create an instance for underline-span<br />
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UnderlineSpan Build( )
+        {
+            UnderlineSpan ret = new UnderlineSpan(Interop.UnderlineSpanBuilder.Build(SwigCPtr), true);
+            return ret;
+        }
+
+        /// <summary>
+        /// Set type of underline for span<br />
+        /// </summary>
+        /// <param name="type">The type of underline</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UnderlineSpanBuilder WithUnderlineType(UnderlineType type)
+        {
+            UnderlineSpanBuilder ret = new UnderlineSpanBuilder(Interop.UnderlineSpanBuilder.WithUnderlineType(SwigCPtr,(int)type), true);
+            return ret;
+        }
+
+        /// <summary>
+        /// Set color of underline for span<br />
+        /// </summary>
+        /// <param name="color">The underline color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UnderlineSpanBuilder WithUnderlineColor(Color color)
+        {
+            UnderlineSpanBuilder ret = new UnderlineSpanBuilder(Interop.UnderlineSpanBuilder.WithUnderlineColor(SwigCPtr,Vector4.getCPtr(color)), true);
+            return ret;
+        }
+
+        /// <summary>
+        /// Set height of underline for span<br />
+        /// </summary>
+        /// <param name="height">The fore color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UnderlineSpanBuilder WithUnderlineHeight(float height)
+        {
+            UnderlineSpanBuilder ret = new UnderlineSpanBuilder(Interop.UnderlineSpanBuilder.WithUnderlineHeight(SwigCPtr,height), true);
+            return ret;
+        }
+
+        /// <summary>
+        /// Set dash-gap of the dashed underline for span<br />
+        /// </summary>
+        /// <param name="dashGap">The dash-gap of the dashed underline</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UnderlineSpanBuilder WithUnderlineDashGap(float dashGap)
+        {
+            UnderlineSpanBuilder ret = new UnderlineSpanBuilder(Interop.UnderlineSpanBuilder.WithUnderlineDashGap(SwigCPtr,dashGap), true);
+            return ret;
+        }
+
+        /// <summary>
+        /// Set dash-width of the dashed underline for span<br />
+        /// </summary>
+        /// <param name="dashWidth">The dash-width of the dashed underline</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UnderlineSpanBuilder WithUnderlineDashWidth(float dashWidth)
+        {
+            UnderlineSpanBuilder ret = new UnderlineSpanBuilder(Interop.UnderlineSpanBuilder.WithUnderlineDashWidth(SwigCPtr,dashWidth), true);
+            return ret;
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.UnderlineSpanBuilder.DeleteUnderlineSpanBuilder(swigCPtr);
+        }
+
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
@@ -1,0 +1,89 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicBaseSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan GetMarkupTagName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.GetMarkupTagName M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanGetMarkupTagName()
+        {
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.GetMarkupTagName();
+                Assert.IsNotNull(result, "null handle");
+                Assert.IsInstanceOf<string>(result, "Should return string instance.");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanDispose()
+        {
+            tlog.Debug(tag, $"BaseSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return BaseSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"BaseSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,122 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColor;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, resutl), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColorDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColorDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColorDefined()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColorDefined;
+                Assert.AreEqual(true, resutl, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
@@ -1,0 +1,118 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanBuilderTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Initialize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Initialize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderInitialize()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Build.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Build M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderBuild()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder WithForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.WithForegroundColor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderWithForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpan.cs
@@ -1,0 +1,377 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicUnderlineSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineType()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineType START");
+
+            UnderlineType expected = UnderlineType.Double;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineType(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineType;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineType END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineTypeDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineTypeDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineTypeDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineTypeDefined START");
+
+            UnderlineType expected = UnderlineType.Double;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineType(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineTypeDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineTypeDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineColor()
+        {
+            tlog.Debug(tag, $"UnderlineSpanForegroundColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineColor;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, result), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineColorDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineColorDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineColorDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineColorDefined START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineColorDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineColorDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineHeight.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineHeight A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineHeight()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeight START");
+
+            float expected = 5.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineHeight(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineHeight;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeight END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineHeightDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineHeightDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineHeightDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeightDefined START");
+
+            float expected = 5.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineHeight(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineHeightDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeightDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashGap.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashGap A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashGap()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGap START");
+
+            float expected = 2.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashGap(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashGap;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGap END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashGapDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashGapDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashGapDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGapDefined START");
+
+            float expected = 2.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashGap(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashGapDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGapDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashWidth.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashWidth A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashWidth()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidth START");
+
+            float expected = 3.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashWidth(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashWidth;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidth END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashWidthDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashWidthDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashWidthDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidthDefined START");
+
+            float expected = 3.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashWidth(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashWidthDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidthDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanDispose()
+        {
+            tlog.Debug(tag, $"UnderlineSpanDispose START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"UnderlineSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpanBuilder.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpanBuilder.cs
@@ -1,0 +1,198 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicUnderlineSpanBuilderTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder Initialize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.Initialize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderInitialize()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderInitialize START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"UnderlineSpanBuilderInitialize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder Build.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.Build M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderBuild()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderBuild START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderBuild END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineType M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineType()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineType START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineType(UnderlineType.Dashed);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineType END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineColor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineColor()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineColor START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineColor(Color.Green);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineHeight.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineHeight M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineHeight()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineHeight START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineHeight(4.0f);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineHeight END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineDashGap.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineDashGap M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineDashGap()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashGap START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashGap(2.0f);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashGap END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineDashWidth.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineDashWidth M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineDashWidth()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashWidth START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashWidth(3.0f);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashWidth END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderDispose()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderDispose START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"UnderlineSpanBuilderDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
@@ -1,0 +1,330 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicSpannableTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextField()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+
+
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSBaseSpan.cs
@@ -1,0 +1,89 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicBaseSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan GetMarkupTagName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.GetMarkupTagName M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanGetMarkupTagName()
+        {
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.GetMarkupTagName();
+                Assert.IsNotNull(result, "null handle");
+                Assert.IsInstanceOf<string>(result, "Should return string instance.");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"BaseSpanGetMarkupTagName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("BaseSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.BaseSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void BaseSpanDispose()
+        {
+            tlog.Debug(tag, $"BaseSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(testingTarget, "Should return BaseSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"BaseSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,122 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColor;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, resutl), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan ForegroundColorDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.ForegroundColorDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanForegroundColorDefined()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var resutl = testingTarget.ForegroundColorDefined;
+                Assert.AreEqual(true, resutl, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanForegroundColorDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpanBuilder.cs
@@ -1,0 +1,118 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanBuilderTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Initialize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Initialize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderInitialize()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderInitialize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder Build.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Build M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderBuild()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderBuild END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpanBuilder WithForegroundColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.WithForegroundColor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderWithForegroundColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderWithForegroundColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpanBuilder.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanBuilderDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose START");
+
+            var testingTarget = ForegroundColorSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpanBuilder>(testingTarget, "Should return ForegroundColorSpanBuilder instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanBuilderDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpan.cs
@@ -1,0 +1,377 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicUnderlineSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineType()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineType START");
+
+            UnderlineType expected = UnderlineType.Double;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineType(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineType;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineType END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineTypeDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineTypeDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineTypeDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineTypeDefined START");
+
+            UnderlineType expected = UnderlineType.Double;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineType(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineTypeDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineTypeDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineColor()
+        {
+            tlog.Debug(tag, $"UnderlineSpanForegroundColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineColor;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, result), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineColorDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineColorDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineColorDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineColorDefined START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineColor(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineColorDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineColorDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineHeight.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineHeight A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineHeight()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeight START");
+
+            float expected = 5.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineHeight(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineHeight;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeight END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineHeightDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineHeightDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineHeightDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeightDefined START");
+
+            float expected = 5.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineHeight(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineHeightDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineHeightDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashGap.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashGap A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashGap()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGap START");
+
+            float expected = 2.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashGap(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashGap;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGap END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashGapDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashGapDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashGapDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGapDefined START");
+
+            float expected = 2.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashGap(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashGapDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashGapDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashWidth.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashWidth A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashWidth()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidth START");
+
+            float expected = 3.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashWidth(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashWidth;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidth END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan UnderlineDashWidthDefined.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.UnderlineDashWidthDefined A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanUnderlineDashWidthDefined()
+        {
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidthDefined START");
+
+            float expected = 3.0f;
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashWidth(expected).Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                var result = testingTarget.UnderlineDashWidthDefined;
+                Assert.AreEqual(true, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanUnderlineDashWidthDefined END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanDispose()
+        {
+            tlog.Debug(tag, $"UnderlineSpanDispose START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"UnderlineSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpanBuilder.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSUnderlineSpanBuilder.cs
@@ -1,0 +1,198 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicUnderlineSpanBuilderTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder Initialize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.Initialize M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderInitialize()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderInitialize START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"UnderlineSpanBuilderInitialize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder Build.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.Build M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderBuild()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderBuild START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().Build();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpan>(testingTarget, "Should return UnderlineSpan instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderBuild END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineType M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineType()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineType START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineType(UnderlineType.Dashed);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineType END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineColor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineColor()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineColor START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineColor(Color.Green);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineHeight.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineHeight M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineHeight()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineHeight START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineHeight(4.0f);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineHeight END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineDashGap.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineDashGap M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineDashGap()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashGap START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashGap(2.0f);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashGap END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpanBuilder WithUnderlineDashWidth.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.WithUnderlineDashWidth M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderWithUnderlineDashWidth()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashWidth START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize().WithUnderlineDashWidth(3.0f);
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"UnderlineSpanBuilderWithUnderlineDashWidth END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("UnderlineSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.UnderlineSpanBuilder.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void UnderlineSpanBuilderDispose()
+        {
+            tlog.Debug(tag, $"UnderlineSpanBuilderDispose START");
+
+            var testingTarget = UnderlineSpanBuilder.Initialize();
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<UnderlineSpanBuilder>(testingTarget, "Should return UnderlineSpanBuilder instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"UnderlineSpanBuilderDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannable.cs
@@ -1,0 +1,330 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicSpannableTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable AttachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableAttachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableAttachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.AttachSpan(testingTarget,span,3,8);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableAttachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable DetachSpan on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableDetachSpanTextField()
+        {
+            tlog.Debug(tag, $"SpannableDetachSpanTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var span = ForegroundColorSpanBuilder.Initialize().WithForegroundColor(Color.Green).Build();
+            Assert.IsNotNull(span, "null handle");
+            Assert.IsInstanceOf<BaseSpan>(span, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.DetachSpan(testingTarget,span);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableDetachSpanTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextLabel.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextLabel()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel START");
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextEditor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextEditor()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor START");
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Spannable BuildSpannedText on TextField.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.BuildSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableBuildSpannedTextTextField()
+        {
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextField START");
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            try
+            {
+                testingTarget.Text = "Hello World!";
+                Spannable.BuildSpannedText(testingTarget);
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"SpannableBuildSpannedTextTextEditor END (OK)");
+        }
+
+
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
### Description of Change ###
UnderlineSpan: Span to change the underlne properties (Type, Color, Height , DashGap and DashWidth) of characters


### API Changes ###
Added:
- Tizen.NUI.Text.Spans.UnderlineSpan // Class
 - Tizen.NUI.Text.Spans.UnderlineSpanBuilder // Class

### Testcases ###
Added the below to (Tizen.NUI.Devel.Tests.Ubuntu) and (Tizen.NUI.Tests):
- Tizen.NUI.Devel.Tests.PublicUnderlineSpanTest
- Tizen.NUI.Devel.Tests.PublicUnderlineSpanBuilderTest

**This PR depends on the below patches:**
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/280336
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/280339

**This PR should be preceded by the PR below:**
- https://github.com/Samsung/TizenFX/pull/4471

**Here's an example how to use it**
- https://github.com/shrouqsabah/NUI-Test/tree/spannable_test/text-spannable-underlinespan
- https://github.com/shrouqsabah/NUI-Test
