### PR TITLE
[Camera] Change bool to byte for 64bit union struct marshaling

### DIFF
--- a/src/Tizen.Multimedia.Camera/Camera/EncodedPlane.cs
+++ b/src/Tizen.Multimedia.Camera/Camera/EncodedPlane.cs
@@ -24,10 +24,10 @@ namespace Tizen.Multimedia
     /// <since_tizen> 3 </since_tizen>
     public class EncodedPlane : IPreviewPlane
     {
-        internal EncodedPlane(byte[] data, bool isDeltaFrame, uint usedSize)
+        internal EncodedPlane(byte[] data, byte isDeltaFrame, uint usedSize)
         {
             Data = data;
-            IsDeltaFrame = isDeltaFrame;
+            IsDeltaFrame = isDeltaFrame == 0 ? false : true;
             UsedSize = usedSize;
         }
 

--- a/src/Tizen.Multimedia.Camera/Interop/Interop.Camera.cs
+++ b/src/Tizen.Multimedia.Camera/Interop/Interop.Camera.cs
@@ -268,6 +268,7 @@ internal static partial class Interop
             internal IntPtr Y;
             internal IntPtr U;
             internal IntPtr V;
+
             internal uint YLength;
             internal uint ULength;
             internal uint VLength;
@@ -278,7 +279,7 @@ internal static partial class Interop
         {
             internal IntPtr Data;
             internal uint DataLength;
-            internal bool IsDeltaFrame;
+            internal byte IsDeltaFrame;
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

By default bool in C# is marshaled as if there was BOOL on native side, which has 4 bytes size. 
So, type of EncodedPlaneStruct.IsDeltaFrame should be changed to byte.