### PR TITLE
[NUI] Remove useless PostProcess callback

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -42,16 +42,13 @@ namespace Tizen.NUI
         internal ProcessorController(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
             processorCallback = new ProcessorEventHandler(Process);
-            processorPostCallback = new ProcessorEventHandler(PostProcess);
             Interop.ProcessorController.SetCallback(SwigCPtr, processorCallback);
-            Interop.ProcessorController.SetPostCallback(SwigCPtr, processorPostCallback);
         }
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate void ProcessorEventHandler();
 
         private ProcessorEventHandler processorCallback = null;
-        private ProcessorEventHandler processorPostCallback = null;
 
         public event EventHandler ProcessorOnceEvent;
         public event EventHandler ProcessorEvent;
@@ -75,10 +72,9 @@ namespace Tizen.NUI
             ProcessorOnceEvent = null;
             ProcessorEvent?.Invoke(this, null);
             LayoutProcessorEvent?.Invoke(this, null);
-        }
 
-        public void PostProcess()
-        {
+            // To avoid ImageView's properties mismatched problem,
+            // We need to invoke events now which attached during LayoutProcessor.
             ProcessorOnceEvent?.Invoke(this, null);
             ProcessorOnceEvent = null;
         }
@@ -90,7 +86,6 @@ namespace Tizen.NUI
         protected override void Dispose(DisposeTypes type)
         {
             Interop.ProcessorController.RemoveCallback(SwigCPtr, processorCallback);
-            Interop.ProcessorController.RemovePostCallback(SwigCPtr, processorPostCallback);
             ProcessorOnceEvent = null;
             ProcessorEvent = null;
             LayoutProcessorEvent = null;


### PR DESCRIPTION
Instead of register PostProcess,
We'd better invoke ProcessorOnceEvent one more time after LayoutProcessorEvent finished.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>