### PR TITLE
[NUI.Scene3D] Add private property ChildrenSensitive

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
@@ -42,6 +42,13 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_GetModelRoot")]
             public static extern global::System.IntPtr GetModelRoot(global::System.Runtime.InteropServices.HandleRef model);
 
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_SetChildrenSensitive")]
+            public static extern void SetChildrenSensitive(global::System.Runtime.InteropServices.HandleRef model, bool enable);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_GetChildrenSensitive")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool GetChildrenSensitive(global::System.Runtime.InteropServices.HandleRef model);
+
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_SetImageBasedLightSource")]
             public static extern global::System.IntPtr SetImageBasedLightSource(global::System.Runtime.InteropServices.HandleRef model, string diffuse, string specular, float scaleFactor);
 

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -78,6 +78,9 @@ namespace Tizen.NUI.Scene3D
     {
         internal Model(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
+            // Currenly, Model don't have API to access it's child. So, we make it false.
+            this.ChildrenSensitive = false;
+            this.FocusableChildren = false;
         }
 
         /// <summary>
@@ -121,6 +124,30 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// Set/Get whether allow this model's children allow to use touch events.
+        /// This property doesn't change Model itself's Sensitive info.
+        /// If this property is true, event can traversal this models children.
+        /// If this property is false, event traversal blocked.
+        /// Default is false.
+        /// </summary>
+        /// <remarks>
+        /// If ChildrenSensitive is true, it could decrease performance but we can connect events into it's children.
+        /// If ChildrenSensitive is false, the performance becomes better but we cannot connect events into it's children.
+        ///
+        /// Currenly, Model don't have API to access it's child. So, we make it as private.
+        /// </remarks>
+        private bool ChildrenSensitive
+        {
+            set
+            {
+                SetChildrenSensitive(value);
+            }
+            get
+            {
+                return GetChildrenSensitive();
+            }
+        }
+
         /// Set/Get the ImageBasedLight ScaleFactor.
         /// Scale factor controls light source intensity in [0.0f, 1.0f]
         /// </summary>
@@ -211,6 +238,19 @@ namespace Tizen.NUI.Scene3D
             View ret = new View(Interop.Model.GetModelRoot(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        internal void SetChildrenSensitive(bool enable)
+        {
+            Interop.Model.SetChildrenSensitive(SwigCPtr, enable);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal bool GetChildrenSensitive()
+        {
+            bool result = Interop.Model.GetChildrenSensitive(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
NUI.Scene3D.Model don't have any method to access
it's children nodes. So, it will be always false now.

required DALi patches :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/280680/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/281062/

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>