### PR TITLE
[Camera] Remove wrong feature tag

### DIFF
--- a/src/Tizen.Multimedia.Camera/Camera/CameraDeviceManager.cs
+++ b/src/Tizen.Multimedia.Camera/Camera/CameraDeviceManager.cs
@@ -29,7 +29,6 @@ namespace Tizen.Multimedia
     /// This supports the product infrastructure and is not intended to be used directly from 3rd party application code.
     /// </remarks>
     /// <since_tizen> 10 </since_tizen>
-    /// <feature> http://tizen.org/feature/camera </feature>
     public class CameraDeviceManager : IDisposable
     {
         private IntPtr _handle;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Remove wrong feature tag.
`CameraDeviceManager` is not related to camera feature directly.