### PR TITLE
[NUI] Add BorderlineColorSelector to ViewStyle

### DIFF
--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -66,7 +66,14 @@ namespace Tizen.NUI.Components
                 ItemSpacing = new Size2D(8, 8),
                 CornerRadius = 12.0f,
                 BorderlineWidth = 2.0f,
-                BorderlineColor = new Color("#FF6200"), // FIXME: BorderlineColor should support Selector<Color>.
+                BorderlineColorSelector = new Selector<Color>()
+                {
+                    Normal = new Color("#FF6200"),
+                    Pressed = new Color("#FFA166"),
+                    Focused = new Color("#FF7119"),
+                    Selected = new Color("#FF8133"),
+                    Disabled = new Color("#CACACA"),
+                },
                 ItemHorizontalAlignment = HorizontalAlignment.Center,
                 ItemVerticalAlignment = VerticalAlignment.Center,
                 BackgroundColor = Color.Transparent,

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -63,6 +63,7 @@ namespace Tizen.NUI.BaseComponents
         private Selector<Rectangle> backgroundImageBorderSelector;
         private Selector<Color> colorSelector;
         private VisualTransformPolicyType? cornerRadiusPolicy;
+        private Selector<Color> borderlineColorSelector;
 
         static ViewStyle() { }
 
@@ -473,6 +474,20 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (Color)GetValue(BorderlineColorProperty);
             set => SetValue(BorderlineColorProperty, value);
+        }
+
+        /// <summary>
+        /// The color selector for the borderline of the View.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Selector<Color> BorderlineColorSelector
+        {
+            get
+            {
+                Selector<Color> color = (Selector<Color>)GetValue(BorderlineColorSelectorProperty);
+                return (null != color) ? color : borderlineColorSelector = new Selector<Color>();
+            }
+            set => SetValue(BorderlineColorSelectorProperty, value);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -414,6 +414,26 @@ namespace Tizen.NUI.BaseComponents
             ((ViewStyle)bindable).borderlineColor = (Color)newValue;
         }, defaultValueCreator: (bindable) => ((ViewStyle)bindable).borderlineColor ?? Tizen.NUI.Color.Black);
 
+        /// <summary> Bindable property of BorderlineColorSelector. Do not open it. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty BorderlineColorSelectorProperty = BindableProperty.Create(nameof(BorderlineColor), typeof(Selector<Color>), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var viewStyle = (ViewStyle)bindable;
+
+            if (newValue == null)
+            {
+                viewStyle.borderlineColorSelector = null;
+            }
+            else
+            {
+                viewStyle.borderlineColorSelector = (Selector<Color>)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            return ((ViewStyle)bindable).borderlineColorSelector;
+        });
+
         /// <summary> Bindable property of BorderlineOffset. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty BorderlineOffsetProperty = BindableProperty.Create(nameof(BorderlineOffset), typeof(float?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2000,17 +2000,29 @@ namespace Tizen.NUI.BaseComponents
         /// BorderlineColor Property
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BorderlineColorProperty = BindableProperty.Create(nameof(BorderlineColor), typeof(Color), typeof(View), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            var view = (View)bindable;
-            (view.backgroundExtraData ?? (view.backgroundExtraData = new BackgroundExtraData())).BorderlineColor = (Color)newValue;
-            view.ApplyBorderline();
-        },
-        defaultValueCreator: (bindable) =>
-        {
-            var view = (View)bindable;
-            return view.backgroundExtraData == null ? Color.Black : view.backgroundExtraData.BorderlineColor;
-        });
+        public static readonly BindableProperty BorderlineColorProperty = BindableProperty.Create(nameof(BorderlineColor), typeof(Color), typeof(View), null,
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+
+                view.themeData?.selectorData?.BorderlineColor?.Reset(view);
+
+                if (newValue is Selector<Color> selector)
+                {
+                    if (selector.HasAll()) view.SetBorderlineColor(selector.All);
+                    else view.EnsureSelectorData().BorderlineColor = new TriggerableSelector<Color>(view, selector, view.SetBorderlineColor, true);
+                }
+                else
+                {
+                    view.SetBorderlineColor((Color)newValue);
+                }
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                return view.backgroundExtraData == null ? Color.Black : view.backgroundExtraData.BorderlineColor;
+            }
+        );
 
         /// <summary>
         /// BorderlineOffset Property
@@ -2673,6 +2685,18 @@ namespace Tizen.NUI.BaseComponents
             }
 
             Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, View.Property.BACKGROUND, new PropertyValue(map));
+        }
+
+        private void SetBorderlineColor(Color value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            (backgroundExtraData ?? (backgroundExtraData = new BackgroundExtraData())).BorderlineColor = value;
+
+            ApplyBorderline();
         }
 
         private void SetBackgroundColor(Color value)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewSelectorData.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewSelectorData.cs
@@ -34,6 +34,7 @@ namespace Tizen.NUI.BaseComponents
         public TriggerableSelector<float?> Opacity{ get; set; }
         public TriggerableSelector<ImageShadow> ImageShadow{ get; set; }
         public TriggerableSelector<Shadow> BoxShadow{ get; set; }
+        public TriggerableSelector<Color> BorderlineColor{ get; set; }
 
         public void ClearBackground(View view)
         {
@@ -61,6 +62,7 @@ namespace Tizen.NUI.BaseComponents
             Opacity?.Reset(view);
             ImageShadow?.Reset(view);
             BoxShadow?.Reset(view);
+            BorderlineColor?.Reset(view);
         }
     }
 }


### PR DESCRIPTION
To support Selector<Color> for BorderlineColor, BorderlineColorSelector
has been added.
BorderlineColorSelector is applied to Outlined Button style.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
