### PR TITLE
[NUI] Fix ContentPageLayout to measure AppBar prior to Content

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -211,6 +211,14 @@ namespace Tizen.NUI.Components
                 var appBar = (Owner as ContentPage)?.AppBar;
                 var content = (Owner as ContentPage)?.Content;
 
+                bool measureAppBarLayout = false;
+
+                if ((appBar != null) && (appBar.Layout != null) && (LayoutChildren.Contains(appBar.Layout)) && appBar.Layout.SetPositionByLayout)
+                {
+                    MeasureChildWithoutPadding(appBar.Layout, widthMeasureSpec, heightMeasureSpec);
+                    measureAppBarLayout = true;
+                }
+
                 foreach (var childLayout in LayoutChildren)
                 {
                     if (!childLayout.SetPositionByLayout)
@@ -218,13 +226,13 @@ namespace Tizen.NUI.Components
                         continue;
                     }
 
-                    if ((content != null) && (content == childLayout.Owner) && (content.HeightSpecification == LayoutParamPolicies.MatchParent))
+                    if ((content != null) && (content == childLayout.Owner) && (content.HeightSpecification == LayoutParamPolicies.MatchParent) && measureAppBarLayout)
                     {
                         var contentSizeH = heightMeasureSpec.Size.AsDecimal() - Padding.Top - Padding.Bottom - content.Margin.Top - content.Margin.Bottom - (appBar?.Layout.MeasuredHeight.Size.AsDecimal() ?? 0);
                         MeasureSpecification contentHeightSpec = new MeasureSpecification(new LayoutLength(contentSizeH), MeasureSpecification.ModeType.Exactly);
                         MeasureChildWithoutPadding(childLayout, widthMeasureSpec, contentHeightSpec);
                     }
-                    else
+                    else if (!measureAppBarLayout || (appBar != childLayout.Owner)) // if childLayout is not appBar.Layout
                     {
                         MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
                     }


### PR DESCRIPTION
Content's height is calculated correctly after AppBar's height is
calculated.

Therefore, AppBar is measured and then Content is measured.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
