### PR TITLE
[NUI] Change property get/set not to use PropertyValue (patch set4)

### DIFF
--- a/src/Tizen.NUI/Tizen.NUI.csproj
+++ b/src/Tizen.NUI/Tizen.NUI.csproj
@@ -5,7 +5,7 @@
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <PropertyGroup>
-        <DefineConstants>NUI_DEBUG_OFF;NUI_PROPERTY_CHANGE_1;NUI_PROPERTY_CHANGE_2;</DefineConstants>
+        <DefineConstants>NUI_DEBUG_OFF;NUI_PROPERTY_CHANGE_1;NUI_PROPERTY_CHANGE_2;NUI_PROPERTY_CHANGE_3;</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
         <TizenPreloadFile Include="Tizen.NUI.preload"

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorInternal.cs
@@ -15,6 +15,7 @@
  *
  */
 
+using global::System.Runtime.InteropServices;
 namespace Tizen.NUI
 {
     internal static partial class Interop
@@ -241,6 +242,24 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_DevelActor_Property_GetTouchAreaOffset")]
             public static extern void GetTouchAreaOffset(global::System.Runtime.InteropServices.HandleRef jarg1, out int jarg2, out int jarg3, out int jarg4, out int jarg5);
+
+#if NUI_PROPERTY_CHANGE_3
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveTargetSize")]
+            public static extern int RetrieveTargetSize(HandleRef actor, HandleRef retrievingVector3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector3")]
+            public static extern int RetrieveCurrentPropertyVector3(HandleRef actor, int propertyType, HandleRef retrievingVector3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector2ActualVector3")]
+            public static extern int RetrieveCurrentPropertyVector2ActualVector3(HandleRef actor, int propertyType, HandleRef retrievingVector2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveNaturalSize")]
+            public static extern int RetrieveNaturalSize(HandleRef actor, HandleRef retrievingVector3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_RetrieveCurrentPropertyVector4")]
+            public static extern int RetrieveCurrentPropertyVector4(HandleRef actor, int propertyType, HandleRef retrievingVector4);
+#endif
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -83,6 +83,20 @@ namespace Tizen.NUI.BaseComponents
         private bool dispatchGestureEvents = true;
         private bool dispatchParentGestureEvents = true;
 
+#if NUI_PROPERTY_CHANGE_3
+        private Vector3 internalCurrentParentOrigin = null;
+        private Vector3 internalCurrentAnchorPoint = null;
+        private Vector3 internalTargetSize = null;
+        private Size2D internalCurrentSize = null;
+        private Vector3 internalNaturalSize = null;
+        private Position internalCurrentPosition = null;
+        private Vector3 internalCurrentWorldPosition = null;
+        private Vector3 internalCurrentScale = null;
+        private Vector3 internalCurrentWorldScale = null;
+        private Vector4 internalCurrentColor = null;
+        private Vector4 internalCurrentWorldColor = null;
+#endif
+
 #if NUI_PROPERTY_CHANGE_DEBUG
 internal static int LayoutSetGetter = 0;
 internal static int SizeGetter = 0;
@@ -213,6 +227,51 @@ internal static int AccessibilityHighlightableGetter = 0;
 internal static int AccessibilityHiddenGetter = 0;
 internal static int AutomationIdGetter = 0;
 
+#if NUI_PROPERTY_CHANGE_3
+internal static int WorldPositionXGetter = 0;
+internal static int WorldPositionYGetter = 0;
+internal static int WorldPositionZGetter = 0;
+internal static int ParentOriginXGetter = 0;
+internal static int ParentOriginXSetter = 0;
+internal static int ParentOriginYGetter = 0;
+internal static int ParentOriginYSetter = 0;
+internal static int ParentOriginZGetter = 0;
+internal static int ParentOriginZSetter = 0;
+internal static int PivotPointXGetter = 0;
+internal static int PivotPointXSetter = 0;
+internal static int PivotPointYGetter = 0;
+internal static int PivotPointYSetter = 0;
+internal static int PivotPointZGetter = 0;
+internal static int PivotPointZSetter = 0;
+internal static int LeftFocusableViewIdGetter = 0;
+internal static int LeftFocusableViewIdSetter = 0;
+internal static int RightFocusableViewIdGetter = 0;
+internal static int RightFocusableViewIdSetter = 0;
+internal static int UpFocusableViewIdGetter = 0;
+internal static int UpFocusableViewIdSetter = 0;
+internal static int DownFocusableViewIdGetter = 0;
+internal static int DownFocusableViewIdSetter = 0;
+internal static int ClockwiseFocusableViewIdGetter = 0;
+internal static int ClockwiseFocusableViewIdSetter = 0;
+internal static int CounterClockwiseFocusableViewIdGetter = 0;
+internal static int CounterClockwiseFocusableViewIdSetter = 0;
+
+internal static int GetCurrentParentOriginCnt = 0;
+internal static int GetCurrentAnchorPointCnt = 0;
+internal static int GetTargetSizeCnt = 0;
+internal static int GetCurrentSizeCnt = 0;
+internal static int GetCurrentSizeFloatCnt = 0;
+internal static int GetNaturalSizeCnt = 0;
+internal static int GetCurrentPositionCnt = 0;
+internal static int GetCurrentWorldPositionCnt = 0;
+internal static int GetCurrentScaleCnt = 0;
+internal static int GetCurrentWorldScaleCnt = 0;
+internal static int GetCurrentColorCnt = 0;
+internal static int GetCurrentWorldColorCnt = 0;
+internal static int GetSizeModeFactorCnt = 0;
+internal static int GetMinimumSizeCnt = 0;
+internal static int GetMaximumSizeCnt = 0;
+#endif
 
 #endif
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -18,6 +18,7 @@
 using System;
 using System.ComponentModel;
 using global::System.Diagnostics;
+using Tizen.NUI;
 
 namespace Tizen.NUI.BaseComponents
 {
@@ -127,11 +128,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+WorldPositionXGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionX);
+#else
                 float returnValue = 0.0f;
                 PropertyValue wordPositionX = GetProperty(View.Property.WorldPositionX);
                 wordPositionX?.Get(out returnValue);
                 wordPositionX?.Dispose();
                 return returnValue;
+#endif                
             }
         }
 
@@ -139,11 +147,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+WorldPositionYGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionY);
+#else
                 float returnValue = 0.0f;
                 PropertyValue wordPositionY = GetProperty(View.Property.WorldPositionY);
                 wordPositionY?.Get(out returnValue);
                 wordPositionY?.Dispose();
                 return returnValue;
+#endif
             }
         }
 
@@ -151,11 +166,18 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+WorldPositionZGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionZ);
+#else
                 float returnValue = 0.0f;
                 PropertyValue wordPositionZ = GetProperty(View.Property.WorldPositionZ);
                 wordPositionZ?.Get(out returnValue);
                 wordPositionZ?.Dispose();
                 return returnValue;
+#endif
             }
         }
 
@@ -195,17 +217,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ParentOriginXGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginX);
+#else
                 float returnValue = 0.0f;
                 PropertyValue parentOriginX = GetProperty(View.Property.ParentOriginX);
                 parentOriginX?.Get(out returnValue);
                 parentOriginX?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ParentOriginXSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.WorldPositionX, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.ParentOriginX, setValue);
                 setValue.Dispose();
+#endif
                 NotifyPropertyChanged();
             }
         }
@@ -214,17 +250,32 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ParentOriginYGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginY);
+#else
                 float returnValue = 0.0f;
                 PropertyValue parentOriginY = GetProperty(View.Property.ParentOriginY);
                 parentOriginY?.Get(out returnValue);
                 parentOriginY?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ParentOriginYSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.ParentOriginY, value);
+#else
+
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.ParentOriginY, setValue);
                 setValue.Dispose();
+#endif
                 NotifyPropertyChanged();
             }
         }
@@ -233,17 +284,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ParentOriginZGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginZ);
+#else
                 float returnValue = 0.0f;
                 PropertyValue parentOriginZ = GetProperty(View.Property.ParentOriginZ);
                 parentOriginZ?.Get(out returnValue);
                 parentOriginZ?.Dispose();
                 return returnValue;
+#endif            
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ParentOriginZSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.ParentOriginZ, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.ParentOriginZ, setValue);
                 setValue.Dispose();
+#endif
                 NotifyPropertyChanged();
             }
         }
@@ -252,17 +317,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PivotPointXGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointX);
+#else
                 float returnValue = 0.0f;
                 PropertyValue anchorPointX = GetProperty(View.Property.AnchorPointX);
                 anchorPointX?.Get(out returnValue);
                 anchorPointX?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PivotPointXSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointX, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.AnchorPointX, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -270,17 +349,32 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PivotPointYGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointY);
+#else
+
                 float returnValue = 0.0f;
                 PropertyValue anchorPointY = GetProperty(View.Property.AnchorPointY);
                 anchorPointY?.Get(out returnValue);
                 anchorPointY?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PivotPointYSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointY, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.AnchorPointY, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -288,17 +382,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PivotPointZGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointZ);
+#else
                 float returnValue = 0.0f;
                 PropertyValue anchorPointZ = GetProperty(View.Property.AnchorPointZ);
                 anchorPointZ?.Get(out returnValue);
                 anchorPointZ?.Dispose();
                 return returnValue;
+#endif            
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+PivotPointZSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointZ, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.AnchorPointZ, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -362,17 +470,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+LeftFocusableViewIdGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.LeftFocusableViewId);
+#else
                 int returnValue = 0;
                 PropertyValue leftFocusableViewId = GetProperty(View.Property.LeftFocusableViewId);
                 leftFocusableViewId?.Get(out returnValue);
                 leftFocusableViewId?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+LeftFocusableViewIdSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.LeftFocusableViewId, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.LeftFocusableViewId, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -380,17 +502,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+RightFocusableViewIdGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.RightFocusableViewId);
+#else
                 int returnValue = 0;
                 PropertyValue rightFocusableViewId = GetProperty(View.Property.RightFocusableViewId);
                 rightFocusableViewId?.Get(out returnValue);
                 rightFocusableViewId?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+RightFocusableViewIdSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.RightFocusableViewId, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.RightFocusableViewId, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -398,17 +534,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+UpFocusableViewIdGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.UpFocusableViewId);
+#else
                 int returnValue = 0;
                 PropertyValue upFocusableViewId = GetProperty(View.Property.UpFocusableViewId);
                 upFocusableViewId?.Get(out returnValue);
                 upFocusableViewId?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+UpFocusableViewIdSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.UpFocusableViewId, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.UpFocusableViewId, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -416,17 +566,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+DownFocusableViewIdGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.DownFocusableViewId);
+#else
                 int returnValue = 0;
                 PropertyValue downFocusableViewId = GetProperty(View.Property.DownFocusableViewId);
                 downFocusableViewId?.Get(out returnValue);
                 downFocusableViewId?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+DownFocusableViewIdSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.DownFocusableViewId, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.DownFocusableViewId, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -434,17 +598,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ClockwiseFocusableViewIdGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.ClockwiseFocusableViewId);
+#else
                 int returnValue = -1;
                 PropertyValue clockwiseFocusableViewId = GetProperty(View.Property.ClockwiseFocusableViewId);
                 clockwiseFocusableViewId?.Get(out returnValue);
                 clockwiseFocusableViewId?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+ClockwiseFocusableViewIdSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.ClockwiseFocusableViewId, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.ClockwiseFocusableViewId, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -452,17 +630,31 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+CounterClockwiseFocusableViewIdGetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.CounterClockwiseFocusableViewId);
+#else
                 int returnValue = -1;
                 PropertyValue counterClockwiseFocusableViewId = GetProperty(View.Property.CounterClockwiseFocusableViewId);
                 counterClockwiseFocusableViewId?.Get(out returnValue);
                 counterClockwiseFocusableViewId?.Dispose();
                 return returnValue;
+#endif
             }
             set
             {
+#if NUI_PROPERTY_CHANGE_DEBUG
+CounterClockwiseFocusableViewIdSetter++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.CounterClockwiseFocusableViewId, value);
+#else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.CounterClockwiseFocusableViewId, setValue);
                 setValue.Dispose();
+#endif
             }
         }
 
@@ -527,10 +719,29 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector3 GetCurrentParentOrigin()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentParentOriginCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentParentOrigin == null)
+            {
+                internalCurrentParentOrigin = new Vector3(0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.ParentOrigin, internalCurrentParentOrigin.SwigCPtr);
+            
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentParentOrigin;
+#else
             Vector3 ret = new Vector3(Interop.ActorInternal.GetCurrentParentOrigin(SwigCPtr), true);
+
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif            
         }
 
         internal void SetAnchorPoint(Vector3 anchorPoint)
@@ -542,10 +753,28 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector3 GetCurrentAnchorPoint()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentAnchorPointCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentAnchorPoint == null)
+            {
+                internalCurrentAnchorPoint = new Vector3(0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.AnchorPoint, internalCurrentAnchorPoint.SwigCPtr);
+            
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentAnchorPoint;
+#else
             Vector3 ret = new Vector3(Interop.ActorInternal.GetCurrentAnchorPoint(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif            
         }
 
         internal void SetSize(float width, float height)
@@ -578,24 +807,63 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector3 GetTargetSize()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetTargetSizeCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalTargetSize == null)
+            {
+                internalTargetSize = new Vector3(0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveTargetSize(SwigCPtr, internalTargetSize.SwigCPtr);
+            
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalTargetSize;
+#else
             Vector3 ret = new Vector3(Interop.ActorInternal.GetTargetSize(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
 
         internal Size2D GetCurrentSize()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentSizeCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentSize == null)
+            {
+                internalCurrentSize = new Size2D(0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector2ActualVector3(SwigCPtr, Property.SIZE, internalCurrentSize.SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentSize;
+#else
             Size ret = new Size(Interop.Actor.GetCurrentSize(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             Size2D size = new Size2D((int)ret.Width, (int)ret.Height);
             ret.Dispose();
             return size;
+#endif
         }
 
         internal Size2D GetCurrentSizeFloat()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentSizeFloatCnt++;
+#endif
             Size ret = new Size(Interop.Actor.GetCurrentSize(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -608,6 +876,10 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         internal virtual Vector3 GetNaturalSize()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetNaturalSizeCnt++;
+#endif
+
             Vector3 ret = new Vector3(Interop.Actor.GetNaturalSize(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -644,18 +916,55 @@ namespace Tizen.NUI.BaseComponents
 
         internal Position GetCurrentPosition()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentPositionCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentPosition == null)
+            {
+                internalCurrentPosition = new Position(0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, Property.POSITION, internalCurrentPosition.SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentPosition;
+#else
+
             Position ret = new Position(Interop.Actor.GetCurrentPosition(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
 
         internal Vector3 GetCurrentWorldPosition()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentWorldPositionCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentWorldPosition == null)
+            {
+                internalCurrentWorldPosition = new Vector3(0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.WorldPosition, internalCurrentWorldPosition.SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentWorldPosition;
+#else
             Vector3 ret = new Vector3(Interop.ActorInternal.GetCurrentWorldPosition(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
 
         internal void SetInheritPosition(bool inherit)
@@ -748,18 +1057,56 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector3 GetCurrentScale()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentScaleCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentScale == null)
+            {
+                internalCurrentScale = new Vector3(0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.SCALE, internalCurrentScale.SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentScale;
+#else
+
             Vector3 ret = new Vector3(Interop.ActorInternal.GetCurrentScale(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif        
         }
 
         internal Vector3 GetCurrentWorldScale()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentWorldScaleCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentWorldScale == null)
+            {
+                internalCurrentWorldScale = new Vector3(0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.WorldScale, internalCurrentWorldScale.SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentWorldScale;
+#else
+
             Vector3 ret = new Vector3(Interop.ActorInternal.GetCurrentWorldScale(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
 
         internal void SetInheritScale(bool inherit)
@@ -824,10 +1171,29 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector4 GetCurrentColor()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentColorCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentColor == null)
+            {
+                internalCurrentColor = new Vector4(0, 0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector4(SwigCPtr, Interop.ActorProperty.ColorGet(), internalCurrentColor.SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentColor;
+#else
+
             Vector4 ret = new Vector4(Interop.ActorInternal.GetCurrentColor(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
         internal ColorMode GetColorMode()
         {
@@ -839,10 +1205,29 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector4 GetCurrentWorldColor()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetCurrentWorldColorCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_3
+            if(internalCurrentWorldColor == null)
+            {
+                internalCurrentWorldColor = new Vector4(0, 0, 0, 0);
+            }
+            
+            Interop.ActorInternal.RetrieveCurrentPropertyVector4(SwigCPtr, Property.WorldColor, internalCurrentWorldColor.SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+            {
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return internalCurrentWorldColor;
+#else
+
             Vector4 ret = new Vector4(Interop.ActorInternal.GetCurrentWorldColor(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif            
         }
 
         internal void SetDrawMode(DrawModeType drawMode)
@@ -922,10 +1307,23 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector3 GetSizeModeFactor()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetSizeModeFactorCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_1
+                if (internalSizeModeFactor == null)
+                {
+                    internalSizeModeFactor = new Vector3(OnSizeModeFactorChanged, 0, 0, 0);
+                }
+                Interop.Actor.InternalRetrievingPropertyVector3(SwigCPtr, View.Property.SizeModeFactor, internalSizeModeFactor.SwigCPtr);
+                return internalSizeModeFactor;
+#else
+
             Vector3 ret = new Vector3(Interop.Actor.GetSizeModeFactor(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
 
         internal void SetMinimumSize(Vector2 size)
@@ -937,10 +1335,22 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector2 GetMinimumSize()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetMinimumSizeCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_1
+            if (internalMinimumSize == null)
+            {
+                internalMinimumSize = new Size2D(OnMinimumSizeChanged, 0, 0);
+            }
+            Interop.Actor.InternalRetrievingPropertyVector2(SwigCPtr, View.Property.MinimumSize, internalMinimumSize.SwigCPtr);
+            return internalMinimumSize;
+#else
             Vector2 ret = new Vector2(Interop.ActorInternal.GetMinimumSize(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
 
         internal void SetMaximumSize(Vector2 size)
@@ -952,10 +1362,23 @@ namespace Tizen.NUI.BaseComponents
 
         internal Vector2 GetMaximumSize()
         {
+#if NUI_PROPERTY_CHANGE_DEBUG
+GetMaximumSizeCnt++;
+#endif
+#if NUI_PROPERTY_CHANGE_1
+            if (internalMaximumSize == null)
+            {
+                internalMaximumSize = new Size2D(OnMaximumSizeChanged, 0, 0);
+            }
+            Interop.Actor.InternalRetrievingPropertyVector2(SwigCPtr, View.Property.MaximumSize, internalMaximumSize.SwigCPtr);
+            return internalMaximumSize;
+#else
+
             Vector2 ret = new Vector2(Interop.ActorInternal.GetMaximumSize(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+#endif
         }
 
         internal int GetHierarchyDepth()
@@ -1225,6 +1648,33 @@ namespace Tizen.NUI.BaseComponents
             tapGestureDetector = null;
             rotationGestureDetector?.Dispose();
             rotationGestureDetector = null;
+
+#if NUI_PROPERTY_CHANGE_3
+            internalCurrentParentOrigin?.Dispose();
+            internalCurrentParentOrigin = null;
+            internalCurrentAnchorPoint?.Dispose();
+            internalCurrentAnchorPoint = null;
+            internalTargetSize?.Dispose();
+            internalTargetSize = null;
+            internalCurrentSize?.Dispose();
+            internalCurrentSize = null;
+            internalNaturalSize?.Dispose();
+            internalNaturalSize = null;
+            internalCurrentPosition?.Dispose();
+            internalCurrentPosition = null;
+            internalCurrentWorldPosition?.Dispose();
+            internalCurrentWorldPosition = null;
+            internalCurrentScale?.Dispose();
+            internalCurrentScale = null;
+            internalCurrentWorldScale?.Dispose();
+            internalCurrentWorldScale = null;
+            internalCurrentColor?.Dispose();
+            internalCurrentColor = null;
+            internalCurrentWorldColor?.Dispose();
+            internalCurrentWorldColor = null;
+            internalSizeModeFactor?.Dispose();
+            internalSizeModeFactor = null;
+#endif
 
             if (type == DisposeTypes.Explicit)
             {

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -165,7 +165,31 @@ private void TestWindowKeyEventHandler(object o, Window.KeyEventArgs e)
         Tizen.Log.Fatal("NUITEST", $"TextGetter: {TextLabel.TextGetter}, TextSetter: {TextLabel.TextSetter}");
         Tizen.Log.Fatal("NUITEST", $"FontFamilyGetter: {TextLabel.FontFamilyGetter}, FontFamilySetter: {TextLabel.FontFamilySetter}");
         Tizen.Log.Fatal("NUITEST", $"PointSizeGetter: {TextLabel.PointSizeGetter}");
-
+#if NUI_PROPERTY_CHANGE_3
+        Tizen.Log.Fatal("NUITEST", $"View internal properties =>");
+        Tizen.Log.Fatal("NUITEST", $"WorldPositionXGetter: {View.WorldPositionXGetter}, WorldPositionYGetter: {View.WorldPositionYGetter}, WorldPositionZGetter: {View.WorldPositionZGetter}");
+        Tizen.Log.Fatal("NUITEST", $"ParentOriginXGetter: {View.ParentOriginXGetter} ParentOriginXSetter: {View.ParentOriginXSetter}");
+        Tizen.Log.Fatal("NUITEST", $"ParentOriginYGetter: {View.ParentOriginYGetter} ParentOriginYSetter: {View.ParentOriginYSetter}");
+        Tizen.Log.Fatal("NUITEST", $"ParentOriginZGetter: {View.ParentOriginZGetter} ParentOriginZSetter: {View.ParentOriginZSetter}");
+        Tizen.Log.Fatal("NUITEST", $"PivotPointXGetter: {View.PivotPointXGetter} PivotPointXSetter: {View.PivotPointXSetter}");
+        Tizen.Log.Fatal("NUITEST", $"PivotPointYGetter: {View.PivotPointYGetter} PivotPointXSetter: {View.PivotPointYSetter}");
+        Tizen.Log.Fatal("NUITEST", $"PivotPointZGetter: {View.PivotPointZGetter} PivotPointXSetter: {View.PivotPointZSetter}");
+        Tizen.Log.Fatal("NUITEST", $"LeftFocusableViewIdGetter: {View.LeftFocusableViewIdGetter} LeftFocusableViewIdSetter: {View.LeftFocusableViewIdSetter}");
+        Tizen.Log.Fatal("NUITEST", $"RightFocusableViewIdGetter: {View.RightFocusableViewIdGetter} RightFocusableViewIdSetter: {View.RightFocusableViewIdSetter}");
+        Tizen.Log.Fatal("NUITEST", $"UpFocusableViewIdGetter: {View.UpFocusableViewIdGetter} UpFocusableViewIdSetter: {View.UpFocusableViewIdSetter}");
+        Tizen.Log.Fatal("NUITEST", $"DownFocusableViewIdGetter: {View.DownFocusableViewIdGetter} DownFocusableViewIdSetter: {View.DownFocusableViewIdSetter}");
+        Tizen.Log.Fatal("NUITEST", $"ClockwiseFocusableViewIdGetter: {View.ClockwiseFocusableViewIdGetter} ClockwiseFocusableViewIdSetter: {View.ClockwiseFocusableViewIdSetter}");
+        Tizen.Log.Fatal("NUITEST", $"CounterClockwiseFocusableViewIdGetter: {View.CounterClockwiseFocusableViewIdGetter} CounterClockwiseFocusableViewIdSetter: {View.CounterClockwiseFocusableViewIdSetter}");        
+        Tizen.Log.Fatal("NUITEST", $"View internal method =>");
+        Tizen.Log.Fatal("NUITEST", $"GetCurrentParentOriginCnt: {View.GetCurrentParentOriginCnt} GetCurrentAnchorPointCnt: {View.GetCurrentAnchorPointCnt}");        
+        Tizen.Log.Fatal("NUITEST", $"GetTargetSizeCnt: {View.GetTargetSizeCnt} GetCurrentSizeCnt: {View.GetCurrentSizeCnt}");        
+        Tizen.Log.Fatal("NUITEST", $"GetCurrentSizeFloatCnt: {View.GetCurrentSizeFloatCnt} GetNaturalSizeCnt: {View.GetNaturalSizeCnt}");        
+        Tizen.Log.Fatal("NUITEST", $"GetCurrentPositionCnt: {View.GetCurrentPositionCnt} GetCurrentWorldPositionCnt: {View.GetCurrentWorldPositionCnt}");
+        Tizen.Log.Fatal("NUITEST", $"GetCurrentScaleCnt: {View.GetCurrentScaleCnt} GetCurrentWorldScaleCnt: {View.GetCurrentWorldScaleCnt}");
+        Tizen.Log.Fatal("NUITEST", $"GetCurrentColorCnt: {View.GetCurrentColorCnt} GetCurrentWorldColorCnt: {View.GetCurrentWorldColorCnt}");
+        Tizen.Log.Fatal("NUITEST", $"GetSizeModeFactorCnt: {View.GetSizeModeFactorCnt} GetMinimumSizeCnt: {View.GetMinimumSizeCnt}");
+        Tizen.Log.Fatal("NUITEST", $"GetMaximumSizeCnt: {View.GetMaximumSizeCnt}");
+#endif
     }
 }
 #endif
@@ -186,7 +210,7 @@ private void TestWindowKeyEventHandler(object o, Window.KeyEventArgs e)
 
             //to fix memory leak issue, match the handle count with native side.
             Window ret = view.GetInstanceSafely<Window>(Interop.Window.Get(View.getCPtr(view)));
-            if (NDalicPINVOKE.SWIGPendingException.Pending)throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
@@ -1531,7 +1555,7 @@ private void TestWindowKeyEventHandler(object o, Window.KeyEventArgs e)
         {
             if (isBorderWindow)
             {
-                if(borderLayer == null)
+                if (borderLayer == null)
                 {
                     borderLayer = GetBorderWindowRootLayer();
                     LayersChildren?.Add(borderLayer);


### PR DESCRIPTION
### Description of Change ###
[NUI] Change property get/set not to use PropertyValue (patch set4)
- this should be merged with https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/282909/
- NUI_PROPERTY_CHANGE_X this macro will be deleted after all changes are completed.
- local testing has been done on NikeM2 target.

### API Changes ###
none