### PR TITLE
[WIP] NUI property test

### DIFF
--- a/src/Tizen.NUI/Tizen.NUI.csproj
+++ b/src/Tizen.NUI/Tizen.NUI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>NUI_DEBUG_OFF;</DefineConstants>
+    <DefineConstants>NUI_DEBUG_OFF;NUI_PROPERTY_TEST</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
@@ -145,6 +145,20 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetNeedGesturePropagation")]
             public static extern float SetNeedGesturePropagation(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+#if NUI_PROPERTY_TEST
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Internal_Get_Values")]
+            public static extern int InternalGetValues(global::System.Runtime.InteropServices.HandleRef actor, int type, out float value1, out float value2, out float value3, out float value4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Internal_Set_Values")]
+            public static extern int InternalSetValues(global::System.Runtime.InteropServices.HandleRef actor, int type, float value1, float value2, float value3, float value4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Internal_Get_PropertyMap")]
+            public static extern global::System.IntPtr InternalGetPropertyMap(global::System.Runtime.InteropServices.HandleRef actor, int type);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Internal_Set_PropertyMap")]
+            public static extern int InternalSetPropertyMap(global::System.Runtime.InteropServices.HandleRef actor, int type, global::System.Runtime.InteropServices.HandleRef propertyMap);
+#endif
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -1268,6 +1268,10 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+#if NUI_PROPERTY_TEST
+        internal PropertyMap internalTextFit;
+#endif
+
         /// <summary>
         /// The text fit parameters.<br />
         /// The textFit map contains the following keys :<br />
@@ -1489,6 +1493,9 @@ namespace Tizen.NUI.BaseComponents
                 SystemSettings.LocaleLanguageChanged -= SystemSettings_LocaleLanguageChanged;
             }
 
+#if NUI_PROPERTY_TEST
+            DisposeAllInteranlObject();
+#endif
             removeFontSizeChangedCallback();
 
             if (type == DisposeTypes.Explicit)
@@ -1538,6 +1545,19 @@ namespace Tizen.NUI.BaseComponents
         {
             base.OnBindingContextChanged();
         }
+
+#if NUI_PROPERTY_TEST
+        internal void DisposeAllInteranlObject()
+        {
+            Tizen.Log.Fatal("NUITEST", $"DisposeAllInteranlObject()");
+            if(internalTextFit != null)
+            {
+                Tizen.Log.Fatal("NUITEST", $"dispose internalTextFit!");
+                internalTextFit.Dispose();
+                internalTextFit = null;
+            }
+        }
+#endif
 
         private void SystemSettings_LocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -630,6 +630,40 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing).Get(out temp);
             return temp;
         }));
+
+#if NUI_PROPERTY_TEST
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty TextFitProperty = BindableProperty.Create(nameof(TextFit), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            if (newValue != null)
+            {
+                if(textLabel.internalTextFit != (PropertyMap)newValue)
+                {
+                    textLabel.internalTextFit?.Dispose();
+                    textLabel.internalTextFit = (PropertyMap)newValue;
+                    Tizen.Log.Fatal("NUITEST", $"textLabel.internalTextFit != (PropertyMap)newValue\n");
+                }
+                var ret = Interop.Actor.InternalSetPropertyMap(textLabel.SwigCPtr, (int)Tizen.NUI.InternalGetSetValueType.TextFit, textLabel.internalTextFit.SwigCPtr);
+                Tizen.Log.Fatal("NUITEST", $"TextFitProperty setter ret={ret}");
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            global::System.IntPtr nativeHandle = Interop.Actor.InternalGetPropertyMap(textLabel.SwigCPtr, (int)Tizen.NUI.InternalGetSetValueType.TextFit);
+            
+            if(textLabel.internalTextFit == null)
+            {
+                textLabel.internalTextFit = new PropertyMap(nativeHandle, true);
+            }
+            else
+            {
+                textLabel.internalTextFit.SwitchNativeHandle(nativeHandle);
+            }
+            return textLabel.internalTextFit;
+        }));
+#else
         /// Only for XAML. No need of public API. Make hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextFitProperty = BindableProperty.Create(nameof(TextFit), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -647,6 +681,7 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.TextFit).Get(temp);
             return temp;
         }));
+#endif //#if NUI_PROPERTY_TEST
 
         /// Only for XAML. No need of public API. Make hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1619,6 +1619,55 @@ namespace Tizen.NUI.BaseComponents
             }
         );
 
+#if NUI_PROPERTY_TEST
+        /// <summary>
+        /// SizeProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(View), null,
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+                if (newValue != null)
+                {
+                    // Size property setter is only used by user.
+                    // Framework code uses SetSize() instead of Size property setter.
+                    // Size set by user is returned by GetUserSize2D() for SuggestedMinimumWidth/Height.
+                    // SuggestedMinimumWidth/Height is used by Layout calculation.
+                    view.userSizeWidth = ((Size)newValue).Width;
+                    view.userSizeHeight = ((Size)newValue).Height;
+
+                    // Set Specification so when layouts measure this View it matches the value set here.
+                    // All Views are currently Layouts.
+                    view.WidthSpecification = (int)System.Math.Ceiling(((Size)newValue).Width);
+                    view.HeightSpecification = (int)System.Math.Ceiling(((Size)newValue).Height);
+        
+                    float dummy = -1;
+                    var ret = Interop.Actor.InternalSetValues(view.SwigCPtr, (int)InternalGetSetValueType.Size, ((Size)newValue).Width, ((Size)newValue).Height, ((Size)newValue).Depth, dummy);
+                    Tizen.Log.Fatal("NUITEST", $"SizeProperty setter ret={ret}");
+                }
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+                float width, height, depth, dummy;
+                var retVal = Interop.Actor.InternalGetValues(view.SwigCPtr, (int)InternalGetSetValueType.Size, out width, out height, out depth, out dummy);
+
+                if (view.internalSize == null)
+                {
+                    view.internalSize = new Size(view.OnSizeChanged, width, height, depth);
+                }
+                else
+                {
+                    view.internalSize.Width = width;
+                    view.internalSize.Height = height;
+                    view.internalSize.Depth = depth;
+                }
+                Tizen.Log.Fatal("NUITEST", $"SizeProperty getter retVal={retVal} width={width}, height={height}, depth={depth}");
+                return view.internalSize;
+            }
+        );
+#else
         /// <summary>
         /// SizeProperty
         /// </summary>
@@ -1659,6 +1708,7 @@ namespace Tizen.NUI.BaseComponents
                 return view.internalSize;
             }
         );
+#endif
 
         /// <summary>
         /// MinimumSizeProperty

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -584,6 +584,23 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
+#if NUI_PROPERTY_TEST
+        private Size2D internalCurrentSize;
+        internal Size2D GetCurrentSize()
+        {
+            if (internalCurrentSize == null)
+            {
+                internalCurrentSize = new Size2D(0, 0);
+            }
+            float width, height, dummy;
+            var retVal = Interop.Actor.InternalGetValues(SwigCPtr, (int)InternalGetSetValueType.CurrentSize, out width, out height, out dummy, out dummy);
+
+            internalCurrentSize.Width = (int)width;
+            internalCurrentSize.Height = (int)height;
+
+            return internalCurrentSize;
+        }
+#else
         internal Size2D GetCurrentSize()
         {
             Size ret = new Size(Interop.Actor.GetCurrentSize(SwigCPtr), true);
@@ -593,6 +610,7 @@ namespace Tizen.NUI.BaseComponents
             ret.Dispose();
             return size;
         }
+#endif //#if NUI_PROPERTY_TEST
 
         internal Size2D GetCurrentSizeFloat()
         {
@@ -1593,3 +1611,21 @@ namespace Tizen.NUI.BaseComponents
 
     }
 }
+
+#if NUI_PROPERTY_TEST
+namespace Tizen.NUI
+{
+    internal enum InternalGetSetValueType
+    {
+        CurrentSize = 1,
+        Size = 2,
+        TextFit = 3,
+    }
+
+    internal enum InternalGetSetReturnType
+    {
+        NoError = 0,
+        ErrorUnknown = 1,
+    }
+}
+#endif

--- a/src/Tizen.NUI/src/public/Common/PropertyMap.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyMap.cs
@@ -425,6 +425,14 @@ namespace Tizen.NUI
         {
             Interop.PropertyMap.DeletePropertyMap(swigCPtr);
         }
+
+#if NUI_PROPERTY_TEST
+        internal void SwitchNativeHandle(global::System.IntPtr newHandle)
+        {
+            Interop.PropertyMap.DeletePropertyMap(SwigCPtr);
+            SwigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, newHandle);
+        }
+#endif
     }
 
     internal static class PropertyMapSetterHelper

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DisposeTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DisposeTest.cs
@@ -281,7 +281,7 @@ namespace Tizen.NUI.Samples
 
             for (int i = 0; i < AutoDisposedObjectCount; i++)
             {
-                int viewSize = 150;
+                int viewSize = rand.Next(100, 150);
                 var view = new Custom3DView()
                 {
                     Size = new Size(viewSize, viewSize, viewSize),
@@ -316,7 +316,7 @@ namespace Tizen.NUI.Samples
 
             for (int i = 0; i < ManualDisposedObjectCount; i++)
             {
-                int viewSize = 150;
+                int viewSize = rand.Next(100, 150);
                 var view = new Custom3DView()
                 {
                     Size = new Size(viewSize, viewSize, viewSize),
@@ -348,6 +348,39 @@ namespace Tizen.NUI.Samples
                 view.AddRenderer(renderer);
 
                 rotateAnimation.AnimateBy(view, "Orientation", new Rotation(new Radian(new Degree(-360.0f)), Vector3.YAxis));
+#if NUI_PROPERTY_TEST
+                Console.WriteLine($"current size=({view.Size.Width},{view.Size.Height}) position=({view.Position.X},{view.Position.Y}), current size=({view.CurrentSize.Width},{view.CurrentSize.Height})");
+                
+                var text = new TextLabel();
+                for(int k=0; k < i; k++)
+                {
+                    text.Text += $"test{k} ";
+                }
+                text.Size = new Size(rand.Next(100, 400), rand.Next(100,110));
+                text.Position = new Position(rand.Next(5, 20), rand.Next(10,600));
+
+                PropertyMap map = text.TextFit;
+                uint mapCnt = map.Count();
+                Tizen.Log.Fatal("NUITEST", $"mapCnt={mapCnt}\n");
+                for(int j=0; j < (int)mapCnt; j++)
+                {
+                    PropertyKey key = map.GetKeyAt((uint)j);
+                    PropertyValue value = map.GetValue((uint)j);
+                    float tmpVal;
+                    value.Get(out tmpVal);
+                    Tizen.Log.Fatal("NUITEST", $"[{j}]key={key.StringKey}({key.Type}) val={tmpVal}({value.GetType()})\n");
+                    key.Dispose();
+                    value.Dispose();
+                }
+                //map.Clear();
+                //map.Add("enable", new PropertyValue(true)).Add("minSize", new PropertyValue(5)).Add("maxSize", new PropertyValue(50));
+                //text.TextFit = map;
+
+                PropertyMap map2 = new PropertyMap();
+                map2.Add("enable", new PropertyValue(true)).Add("minSize", new PropertyValue(5)).Add("maxSize", new PropertyValue(50));
+                text.TextFit = map2;
+                root.Add(text);
+#endif //#if NUI_PROPERTY_TEST                
             }
             rotateAnimation.Looping = true;
             rotateAnimation.Play();
@@ -357,6 +390,24 @@ namespace Tizen.NUI.Samples
             uint cnt = root.ChildCount;
             for (int i = (int)(cnt - 1); i >= 0; i--)
             {
+#if NUI_PROPERTY_TEST
+                if(root.GetChildAt((uint)i) is TextLabel text)
+                {
+                    PropertyMap map = text.TextFit;
+                    uint mapCnt = map.Count();
+                    for(int j=0; j < (int)mapCnt; j++)
+                    {
+                        PropertyKey key = map.GetKeyAt((uint)j);
+                        PropertyValue value = map.GetValue((uint)j);
+                        float tmpVal;
+                        value.Get(out tmpVal);
+                        Tizen.Log.Fatal("NUITEST", $"[{j}]key={key.StringKey}({key.Type}) val={tmpVal}({value.GetType()})\n");
+                        key.Dispose();
+                        value.Dispose();
+                    }
+                    map.Dispose();
+                }
+#endif //#if NUI_PROPERTY_TEST
                 root.Remove(root.GetChildAt((uint)i));
             }
             foreach(var view in views)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Tizen.NUI.Samples.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Tizen.NUI.Samples</RootNamespace>
     <AssemblyName>Tizen.NUI.Samples</AssemblyName>
     <StartupObject>Tizen.NUI.Samples.Application</StartupObject>
+    <DefineConstants>NUI_DEBUG_OFF;NUI_PROPERTY_TEST</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
### Description of Change ###
[WIP] NUI property test
- this is just a POC to remove `new PropertyValue()` when getting/setting properties
- many `new PropertyValue()` causes to increase GC delay
- replace `Tizen.NUI.Object.SetProperty()` and `Tizen.NUI.Object.GetProperty()` with `Interop.Actor.InternalSetPropertyValues()` and `Interop.Actor.InternalGetPropertyValues()`

### API Changes ###
none