### PR TITLE
[NUI] Fix ViewStyle.BorderlineColorSelector to work

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -689,6 +689,24 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The color selector for the borderline of the View.
+        /// Like BackgroundColor, color selector typed BorderlineColor should be used in ViewStyle only.
+        /// So this API is internally used only.
+        /// </summary>
+        internal Selector<Color> BorderlineColorSelector
+        {
+            get
+            {
+                return (Selector<Color>)GetValue(BorderlineColorSelectorProperty);
+            }
+            set
+            {
+                SetValue(BorderlineColorSelectorProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The Relative offset for the borderline of the View.
         /// Recommended range : [-1.0f to 1.0f].
         /// If -1.0f, draw borderline inside of the View.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2025,6 +2025,30 @@ namespace Tizen.NUI.BaseComponents
         );
 
         /// <summary>
+        /// BorderlineColorSelector Property
+        /// Like BackgroundColor, color selector typed BorderlineColor should be used in ViewStyle only.
+        /// So this API is internally used only.
+        /// </summary>
+        internal static readonly BindableProperty BorderlineColorSelectorProperty = BindableProperty.Create(nameof(BorderlineColorSelector), typeof(Selector<Color>), typeof(View), null,
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+
+                view.themeData?.selectorData?.BorderlineColor?.Reset(view);
+
+                Selector<Color> selector = newValue as Selector<Color>;
+                if (selector.HasAll()) view.SetBorderlineColor(selector.All);
+                else view.EnsureSelectorData().BorderlineColor = new TriggerableSelector<Color>(view, selector, view.SetBorderlineColor, true);
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                var selector = view.themeData?.selectorData?.BorderlineColor?.Get();
+                return (null != selector) ? selector : new Selector<Color>();
+            }
+        );
+
+        /// <summary>
         /// BorderlineOffset Property
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
ViewStyle.BorderlineColorSelector did not work properly because View.BorderlineColorSelector property was not added.

Like BackgroundColor, color selector typed BorderlineColor should be used in ViewStyle only.
So View.BorderlineColorSelector is internally used only.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
