### PR TITLE
[NUI] Add constructor with style instance

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -48,15 +48,30 @@ namespace Tizen.NUI.Components
 
         private View content = null;
 
+        private void Initialize()
+        {
+            Layout = new AbsoluteLayout();
+
+            this.Relayout += OnRelayout;
+        }
+
         /// <summary>
         /// Creates a new instance of Dialog.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public Dialog() : base()
         {
-            Layout = new AbsoluteLayout();
+            Initialize();
+        }
 
-            this.Relayout += OnRelayout;
+        /// <summary>
+        /// Creates a new instance of a Dialog with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created Dialog.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Dialog(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -58,6 +58,16 @@ namespace Tizen.NUI.Components
             Initialize();
         }
 
+        /// <summary>
+        /// Creates a new instance of a Menu with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created Menu.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Menu(MenuStyle style) : base(style)
+        {
+            Initialize();
+        }
+
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(DisposeTypes type)
@@ -467,8 +477,6 @@ namespace Tizen.NUI.Components
 
             WidthSpecification = LayoutParamPolicies.WrapContent;
             HeightSpecification = LayoutParamPolicies.WrapContent;
-
-            BackgroundColor = Color.Transparent;
 
             // Menu is added to Anchor so Menu should exclude layouting because
             // if Anchor has Layout, then Menu is displayed at an incorrect position.

--- a/src/Tizen.NUI.Components/Controls/MenuItem.cs
+++ b/src/Tizen.NUI.Components/Controls/MenuItem.cs
@@ -48,6 +48,16 @@ namespace Tizen.NUI.Components
             Initialize();
         }
 
+        /// <summary>
+        /// Creates a new instance of a MenuItem with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created MenuItem.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public MenuItem(ButtonStyle style) : base(style)
+        {
+            Initialize();
+        }
+
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(DisposeTypes type)

--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -29,17 +29,32 @@ namespace Tizen.NUI.Components
         private AppBar appBar = null;
         private View content = null;
 
-        /// <summary>
-        /// Creates a new instance of a ContentPage.
-        /// </summary>
-        /// <since_tizen> 9 </since_tizen>
-        public ContentPage() : base()
+        private void Initialize()
         {
             Layout = new ContentPageLayout();
 
             // ContentPage matches to parent by default.
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
+        }
+
+        /// <summary>
+        /// Creates a new instance of a ContentPage.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public ContentPage() : base()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a ContentPage with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created ContentPage.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ContentPage(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
@@ -32,11 +32,7 @@ namespace Tizen.NUI.Components
         private View scrim = null;
         private bool enableScrim = true;
 
-        /// <summary>
-        /// Creates a new instance of a DialogPage.
-        /// </summary>
-        /// <since_tizen> 9 </since_tizen>
-        public DialogPage() : base()
+        private void Initialize()
         {
             Layout = new AbsoluteLayout();
 
@@ -49,6 +45,25 @@ namespace Tizen.NUI.Components
             EnableControlState = false;
 
             Scrim = CreateDefaultScrim();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a DialogPage.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public DialogPage() : base()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a DialogPage with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created DialogPage.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DialogPage(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -117,13 +117,28 @@ namespace Tizen.NUI.Components
 
         private List<Page> navigationPages = new List<Page>();
 
+        private void Initialize()
+        {
+            Layout = new AbsoluteLayout();
+        }
+
         /// <summary>
         /// Creates a new instance of a Navigator.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public Navigator() : base()
         {
-            Layout = new AbsoluteLayout();
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a Navigator with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created Navigator.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Navigator(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -114,6 +114,15 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of a Page with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created Page.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Page(ControlStyle style) : base(style)
+        {
+        }
+
+        /// <summary>
         /// Navigator which has pushed the Page into its stack.
         /// If this Page has not been pushed into any Navigator, then Navigator is null.
         /// </summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -164,14 +164,19 @@ namespace Tizen.NUI.Components
         private bool delayedIndexScrollTo;
         private (int index, bool anim, ItemScrollTo scrollTo) delayedIndexScrollToParam;
 
+        private void Initialize()
+        {
+            FocusGroup = true;
+            SetKeyboardNavigationSupport(true);
+        }
+
         /// <summary>
         /// Base constructor.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public CollectionView() : base()
         {
-            FocusGroup = true;
-            SetKeyboardNavigationSupport(true);
+            Initialize();
         }
 
         /// <summary>
@@ -196,6 +201,16 @@ namespace Tizen.NUI.Components
             ItemsSource = itemsSource;
             ItemTemplate = template;
             ItemsLayouter = layouter;
+        }
+
+        /// <summary>
+        /// Creates a new instance of a CollectionView with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created CollectionView.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public CollectionView(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/RecyclerView.cs
@@ -79,13 +79,28 @@ namespace Tizen.NUI.Components
             return instance.InternalItemTemplate;
         });
 
+        private void Initialize()
+        {
+            Scrolling += OnScrolling;
+        }
+
         /// <summary>
         /// Base Constructor
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public RecyclerView() : base()
         {
-            Scrolling += OnScrolling;
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a RecyclerView with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created RecyclerView.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RecyclerView(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -873,11 +873,7 @@ namespace Tizen.NUI.Components
         private bool isOverShootingShadowShown = false;
         private float startShowShadowDisplacement;
 
-        /// <summary>
-        /// Default Constructor
-        /// </summary>
-        /// <since_tizen> 8 </since_tizen>
-        public ScrollableBase() : base()
+        private void Initialize()
         {
             DecelerationRate = 0.998f;
 
@@ -949,6 +945,25 @@ namespace Tizen.NUI.Components
             AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Trait, "ScrollableBase");
 
             SetKeyboardNavigationSupport(true);
+        }
+
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        /// <since_tizen> 8 </since_tizen>
+        public ScrollableBase() : base()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a ScrollableBase with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created ScrollableBase.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ScrollableBase(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         private bool OnInterruptTouchingChildTouched(object source, View.TouchEventArgs args)

--- a/src/Tizen.NUI.Components/Controls/TabBar.cs
+++ b/src/Tizen.NUI.Components/Controls/TabBar.cs
@@ -57,11 +57,7 @@ namespace Tizen.NUI.Components
 
         private TabButtonGroup tabButtonGroup;
 
-        /// <summary>
-        /// Creates a new instance of TabBar.
-        /// </summary>
-        /// <since_tizen> 9 </since_tizen>
-        public TabBar()
+        private void Initialize()
         {
             Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal };
 
@@ -70,6 +66,25 @@ namespace Tizen.NUI.Components
             tabButtons = new List<TabButton>();
             tabButtonGroup = new TabButtonGroup();
             SelectedIndex = -1;
+        }
+
+        /// <summary>
+        /// Creates a new instance of TabBar.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public TabBar()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a TabBar with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created TabBar.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabBar(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/TabContent.cs
+++ b/src/Tizen.NUI.Components/Controls/TabContent.cs
@@ -29,14 +29,29 @@ namespace Tizen.NUI.Components
     {
         private IList<View> views;
 
+        private void Initialize()
+        {
+            SelectedIndex = -1;
+            views = new List<View>();
+        }
+
         /// <summary>
         /// Creates a new instance of TabContent.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
         public TabContent()
         {
-            SelectedIndex = -1;
-            views = new List<View>();
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a TabContent with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created TabContent.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabContent(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/TabView.cs
+++ b/src/Tizen.NUI.Components/Controls/TabView.cs
@@ -85,11 +85,7 @@ namespace Tizen.NUI.Components
 
         private TabContent content = null;
 
-        /// <summary>
-        /// Creates a new instance of TabView.
-        /// </summary>
-        /// <since_tizen> 9 </since_tizen>
-        public TabView()
+        private void Initialize()
         {
             Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Vertical };
             WidthSpecification = LayoutParamPolicies.MatchParent;
@@ -100,6 +96,25 @@ namespace Tizen.NUI.Components
 
             // To show TabBar's shadow TabBar is raised above Content.
             TabBar.RaiseAbove(Content);
+        }
+
+        /// <summary>
+        /// Creates a new instance of TabView.
+        /// </summary>
+        /// <since_tizen> 9 </since_tizen>
+        public TabView()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a TabView with style.
+        /// </summary>
+        /// <param name="style">A style applied to the newly created TabView.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabView(ControlStyle style) : base(style)
+        {
+            Initialize();
         }
 
         /// <inheritdoc/>

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -777,6 +777,7 @@ namespace Tizen.NUI.Components
             // Menu base style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.Menu", new MenuStyle()
             {
+                BackgroundColor = Color.Transparent,
                 Content = new ViewStyle()
                 {
                     BackgroundColor = new Color("#FFFEFE"),


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
To customize and apply app's own style instance, constructor with style
instance should be added.

For now, ApplyStyle() modifies the given properties only based on the
default style unlike applying style in constructor.
e.g. Let default style contain properties A, B, C.
     Let custom style contain properties B, C.
     Then ApplyStyle(custom style) contain default style's A and custom
     style's B and C.

Consequently, to apply custom style without applying default style,
constructor with style instance is required.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
