### PR TITLE
[NUI] Add null checking in internalSet/GetPropertyXXX()

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -144,7 +144,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     // Else, we don't need to re-create view. Get value from current ImageView.
 #if NUI_PROPERTY_CHANGE_2
-                    Interop.Actor.InternalSetPropertyBool(imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha, (bool)newValue);
+                    Object.InternalSetPropertyBool(imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha, (bool)newValue);
 #else
                     Tizen.NUI.Object.SetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif                    
@@ -165,7 +165,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 // Else, PremultipliedAlpha may not setuped in cached property. Get value from current ImageView.
 #if NUI_PROPERTY_CHANGE_2
-                temp = Interop.Actor.InternalGetPropertyBool(imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha);
+                temp = Object.InternalGetPropertyBool(imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha);
 #else
                 Tizen.NUI.Object.GetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha).Get(out temp);
 #endif                
@@ -181,7 +181,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(imageView.SwigCPtr, ImageView.Property.PixelArea, ((RelativeVector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(imageView.SwigCPtr, ImageView.Property.PixelArea, ((RelativeVector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((HandleRef)imageView.SwigCPtr, ImageView.Property.PixelArea, new Tizen.NUI.PropertyValue((RelativeVector4)newValue));
 #endif
@@ -195,7 +195,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 imageView.internalPixelArea = new RelativeVector4(imageView.OnPixelAreaChanged, 0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(imageView.SwigCPtr, ImageView.Property.PixelArea, imageView.internalPixelArea.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(imageView.SwigCPtr, ImageView.Property.PixelArea, imageView.internalPixelArea.SwigCPtr);
             return imageView.internalPixelArea;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.isSettingTextInCSharp = true;
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.TEXT, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.TEXT, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.TEXT, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -46,7 +46,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.TEXT);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.TEXT);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.TEXT).Get(out temp);
@@ -61,7 +61,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.TextColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.TextColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.TextColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -75,7 +75,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.internalTextColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.TextColor, textEditor.internalTextColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.TextColor, textEditor.internalTextColor.SwigCPtr);
             return textEditor.internalTextColor;
 #else
 
@@ -92,7 +92,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.FontFamily, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.FontFamily, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.FontFamily, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -102,7 +102,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.FontFamily);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.FontFamily);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.FontFamily).Get(out temp);
@@ -134,7 +134,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PointSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PointSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PointSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -144,7 +144,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PointSize);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PointSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PointSize).Get(out temp);
@@ -159,7 +159,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.HorizontalAlignment, (int)newValue);
+                Object.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.HorizontalAlignment, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.HorizontalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -170,7 +170,7 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             string temp;
 #if NUI_PROPERTY_CHANGE_2
-            temp = Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.HorizontalAlignment);
+            temp = Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.HorizontalAlignment);
 #else
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.HorizontalAlignment).Get(out temp) == false)
             {
@@ -186,7 +186,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment, (int)newValue);
+                Object.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -197,7 +197,7 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             string temp;
 #if NUI_PROPERTY_CHANGE_2
-            temp = Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment);
+            temp = Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment);
 #else
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment).Get(out temp) == false)
             {
@@ -214,7 +214,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollThreshold, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollThreshold, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollThreshold, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -224,7 +224,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollThreshold);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollThreshold);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollThreshold).Get(out temp);
@@ -239,7 +239,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollSpeed, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollSpeed, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollSpeed, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -249,7 +249,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollSpeed);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollSpeed);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollSpeed).Get(out temp);
@@ -264,7 +264,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PrimaryCursorColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PrimaryCursorColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PrimaryCursorColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -278,7 +278,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.internalPrimaryCursorColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PrimaryCursorColor, textEditor.internalPrimaryCursorColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PrimaryCursorColor, textEditor.internalPrimaryCursorColor.SwigCPtr);
             return textEditor.internalPrimaryCursorColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -294,7 +294,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SecondaryCursorColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SecondaryCursorColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SecondaryCursorColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif            
@@ -308,7 +308,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.internalSecondaryCursorColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SecondaryCursorColor, textEditor.internalSecondaryCursorColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SecondaryCursorColor, textEditor.internalSecondaryCursorColor.SwigCPtr);
             return textEditor.internalSecondaryCursorColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -324,7 +324,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableCursorBlink, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableCursorBlink, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableCursorBlink, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -334,7 +334,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableCursorBlink);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableCursorBlink);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableCursorBlink).Get(out temp);
@@ -349,7 +349,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkInterval, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkInterval, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CursorBlinkInterval, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -359,7 +359,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkInterval);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkInterval);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CursorBlinkInterval).Get(out temp);
@@ -374,7 +374,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkDuration, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkDuration, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CursorBlinkDuration, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -384,7 +384,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkDuration);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkDuration);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CursorBlinkDuration).Get(out temp);
@@ -399,7 +399,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.CursorWidth, (int)newValue);
+                Object.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.CursorWidth, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CursorWidth, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -409,7 +409,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.CursorWidth);
+            return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.CursorWidth);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CursorWidth).Get(out temp);
@@ -424,7 +424,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandleImage, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandleImage, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.GrabHandleImage, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -434,7 +434,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandleImage);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandleImage);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.GrabHandleImage).Get(out temp);
@@ -449,7 +449,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandlePressedImage, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandlePressedImage, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.GrabHandlePressedImage, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -459,7 +459,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandlePressedImage);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandlePressedImage);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.GrabHandlePressedImage).Get(out temp);
@@ -594,7 +594,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SelectionHighlightColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SelectionHighlightColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionHighlightColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -608,7 +608,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.internalSelectionHighlightColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SelectionHighlightColor, textEditor.internalSelectionHighlightColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SelectionHighlightColor, textEditor.internalSelectionHighlightColor.SwigCPtr);
             return textEditor.internalSelectionHighlightColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -641,7 +641,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableMarkup, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableMarkup, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableMarkup, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -651,7 +651,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableMarkup);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableMarkup);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableMarkup).Get(out temp);
@@ -666,7 +666,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.InputColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.InputColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -680,7 +680,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.internalInputColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.InputColor, textEditor.internalInputColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.InputColor, textEditor.internalInputColor.SwigCPtr);
             return textEditor.internalInputColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -696,7 +696,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputFontFamily, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputFontFamily, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputFontFamily, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -706,7 +706,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputFontFamily);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputFontFamily);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputFontFamily).Get(out temp);
@@ -738,7 +738,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputPointSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputPointSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputPointSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -748,7 +748,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputPointSize);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputPointSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputPointSize).Get(out temp);
@@ -763,7 +763,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.LineSpacing, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.LineSpacing, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.LineSpacing, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -773,7 +773,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.LineSpacing);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.LineSpacing);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.LineSpacing).Get(out temp);
@@ -788,7 +788,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -798,7 +798,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing).Get(out temp);
@@ -812,7 +812,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -822,7 +822,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight).Get(out temp);
@@ -854,7 +854,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputUnderline, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputUnderline, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputUnderline, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -864,7 +864,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputUnderline);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputUnderline);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputUnderline).Get(out temp);
@@ -897,7 +897,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputShadow, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputShadow, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputShadow, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -907,7 +907,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputShadow);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputShadow);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputShadow).Get(out temp);
@@ -922,7 +922,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.EMBOSS, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.EMBOSS, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EMBOSS, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -932,7 +932,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.EMBOSS);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.EMBOSS);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EMBOSS).Get(out temp);
@@ -947,7 +947,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputEmboss, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputEmboss, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputEmboss, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -957,7 +957,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputEmboss);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputEmboss);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputEmboss).Get(out temp);
@@ -989,7 +989,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputOutline, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputOutline, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputOutline, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -999,7 +999,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputOutline);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputOutline);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputOutline).Get(out temp);
@@ -1014,7 +1014,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.SmoothScroll, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.SmoothScroll, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SmoothScroll, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1024,7 +1024,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.SmoothScroll);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.SmoothScroll);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SmoothScroll).Get(out temp);
@@ -1039,7 +1039,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.SmoothScrollDuration, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.SmoothScrollDuration, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SmoothScrollDuration, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1049,7 +1049,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.SmoothScrollDuration);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.SmoothScrollDuration);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SmoothScrollDuration).Get(out temp);
@@ -1064,7 +1064,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableScrollBar, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableScrollBar, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableScrollBar, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1074,7 +1074,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableScrollBar);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableScrollBar);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableScrollBar).Get(out temp);
@@ -1089,7 +1089,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarShowDuration, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarShowDuration, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollBarShowDuration, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1099,7 +1099,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarShowDuration);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarShowDuration);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollBarShowDuration).Get(out temp);
@@ -1114,7 +1114,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarFadeDuration, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarFadeDuration, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollBarFadeDuration, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1124,7 +1124,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarFadeDuration);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarFadeDuration);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ScrollBarFadeDuration).Get(out temp);
@@ -1139,7 +1139,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PixelSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PixelSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PixelSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1149,7 +1149,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PixelSize);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PixelSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PixelSize).Get(out temp);
@@ -1164,7 +1164,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.PlaceholderText, (string)newValue);
+                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.PlaceholderText, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PlaceholderText, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -1174,7 +1174,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.PlaceholderText);
+            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.PlaceholderText);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PlaceholderText).Get(out temp);
@@ -1189,7 +1189,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PlaceholderTextColor, ((Color)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PlaceholderTextColor, ((Color)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PlaceholderTextColor, new Tizen.NUI.PropertyValue((Color)newValue));
 #endif
@@ -1203,7 +1203,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.internalPlaceholderTextColor = new Color(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PlaceholderTextColor, textEditor.internalPlaceholderTextColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PlaceholderTextColor, textEditor.internalPlaceholderTextColor.SwigCPtr);
             return textEditor.internalPlaceholderTextColor;
 #else
             Color temp = new Color(0.0f, 0.0f, 0.0f, 0.0f);
@@ -1219,7 +1219,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableSelection, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableSelection, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableSelection, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1229,7 +1229,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableSelection);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableSelection);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableSelection).Get(out temp);
@@ -1261,7 +1261,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.LineWrapMode, (int)newValue);
+                Object.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.LineWrapMode, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.LineWrapMode, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -1271,7 +1271,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.LineWrapMode);
+            return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.LineWrapMode);
 #else
             int temp;
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.LineWrapMode).Get(out temp) == false)
@@ -1289,7 +1289,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableShiftSelection, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableShiftSelection, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableShiftSelection, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1300,7 +1300,7 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             //textEditor.mShiftSelectionFlag(true);
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableShiftSelection);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableShiftSelection);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableShiftSelection).Get(out temp);
@@ -1315,7 +1315,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.MatchSystemLanguageDirection, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.MatchSystemLanguageDirection, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.MatchSystemLanguageDirection, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1325,7 +1325,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.MatchSystemLanguageDirection);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.MatchSystemLanguageDirection);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.MatchSystemLanguageDirection).Get(out temp);
@@ -1340,7 +1340,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.MaxLength, (int)newValue);
+                Object.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.MaxLength, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.MaxLength, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -1350,7 +1350,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.MaxLength);
+            return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.MaxLength);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.MaxLength).Get(out temp);
@@ -1365,7 +1365,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.FontSizeScale, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.FontSizeScale, (float)newValue);
 #else
                 using (var property = new Tizen.NUI.PropertyValue((float)newValue))
                 {
@@ -1378,7 +1378,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.FontSizeScale);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.FontSizeScale);
 #else
             float temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.FontSizeScale).Get(out temp);
@@ -1393,7 +1393,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableFontSizeScale, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableFontSizeScale, (bool)newValue);
 #else
                 using (var property = new Tizen.NUI.PropertyValue((bool)newValue))
                 {
@@ -1406,7 +1406,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableFontSizeScale);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableFontSizeScale);
 #else
             bool temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableFontSizeScale).Get(out temp);
@@ -1422,7 +1422,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.GrabHandleColor, ((Color)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.GrabHandleColor, ((Color)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.GrabHandleColor, new Tizen.NUI.PropertyValue((Color)newValue));
 #endif
@@ -1436,7 +1436,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textEditor.internalGrabHandleColor = new Color(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.GrabHandleColor, textEditor.internalGrabHandleColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.GrabHandleColor, textEditor.internalGrabHandleColor.SwigCPtr);
             return textEditor.internalGrabHandleColor;
 #else
             Color temp = new Color(0.0f, 0.0f, 0.0f, 0.0f);
@@ -1452,7 +1452,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandle, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandle, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandle, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1462,7 +1462,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandle);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandle);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandle).Get(out temp);
@@ -1477,7 +1477,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandlePopup, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandlePopup, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandlePopup, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1487,7 +1487,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandlePopup);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandlePopup);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandlePopup).Get(out temp);
@@ -1519,7 +1519,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS, (bool)newValue);
+                Object.InternalSetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1529,7 +1529,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS);
+            return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS).Get(out temp);
@@ -1544,7 +1544,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition, (int)newValue);
+                Object.InternalSetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -1554,7 +1554,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition);
+            return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition).Get(out temp);
@@ -1570,7 +1570,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.MinLineSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.MinLineSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.MinLineSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1580,7 +1580,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.MinLineSize);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.MinLineSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.MinLineSize).Get(out temp);
@@ -1704,7 +1704,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CharacterSpacing, (float)newValue);
+                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CharacterSpacing, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CharacterSpacing, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1714,7 +1714,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CharacterSpacing);
+            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CharacterSpacing);
 #else
             float temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.CharacterSpacing).Get(out temp);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -86,7 +86,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.isSettingTextInCSharp = true;
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.TEXT, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.TEXT, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.TEXT, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -97,7 +97,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.TEXT);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.TEXT);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.TEXT).Get(out temp);
@@ -112,7 +112,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderText, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderText, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PlaceholderText, new Tizen.NUI.PropertyValue((string)newValue));
 #endif            
@@ -122,7 +122,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderText);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderText);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PlaceholderText).Get(out temp);
@@ -137,7 +137,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderTextFocused, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderTextFocused, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PlaceholderTextFocused, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -147,7 +147,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderTextFocused);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderTextFocused);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PlaceholderTextFocused).Get(out temp);
@@ -162,7 +162,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.FontFamily, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.FontFamily, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.FontFamily, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -172,7 +172,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.FontFamily);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.FontFamily);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.FontFamily).Get(out temp);
@@ -205,7 +205,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.PointSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.PointSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PointSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -215,7 +215,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.PointSize);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.PointSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PointSize).Get(out temp);
@@ -230,7 +230,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.MaxLength, (int)newValue);
+                Object.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.MaxLength, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.MaxLength, new Tizen.NUI.PropertyValue((int)newValue));
 #endif            
@@ -240,7 +240,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.MaxLength);
+            return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.MaxLength);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.MaxLength).Get(out temp);
@@ -255,7 +255,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.ExceedPolicy, (int)newValue);
+                Object.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.ExceedPolicy, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ExceedPolicy, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -265,7 +265,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.ExceedPolicy);
+            return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.ExceedPolicy);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ExceedPolicy).Get(out temp);
@@ -280,7 +280,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.HorizontalAlignment, (int)newValue);
+                Object.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.HorizontalAlignment, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.HorizontalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
 #endif            
@@ -291,7 +291,7 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             string temp;
 #if NUI_PROPERTY_CHANGE_2
-            temp = Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.HorizontalAlignment);
+            temp = Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.HorizontalAlignment);
 #else
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.HorizontalAlignment).Get(out temp) == false)
             {
@@ -308,7 +308,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.VerticalAlignment, (int)newValue);
+                Object.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.VerticalAlignment, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.VerticalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -319,7 +319,7 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             string temp;
 #if NUI_PROPERTY_CHANGE_2
-            temp = Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.VerticalAlignment);
+            temp = Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.VerticalAlignment);
 #else
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.VerticalAlignment).Get(out temp) == false)
             {
@@ -336,7 +336,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.TextColor, ((Color)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.TextColor, ((Color)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.TextColor, new Tizen.NUI.PropertyValue((Color)newValue));
 #endif
@@ -350,7 +350,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.internalTextColor = new Color(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.TextColor, textField.internalTextColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.TextColor, textField.internalTextColor.SwigCPtr);
             return textField.internalTextColor;
 
 #else
@@ -367,7 +367,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.PlaceholderTextColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.PlaceholderTextColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PlaceholderTextColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -381,7 +381,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.internalPlaceholderTextColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.PlaceholderTextColor, textField.internalPlaceholderTextColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.PlaceholderTextColor, textField.internalPlaceholderTextColor.SwigCPtr);
             return textField.internalPlaceholderTextColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -397,7 +397,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandle, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandle, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableGrabHandle, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -407,7 +407,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandle);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandle);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableGrabHandle).Get(out temp);
@@ -422,7 +422,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandlePopup, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandlePopup, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableGrabHandlePopup, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -432,7 +432,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandlePopup);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandlePopup);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableGrabHandlePopup).Get(out temp);
@@ -447,7 +447,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.PrimaryCursorColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.PrimaryCursorColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PrimaryCursorColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -461,7 +461,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.internalPrimaryCursorColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.PrimaryCursorColor, textField.internalPrimaryCursorColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.PrimaryCursorColor, textField.internalPrimaryCursorColor.SwigCPtr);
             return textField.internalPrimaryCursorColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -477,7 +477,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.SecondaryCursorColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.SecondaryCursorColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SecondaryCursorColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -491,7 +491,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.internalSecondaryCursorColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.SecondaryCursorColor, textField.internalSecondaryCursorColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.SecondaryCursorColor, textField.internalSecondaryCursorColor.SwigCPtr);
             return textField.internalSecondaryCursorColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -507,7 +507,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableCursorBlink, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableCursorBlink, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableCursorBlink, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -517,7 +517,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableCursorBlink);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableCursorBlink);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableCursorBlink).Get(out temp);
@@ -532,7 +532,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkInterval, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkInterval, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CursorBlinkInterval, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -542,7 +542,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkInterval);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkInterval);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CursorBlinkInterval).Get(out temp);
@@ -557,7 +557,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkDuration, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkDuration, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CursorBlinkDuration, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -567,7 +567,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkDuration);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkDuration);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CursorBlinkDuration).Get(out temp);
@@ -582,7 +582,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.CursorWidth, (int)newValue);
+                Object.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.CursorWidth, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CursorWidth, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -592,7 +592,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.CursorWidth);
+            return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.CursorWidth);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CursorWidth).Get(out temp);
@@ -607,7 +607,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandleImage, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandleImage, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.GrabHandleImage, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -617,7 +617,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandleImage);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandleImage);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.GrabHandleImage).Get(out temp);
@@ -632,7 +632,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandlePressedImage, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandlePressedImage, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.GrabHandlePressedImage, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -642,7 +642,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandlePressedImage);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandlePressedImage);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.GrabHandlePressedImage).Get(out temp);
@@ -657,7 +657,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollThreshold, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollThreshold, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ScrollThreshold, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -667,7 +667,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollThreshold);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollThreshold);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ScrollThreshold).Get(out temp);
@@ -682,7 +682,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollSpeed, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollSpeed, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ScrollSpeed, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -692,7 +692,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollSpeed);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollSpeed);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ScrollSpeed).Get(out temp);
@@ -827,7 +827,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.SelectionHighlightColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.SelectionHighlightColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionHighlightColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -841,7 +841,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.internalSelectionHighlightColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.SelectionHighlightColor, textField.internalSelectionHighlightColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.SelectionHighlightColor, textField.internalSelectionHighlightColor.SwigCPtr);
             return textField.internalSelectionHighlightColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -891,7 +891,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.InputColor, ((Vector4)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.InputColor, ((Vector4)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputColor, new Tizen.NUI.PropertyValue((Vector4)newValue));
 #endif
@@ -905,7 +905,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.internalInputColor = new Vector4(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.InputColor, textField.internalInputColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.InputColor, textField.internalInputColor.SwigCPtr);
             return textField.internalInputColor;
 #else
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
@@ -921,7 +921,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableMarkup, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableMarkup, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableMarkup, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -931,7 +931,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableMarkup);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableMarkup);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableMarkup).Get(out temp);
@@ -946,7 +946,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputFontFamily, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputFontFamily, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputFontFamily, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -956,7 +956,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputFontFamily);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputFontFamily);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputFontFamily).Get(out temp);
@@ -988,7 +988,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.InputPointSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.InputPointSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputPointSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -998,7 +998,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.InputPointSize);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.InputPointSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputPointSize).Get(out temp);
@@ -1030,7 +1030,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputUnderline, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputUnderline, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputUnderline, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -1040,7 +1040,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputUnderline);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputUnderline);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputUnderline).Get(out temp);
@@ -1073,7 +1073,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputShadow, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputShadow, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputShadow, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -1083,7 +1083,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputShadow);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputShadow);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputShadow).Get(out temp);
@@ -1098,7 +1098,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.EMBOSS, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.EMBOSS, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EMBOSS, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -1108,7 +1108,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.EMBOSS);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.EMBOSS);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EMBOSS).Get(out temp);
@@ -1123,7 +1123,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputEmboss, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputEmboss, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputEmboss, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -1133,7 +1133,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputEmboss);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputEmboss);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputEmboss).Get(out temp);
@@ -1165,7 +1165,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputOutline, (string)newValue);
+                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.InputOutline, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputOutline, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -1175,7 +1175,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputOutline);
+            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputOutline);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputOutline).Get(out temp);
@@ -1207,7 +1207,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.PixelSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.PixelSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PixelSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1217,7 +1217,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.PixelSize);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.PixelSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PixelSize).Get(out temp);
@@ -1232,7 +1232,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableSelection, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableSelection, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableSelection, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1242,7 +1242,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableSelection);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableSelection);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableSelection).Get(out temp);
@@ -1274,7 +1274,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.ELLIPSIS, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.ELLIPSIS, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ELLIPSIS, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1284,7 +1284,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.ELLIPSIS);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.ELLIPSIS);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.ELLIPSIS).Get(out temp);
@@ -1299,7 +1299,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.EllipsisPosition, (int)newValue);
+                Object.InternalSetPropertyInt(textField.SwigCPtr, TextField.Property.EllipsisPosition, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisPosition, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -1309,7 +1309,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.EllipsisPosition);
+            return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.EllipsisPosition);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EllipsisPosition).Get(out temp);
@@ -1324,7 +1324,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableShiftSelection, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableShiftSelection, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableShiftSelection, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1334,7 +1334,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableShiftSelection);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableShiftSelection);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableShiftSelection).Get(out temp);
@@ -1349,7 +1349,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.MatchSystemLanguageDirection, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.MatchSystemLanguageDirection, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.MatchSystemLanguageDirection, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -1359,7 +1359,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.MatchSystemLanguageDirection);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.MatchSystemLanguageDirection);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.MatchSystemLanguageDirection).Get(out temp);
@@ -1374,7 +1374,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.FontSizeScale, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.FontSizeScale, (float)newValue);
 #else
                 using (var property = new Tizen.NUI.PropertyValue((float)newValue))
                 {
@@ -1387,7 +1387,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.FontSizeScale);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.FontSizeScale);
 #else
             float temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.FontSizeScale).Get(out temp);
@@ -1402,7 +1402,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableFontSizeScale, (bool)newValue);
+                Object.InternalSetPropertyBool(textField.SwigCPtr, TextField.Property.EnableFontSizeScale, (bool)newValue);
 #else
                 using (var property = new Tizen.NUI.PropertyValue((bool)newValue))
                 {
@@ -1415,7 +1415,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableFontSizeScale);
+            return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableFontSizeScale);
 #else
             bool temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.EnableFontSizeScale).Get(out temp);
@@ -1431,7 +1431,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.GrabHandleColor, ((Color)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textField.SwigCPtr, TextField.Property.GrabHandleColor, ((Color)newValue).SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.GrabHandleColor, new Tizen.NUI.PropertyValue((Color)newValue));
 #endif
@@ -1445,7 +1445,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textField.internalGrabHandleColor = new Color(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.GrabHandleColor, textField.internalGrabHandleColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.GrabHandleColor, textField.internalGrabHandleColor.SwigCPtr);
             return textField.internalGrabHandleColor;
 #else
             Color temp = new Color(0.0f, 0.0f, 0.0f, 0.0f);
@@ -1533,7 +1533,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.CharacterSpacing, (float)newValue);
+                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.CharacterSpacing, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CharacterSpacing, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -1543,7 +1543,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CharacterSpacing);
+            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CharacterSpacing);
 #else
             float temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.CharacterSpacing).Get(out temp);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -71,7 +71,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.TEXT);
+            return Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.TEXT);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.TEXT).Get(out temp);
@@ -98,7 +98,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.FontFamily);
+            return Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.FontFamily);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.FontFamily).Get(out temp);
@@ -143,7 +143,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.PointSize);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.PointSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.PointSize).Get(out temp);
@@ -158,7 +158,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MultiLine, (bool)newValue);
+                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MultiLine, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.MultiLine, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -169,7 +169,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MultiLine);
+            return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MultiLine);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.MultiLine).Get(out temp);
@@ -184,7 +184,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -195,7 +195,7 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             string temp;
 #if NUI_PROPERTY_CHANGE_2
-            temp = Interop.Actor.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment);
+            temp = Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment);
 #else
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment).Get(out temp) == false)
             {
@@ -228,7 +228,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -239,7 +239,7 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             string temp;
 #if NUI_PROPERTY_CHANGE_2
-            temp = Interop.Actor.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment);
+            temp = Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment);
 #else
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment).Get(out temp) == false)
             {
@@ -288,7 +288,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 textLabel.internalTextColor = new Color(0, 0, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.TextColor, textLabel.internalTextColor.SwigCPtr);
+            Object.InternalRetrievingPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.TextColor, textLabel.internalTextColor.SwigCPtr);
             return textLabel.internalTextColor;
 #else
             Color temp = new Color(0.0f, 0.0f, 0.0f, 0.0f);
@@ -305,7 +305,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableMarkup, (bool)newValue);
+                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableMarkup, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EnableMarkup, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -315,7 +315,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableMarkup);
+            return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableMarkup);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EnableMarkup).Get(out temp);
@@ -330,7 +330,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll, (bool)newValue);
+                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -340,7 +340,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll);
+            return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll).Get(out temp);
@@ -355,7 +355,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -365,7 +365,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed);
+            return Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed).Get(out temp);
@@ -380,7 +380,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -390,7 +390,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount);
+            return Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount).Get(out temp);
@@ -405,7 +405,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -415,7 +415,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap).Get(out temp);
@@ -430,7 +430,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.LineSpacing, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.LineSpacing, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.LineSpacing, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -441,7 +441,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.LineSpacing);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.LineSpacing);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.LineSpacing).Get(out temp);
@@ -455,7 +455,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -465,7 +465,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight).Get(out temp);
@@ -538,7 +538,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(textLabel.SwigCPtr, TextLabel.Property.EMBOSS, (string)newValue);
+                Object.InternalSetPropertyString(textLabel.SwigCPtr, TextLabel.Property.EMBOSS, (string)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EMBOSS, new Tizen.NUI.PropertyValue((string)newValue));
 #endif
@@ -548,7 +548,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.EMBOSS);
+            return Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.EMBOSS);
 #else
             string temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EMBOSS).Get(out temp);
@@ -592,7 +592,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.PixelSize);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.PixelSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.PixelSize).Get(out temp);
@@ -607,7 +607,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS, (bool)newValue);
+                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -617,7 +617,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS);
+            return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS).Get(out temp);
@@ -632,7 +632,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -642,7 +642,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return (EllipsisPosition)Interop.Actor.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition);
+            return (EllipsisPosition)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition).Get(out temp);
@@ -657,7 +657,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -667,7 +667,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay).Get(out temp);
@@ -682,7 +682,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -693,7 +693,7 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             string temp;
 #if NUI_PROPERTY_CHANGE_2
-            temp = Interop.Actor.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode);
+            temp = Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode);
 #else
             if (Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode).Get(out temp) == false)
             {
@@ -710,7 +710,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.LineWrapMode, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.LineWrapMode, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.LineWrapMode, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -720,7 +720,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return (LineWrapMode)Interop.Actor.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.LineWrapMode);
+            return (LineWrapMode)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.LineWrapMode);
 #else
             int temp;
             if (false == Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.LineWrapMode).Get(out temp))
@@ -738,7 +738,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment, (int)newValue);
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment, (int)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment, new Tizen.NUI.PropertyValue((int)newValue));
 #endif
@@ -748,7 +748,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return (VerticalLineAlignment)Interop.Actor.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment);
+            return (VerticalLineAlignment)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment);
 #else
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment).Get(out temp);
@@ -763,7 +763,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection, (bool)newValue);
+                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection, (bool)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection, new Tizen.NUI.PropertyValue((bool)newValue));
 #endif
@@ -773,7 +773,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection);
+            return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection);
 #else
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection).Get(out temp);
@@ -788,7 +788,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -798,7 +798,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing);
 #else
             float temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing).Get(out temp);
@@ -831,7 +831,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.MinLineSize, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.MinLineSize, (float)newValue);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.MinLineSize, new Tizen.NUI.PropertyValue((float)newValue));
 #endif
@@ -842,7 +842,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.MinLineSize);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.MinLineSize);
 #else
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.MinLineSize).Get(out temp);
@@ -857,7 +857,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.FontSizeScale, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.FontSizeScale, (float)newValue);
                 textLabel.RequestLayout();
 #else
                 using (var property = new Tizen.NUI.PropertyValue((float)newValue))
@@ -872,7 +872,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.FontSizeScale);
+            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.FontSizeScale);
 #else
             float temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.FontSizeScale).Get(out temp);
@@ -887,7 +887,7 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale, (bool)newValue);
+                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale, (bool)newValue);
                 textLabel.RequestLayout();
 #else
                 using (var property = new Tizen.NUI.PropertyValue((bool)newValue))
@@ -902,7 +902,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 #if NUI_PROPERTY_CHANGE_2
-            return Interop.Actor.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale);
+            return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale);
 #else
             bool temp;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale).Get(out temp);
@@ -1118,7 +1118,7 @@ namespace Tizen.NUI.BaseComponents
             if (value != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(SwigCPtr, TextLabel.Property.TEXT, value);
+                Object.InternalSetPropertyString(SwigCPtr, TextLabel.Property.TEXT, value);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, TextLabel.Property.TEXT, new Tizen.NUI.PropertyValue(value));
 #endif
@@ -1131,7 +1131,7 @@ namespace Tizen.NUI.BaseComponents
             if (value != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyString(SwigCPtr, TextLabel.Property.FontFamily, value);
+                Object.InternalSetPropertyString(SwigCPtr, TextLabel.Property.FontFamily, value);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, TextLabel.Property.FontFamily, new Tizen.NUI.PropertyValue(value));
 #endif
@@ -1144,7 +1144,7 @@ namespace Tizen.NUI.BaseComponents
             if (value != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyVector4(SwigCPtr, TextLabel.Property.TextColor, value.SwigCPtr);
+                Object.InternalSetPropertyVector4(SwigCPtr, TextLabel.Property.TextColor, value.SwigCPtr);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, TextLabel.Property.TextColor, new Tizen.NUI.PropertyValue(value));
 #endif
@@ -1156,7 +1156,7 @@ namespace Tizen.NUI.BaseComponents
             if (value != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, TextLabel.Property.PointSize, (float)value);
+                Object.InternalSetPropertyFloat(SwigCPtr, TextLabel.Property.PointSize, (float)value);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, TextLabel.Property.PointSize, new Tizen.NUI.PropertyValue((float)value));
 #endif
@@ -1169,7 +1169,7 @@ namespace Tizen.NUI.BaseComponents
             if (value != null)
             {
 #if NUI_PROPERTY_CHANGE_2
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, TextLabel.Property.PixelSize, (float)value);
+                Object.InternalSetPropertyFloat(SwigCPtr, TextLabel.Property.PixelSize, (float)value);
 #else
                 Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, TextLabel.Property.PixelSize, new Tizen.NUI.PropertyValue((float)value));
 #endif

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -132,7 +132,7 @@ namespace Tizen.NUI.BaseComponents
 WorldPositionXGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionX);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionX);
 #else
                 float returnValue = 0.0f;
                 PropertyValue wordPositionX = GetProperty(View.Property.WorldPositionX);
@@ -151,7 +151,7 @@ WorldPositionXGetter++;
 WorldPositionYGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionY);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionY);
 #else
                 float returnValue = 0.0f;
                 PropertyValue wordPositionY = GetProperty(View.Property.WorldPositionY);
@@ -170,7 +170,7 @@ WorldPositionYGetter++;
 WorldPositionZGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionZ);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.WorldPositionZ);
 #else
                 float returnValue = 0.0f;
                 PropertyValue wordPositionZ = GetProperty(View.Property.WorldPositionZ);
@@ -221,7 +221,7 @@ WorldPositionZGetter++;
 ParentOriginXGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginX);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginX);
 #else
                 float returnValue = 0.0f;
                 PropertyValue parentOriginX = GetProperty(View.Property.ParentOriginX);
@@ -236,7 +236,7 @@ ParentOriginXGetter++;
 ParentOriginXSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.WorldPositionX, value);
+                Object.InternalSetPropertyFloat(SwigCPtr, View.Property.WorldPositionX, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.ParentOriginX, setValue);
@@ -254,7 +254,7 @@ ParentOriginXSetter++;
 ParentOriginYGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginY);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginY);
 #else
                 float returnValue = 0.0f;
                 PropertyValue parentOriginY = GetProperty(View.Property.ParentOriginY);
@@ -269,7 +269,7 @@ ParentOriginYGetter++;
 ParentOriginYSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.ParentOriginY, value);
+                Object.InternalSetPropertyFloat(SwigCPtr, View.Property.ParentOriginY, value);
 #else
 
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
@@ -288,7 +288,7 @@ ParentOriginYSetter++;
 ParentOriginZGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginZ);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.ParentOriginZ);
 #else
                 float returnValue = 0.0f;
                 PropertyValue parentOriginZ = GetProperty(View.Property.ParentOriginZ);
@@ -303,7 +303,7 @@ ParentOriginZGetter++;
 ParentOriginZSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.ParentOriginZ, value);
+                Object.InternalSetPropertyFloat(SwigCPtr, View.Property.ParentOriginZ, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.ParentOriginZ, setValue);
@@ -321,7 +321,7 @@ ParentOriginZSetter++;
 PivotPointXGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointX);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointX);
 #else
                 float returnValue = 0.0f;
                 PropertyValue anchorPointX = GetProperty(View.Property.AnchorPointX);
@@ -336,7 +336,7 @@ PivotPointXGetter++;
 PivotPointXSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointX, value);
+                Object.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointX, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.AnchorPointX, setValue);
@@ -353,7 +353,7 @@ PivotPointXSetter++;
 PivotPointYGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointY);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointY);
 #else
 
                 float returnValue = 0.0f;
@@ -369,7 +369,7 @@ PivotPointYGetter++;
 PivotPointYSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointY, value);
+                Object.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointY, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.AnchorPointY, setValue);
@@ -386,7 +386,7 @@ PivotPointYSetter++;
 PivotPointZGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointZ);
+                return Object.InternalGetPropertyFloat(SwigCPtr, View.Property.AnchorPointZ);
 #else
                 float returnValue = 0.0f;
                 PropertyValue anchorPointZ = GetProperty(View.Property.AnchorPointZ);
@@ -401,7 +401,7 @@ PivotPointZGetter++;
 PivotPointZSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointZ, value);
+                Object.InternalSetPropertyFloat(SwigCPtr, View.Property.AnchorPointZ, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.AnchorPointZ, setValue);
@@ -474,7 +474,7 @@ PivotPointZSetter++;
 LeftFocusableViewIdGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.LeftFocusableViewId);
+                return Object.InternalGetPropertyInt(SwigCPtr, View.Property.LeftFocusableViewId);
 #else
                 int returnValue = 0;
                 PropertyValue leftFocusableViewId = GetProperty(View.Property.LeftFocusableViewId);
@@ -489,7 +489,7 @@ LeftFocusableViewIdGetter++;
 LeftFocusableViewIdSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.LeftFocusableViewId, value);
+                Object.InternalSetPropertyInt(SwigCPtr, View.Property.LeftFocusableViewId, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.LeftFocusableViewId, setValue);
@@ -506,7 +506,7 @@ LeftFocusableViewIdSetter++;
 RightFocusableViewIdGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.RightFocusableViewId);
+                return Object.InternalGetPropertyInt(SwigCPtr, View.Property.RightFocusableViewId);
 #else
                 int returnValue = 0;
                 PropertyValue rightFocusableViewId = GetProperty(View.Property.RightFocusableViewId);
@@ -521,7 +521,7 @@ RightFocusableViewIdGetter++;
 RightFocusableViewIdSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.RightFocusableViewId, value);
+                Object.InternalSetPropertyInt(SwigCPtr, View.Property.RightFocusableViewId, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.RightFocusableViewId, setValue);
@@ -538,7 +538,7 @@ RightFocusableViewIdSetter++;
 UpFocusableViewIdGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.UpFocusableViewId);
+                return Object.InternalGetPropertyInt(SwigCPtr, View.Property.UpFocusableViewId);
 #else
                 int returnValue = 0;
                 PropertyValue upFocusableViewId = GetProperty(View.Property.UpFocusableViewId);
@@ -553,7 +553,7 @@ UpFocusableViewIdGetter++;
 UpFocusableViewIdSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.UpFocusableViewId, value);
+                Object.InternalSetPropertyInt(SwigCPtr, View.Property.UpFocusableViewId, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.UpFocusableViewId, setValue);
@@ -570,7 +570,7 @@ UpFocusableViewIdSetter++;
 DownFocusableViewIdGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.DownFocusableViewId);
+                return Object.InternalGetPropertyInt(SwigCPtr, View.Property.DownFocusableViewId);
 #else
                 int returnValue = 0;
                 PropertyValue downFocusableViewId = GetProperty(View.Property.DownFocusableViewId);
@@ -585,7 +585,7 @@ DownFocusableViewIdGetter++;
 DownFocusableViewIdSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.DownFocusableViewId, value);
+                Object.InternalSetPropertyInt(SwigCPtr, View.Property.DownFocusableViewId, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.DownFocusableViewId, setValue);
@@ -602,7 +602,7 @@ DownFocusableViewIdSetter++;
 ClockwiseFocusableViewIdGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.ClockwiseFocusableViewId);
+                return Object.InternalGetPropertyInt(SwigCPtr, View.Property.ClockwiseFocusableViewId);
 #else
                 int returnValue = -1;
                 PropertyValue clockwiseFocusableViewId = GetProperty(View.Property.ClockwiseFocusableViewId);
@@ -617,7 +617,7 @@ ClockwiseFocusableViewIdGetter++;
 ClockwiseFocusableViewIdSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.ClockwiseFocusableViewId, value);
+                Object.InternalSetPropertyInt(SwigCPtr, View.Property.ClockwiseFocusableViewId, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.ClockwiseFocusableViewId, setValue);
@@ -634,7 +634,7 @@ ClockwiseFocusableViewIdSetter++;
 CounterClockwiseFocusableViewIdGetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                return Interop.Actor.InternalGetPropertyInt(SwigCPtr, View.Property.CounterClockwiseFocusableViewId);
+                return Object.InternalGetPropertyInt(SwigCPtr, View.Property.CounterClockwiseFocusableViewId);
 #else
                 int returnValue = -1;
                 PropertyValue counterClockwiseFocusableViewId = GetProperty(View.Property.CounterClockwiseFocusableViewId);
@@ -649,7 +649,7 @@ CounterClockwiseFocusableViewIdGetter++;
 CounterClockwiseFocusableViewIdSetter++;
 #endif
 #if NUI_PROPERTY_CHANGE_3
-                Interop.Actor.InternalSetPropertyInt(SwigCPtr, View.Property.CounterClockwiseFocusableViewId, value);
+                Object.InternalSetPropertyInt(SwigCPtr, View.Property.CounterClockwiseFocusableViewId, value);
 #else
                 PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
                 SetProperty(View.Property.CounterClockwiseFocusableViewId, setValue);
@@ -1315,7 +1315,7 @@ GetSizeModeFactorCnt++;
                 {
                     internalSizeModeFactor = new Vector3(OnSizeModeFactorChanged, 0, 0, 0);
                 }
-                Interop.Actor.InternalRetrievingPropertyVector3(SwigCPtr, View.Property.SizeModeFactor, internalSizeModeFactor.SwigCPtr);
+                Object.InternalRetrievingPropertyVector3(SwigCPtr, View.Property.SizeModeFactor, internalSizeModeFactor.SwigCPtr);
                 return internalSizeModeFactor;
 #else
 
@@ -1343,7 +1343,7 @@ GetMinimumSizeCnt++;
             {
                 internalMinimumSize = new Size2D(OnMinimumSizeChanged, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector2(SwigCPtr, View.Property.MinimumSize, internalMinimumSize.SwigCPtr);
+            Object.InternalRetrievingPropertyVector2(SwigCPtr, View.Property.MinimumSize, internalMinimumSize.SwigCPtr);
             return internalMinimumSize;
 #else
             Vector2 ret = new Vector2(Interop.ActorInternal.GetMinimumSize(SwigCPtr), true);
@@ -1370,7 +1370,7 @@ GetMaximumSizeCnt++;
             {
                 internalMaximumSize = new Size2D(OnMaximumSizeChanged, 0, 0);
             }
-            Interop.Actor.InternalRetrievingPropertyVector2(SwigCPtr, View.Property.MaximumSize, internalMaximumSize.SwigCPtr);
+            Object.InternalRetrievingPropertyVector2(SwigCPtr, View.Property.MaximumSize, internalMaximumSize.SwigCPtr);
             return internalMaximumSize;
 #else
 


### PR DESCRIPTION
### Description of Change ###
[NUI] Add null checking in internalSet/GetPropertyXXX()
- Add null checking in internalSet/GetPropertyXXX() in ViewInternal, ImageViewBindableProperty and TextLabel/TextField/TextEditor BindableProperty.
- tested with NikeM2 locally

### API Changes ###
none