### PR TITLE
[NUI] Add DispatchGestureEvents and DispatchParentGestureEvents

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1210,6 +1210,17 @@ namespace Tizen.NUI.BaseComponents
             internalSize2D?.Dispose();
             internalSize2D = null;
 
+            panGestureDetector?.Dispose();
+            panGestureDetector = null;
+            longGestureDetector?.Dispose();
+            longGestureDetector = null;
+            pinchGestureDetector?.Dispose();
+            pinchGestureDetector = null;
+            tapGestureDetector?.Dispose();
+            tapGestureDetector = null;
+            rotationGestureDetector?.Dispose();
+            rotationGestureDetector = null;
+
             if (type == DisposeTypes.Explicit)
             {
                 //Called by User

--- a/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
@@ -217,6 +217,12 @@ namespace Tizen.NUI
                 e.View = Registry.GetManagedBaseHandleFromRefObject(actor) as View;
             }
 
+            // If DispatchGestureEvents is false, no gesture events are dispatched.
+            if (e.View != null && e.View.DispatchGestureEvents == false)
+            {
+                return;
+            }
+
             e.LongPressGesture = Tizen.NUI.LongPressGesture.GetLongPressGestureFromPtr(longPressGesture);
 
             if (detectedEventHandler != null)

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -569,6 +569,12 @@ namespace Tizen.NUI
                     e.View = Registry.GetManagedBaseHandleFromRefObject(actor) as View;
                 }
 
+                // If DispatchGestureEvents is false, no gesture events are dispatched.
+                if (e.View != null && e.View.DispatchGestureEvents == false)
+                {
+                    return;
+                }
+
                 e.PanGesture = Tizen.NUI.PanGesture.GetPanGestureFromPtr(panGesture);
                 detectedEventHandler(this, e);
             }

--- a/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
@@ -142,6 +142,12 @@ namespace Tizen.NUI
                     e.View = Registry.GetManagedBaseHandleFromRefObject(actor) as View;
                 }
 
+                // If DispatchGestureEvents is false, no gesture events are dispatched.
+                if (e.View != null && e.View.DispatchGestureEvents == false)
+                {
+                    return;
+                }
+
                 e.PinchGesture = Tizen.NUI.PinchGesture.GetPinchGestureFromPtr(pinchGesture);
                 //Here we send all data to user event handlers.
                 detectedEventHandler(this, e);

--- a/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
@@ -142,6 +142,12 @@ namespace Tizen.NUI
                     e.View = Registry.GetManagedBaseHandleFromRefObject(actor) as View;
                 }
 
+                // If DispatchGestureEvents is false, no gesture events are dispatched.
+                if (e.View != null && e.View.DispatchGestureEvents == false)
+                {
+                    return;
+                }
+
                 e.RotationGesture = Tizen.NUI.RotationGesture.GetRotationGestureFromPtr(rotationGesture);
                 //Here we send all data to user event handlers.
                 detectedEventHandler(this, e);

--- a/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
@@ -205,6 +205,12 @@ namespace Tizen.NUI
                 e.View = Registry.GetManagedBaseHandleFromRefObject(actor) as View;
             }
 
+            // If DispatchGestureEvents is false, no gesture events are dispatched.
+            if (e.View != null && e.View.DispatchGestureEvents == false)
+            {
+                return;
+            }
+
             e.TapGesture = Tizen.NUI.TapGesture.GetTapGestureFromPtr(tapGesture);
 
             if (_detectedEventHandler != null)

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -450,6 +450,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnLeftTopCornerIconTouched(object sender, View.TouchEventArgs e)
         {
+            SetDispatchParentGestureEvents(sender as View, false);
             if (e != null && e.Touch.GetState(0) == PointStateType.Down)
             {
               ClearWindowGesture();
@@ -468,6 +469,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnRightTopCornerIconTouched(object sender, View.TouchEventArgs e)
         {
+            SetDispatchParentGestureEvents(sender as View, false);
             if (e != null && e.Touch.GetState(0) == PointStateType.Down)
             {
               ClearWindowGesture();
@@ -487,6 +489,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnLeftBottomCornerIconTouched(object sender, View.TouchEventArgs e)
         {
+            SetDispatchParentGestureEvents(sender as View, false);
             if (e != null && e.Touch.GetState(0) == PointStateType.Down)
             {
               ClearWindowGesture();
@@ -505,6 +508,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnRightBottomCornerIconTouched(object sender, View.TouchEventArgs e)
         {
+            SetDispatchParentGestureEvents(sender as View, false);
             if (e != null && e.Touch.GetState(0) == PointStateType.Down)
             {
               ClearWindowGesture();
@@ -535,6 +539,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnMinimizeIconTouched(object sender, View.TouchEventArgs e)
         {
+            SetDispatchParentGestureEvents(sender as View, false);
             if (e != null && e.Touch.GetState(0) == PointStateType.Up)
             {
                 MinimizeBorderWindow();
@@ -565,6 +570,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnMaximizeIconTouched(object sender, View.TouchEventArgs e)
         {
+            SetDispatchParentGestureEvents(sender as View, false);
             if (e != null && e.Touch.GetState(0) == PointStateType.Up)
             {
                 MaximizeBorderWindow();
@@ -587,11 +593,22 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual bool OnCloseIconTouched(object sender, View.TouchEventArgs e)
         {
+            SetDispatchParentGestureEvents(sender as View, false);
             if (e != null && e.Touch.GetState(0) == PointStateType.Up)
             {
                 CloseBorderWindow();
             }
             return true;
+        }
+
+        private void SetDispatchParentGestureEvents(View view, bool dispatch)
+        {
+            if (view != null)
+            {
+                // If this is set, my parents will not receive gesture events.
+                // This is to prevent the move action by PanGesture when the icon is touched.
+                view.DispatchParentGestureEvents = dispatch;
+            }
         }
 
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This determines whether gesture events are emitted or not.

If DispatchGestureEvents is set to false, then itself and parents will not receive all gesture event signals.
If DispatchParentGestureEvents is set to false, then parents will not receive all gesture event signals.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
