### PR TITLE
[NUI] Fix some errors when we remove NUI_PROPERTY_CHANGE tag

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
+++ b/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
@@ -260,6 +260,7 @@ namespace Tizen.NUI
                 return PropertyValue.CreateFromObject(refined);
             }
 
+#if NUI_ANIMATION_PROPERTY_CHANGE_1
             // Refine object as IntPtr of PropertyValue to optimize.
             // Warning : This API don't automatically release memory.
             internal global::System.IntPtr RefineValueIntPtr(object value)
@@ -280,6 +281,7 @@ namespace Tizen.NUI
 
                 return PropertyValue.CreateFromObjectIntPtr(refined);
             }
+#endif
 
             internal KeyFrames RefineKeyFrames(KeyFrames keyFrames)
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1318,7 +1318,8 @@ namespace Tizen.NUI.BaseComponents
             Interop.View.InternalRetrievingVisualPropertyInt(this.SwigCPtr, Property.BACKGROUND, Visual.Property.Type, out visualType);
             return visualType == (int)Visual.Type.Invalid;
 #else
-            return Background.Empty();
+            PropertyMap background = Background;
+            return (background == null || background.Empty());
 #endif
         }
 


### PR DESCRIPTION
1. Add nullcheck when NUI_VISUAL_PROPERTY_CHANGE_1 not defined.
2. Fix compile error when NUI_ANIMATION_PROPERTY_CHANGE_1 not defined.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>