### PR TITLE
[NUI] BorderLineThickness should be taken into account when setting MimimumSize and MaximumSize.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -149,13 +149,13 @@ namespace Tizen.NUI
 
                 if (minSize != borderInterface.MinSize)
                 {
-                    using Size2D mimimumSize = new Size2D((borderInterface.MinSize?.Width ?? 0), (borderInterface.MinSize?.Height ?? 0) + (int)borderHeight);
+                    using Size2D mimimumSize = new Size2D((borderInterface.MinSize?.Width + (int)borderInterface.BorderLineThickness * 2 ?? 0), (borderInterface.MinSize?.Height ?? 0) + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMimimumSize(mimimumSize);
                     minSize = borderInterface.MinSize;
                 }
                 if (maxSize != borderInterface.MaxSize)
                 {
-                    using Size2D maximumSize = new Size2D((borderInterface.MaxSize?.Width ?? 0), (borderInterface.MaxSize?.Height ?? 0) + (int)borderHeight);
+                    using Size2D maximumSize = new Size2D((borderInterface.MaxSize?.Width + (int)borderInterface.BorderLineThickness * 2 ?? 0), (borderInterface.MaxSize?.Height ?? 0) + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMaximumSize(maximumSize);
                     maxSize = borderInterface.MaxSize;
                 }
@@ -245,12 +245,12 @@ namespace Tizen.NUI
                 // Sets the minimum / maximum size to be resized by RequestResizeToServer.
                 if (borderInterface.MinSize != null)
                 {
-                    using Size2D mimimumSize = new Size2D(borderInterface.MinSize.Width, borderInterface.MinSize.Height + (int)borderHeight);
+                    using Size2D mimimumSize = new Size2D(borderInterface.MinSize.Width + (int)borderInterface.BorderLineThickness * 2, borderInterface.MinSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMimimumSize(mimimumSize);
                 }
                 if (borderInterface.MaxSize != null)
                 {
-                    using Size2D maximumSize = new Size2D(borderInterface.MaxSize.Width, borderInterface.MaxSize.Height + (int)borderHeight);
+                    using Size2D maximumSize = new Size2D(borderInterface.MaxSize.Width + (int)borderInterface.BorderLineThickness * 2, borderInterface.MaxSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMaximumSize(maximumSize);
                 }
 


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
 BorderLineThickness should be taken into account when setting MimimumSize and MaximumSize.

If BorderLineThickness is not calculated, there will be a problem with window resize when it is reduced by MimimumSize.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
