### PR TITLE
[Applications.Common] Modify Post method of CoreApplication and CoreTask

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -280,32 +280,40 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// Dispatches an asynchronous message to the main loop of the CoreTask.
+        /// Dispatches an asynchronous message to a main loop of the CoreApplication.
         /// </summary>
+        /// <remarks>
+        /// If an application uses UI thread App Model, the asynchronous message will be delivered to the UI thread.
+        /// If not, the asynchronous message will be delivered to the main thread.
+        /// </remarks>
         /// <param name="runner">The runner callaback.</param>
         /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
         /// <since_tizen> 10 </since_tizen>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Post(Action runner)
+        public static void Post(Action runner)
         {
             if (runner == null)
             {
                 throw new ArgumentNullException(nameof(runner));
             }
 
-            GSourceManager.Post(runner);
+            GSourceManager.Post(runner, true);
         }
 
         /// <summary>
-        /// Dispatches an asynchronous message to the main loop of the CoreTask.
+        /// Dispatches an asynchronous message to a main loop of the CoreApplication.
         /// </summary>
+        /// <remarks>
+        /// If an application uses UI thread App Model, the asynchronous message will be delivered to the UI thread.
+        /// If not, the asynchronous message will be delivered to the main thread.
+        /// </remarks>
         /// <typeparam name="T">The type of the result.</typeparam>
         /// <param name="runner">The runner callback.</param>
         /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
         /// <returns>A task with the result.</returns>
         /// <since_tizen> 10 </since_tizen>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public async Task<T> Post<T>(Func<T> runner)
+        public static async Task<T> Post<T>(Func<T> runner)
         {
             if (runner == null)
             {
@@ -313,7 +321,7 @@ namespace Tizen.Applications
             }
 
             var task = new TaskCompletionSource<T>();
-            GSourceManager.Post(() => { task.SetResult(runner()); });
+            GSourceManager.Post(() => { task.SetResult(runner()); }, true);
             return await task.Task.ConfigureAwait(false);
         }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreTask.cs
@@ -115,31 +115,37 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// Dispatches an asynchronous message to the main loop of the CoreApplication.
+        /// Dispatches an asynchronous message to a main loop of the CoreTask.
         /// </summary>
+        /// <remarks>
+        /// The asynchronous message will be delivered to the main thread.
+        /// </remarks>
         /// <param name="runner">The runner callback.</param>
         /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
         /// <since_tizen> 10 </since_tizen>
-        public void Post(Action runner)
+        public static void Post(Action runner)
         {
             if (runner == null)
             {
                 throw new ArgumentNullException(nameof(runner));
             }
 
-            GSourceManager.Post(runner, true);
+            GSourceManager.Post(runner);
         }
 
         /// <summary>
-        /// Dispatches an asynchronous message to the main loop of the CoreApplication.
+        /// Dispatches an asynchronous message to a main loop of the CoreTask.
         /// </summary>
+        /// <remarks>
+        /// The asynchronous message will be delivered to the main thread.
+        /// </remarks>
         /// <typeparam name="T">The type of the result. </typeparam>
         /// <param name="runner">The runner callback.</param>
         /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
         /// <returns>A task with the result.</returns>
         /// <since_tizen> 10 </since_tizen>
 
-        public async Task<T> Post<T>(Func<T> runner)
+        public static async Task<T> Post<T>(Func<T> runner)
         {
             if (runner == null)
             {
@@ -147,7 +153,7 @@ namespace Tizen.Applications
             }
 
             var task = new TaskCompletionSource<T>();
-            GSourceManager.Post(() => { task.SetResult(runner()); }, true);
+            GSourceManager.Post(() => { task.SetResult(runner()); });
             return await task.Task.ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->

The static keyword is added to the methods.
The runner of the CoreApplication.Post() method will be delivered to the UI thread if the application uses the UI thread App Model. The runner of the CoreTask.Post() method will be delivered to the main thread.
