### PR TITLE
[Applications.ThemeManager] Fix return type of theme loader add event callback for internal.

### DIFF
--- a/src/Tizen.Applications.ThemeManager/Interop/Interop.ThemeManager.cs
+++ b/src/Tizen.Applications.ThemeManager/Interop/Interop.ThemeManager.cs
@@ -61,7 +61,7 @@ internal static partial class Interop
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate void ThemeLoaderChangedCallback(IntPtr handle, IntPtr userData);
+        internal delegate int ThemeLoaderChangedCallback(IntPtr handle, IntPtr userData);
 
         [DllImport(Libraries.ThemeManager, EntryPoint = "theme_get_id")]
         internal static extern ErrorCode GetId(IntPtr handle, out string id);

--- a/src/Tizen.Applications.ThemeManager/Tizen.Applications.ThemeManager/ThemeLoader.cs
+++ b/src/Tizen.Applications.ThemeManager/Tizen.Applications.ThemeManager/ThemeLoader.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 namespace Tizen.Applications.ThemeManager
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <since_tizen> 8 </since_tizen>
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -51,10 +51,14 @@ namespace Tizen.Applications.ThemeManager
             }
         }
 
-        private void OnThemeChanged(IntPtr handle, IntPtr userData)
+        private int OnThemeChanged(IntPtr handle, IntPtr userData)
         {
-            Interop.ThemeManager.ThemeClone(handle, out IntPtr cloned);
+            Interop.ThemeManager.ErrorCode err = Interop.ThemeManager.ThemeClone(handle, out IntPtr cloned);
+            if (err != Interop.ThemeManager.ErrorCode.None)
+                return -1;
+
             _changedEventHandler?.Invoke(this, new ThemeEventArgs(new Theme(cloned)));
+            return 0;
         }
 
         /// <summary>


### PR DESCRIPTION
Signed-off-by: Ilho Kim <ilho159.kim@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
change return type of theme loader add event callback from void to int to match with c api.
it's for internal code.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:None
