### PR TITLE
[NUI] Add input source type to Gesture.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
@@ -48,6 +48,12 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_time_get")]
             public static extern uint TimeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceType_get")]
+            public static extern int SourceTypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_sourceData_get")]
+            public static extern int SourceDataGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
@@ -63,8 +63,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_localPoint_get")]
             public static extern global::System.IntPtr LocalPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_sourceType_get")]
-            public static extern int SourceTypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Events/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Events/Gesture.cs
@@ -108,6 +108,52 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// This is the value of which source the gesture was started with. (ex : mouse)
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum SourceType
+        {
+            /// <summary>
+            /// invalid data.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Invalid,
+            /// <summary>
+            /// Mouse.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Mouse,
+        }
+
+        /// <summary>
+        /// This is the data of source type
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum SourceDataType
+        {
+            /// <summary>
+            /// invalid data.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Invalid = -1,
+            /// <summary>
+            /// Primary(Left) mouse button.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            MousePrimary = 1,
+            /// <summary>
+            /// Secondary(Right) mouse button.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            MouseSecondary = 3,
+            /// <summary>
+            /// Tertiary(Third) mouse button.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            MouseTertiary = 2,
+        }        
+
+        /// <summary>
         /// The gesture type.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
@@ -140,6 +186,32 @@ namespace Tizen.NUI
             get
             {
                 return time;
+            }
+        }
+
+        /// <summary>
+        /// This is the property of which source type the gesture (read-only).
+        /// If you started the gesture with the mouse, it will tell you what type of mouse it is.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Gesture.SourceType Source
+        {
+            get
+            {
+                return sourceType;
+            }
+        }
+
+        /// <summary>
+        /// This is a property of the source type data (read-only).
+        /// If you started the gesture with the mouse, it will tell you which mouse button you started the gesture with.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Gesture.SourceDataType SourceData
+        {
+            get
+            {
+                return sourceDataType;
             }
         }
 
@@ -188,6 +260,26 @@ namespace Tizen.NUI
             }
         }
 
+        private Gesture.SourceType sourceType
+        {
+            get
+            {
+                Gesture.SourceType ret = (Gesture.SourceType)Interop.Gesture.SourceTypeGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private Gesture.SourceDataType sourceDataType
+        {
+            get
+            {
+                Gesture.SourceDataType ret = (Gesture.SourceDataType)Interop.Gesture.SourceDataGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
         internal static Gesture GetGestureFromPtr(global::System.IntPtr cPtr)
         {
             Gesture ret = new Gesture(cPtr, false);
@@ -202,4 +294,5 @@ namespace Tizen.NUI
             Interop.Gesture.DeleteGesture(swigCPtr);
         }
     }
+
 }

--- a/src/Tizen.NUI/src/public/Events/TapGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGesture.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+using System;
 using System.ComponentModel;
 
 namespace Tizen.NUI
@@ -89,15 +90,17 @@ namespace Tizen.NUI
 
         /// <summary>
         /// The gesture source type of touches property (read-only).
-        /// If you tap with a mouse button, this will tell you which mouse input you tapped.
+        /// If you touch with a mouse button, this will tell you which mouse input you touched.
         /// Primary(Left), Secondary(Right). Tertiary(Wheel).
+        /// Deprecated. This api will be deleted without notice. Please do not use it.
         /// </summary>
+        [Obsolete("This property will be deleted without notice. Please do not use it. Use Gesture.SourceData instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public GestureSourceType SourceType
+        public new GestureSourceType SourceType
         {
             get
             {
-                return sourceType;
+                return (GestureSourceType)SourceData;
             }
         }
 
@@ -163,16 +166,6 @@ namespace Tizen.NUI
             }
         }
 
-        private GestureSourceType sourceType
-        {
-            get
-            {
-                GestureSourceType ret = (GestureSourceType)Interop.TapGesture.SourceTypeGet(SwigCPtr);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
-            }
-        }
-
         /// <summary>
         /// Gets the TapGesture from the pointer.
         /// </summary>
@@ -195,7 +188,9 @@ namespace Tizen.NUI
 
     /// <summary>
     /// Gesture source type.
+    /// Deprecated. This value will be deleted without notice. Please do not use it.
     /// </summary>
+    [Obsolete("This enum will be deleted without notice. Please do not use it.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum GestureSourceType
     {
@@ -220,4 +215,5 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         Tertiary = 2,
     }
+
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This is similar to MouseButton in TouchEvent.
Now, you can see from which input the gesture was made.
```c#
longPressGestureDetector.Detected += (s, e) =>
{
  if (e.LongPressGesture.Source == Gesture.SourceType.Mouse)
  {
  }
  if (e.LongPressGesture.SourceData == Gesture.SourceDataType.MousePrimary)
  {
  }
}
```
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/283368/ 
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/283369/




### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
