### PR TITLE
[NUI] Add View.ColorRed / ColorBlue / ColorGreen Property

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2773,6 +2773,10 @@ namespace Tizen.NUI.BaseComponents
 
         /// <summary>
         /// The Color of View. This is an RGBA value.
+        /// Each RGBA components match as <see cref="ColorRed"/>, <see cref="ColorGreen"/>, <see cref="ColorBlue"/>, and <see cref="Opacity"/>.
+        /// This property will multiply the final color of this view. (BackgroundColor, BorderlineColor, BackgroundImage, etc).
+        /// For example, if view.BackgroundColor = Color.Yellow and view.Color = Color.Purple, this view will shown as Red.
+        /// Inherient of color value depend on <see cref="ColorMode"/>.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -2801,6 +2805,72 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 SetValue(ColorProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The Red component of View.Color.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Animatable - This property can be animated using <c>Animation</c> class.
+        /// </para>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float ColorRed
+        {
+            get
+            {
+                return (float)GetValue(ColorRedProperty);
+            }
+            set
+            {
+                SetValue(ColorRedProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The Green component of View.Color.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Animatable - This property can be animated using <c>Animation</c> class.
+        /// </para>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float ColorGreen
+        {
+            get
+            {
+                return (float)GetValue(ColorGreenProperty);
+            }
+            set
+            {
+                SetValue(ColorGreenProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The Blue component of View.Color.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Animatable - This property can be animated using <c>Animation</c> class.
+        /// </para>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float ColorBlue
+        {
+            get
+            {
+                return (float)GetValue(ColorBlueProperty);
+            }
+            set
+            {
+                SetValue(ColorBlueProperty, value);
                 NotifyPropertyChanged();
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -154,7 +154,7 @@ namespace Tizen.NUI.BaseComponents
             defaultValueCreator: (bindable) =>
             {
                 var view = (View)bindable;
-                var tmpProperty = view.GetProperty(Interop.ActorProperty.ColorGet());
+                var tmpProperty = view.GetProperty(View.Property.COLOR);
 
                 if (view.internalColor == null)
                 {
@@ -165,6 +165,63 @@ namespace Tizen.NUI.BaseComponents
                 tmpProperty?.Dispose();
 
                 return view.internalColor;
+            }
+        );
+
+        /// <summary>
+        /// ColorRedProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ColorRedProperty = BindableProperty.Create(nameof(ColorRed), typeof(float), typeof(View), default(float),
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+                view.SetColorRed((float?)newValue);
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                float temp = 0.0f;
+                Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.ColorRed).Get(out temp);
+                return temp;
+            }
+        );
+
+        /// <summary>
+        /// ColorGreenProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ColorGreenProperty = BindableProperty.Create(nameof(ColorGreen), typeof(float), typeof(View), default(float),
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+                view.SetColorGreen((float?)newValue);
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                float temp = 0.0f;
+                Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.ColorGreen).Get(out temp);
+                return temp;
+            }
+        );
+
+        /// <summary>
+        /// ColorBlueProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ColorBlueProperty = BindableProperty.Create(nameof(ColorBlue), typeof(float), typeof(View), default(float),
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+                view.SetColorBlue((float?)newValue);
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                float temp = 0.0f;
+                Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.ColorBlue).Get(out temp);
+                return temp;
             }
         );
 
@@ -2781,6 +2838,45 @@ namespace Tizen.NUI.BaseComponents
             }
 
             Interop.ActorInternal.SetColor(SwigCPtr, value.SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        private void SetColorRed(float? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            using var propertyValue = new Tizen.NUI.PropertyValue((float)value);
+            Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, View.Property.ColorRed, propertyValue);
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        private void SetColorGreen(float? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            using var propertyValue = new Tizen.NUI.PropertyValue((float)value);
+            Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, View.Property.ColorGreen, propertyValue);
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        private void SetColorBlue(float? value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            using var propertyValue = new Tizen.NUI.PropertyValue((float)value);
+            Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, View.Property.ColorBlue, propertyValue);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -224,6 +224,10 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int ScaleZ = Interop.ActorProperty.ScaleZGet();
             internal static readonly int WorldScale = Interop.ActorProperty.WorldScaleGet();
             internal static readonly int VISIBLE = Interop.ActorProperty.VisibleGet();
+            internal static readonly int COLOR = Interop.ActorProperty.ColorGet();
+            internal static readonly int ColorRed = Interop.ActorProperty.ColorRedGet();
+            internal static readonly int ColorGreen = Interop.ActorProperty.ColorGreenGet();
+            internal static readonly int ColorBlue = Interop.ActorProperty.ColorBlueGet();
             internal static readonly int WorldColor = Interop.ActorProperty.WorldColorGet();
             internal static readonly int WorldMatrix = Interop.ActorProperty.WorldMatrixGet();
             internal static readonly int NAME = Interop.ActorProperty.NameGet();

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
@@ -124,5 +124,88 @@ namespace Tizen.NUI.Devel.Tests
 
             testView.Dispose();
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("Get value test for View.ColorRed")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorRed")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void ColorRed_GET_SET_VALUE()
+        {
+            /* TEST CODE */
+            View testView = new View();
+
+            Assert.AreEqual(1.0f, testView.ColorRed, "Default red value is 1.0f");
+
+            testView.ColorRed = 0.5f;
+
+            Assert.AreEqual(0.5f, testView.ColorRed, "ColorRed set");
+            Assert.AreEqual(new Color(0.5f, 1.0f, 1.0f, 1.0f), testView.Color, "ColorRed should change View.Color");
+
+            testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
+
+            Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
+            Assert.AreEqual(0.0f, testView.ColorRed, "Color should change View.ColorRed");
+
+            testView.Dispose();
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Get value test for View.ColorGreen")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorGreen")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void ColorGreen_GET_SET_VALUE()
+        {
+            /* TEST CODE */
+            View testView = new View();
+
+            Assert.AreEqual(1.0f, testView.ColorGreen, "Default green value is 1.0f");
+
+            testView.ColorGreen = 0.5f;
+
+            Assert.AreEqual(0.5f, testView.ColorGreen, "ColorGreen set");
+            Assert.AreEqual(new Color(1.0f, 0.5f, 1.0f, 1.0f), testView.Color, "ColorGreen should change View.Color");
+
+            testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
+
+            Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
+            Assert.AreEqual(0.0f, testView.ColorGreen, "Color should change View.ColorGreen");
+
+            testView.Dispose();
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Get value test for View.ColorBlue")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorBlue")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void ColorBlue_GET_SET_VALUE()
+        {
+            /* TEST CODE */
+            View testView = new View();
+
+            Assert.AreEqual(1.0f, testView.ColorBlue, "Default blue value is 1.0f");
+
+            testView.ColorBlue = 0.5f;
+
+            Assert.AreEqual(0.5f, testView.ColorBlue, "ColorBlue set");
+            Assert.AreEqual(new Color(1.0f, 1.0f, 0.5f, 1.0f), testView.Color, "ColorBlue should change View.Color");
+
+            testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
+
+            Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
+            Assert.AreEqual(0.0f, testView.ColorBlue, "Color should change View.ColorBlue");
+
+            testView.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Previously, we can only change whole color components (RGBA) or change Opacity (A).

If we change only RGB values without change Opacity value, we need to get opacity property first, and make new Color().

To change each components without create new Color class, We make new property to change each components.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
