### PR TITLE
[NUI] Apply dotnet-nui type

### DIFF
--- a/test/NUIDnDSource/tizen-manifest.xml
+++ b/test/NUIDnDSource/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <ui-application appid="org.tizen.example.NUIDnDSource"
 					exec="NUIDnDSource.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/NUIDnDTarget/tizen-manifest.xml
+++ b/test/NUIDnDTarget/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <ui-application appid="org.tizen.example.NUIDnDTarget"
 					exec="NUIDnDTarget.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/NUISettings/NUISettings/tizen-manifest.xml
+++ b/test/NUISettings/NUISettings/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="tv" />
   <ui-application appid="NUISettings" exec="NUISettings.dll" multiple="false" nodisplay="false" taskmanage="true"
                   splash-screen-display="true"
-                  type="dotnet"
+                  type="dotnet-nui"
                   launch_mode="single">
     <label>NUISettings</label>
     <icon>NUISettings.png</icon>

--- a/test/NUISettings/NUISettingsReset/tizen-manifest.xml
+++ b/test/NUISettings/NUISettingsReset/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <widget-application appid="NUISettingsReset"
 					exec="NUISettingsReset.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"
@@ -22,4 +22,3 @@
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />
   </widget-application>
 </manifest>
-

--- a/test/NUITestSample/NUITestSample/tizen-manifest.xml
+++ b/test/NUITestSample/NUITestSample/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <ui-application appid="org.tizen.example.NUITestSample"
 					exec="NUITestSample.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/Tizen.NUI.ComponentApplication/NUIComponentApplication/tizen-manifest.xml
+++ b/test/Tizen.NUI.ComponentApplication/NUIComponentApplication/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <component-based-application  appid="org.tizen.example.NUIComponentApplication"
 					exec="NUIComponentApplication.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/tizen-manifest.xml
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/tizen-manifest.xml
@@ -3,7 +3,7 @@
     <profile name="common" />
     <ui-application appid="Tizen.NUI.Devel.Tests"
                     exec="Tizen.NUI.Devel.Tests.dll"
-                    type="dotnet"
+                    type="dotnet-nui"
                     multiple="false"
                     taskmanage="true"
                     launch_mode="single">

--- a/test/Tizen.NUI.LayoutSamples/Tizen.NUI.LayoutSamples/tizen-manifest.xml
+++ b/test/Tizen.NUI.LayoutSamples/Tizen.NUI.LayoutSamples/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <ui-application appid="org.tizen.example.Tizen.NUI.LayoutSamples"
 					exec="Tizen.NUI.LayoutSamples.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/tizen-manifest.xml
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <ui-application appid="org.tizen.example.Tizen.NUI.Samples"
 					exec="Tizen.NUI.Samples.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/Tizen.NUI.SeamlessSamples/BrokerSample/tizen-manifest.xml
+++ b/test/Tizen.NUI.SeamlessSamples/BrokerSample/tizen-manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.example.BrokerSample" version="1.0.0" api-version="6" xmlns="http://tizen.org/ns/packages">
     <profile name="common" />
-    <ui-application appid="org.tizen.example.BrokerSample" exec="BrokerSample.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+    <ui-application appid="org.tizen.example.BrokerSample" exec="BrokerSample.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet-nui" launch_mode="single">
         <label>BrokerSample</label>
         <icon>BrokerSample.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />

--- a/test/Tizen.NUI.SeamlessSamples/ProviderSample/tizen-manifest.xml
+++ b/test/Tizen.NUI.SeamlessSamples/ProviderSample/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <ui-application appid="org.tizen.example.ProviderSample"
 					exec="ProviderSample.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/tizen-manifest.xml
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Components.Devel.Tests/tizen-manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="Tizen.NUI.Components.Devel.Tests" version="1.0.2" api-version="7" xmlns="http://tizen.org/ns/packages">
     <profile name="common" />
-    <ui-application appid="Tizen.NUI.Components.Devel.Tests" exec="Tizen.NUI.Components.Devel.Tests.dll" multiple="false" taskmanage="true" splash-screen-display="true" type="dotnet" launch_mode="single">
+    <ui-application appid="Tizen.NUI.Components.Devel.Tests" exec="Tizen.NUI.Components.Devel.Tests.dll" multiple="false" taskmanage="true" splash-screen-display="true" type="dotnet-nui" launch_mode="single">
         <icon>Tizen.NUI.Components.Devel.Tests.png</icon>
         <label>Tizen.NUI.Components.Devel.Tests</label>
     </ui-application>

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/tizen-manifest.xml
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/tizen-manifest.xml
@@ -3,7 +3,7 @@
     <profile name="common" />
     <ui-application appid="Tizen.NUI.Devel.Tests"
                     exec="Tizen.NUI.Devel.Tests.dll"
-                    type="dotnet"
+                    type="dotnet-nui"
                     multiple="false"
                     taskmanage="true"
                     launch_mode="single">

--- a/test/Tizen.NUI.UIThread/tizen-manifest.xml
+++ b/test/Tizen.NUI.UIThread/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <ui-application appid="org.tizen.example.Tizen.NUI.UIThread"
 					exec="Tizen.NUI.UIThread.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"

--- a/test/Tizen.NUI.WidgetViewTest/0.Template/Tizen.NUI.WidgetTest/tizen-manifest.xml
+++ b/test/Tizen.NUI.WidgetViewTest/0.Template/Tizen.NUI.WidgetTest/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <widget-application appid="Tizen.NUI.WidgetTest"
 					exec="Tizen.NUI.WidgetTest.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"
@@ -19,4 +19,3 @@
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />
   </widget-application>
 </manifest>
-

--- a/test/Tizen.NUI.WidgetViewTest/0.Template/Tizen.NUI.WidgetViewTest/tizen-manifest.xml
+++ b/test/Tizen.NUI.WidgetViewTest/0.Template/Tizen.NUI.WidgetViewTest/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="tv" />
   <ui-application appid="Tizen.NUI.WidgetViewTest" exec="Tizen.NUI.WidgetViewTest.dll" multiple="false" nodisplay="false" taskmanage="true"
                   splash-screen-display="true"
-                  type="dotnet"
+                  type="dotnet-nui"
                   launch_mode="single">
     <label>Tizen.NUI.WidgetViewTest</label>
     <icon>Tizen.NUI.WidgetViewTest.png</icon>

--- a/test/Tizen.NUI.WidgetViewTest/1.SendInfo/Tizen.NUI.WidgetTest/tizen-manifest.xml
+++ b/test/Tizen.NUI.WidgetViewTest/1.SendInfo/Tizen.NUI.WidgetTest/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="common" />
   <widget-application appid="Tizen.NUI.WidgetTest"
 					exec="Tizen.NUI.WidgetTest.dll"
-					type="dotnet"
+					type="dotnet-nui"
 					multiple="false"
 					taskmanage="true"
 					nodisplay="false"
@@ -19,4 +19,3 @@
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />
   </widget-application>
 </manifest>
-

--- a/test/Tizen.NUI.WidgetViewTest/1.SendInfo/Tizen.NUI.WidgetViewTest/tizen-manifest.xml
+++ b/test/Tizen.NUI.WidgetViewTest/1.SendInfo/Tizen.NUI.WidgetViewTest/tizen-manifest.xml
@@ -3,7 +3,7 @@
   <profile name="tv" />
   <ui-application appid="Tizen.NUI.WidgetViewTest" exec="Tizen.NUI.WidgetViewTest.dll" multiple="false" nodisplay="false" taskmanage="true"
                   splash-screen-display="true"
-                  type="dotnet"
+                  type="dotnet-nui"
                   launch_mode="single">
     <label>Tizen.NUI.WidgetViewTest</label>
     <icon>Tizen.NUI.WidgetViewTest.png</icon>

--- a/test/Tizen.NUI.WindowSystem.Samples/tizen-manifest.xml
+++ b/test/Tizen.NUI.WindowSystem.Samples/tizen-manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.tizen.example.Tizen.NUI.WindowSystem.Samples" version="1.0.0" api-version="5.5" xmlns="http://tizen.org/ns/packages">
     <profile name="common" />
-    <ui-application appid="org.tizen.example.Tizen.NUI.WindowSystem.Samples" exec="Tizen.NUI.WindowSystem.Samples.dll" multiple="false" nodisplay="false" taskmanage="true" api-version="6" type="dotnet" launch_mode="single">
+    <ui-application appid="org.tizen.example.Tizen.NUI.WindowSystem.Samples" exec="Tizen.NUI.WindowSystem.Samples.dll" multiple="false" nodisplay="false" taskmanage="true" api-version="6" type="dotnet-nui" launch_mode="single">
         <label>Tizen.NUI.WindowSystem.Samples</label>
         <icon>Tizen.NUI.WindowSystem.Samples.png</icon>
         <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />


### PR DESCRIPTION
NUI apps have to set dotnet-nui app type in tizen-manifest.xml. Then the apps are preloaded from dotnet-loader.
It improves the launching performance.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
