### PR TITLE
[WebRTC] Disable MediaPacket native handle destroy

### DIFF
--- a/src/Tizen.Multimedia.Remoting/WebRTC/MediaPacketSource.cs
+++ b/src/Tizen.Multimedia.Remoting/WebRTC/MediaPacketSource.cs
@@ -225,6 +225,9 @@ namespace Tizen.Multimedia.Remoting
                 throw new ArgumentException("Audio is not configured with the current source.");
             }
 
+            // MediaPacket native handle will be destroyed internally in native webrtc fw
+            packet.DisableNativeHandleDestroy();
+
             NativeWebRTC.PushMediaPacket(WebRtc.Handle, SourceId.Value, packet.GetHandle()).
                 ThrowIfFailed("Failed to push the packet to the WebRTC");
         }

--- a/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
@@ -572,7 +572,7 @@ namespace Tizen.Multimedia
 
         private bool _isNativeHandleDestroyEnabled = true;
         /// <summary>
-        /// Disable native handle destroy when native fw destroy media packet handle itself.
+        /// Disables native handle destruction when native fw destroys media packet handle itself.
         /// </summary>
         internal void DisableNativeHandleDestroy()
         {

--- a/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
@@ -547,7 +547,11 @@ namespace Tizen.Multimedia
 
             if (_handle != IntPtr.Zero)
             {
-                Native.Unref(_handle);
+                if (_isNativeHandleDestroyEnabled)
+                {
+                    Native.Unref(_handle);
+                }
+
                 _handle = IntPtr.Zero;
             }
 
@@ -564,6 +568,15 @@ namespace Tizen.Multimedia
             {
                 throw new ObjectDisposedException("This packet has already been disposed.");
             }
+        }
+
+        private bool _isNativeHandleDestroyEnabled = true;
+        /// <summary>
+        /// Disable native handle destroy when native fw destroy media packet handle itself.
+        /// </summary>
+        internal void DisableNativeHandleDestroy()
+        {
+            _isNativeHandleDestroyEnabled = false;
         }
         #endregion
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Disable MediaPacket native handle destroy when Native FW destroys native media packet handle.