### PR TITLE
[NUI] Fix Linear Layouter crash and update issue

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -197,7 +197,7 @@ namespace Tizen.NUI.Components
                                             width + itemMargin.Start + itemMargin.End:
                                             height + itemMargin.Top + itemMargin.Bottom;
                         groupFooterMargin = new Extents(itemMargin);
-                    
+
                         colView.UnrealizeItem(groupFooter);
                     }
                 }
@@ -378,7 +378,7 @@ namespace Tizen.NUI.Components
 
             //Console.WriteLine("[NUI] itemsView [{0},{1}] [{2},{3}]", colView.Size.Width, colView.Size.Height, colView.ContentContainer.Size.Width, colView.ContentContainer.Size.Height);
 
-            // 1. Set First/Last Visible Item Index. 
+            // 1. Set First/Last Visible Item Index.
             (int start, int end) = FindVisibleItems(visibleArea);
             FirstVisible = start;
             LastVisible = end;
@@ -889,7 +889,7 @@ namespace Tizen.NUI.Components
                 {
                     currentSize = StepCandidate;
                 }
-                
+
             }
 
             ScrollContentSize -= currentSize;
@@ -1053,7 +1053,7 @@ namespace Tizen.NUI.Components
             float offset = 0F;
             (topInScreenIndex, offset) = FindTopItemInScreen();
             */
-            
+
             // Move can only happen in it's own groups.
             // so there will be no changes in position, startIndex in ohter groups.
             // check visible item and update indexs.
@@ -1155,7 +1155,7 @@ namespace Tizen.NUI.Components
 
                 int startGroup = (diff > 0? fromParentIndex: toParentIndex);
                 int endGroup =  (diff > 0? toParentIndex: fromParentIndex);
-                
+
                 for (int i = startGroup; i <= endGroup; i++)
                 {
                     if (i == toParentIndex) continue;
@@ -1501,7 +1501,7 @@ namespace Tizen.NUI.Components
         }
 
         internal override (float Width, float Height) GetItemSize(int index)
-        {            
+        {
             return (sizeCandidate.Width - CandidateMargin.Start - CandidateMargin.End,
                     sizeCandidate.Height - CandidateMargin.Top - CandidateMargin.Bottom);
         }
@@ -1519,6 +1519,7 @@ namespace Tizen.NUI.Components
                 RequestLayout(scrollPosition, force);
                 return false;
             });
+            requestLayoutTimer.Start();
         }
 
         private RecyclerViewItem GetVisibleItem(int index)

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -190,7 +190,7 @@ namespace Tizen.NUI.Components
                         groupFooterSize = IsHorizontal?
                                             width + itemMargin.Start + itemMargin.End:
                                             height + itemMargin.Top + itemMargin.Bottom;
-                        groupFooterMargin = new Extents(itemMargin);  
+                        groupFooterMargin = new Extents(itemMargin);
                         colView.UnrealizeItem(groupFooter);
                     }
                 }
@@ -202,12 +202,14 @@ namespace Tizen.NUI.Components
             else isGrouped = false;
 
             bool failed = false;
+
             //Final Check of FirstIndex
             while (colView.InternalItemSource.IsHeader(firstIndex) ||
                     colView.InternalItemSource.IsGroupHeader(firstIndex) ||
                     colView.InternalItemSource.IsGroupFooter(firstIndex))
             {
-                if (colView.InternalItemSource.IsFooter(firstIndex))
+                if (colView.InternalItemSource.IsFooter(firstIndex)
+                    || ((colView.InternalItemSource.Count - 1) <= firstIndex))
                 {
                     StepCandidate = 0F;
                     failed = true;
@@ -245,7 +247,7 @@ namespace Tizen.NUI.Components
                 StepCandidate = IsHorizontal?
                                 width + itemMargin.Start + itemMargin.End:
                                 height + itemMargin.Top + itemMargin.Bottom;
-                CandidateMargin = new Extents(itemMargin);  
+                CandidateMargin = new Extents(itemMargin);
                 if (StepCandidate == 0) StepCandidate = 1; //????
 
                 colView.UnrealizeItem(sizeDeligate);
@@ -388,7 +390,7 @@ namespace Tizen.NUI.Components
                 PrevScrollPosition + (IsHorizontal? colView.Size.Width : colView.Size.Height)
             );
 
-            // 1. Set First/Last Visible Item Index. 
+            // 1. Set First/Last Visible Item Index.
             (int start, int end) = FindVisibleItems(visibleArea);
             FirstVisible = start;
             LastVisible = end;
@@ -571,7 +573,7 @@ namespace Tizen.NUI.Components
             float offset = 0F;
             (topInScreenIndex, offset) = FindTopItemInScreen();
             */
-        
+
             // 1. Handle MeasureAll
             /*
             if (colView.SizingStrategy == ItemSizingStrategy.MeasureAll)
@@ -1133,7 +1135,7 @@ namespace Tizen.NUI.Components
                 //Need To Implement
             }
             */
-            
+
             // Move can only happen in it's own groups.
             // so there will be no changes in position, startIndex in ohter groups.
             // check visible item and update indexs.
@@ -1235,7 +1237,7 @@ namespace Tizen.NUI.Components
 
                 int startGroup = (diff > 0? fromParentIndex: toParentIndex);
                 int endGroup =  (diff > 0? toParentIndex: fromParentIndex);
-                
+
                 for (int i = startGroup; i <= endGroup; i++)
                 {
                     if (i == toParentIndex) continue;
@@ -1594,7 +1596,7 @@ namespace Tizen.NUI.Components
                         - CandidateMargin.Start - CandidateMargin.End,
                         (IsHorizontal? (int)colView.Size.Height - Padding.Top - Padding.Bottom: (int)StepCandidate)
                         - CandidateMargin.Top - CandidateMargin.Bottom);
-            }            
+            }
         }
 
         private void DelayedRequestLayout(float scrollPosition , bool force = true)
@@ -1611,6 +1613,7 @@ namespace Tizen.NUI.Components
                 RequestLayout(scrollPosition, force);
                 return false;
             });
+            requestLayoutTimer.Start();
         }
 
         /*
@@ -1653,7 +1656,7 @@ namespace Tizen.NUI.Components
                     return groupFooterSize;
                 else
                     return StepCandidate;
-            }            
+            }
         }
 
         private void UpdatePosition(int index)


### PR DESCRIPTION
i### Description of Change ###
<!-- Describe your changes here. -->
1. Linear Layouter get crashed when group has no children.
2. Linear, Grid Layouter update is not working well because delayed
update timer is not started.
3. remove spaces.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
