### PR TITLE
[NUI] Update NUISettings to guide how to use Navigator in Widget

### DIFF
--- a/test/NUISettings/NUISettings/NUISettings.cs
+++ b/test/NUISettings/NUISettings/NUISettings.cs
@@ -40,6 +40,8 @@ namespace WidgetApplicationTemplate
             int widgetWidth = window.Size.Width;
             int widgetHeight = window.Size.Height;
 
+            Navigator navigator = window.GetDefaultNavigator();
+
             Bundle bundle = new Bundle();
             bundle.AddItem(" ", " ");
             String encodedBundle = bundle.Encode();
@@ -47,23 +49,74 @@ namespace WidgetApplicationTemplate
             // Add Widget of "secondPage@NUISettingsReset" in advance to avoid loading pending.
             AddWidget(out secondPageWidgetView, "secondPage@NUISettingsReset", encodedBundle, widgetWidth, widgetHeight, 0.0f);
 
-            Navigator navigator = window.GetDefaultNavigator();
+            // Add Widget of "thirdPage@NUISettingsReset" in advance to avoid loading pending.
+            AddWidget(out thirdPageWidgetView, "thirdPage@NUISettingsReset", encodedBundle, widgetWidth, widgetHeight, 0.0f);
 
-            var button = new Button()
+            // Add Widget of "fourthPage@NUISettingsReset" in advance to avoid loading pending.
+            AddWidget(out fourthPageWidgetView, "fourthPage@NUISettingsReset", encodedBundle, widgetWidth, widgetHeight, 0.0f);
+
+            var content = new View()
+            {
+                Layout = new LinearLayout()
+                {
+                    LinearOrientation = LinearLayout.Orientation.Vertical,
+                    CellPadding = new Size2D(0, 20),
+                },
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+            };
+
+            var secondPageButton = new Button()
             {
                 Text = "Click to Second Page",
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
             };
-            button.Clicked += (o, e) =>
+            secondPageButton.Clicked += (o, e) =>
             {
-                var page = new ContentPage();
-                page.Content = secondPageWidgetView;
+                var page = new ContentPage()
+                {
+                    Content = secondPageWidgetView,
+                };
                 navigator.Push(page);
             };
+            content.Add(secondPageButton);
+
+            var thirdPageButton = new Button()
+            {
+                Text = "Click to Third Page",
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+            };
+            thirdPageButton.Clicked += (o, e) =>
+            {
+                var page = new ContentPage()
+                {
+                    Content = thirdPageWidgetView,
+                };
+                navigator.Push(page);
+            };
+            content.Add(thirdPageButton);
+
+            var fourthPageButton = new Button()
+            {
+                Text = "Click to Fourth Page",
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+            };
+            fourthPageButton.Clicked += (o, e) =>
+            {
+                var page = new DialogPage()
+                {
+                    Content = fourthPageWidgetView,
+                    EnableScrim = false, // fourthPageWidgetView's DialogPage.Scrim is used, so this DialogPage.Scrim should not be used.
+                };
+                navigator.Push(page);
+            };
+            content.Add(fourthPageButton);
 
             // Push the first page.
-            PushContentPage("First Page", button);
+            PushContentPage("First Page", content);
         }
 
         void AddWidget(out WidgetView widgetView, string widgetID, string contentInfo, int width, int height, float updatePeriod)
@@ -76,9 +129,6 @@ namespace WidgetApplicationTemplate
         {
             Window window = GetDefaultWindow();
             Navigator navigator = window.GetDefaultNavigator();
-
-            window.KeyEvent += OnKeyEvent;
-            window.TouchEvent += OnTouchEvent;
 
             var page = new ContentPage()
             {

--- a/test/NUISettings/NUISettingsReset/NUISettingsReset.cs
+++ b/test/NUISettings/NUISettingsReset/NUISettingsReset.cs
@@ -23,47 +23,21 @@ using Tizen.Applications;
 
 namespace WidgetTemplate
 {
-    class SecondPage : Widget
+    class SecondPage : ContentPage
     {
-        protected override void OnCreate(string contentInfo, Window window)
+        public SecondPage(Window window) : base()
         {
-            Bundle bundle = Bundle.Decode(contentInfo);
-
-            window.BackgroundColor = Color.Transparent;
-
-            // Update Widget Content by sending message to add the third page in advance.
-            Bundle nextBundle = new Bundle();
-            nextBundle.AddItem("WIDGET_ID", "thirdPage@NUISettingsReset");
-            nextBundle.AddItem("WIDGET_ACTION", "ADD");
-            nextBundle.AddItem("WIDGET_WIDTH", window.Size.Width.ToString());
-            nextBundle.AddItem("WIDGET_HEIGHT", window.Size.Height.ToString());
-            String encodedBundle = nextBundle.Encode();
-            SetContentInfo(encodedBundle);
+            if (window == null)
+            {
+                throw new ArgumentNullException(nameof(window), "window should not be null.");
+            }
 
             var appBar = new AppBar()
             {
                 Title = "Second Page",
-                AutoNavigationContent = false,
             };
 
-            var appBarStyle = ThemeManager.GetStyle("Tizen.NUI.Components.AppBar");
-
-            var navigationContent = new Button(((AppBarStyle)appBarStyle).BackButton);
-            navigationContent.Clicked += (o, e) =>
-            {
-                // Update Widget Content by sending message to pop the second page.
-                Bundle nextBundle2 = new Bundle();
-                nextBundle2.AddItem("WIDGET_ACTION", "POP");
-                String encodedBundle2 = nextBundle2.Encode();
-                SetContentInfo(encodedBundle2);
-            };
-
-            appBar.NavigationContent = navigationContent;
-
-            var page = new ContentPage()
-            {
-                AppBar = appBar,
-            };
+            AppBar = appBar;
 
             var button = new Button()
             {
@@ -73,17 +47,48 @@ namespace WidgetTemplate
             };
             button.Clicked += (o, e) =>
             {
-                // Update Widget Content by sending message to push the third page.
-                Bundle nextBundle2 = new Bundle();
-                nextBundle2.AddItem("WIDGET_ID", "thirdPage@NUISettingsReset");
-                nextBundle2.AddItem("WIDGET_PAGE", "CONTENT_PAGE");
-                nextBundle2.AddItem("WIDGET_ACTION", "PUSH");
-                String encodedBundle2 = nextBundle2.Encode();
-                SetContentInfo(encodedBundle2);
+                window.GetDefaultNavigator().Push(new ThirdPage(window));
             };
 
-            page.Content = button;
-            window.Add(page);
+            Content = button;
+        }
+    }
+
+    class SecondPageWidget : Widget
+    {
+        protected override void OnCreate(string contentInfo, Window window)
+        {
+            Bundle bundle = Bundle.Decode(contentInfo);
+
+            window.BackgroundColor = Color.Transparent;
+
+            var secondPage = new SecondPage(window);
+
+            var appBar = new AppBar()
+            {
+                Title = secondPage.AppBar.Title,
+                AutoNavigationContent = false,
+            };
+
+            // Since this is Widget, bundle with "POP" message should be sent to make the main app pops this.
+            var appBarStyle = ThemeManager.GetStyle("Tizen.NUI.Components.AppBar");
+
+            var navigationContent = new Button(((AppBarStyle)appBarStyle).BackButton);
+            navigationContent.Clicked += (o, e) =>
+            {
+                // Update Widget Content by sending message to pop the current page.
+                Bundle nextBundle = new Bundle();
+                nextBundle.AddItem("WIDGET_ACTION", "POP");
+                String encodedBundle = nextBundle.Encode();
+                SetContentInfo(encodedBundle);
+            };
+
+            appBar.AutoNavigationContent = false;
+            appBar.NavigationContent = navigationContent;
+
+            secondPage.AppBar = appBar;
+
+            window.GetDefaultNavigator().Push(secondPage);
         }
 
         protected override void OnPause()
@@ -112,47 +117,20 @@ namespace WidgetTemplate
         }
     }
 
-    class ThirdPage : Widget
+    class ThirdPage : ContentPage
     {
-        protected override void OnCreate(string contentInfo, Window window)
+        public ThirdPage(Window window) : base()
         {
-            Bundle bundle = Bundle.Decode(contentInfo);
-
-            window.BackgroundColor = Color.Transparent;
-
-            // Update Widget Content by sending message to add the fourth page in advance.
-            Bundle nextBundle = new Bundle();
-            nextBundle.AddItem("WIDGET_ID", "fourthPage@NUISettingsReset");
-            nextBundle.AddItem("WIDGET_WIDTH", window.Size.Width.ToString());
-            nextBundle.AddItem("WIDGET_HEIGHT", window.Size.Height.ToString());
-            nextBundle.AddItem("WIDGET_ACTION", "ADD");
-            String encodedBundle = nextBundle.Encode();
-            SetContentInfo(encodedBundle);
+            if (window == null)
+            {
+                throw new ArgumentNullException(nameof(window), "window should not be null.");
+            }
 
             var appBar = new AppBar()
             {
                 Title = "Third Page",
-                AutoNavigationContent = false,
             };
-
-            var appBarStyle = ThemeManager.GetStyle("Tizen.NUI.Components.AppBar");
-
-            var navigationContent = new Button(((AppBarStyle)appBarStyle).BackButton);
-            navigationContent.Clicked += (o, e) =>
-            {
-                // Update Widget Content by sending message to pop the third page.
-                Bundle nextBundle2 = new Bundle();
-                nextBundle2.AddItem("WIDGET_ACTION", "POP");
-                String encodedBundle2 = nextBundle2.Encode();
-                SetContentInfo(encodedBundle2);
-            };
-
-            appBar.NavigationContent = navigationContent;
-
-            var page = new ContentPage()
-            {
-                AppBar = appBar,
-            };
+            AppBar = appBar;
 
             var button = new Button()
             {
@@ -162,17 +140,48 @@ namespace WidgetTemplate
             };
             button.Clicked += (o, e) =>
             {
-                // Update Widget Content by sending message to push the fourth page.
-                Bundle nextBundle2 = new Bundle();
-                nextBundle2.AddItem("WIDGET_ID", "fourthPage@NUISettingsReset");
-                nextBundle2.AddItem("WIDGET_PAGE", "DIALOG_PAGE");
-                nextBundle2.AddItem("WIDGET_ACTION", "PUSH");
-                String encodedBundle2 = nextBundle2.Encode();
-                SetContentInfo(encodedBundle2);
+                window.GetDefaultNavigator().Push(new FourthPage(window));
             };
 
-            page.Content = button;
-            window.Add(page);
+            Content = button;
+        }
+    }
+
+    class ThirdPageWidget : Widget
+    {
+        protected override void OnCreate(string contentInfo, Window window)
+        {
+            Bundle bundle = Bundle.Decode(contentInfo);
+
+            window.BackgroundColor = Color.Transparent;
+
+            var thirdPage = new ThirdPage(window);
+
+            var appBar = new AppBar()
+            {
+                Title = thirdPage.AppBar.Title,
+                AutoNavigationContent = false,
+            };
+
+            // Since this is Widget, bundle with "POP" message should be sent to make the main app pops this.
+            var appBarStyle = ThemeManager.GetStyle("Tizen.NUI.Components.AppBar");
+
+            var navigationContent = new Button(((AppBarStyle)appBarStyle).BackButton);
+            navigationContent.Clicked += (o, e) =>
+            {
+                // Update Widget Content by sending message to pop the current page.
+                Bundle nextBundle = new Bundle();
+                nextBundle.AddItem("WIDGET_ACTION", "POP");
+                String encodedBundle = nextBundle.Encode();
+                SetContentInfo(encodedBundle);
+            };
+
+            appBar.AutoNavigationContent = false;
+            appBar.NavigationContent = navigationContent;
+
+            thirdPage.AppBar = appBar;
+
+            window.GetDefaultNavigator().Push(thirdPage);
         }
 
         protected override void OnPause()
@@ -201,13 +210,14 @@ namespace WidgetTemplate
         }
     }
 
-    class FourthPage : Widget
+    class FourthPage : DialogPage
     {
-        protected override void OnCreate(string contentInfo, Window window)
+        public FourthPage(Window window) : base()
         {
-            Bundle bundle = Bundle.Decode(contentInfo);
-
-            window.BackgroundColor = Color.Transparent;
+            if (window == null)
+            {
+                throw new ArgumentNullException(nameof(window), "window should not be null.");
+            }
 
             var button = new Button()
             {
@@ -215,11 +225,7 @@ namespace WidgetTemplate
             };
             button.Clicked += (o, e) =>
             {
-                // Update Widget Content by sending message to pop the fourth page.
-                Bundle nextBundle2 = new Bundle();
-                nextBundle2.AddItem("WIDGET_ACTION", "POP");
-                String encodedBundle2 = nextBundle2.Encode();
-                SetContentInfo(encodedBundle2);
+                window.GetDefaultNavigator().Pop();
             };
 
             var dialog = new AlertDialog()
@@ -229,7 +235,95 @@ namespace WidgetTemplate
                 Actions = new View[] { button },
             };
 
-            window.Add(dialog);
+            Content = dialog;
+        }
+    }
+
+    class WidgetDialogPage : DialogPage
+    {
+        public WidgetDialogPage(Window window) : base()
+        {
+            if (window == null)
+            {
+                throw new ArgumentNullException(nameof(window), "window should not be null.");
+            }
+
+            // Default Scrim calls navigator.Pop() when the Scrim is touched.
+            // To pop widget page when the Scrim is touched, bundle with "POP" message should be sent to make the main app pops this.
+            Scrim = CreateScrim(window);
+        }
+
+        public EventHandler<TouchEventArgs> ScrimTouchEvent;
+
+        private View CreateScrim(Window window)
+        {
+            if (window == null)
+            {
+                throw new ArgumentNullException(nameof(window), "window should not be null.");
+            }
+
+            var scrimStyle = ThemeManager.GetStyle("Tizen.NUI.Components.DialogPage.Scrim");
+            var scrim = new VisualView(scrimStyle);
+            scrim.Size = window.Size;
+            scrim.TouchEvent += (object source, TouchEventArgs e) =>
+            {
+                if ((EnableDismissOnScrim == true) && (e.Touch.GetState(0) == PointStateType.Up))
+                {
+                    // Default Scrim calls navigator.Pop() when the Scrim is touched.
+                    // To pop widget page when the Scrim is touched, bundle with "POP" message should be sent to make the main app pops this.
+                    ScrimTouchEvent?.Invoke(source, e);
+                }
+                return true;
+            };
+
+            return scrim;
+        }
+    }
+
+    class FourthPageWidget : Widget
+    {
+        protected override void OnCreate(string contentInfo, Window window)
+        {
+            Bundle bundle = Bundle.Decode(contentInfo);
+
+            window.BackgroundColor = Color.Transparent;
+
+            var fourthPage = new WidgetDialogPage(window);
+
+            var button = new Button()
+            {
+                Text = "OK",
+            };
+            button.Clicked += (o, e) =>
+            {
+                // Update Widget Content by sending message to pop the current page.
+                Bundle nextBundle = new Bundle();
+                nextBundle.AddItem("WIDGET_ACTION", "POP");
+                String encodedBundle = nextBundle.Encode();
+                SetContentInfo(encodedBundle);
+            };
+
+            var dialog = new AlertDialog()
+            {
+                Title = "Fourth Page",
+                Message = "Message",
+                Actions = new View[] { button },
+            };
+
+            fourthPage.Content = dialog;
+
+            // Default Scrim calls navigator.Pop() when the Scrim is touched.
+            // To pop widget page when the Scrim is touched, bundle with "POP" message should be sent to make the main app pops this.
+            fourthPage.ScrimTouchEvent += (o, e) =>
+            {
+                // Update Widget Content by sending message to pop the current page.
+                Bundle nextBundle = new Bundle();
+                nextBundle.AddItem("WIDGET_ACTION", "POP");
+                String encodedBundle = nextBundle.Encode();
+                SetContentInfo(encodedBundle);
+            };
+
+            window.GetDefaultNavigator().Push(fourthPage);
         }
 
         protected override void OnPause()
@@ -286,9 +380,9 @@ namespace WidgetTemplate
         static void Main(string[] args)
         {
             Dictionary<System.Type, string> widgetSet = new Dictionary<Type, string>();
-            widgetSet.Add(typeof(SecondPage), "secondPage@NUISettingsReset");
-            widgetSet.Add(typeof(ThirdPage), "thirdPage@NUISettingsReset");
-            widgetSet.Add(typeof(FourthPage), "fourthPage@NUISettingsReset");
+            widgetSet.Add(typeof(SecondPageWidget), "secondPage@NUISettingsReset");
+            widgetSet.Add(typeof(ThirdPageWidget), "thirdPage@NUISettingsReset");
+            widgetSet.Add(typeof(FourthPageWidget), "fourthPage@NUISettingsReset");
             var app = new Program(widgetSet);
             app.Run(args);
         }


### PR DESCRIPTION
To pass data between Widgets, data is passed from Widget to Main app and
Main app passes the data to another Widget.
Since this is difficult to support, NUISettings guides how to use
Navigator in Widget.
By using Widget's own Navigator, Widget knows its Navigator and its
Pages. So Widget can pass data between its Pages easily.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
