### PR TITLE
[NUI] Change property get/set not to use PropertyValue

### DIFF
--- a/src/Tizen.NUI/Tizen.NUI.csproj
+++ b/src/Tizen.NUI/Tizen.NUI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>NUI_DEBUG_OFF;</DefineConstants>
+    <DefineConstants>NUI_DEBUG_OFF;NUI_PROPERTY_CHANGE_1;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
@@ -15,6 +15,8 @@
  *
  */
 
+using global::System.Runtime.InteropServices;
+
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -145,6 +147,37 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_SetNeedGesturePropagation")]
             public static extern float SetNeedGesturePropagation(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+#if NUI_PROPERTY_CHANGE_1
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector2")]
+            public static extern int InternalRetrievingPropertyVector2(HandleRef actor, int propertyType, HandleRef retrievingVector2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector2")]
+            public static extern int InternalSetPropertyVector2(HandleRef actor, int propertyType, HandleRef vector2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector3")]
+            public static extern int InternalRetrievingPropertyVector3(HandleRef actor, int propertyType, HandleRef retrievingVector3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector3")]
+            public static extern int InternalSetPropertyVector3(HandleRef actor, int propertyType, HandleRef vector3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector3")]
+            public static extern int InternalRetrievingPropertyVector4(HandleRef actor, int propertyType, HandleRef retrievingVector4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector4")]
+            public static extern int InternalSetPropertyVector4(HandleRef actor, int propertyType, HandleRef vector4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector2ActualVector3")]
+            public static extern int InternalRetrievingPropertyVector2ActualVector3(HandleRef actor, int propertyType, HandleRef retrievingVector2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyVector2ActualVector3")]
+            public static extern int InternalSetPropertyVector2ActualVector3(HandleRef actor, int propertyType, HandleRef vector2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyFloat")]
+            public static extern int InternalRetrievingPropertyFloat(HandleRef actor, int propertyType, out float valFloat);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalSetPropertyFloat")]
+            public static extern int InternalSetPropertyFloat(HandleRef actor, int propertyType, float valFloat);
+#endif
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -73,6 +73,32 @@ namespace Tizen.NUI.BaseComponents
         private ControlState propagatableControlStates = ControlState.All;
         private bool dispatchTouchEvents = true;
 
+#if NUI_PROPERTY_CHANGE_DEBUG
+internal static int LayoutSetGetter = 0;
+internal static int SizeGetter = 0;
+internal static int SizeSetter = 0;
+internal static int Size2DGetter = 0;
+internal static int Size2DSetter = 0;
+internal static int MaximumSizeGetter = 0;
+internal static int MaximumSizeSetter = 0;
+internal static int MinimumSizeGetter = 0;
+internal static int MinimumSizeSetter = 0;
+internal static int PositionGetter = 0;
+internal static int PositionSetter = 0;
+internal static int Position2DGetter = 0;
+internal static int Position2DSetter = 0;
+internal static int SizeWidthGetter = 0;
+internal static int SizeWidthSetter = 0;
+internal static int SizeHeightGetter = 0;
+internal static int SizeHeightSetter = 0;
+internal static int PositionXGetter = 0;
+internal static int PositionXSetter = 0;
+internal static int PositionYGetter = 0;
+internal static int PositionYSetter = 0;
+internal static int PositionZGetter = 0;
+internal static int PositionZSetter = 0;
+#endif
+
         static View()
         {
             RegisterPropertyGroup(PositionProperty, positionPropertyGroup);
@@ -188,6 +214,9 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+LayoutSetGetter++;
+#endif
                 return layoutSet;
             }
         }
@@ -1218,6 +1247,10 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+Size2DGetter++;
+#endif
+
                 var temp = (Size2D)GetValue(Size2DProperty);
 
                 if (this.Layout == null)
@@ -1230,6 +1263,10 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+Size2DSetter++;
+#endif
+
                 SetValue(Size2DProperty, value);
 
                 NotifyPropertyChanged();
@@ -1304,10 +1341,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+Position2DGetter++;
+#endif
+
                 return (Position2D)GetValue(Position2DProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+Position2DSetter++;
+#endif
+
                 SetValue(Position2DProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1553,10 +1598,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+SizeWidthGetter++;
+#endif
+
                 return (float)GetValue(SizeWidthProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+SizeWidthSetter++;
+#endif
+
                 SetValue(SizeWidthProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1578,10 +1631,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+SizeHeightGetter++;
+#endif
+
                 return (float)GetValue(SizeHeightProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+SizeHeightSetter++;
+#endif
+
                 SetValue(SizeHeightProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1617,10 +1678,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionGetter++;
+#endif
+
                 return (Position)GetValue(PositionProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionSetter++;
+#endif
+
                 SetValue(PositionProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1642,10 +1711,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionXGetter++;
+#endif
                 return (float)GetValue(PositionXProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionXSetter++;
+#endif
                 SetValue(PositionXProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1667,10 +1742,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionYGetter++;
+#endif
                 return (float)GetValue(PositionYProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionYSetter++;
+#endif
                 SetValue(PositionYProperty, value);
                 NotifyPropertyChanged();
             }
@@ -1692,10 +1773,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionZGetter++;
+#endif
+
                 return (float)GetValue(PositionZProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PositionZSetter++;
+#endif
+
                 SetValue(PositionZProperty, value);
                 NotifyPropertyChanged();
             }
@@ -2259,10 +2348,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+MinimumSizeGetter++;
+#endif
                 return (Size2D)GetValue(MinimumSizeProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+MinimumSizeSetter++;
+#endif
                 if (value == null)
                 {
                     throw new ArgumentNullException(nameof(value));
@@ -2299,10 +2394,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+MaximumSizeGetter++;
+#endif
                 return (Size2D)GetValue(MaximumSizeProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+MaximumSizeSetter++;
+#endif
                 // We don't have Layout.Maximum(Width|Height) so we cannot apply it to layout.
                 // MATCH_PARENT spec + parent container size can be used to limit
                 if (layout != null)
@@ -2439,10 +2540,16 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+SizeGetter++;
+#endif
                 return (Size)GetValue(SizeProperty);
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+SizeSetter++;
+#endif
                 SetValue(SizeProperty, value);
                 NotifyPropertyChanged();
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -763,8 +763,11 @@ namespace Tizen.NUI.BaseComponents
                     view.userSizeWidth = ((Size2D)newValue).Width;
                     view.userSizeHeight = ((Size2D)newValue).Height;
 
+#if NUI_PROPERTY_CHANGE_1
+                    Interop.Actor.InternalSetPropertyVector2ActualVector3(view.SwigCPtr, View.Property.SIZE, ((Size2D)newValue).SwigCPtr);
+#else
                     view.SetSize(((Size2D)newValue).Width, ((Size2D)newValue).Height, 0);
-
+#endif
                     view.widthPolicy = ((Size2D)newValue).Width;
                     view.heightPolicy = ((Size2D)newValue).Height;
 
@@ -774,6 +777,13 @@ namespace Tizen.NUI.BaseComponents
             defaultValueCreator: (bindable) =>
             {
                 var view = (View)bindable;
+#if NUI_PROPERTY_CHANGE_1
+                if (view.internalSize2D == null)
+                {
+                    view.internalSize2D = new Size2D(view.OnSize2DChanged, 0, 0);
+                }
+                Interop.Actor.InternalRetrievingPropertyVector2ActualVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize2D.SwigCPtr);
+#else
                 var tmp = new Size(0, 0, 0);
                 var tmpProperty = Object.GetProperty(view.SwigCPtr, Property.SIZE);
                 tmpProperty?.Get(tmp);
@@ -793,7 +803,7 @@ namespace Tizen.NUI.BaseComponents
 
                 tmpProperty?.Dispose();
                 tmp?.Dispose();
-
+#endif
                 return view.internalSize2D;
             }
         );
@@ -836,12 +846,23 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
                 if (newValue != null)
                 {
+#if NUI_PROPERTY_CHANGE_1
+                    Interop.Actor.InternalSetPropertyVector2ActualVector3(view.SwigCPtr, View.Property.POSITION, ((Position2D)newValue).SwigCPtr);
+#else
                     view.SetPosition(((Position2D)newValue).X, ((Position2D)newValue).Y, 0);
+#endif
                 }
             },
             defaultValueCreator: (bindable) =>
             {
                 var view = (View)bindable;
+#if NUI_PROPERTY_CHANGE_1
+                if (view.internalPosition2D == null)
+                {
+                    view.internalPosition2D = new Position2D(view.OnPosition2DChanged, 0, 0);
+                }
+                Interop.Actor.InternalRetrievingPropertyVector2ActualVector3(view.SwigCPtr, View.Property.POSITION, view.internalPosition2D.SwigCPtr);
+#else
                 var tmp = new Position(0, 0, 0);
                 var tmpProperty = Object.GetProperty(view.SwigCPtr, Property.POSITION);
                 tmpProperty?.Get(tmp);
@@ -861,7 +882,7 @@ namespace Tizen.NUI.BaseComponents
 
                 tmpProperty?.Dispose();
                 tmp?.Dispose();
-
+#endif
                 return view.internalPosition2D;
             }
         );
@@ -998,8 +1019,11 @@ namespace Tizen.NUI.BaseComponents
                 // Size set by user is returned by GetUserSize2D() for SuggestedMinimumWidth/Height.
                 // SuggestedMinimumWidth/Height is used by Layout calculation.
                 view.userSizeWidth = (float)newValue;
-
+#if NUI_PROPERTY_CHANGE_1
+                Interop.Actor.InternalSetPropertyFloat(view.SwigCPtr, View.Property.SizeWidth, (float)newValue);
+#else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SizeWidth, new Tizen.NUI.PropertyValue((float)newValue));
+#endif
                 view.WidthSpecification = (int)System.Math.Ceiling((float)newValue);
             }
         }),
@@ -1007,7 +1031,11 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             float temp = 0.0f;
+#if NUI_PROPERTY_CHANGE_1
+            Interop.Actor.InternalRetrievingPropertyFloat(view.SwigCPtr, View.Property.SizeWidth, out temp);
+#else
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SizeWidth).Get(out temp);
+#endif
             return temp;
         }));
 
@@ -1025,8 +1053,11 @@ namespace Tizen.NUI.BaseComponents
                 // Size set by user is returned by GetUserSize2D() for SuggestedMinimumWidth/Height.
                 // SuggestedMinimumWidth/Height is used by Layout calculation.
                 view.userSizeHeight = (float)newValue;
-
+#if NUI_PROPERTY_CHANGE_1
+                Interop.Actor.InternalSetPropertyFloat(view.SwigCPtr, View.Property.SizeHeight, (float)newValue);
+#else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SizeHeight, new Tizen.NUI.PropertyValue((float)newValue));
+#endif
                 view.HeightSpecification = (int)System.Math.Ceiling((float)newValue);
             }
         }),
@@ -1034,7 +1065,11 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             float temp = 0.0f;
+#if NUI_PROPERTY_CHANGE_1
+            Interop.Actor.InternalRetrievingPropertyFloat(view.SwigCPtr, View.Property.SizeHeight, out temp);
+#else
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SizeHeight).Get(out temp);
+#endif
             return temp;
         }));
 
@@ -1048,12 +1083,23 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
                 if (newValue != null)
                 {
+#if NUI_PROPERTY_CHANGE_1
+                    Interop.Actor.InternalSetPropertyVector3(view.SwigCPtr, View.Property.POSITION, ((Position)newValue).SwigCPtr);
+#else
                     view.SetPosition(((Position)newValue).X, ((Position)newValue).Y, ((Position)newValue).Z);
+#endif
                 }
             },
             defaultValueCreator: (bindable) =>
             {
                 var view = (View)bindable;
+#if NUI_PROPERTY_CHANGE_1
+                if (view.internalPosition == null)
+                {
+                    view.internalPosition = new Position(view.OnPositionChanged, 0, 0, 0);
+                }
+                Interop.Actor.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.POSITION, view.internalPosition.SwigCPtr);
+#else
                 var tmpProperty = Object.GetProperty(view.SwigCPtr, Property.POSITION);
 
                 if (view.internalPosition == null)
@@ -1062,7 +1108,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 tmpProperty?.Get(view.internalPosition);
                 tmpProperty?.Dispose();
-
+#endif
                 return view.internalPosition;
             }
         );
@@ -1076,14 +1122,22 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (newValue != null)
             {
+#if NUI_PROPERTY_CHANGE_1
+                Interop.Actor.InternalSetPropertyFloat(view.SwigCPtr, View.Property.PositionX, (float)newValue);
+#else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.PositionX, new Tizen.NUI.PropertyValue((float)newValue));
+#endif
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var view = (View)bindable;
             float temp = 0.0f;
+#if NUI_PROPERTY_CHANGE_1
+            Interop.Actor.InternalRetrievingPropertyFloat(view.SwigCPtr, View.Property.PositionX, out temp);
+#else
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.PositionX).Get(out temp);
+#endif
             return temp;
         }));
 
@@ -1096,14 +1150,22 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (newValue != null)
             {
+#if NUI_PROPERTY_CHANGE_1
+                Interop.Actor.InternalSetPropertyFloat(view.SwigCPtr, View.Property.PositionY, (float)newValue);
+#else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.PositionY, new Tizen.NUI.PropertyValue((float)newValue));
+#endif
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var view = (View)bindable;
             float temp = 0.0f;
+#if NUI_PROPERTY_CHANGE_1
+            Interop.Actor.InternalRetrievingPropertyFloat(view.SwigCPtr, View.Property.PositionY, out temp);
+#else
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.PositionY).Get(out temp);
+#endif
             return temp;
         }));
 
@@ -1116,14 +1178,22 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (newValue != null)
             {
+#if NUI_PROPERTY_CHANGE_1
+                Interop.Actor.InternalSetPropertyFloat(view.SwigCPtr, View.Property.PositionZ, (float)newValue);
+#else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.PositionZ, new Tizen.NUI.PropertyValue((float)newValue));
+#endif
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var view = (View)bindable;
             float temp = 0.0f;
+#if NUI_PROPERTY_CHANGE_1
+            Interop.Actor.InternalRetrievingPropertyFloat(view.SwigCPtr, View.Property.PositionZ, out temp);
+#else
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.PositionZ).Get(out temp);
+#endif
             return temp;
         }));
 
@@ -1676,6 +1746,45 @@ namespace Tizen.NUI.BaseComponents
             }
         );
 
+#if NUI_PROPERTY_CHANGE_1
+        /// <summary>
+        /// SizeProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(View), null,
+            propertyChanged: (bindable, oldValue, newValue) =>
+            {
+                var view = (View)bindable;
+                if (newValue != null)
+                {
+                    // Size property setter is only used by user.
+                    // Framework code uses SetSize() instead of Size property setter.
+                    // Size set by user is returned by GetUserSize2D() for SuggestedMinimumWidth/Height.
+                    // SuggestedMinimumWidth/Height is used by Layout calculation.
+                    view.userSizeWidth = ((Size)newValue).Width;
+                    view.userSizeHeight = ((Size)newValue).Height;
+
+                    // Set Specification so when layouts measure this View it matches the value set here.
+                    // All Views are currently Layouts.
+                    view.WidthSpecification = (int)System.Math.Ceiling(((Size)newValue).Width);
+                    view.HeightSpecification = (int)System.Math.Ceiling(((Size)newValue).Height);
+
+                    Interop.Actor.InternalSetPropertyVector2(view.SwigCPtr, View.Property.SIZE, ((Size)newValue).SwigCPtr);
+                }
+            },
+            defaultValueCreator: (bindable) =>
+            {
+                var view = (View)bindable;
+
+                if (view.internalSize == null)
+                {
+                    view.internalSize = new Size(view.OnSizeChanged, 0, 0, 0);
+                }
+                Interop.Actor.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.SIZE, view.internalSize.SwigCPtr);
+                return view.internalSize;
+            }
+        );
+#else
         /// <summary>
         /// SizeProperty
         /// </summary>
@@ -1716,7 +1825,7 @@ namespace Tizen.NUI.BaseComponents
                 return view.internalSize;
             }
         );
-
+#endif
         /// <summary>
         /// MinimumSizeProperty
         /// </summary>
@@ -1727,11 +1836,23 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
                 if (newValue != null)
                 {
+#if NUI_PROPERTY_CHANGE_1
+                    Interop.Actor.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, ((Size2D)newValue).SwigCPtr);
+#else
                     view.SetMinimumSize((Size2D)newValue);
+#endif                    
                 }
             },
             defaultValueCreator: (bindable) =>
             {
+#if NUI_PROPERTY_CHANGE_1
+                var view = (View)bindable;
+                if (view.internalMinimumSize == null)
+                {
+                    view.internalMinimumSize = new Size2D(view.OnMinimumSizeChanged, 0, 0);
+                }
+                Interop.Actor.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, view.internalMinimumSize.SwigCPtr);
+#else
                 var view = (View)bindable;
                 if (view.internalMinimumSize == null)
                 {
@@ -1740,7 +1861,7 @@ namespace Tizen.NUI.BaseComponents
                 var tmp = Object.GetProperty(view.SwigCPtr, Property.MinimumSize);
                 tmp?.Get(view.internalMinimumSize);
                 tmp?.Dispose();
-
+#endif
                 return view.internalMinimumSize;
             }
         );
@@ -1755,20 +1876,32 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
                 if (newValue != null)
                 {
+#if NUI_PROPERTY_CHANGE_1
+                    Interop.Actor.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, ((Size2D)newValue).SwigCPtr);
+#else
                     view.SetMaximumSize((Size2D)newValue);
+#endif                    
                 }
             },
             defaultValueCreator: (bindable) =>
             {
                 var view = (View)bindable;
+#if NUI_PROPERTY_CHANGE_1
                 if (view.internalMaximumSize == null)
                 {
                     view.internalMaximumSize = new Size2D(view.OnMaximumSizeChanged, 0, 0);
                 }
+                Interop.Actor.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, view.internalMaximumSize.SwigCPtr);
+#else
+                if (view.internalMaximumSize == null)
+                {
+                    view.internalMaximumSize = new Size2D(view.OnMaximumSizeChanged, 0, 0);
+                }
+
                 var tmp = Object.GetProperty(view.SwigCPtr, Property.MaximumSize);
                 tmp?.Get(view.internalMaximumSize);
                 tmp?.Dispose();
-
+#endif
                 return view.internalMaximumSize;
             }
         );

--- a/src/Tizen.NUI/src/public/Common/PropertyValue.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyValue.cs
@@ -224,9 +224,14 @@ namespace Tizen.NUI
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
-
+#if NUI_PROPERTY_CHANGE_DEBUG
+        internal static int PropertyValueConstructor = 0;
+#endif        
         internal PropertyValue(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+            PropertyValueConstructor++;
+#endif
         }
 
         internal PropertyValue(Matrix3 matrixValue) : this(Interop.PropertyValue.NewPropertyValueMatrix3(Matrix3.getCPtr(matrixValue)), true)

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -54,7 +54,9 @@ namespace Tizen.NUI
             }
             return isSupported;
         }
-
+#if NUI_PROPERTY_CHANGE_DEBUG
+private bool flag1 = false;
+#endif
         internal Window(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
             if (Interop.Stage.IsInstalled())
@@ -63,8 +65,50 @@ namespace Tizen.NUI
 
                 localController = new LayoutController(this);
                 NUILog.Debug("layoutController id:" + localController.GetId());
+
+#if NUI_PROPERTY_CHANGE_DEBUG
+Tizen.Log.Fatal("NUITEST", $"Window constructor called!");
+if(flag1 == false)
+{
+    flag1 = true;
+    var curTh = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+    Tizen.Log.Fatal("NUITEST", $"current threadID : {curTh}");
+    if(curTh == 1)
+    {
+        this.KeyEvent += TestWindowKeyEventHandler;
+        Tizen.Log.Fatal("NUITEST", $"TestWindowKeyEventHandler() added");
+    }
+}
+#endif
+
             }
         }
+
+#if NUI_PROPERTY_CHANGE_DEBUG
+private void TestWindowKeyEventHandler(object o, Window.KeyEventArgs e)
+{
+    if(e.Key.State == Key.StateType.Down && e.Key.KeyPressedName == "1")
+    {
+#if NUI_PROPERTY_CHANGE_1
+        Tizen.Log.Fatal("NUITEST", $"### (FIXED) currently used View's properties ###");
+#else
+        Tizen.Log.Fatal("NUITEST", $"### currently used View's properties ###");
+#endif
+        Tizen.Log.Fatal("NUITEST", $"PropertyValueConstructor: {Tizen.NUI.PropertyValue.PropertyValueConstructor}");
+        Tizen.Log.Fatal("NUITEST", $"SizeGetter: {View.SizeGetter}, SizeSetter: {View.SizeSetter}");
+        Tizen.Log.Fatal("NUITEST", $"Size2DGetter: {View.Size2DGetter}, Size2DSetter: {View.Size2DSetter}");
+        Tizen.Log.Fatal("NUITEST", $"SizeWidthGetter: {View.SizeWidthGetter}, SizeWidthSetter: {View.SizeWidthSetter}");
+        Tizen.Log.Fatal("NUITEST", $"SizeHeightGetter: {View.SizeHeightGetter}, SizeHeightSetter: {View.SizeHeightSetter}");
+        Tizen.Log.Fatal("NUITEST", $"PositionGetter: {View.PositionGetter}, PositionSetter: {View.PositionSetter}");
+        Tizen.Log.Fatal("NUITEST", $"Position2DGetter: {View.Position2DGetter}, Position2DSetter: {View.Position2DSetter}");
+        Tizen.Log.Fatal("NUITEST", $"PositionXGetter: {View.PositionXGetter}, PositionXSetter: {View.PositionXSetter}");
+        Tizen.Log.Fatal("NUITEST", $"PositionYGetter: {View.PositionYGetter}, PositionYSetter: {View.PositionYSetter}");
+        Tizen.Log.Fatal("NUITEST", $"PositionZGetter: {View.PositionZGetter}, PositionZSetter: {View.PositionZSetter}");
+        Tizen.Log.Fatal("NUITEST", $"MaximumSizeGetter: {View.MaximumSizeGetter}, MaximumSizeSetter: {View.MaximumSizeSetter}");
+        Tizen.Log.Fatal("NUITEST", $"MinimumSizeGetter: {View.MinimumSizeGetter}, MinimumSizeSetter: {View.MinimumSizeSetter}");
+    }
+}
+#endif
 
         /// <summary>
         /// A helper method to get the current window where the view is added


### PR DESCRIPTION
### Description of Change ###
[NUI] Change property get/set not to use PropertyValue
- this should be merged with https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/281975/
- this is the first patch and it will be continuously changed and modified.
- `NUI_PROPERTY_CHANGE_1` this macro will be deleted after all changes are completed.
- start with View and expand it to ImageView, Text, etc.
- local testing has been done on NikeM2 target.

### API Changes ###
none