### PR TITLE
[NUI] Fix relative layout issue on DefaultLinearItem

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultLinearItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultLinearItem.cs
@@ -89,9 +89,10 @@ namespace Tizen.NUI.Components
                     itemIcon = CreateIcon(ItemStyle?.Icon);
                     if (itemIcon != null)
                     {
-                        layoutChanged = true;
                         Add(itemIcon);
                         itemIcon.Relayout += OnIconRelayout;
+                        layoutChanged = true;
+                        LayoutChild();
                     }
                 }
                 return itemIcon;
@@ -108,6 +109,7 @@ namespace Tizen.NUI.Components
                     itemIcon.Relayout += OnIconRelayout;
                 }
                 layoutChanged = true;
+                LayoutChild();
             }
         }
 
@@ -147,8 +149,9 @@ namespace Tizen.NUI.Components
                     itemLabel = CreateLabel(ItemStyle?.Label);
                     if (itemLabel != null)
                     {
-                        layoutChanged = true;
                         Add(itemLabel);
+                        layoutChanged = true;
+                        LayoutChild();
                     }
                 }
                 return itemLabel;
@@ -156,6 +159,8 @@ namespace Tizen.NUI.Components
             internal set
             {
                 itemLabel = value;
+                layoutChanged = true;
+                LayoutChild();
             }
         }
 
@@ -200,8 +205,9 @@ namespace Tizen.NUI.Components
                     itemSubLabel = CreateLabel(ItemStyle?.SubLabel);
                     if (itemLabel != null)
                     {
-                        layoutChanged = true;
                         Add(itemSubLabel);
+                        layoutChanged = true;
+                        LayoutChild();
                     }
                 }
                 return itemSubLabel;
@@ -209,6 +215,8 @@ namespace Tizen.NUI.Components
             internal set
             {
                 itemSubLabel = value;
+                layoutChanged = true;
+                LayoutChild();
             }
         }
 
@@ -265,9 +273,10 @@ namespace Tizen.NUI.Components
                     itemExtra = CreateIcon(ItemStyle?.Extra);
                     if (itemExtra != null)
                     {
-                        layoutChanged = true;
                         Add(itemExtra);
                         itemExtra.Relayout += OnExtraRelayout;
+                        layoutChanged = true;
+                        LayoutChild();
                     }
                 }
                 return itemExtra;
@@ -283,6 +292,7 @@ namespace Tizen.NUI.Components
                     Add(itemExtra);
                 }
                 layoutChanged = true;
+                LayoutChild();
             }
         }
 
@@ -342,6 +352,8 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void OnRelayout(Vector2 size, RelayoutContainer container)
         {
+            LayoutChild();
+
             base.OnRelayout(size, container);
 
             if (prevSize != Size)


### PR DESCRIPTION
### Description of Change ###
DefaultLinearItem sometimes layouting text in wrong position and upadated later.
this issue occurs relativeLayouting is set after object relayout is done.
now it fix to set relativeLayout right after the chlidren generation.  

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
