### PR TITLE
[NUI] disable acessibilityPanGesture when scroll disabled.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1380,7 +1380,7 @@ namespace Tizen.NUI.Components
 
         internal override bool OnAccessibilityPan(PanGesture gestures)
         {
-            return OnPanGesture(gestures);
+            return (mScrollEnabled ? OnPanGesture(gestures) : false);
         }
 
         private float CustomScrollAlphaFunction(float progress)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Accessibiliy call OnPanGesture directly without check ScrollEnabled variable.
this patch fix to check ScrollEnabled value before sending OnPanGesture.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
