### PR TITLE
[NUI][TCSACR-503] Camera class and CameraType enum, which are not used, are deprecated

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTask.cs
@@ -199,7 +199,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [Obsolete("Do not use this. Use Tizen.NUI.Scene3D.Camera instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetCamera(Camera camera)
         {
@@ -207,7 +207,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [Obsolete("Do not use this. Use Tizen.NUI.Scene3D.Camera instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Camera GetCamera()
         {

--- a/src/Tizen.NUI/src/internal/Utility/Camera.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Camera.cs
@@ -20,7 +20,7 @@ using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
 {
-    /// This will be released at Tizen.NET API Level 6, so currently this would be used as inhouse API.
+    [global::System.Obsolete("Do not use this. Use Tizen.NUI.Scene3D.Camera instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public partial class Camera : View
     {

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -237,6 +237,7 @@ namespace Tizen.NUI
     /// Enumeration for type determination of how the camera operates.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [Obsolete("This has been deprecated in API10 and will be removed in API12. Do not use this.")]
     public enum CameraType
     {
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
[NUI][TCSACR-503] Camera class and CameraType enum, which are not used, are deprecated


### API Changes ###
https://code.sec.samsung.net/jira/browse/TCSACR-503