### PR TITLE
[Applications.Common] Remove GC Timer from OnLowMemory()

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -219,21 +219,6 @@ namespace Tizen.Applications
         protected virtual void OnLowMemory(LowMemoryEventArgs e)
         {
             LowMemory?.Invoke(this, e);
-            if (e.LowMemoryStatus == LowMemoryStatus.SoftWarning || e.LowMemoryStatus == LowMemoryStatus.HardWarning)
-            {
-                double interval = new Random().Next(10 * 1000);
-                if (interval <= 0)
-                    interval = 10 * 1000;
-
-                sTimer = new System.Timers.Timer(interval);
-                sTimer.Elapsed += OnTimedEvent;
-                sTimer.AutoReset = false;
-                sTimer.Enabled = true;
-            }
-        }
-
-        private static void OnTimedEvent(Object source, ElapsedEventArgs e)
-        {
             System.GC.Collect();
         }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -219,7 +219,10 @@ namespace Tizen.Applications
         protected virtual void OnLowMemory(LowMemoryEventArgs e)
         {
             LowMemory?.Invoke(this, e);
-            System.GC.Collect();
+            if (e.LowMemoryStatus == LowMemoryStatus.SoftWarning || e.LowMemoryStatus == LowMemoryStatus.HardWarning)
+            {
+                System.GC.Collect();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
According to the test result about calling GC.Collect(), it mostly takes 100 ms.
This PR removes the GC timer. 

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
