### PR TITLE
[Applications.Common] Increment the reference counter on SafeHandle instances

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
@@ -429,7 +429,6 @@ namespace Tizen.Applications.RPCPort
             using (SafeBundleHandle safeBundleHandle = new SafeBundleHandle(b, true))
             {
                 bundle = new Bundle(safeBundleHandle);
-
             }
 
             return bundle;

--- a/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications.RPCPort/Parcel.cs
@@ -425,7 +425,14 @@ namespace Tizen.Applications.RPCPort
         {
             Interop.LibRPCPort.Parcel.ReadBundle(_handle, out IntPtr b);
 
-            return new Bundle(new SafeBundleHandle(b, true));
+            Bundle bundle = null;
+            using (SafeBundleHandle safeBundleHandle = new SafeBundleHandle(b, true))
+            {
+                bundle = new Bundle(safeBundleHandle);
+
+            }
+
+            return bundle;
         }
 
         /// <summary>

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -111,6 +111,11 @@ namespace Tizen.Applications
                 throw new ArgumentNullException(nameof(handle));
             }
 
+            if (handle.IsInvalid)
+            {
+                throw new ArgumentNullException(nameof(handle), "handle is invalid");
+            }
+
             bool mustRelease = false;
             try
             {
@@ -120,6 +125,10 @@ namespace Tizen.Applications
                 {
                     throw new InvalidOperationException("Failed to clone the appcontrol handle. Err = " + err);
                 }
+            }
+            catch (ObjectDisposedException e)
+            {
+                throw new ArgumentNullException(nameof(handle), e.Message);
             }
             finally
             {

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -108,13 +108,25 @@ namespace Tizen.Applications
         {
             if (handle == null)
             {
-                throw new ArgumentNullException("handle");
+                throw new ArgumentNullException(nameof(handle));
             }
 
-            Interop.AppControl.ErrorCode err = Interop.AppControl.DangerousClone(out _handle, handle.DangerousGetHandle());
-            if (err != Interop.AppControl.ErrorCode.None)
+            bool mustRelease = false;
+            try
             {
-                throw new InvalidOperationException("Failed to clone the appcontrol handle. Err = " + err);
+                handle.DangerousAddRef(ref mustRelease);
+                Interop.AppControl.ErrorCode err = Interop.AppControl.DangerousClone(out _handle, handle.DangerousGetHandle());
+                if (err != Interop.AppControl.ErrorCode.None)
+                {
+                    throw new InvalidOperationException("Failed to clone the appcontrol handle. Err = " + err);
+                }
+            }
+            finally
+            {
+                if (mustRelease)
+                {
+                    handle.DangerousRelease();
+                }
             }
         }
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
@@ -73,7 +73,20 @@ namespace Tizen.Applications
                 throw new ArgumentNullException("handle", "handle is invalid");
             }
 
-            _handle = Interop.Bundle.DangerousClone(handle.DangerousGetHandle());
+            bool mustRelease = false;
+            try
+            {
+                handle.DangerousAddRef(ref mustRelease);
+                _handle = Interop.Bundle.DangerousClone(handle.DangerousGetHandle());
+            }
+            finally
+            {
+                if (mustRelease)
+                {
+                    handle.DangerousRelease();
+                }
+            }
+
             _keys = new HashSet<string>();
             Interop.Bundle.Iterator iterator = (string key, int type, IntPtr keyval, IntPtr userData) =>
             {

--- a/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
@@ -65,12 +65,12 @@ namespace Tizen.Applications
         {
             if (handle == null)
             {
-                throw new ArgumentNullException("handle");
+                throw new ArgumentNullException(nameof(handle));
             }
 
             if (handle.IsInvalid)
             {
-                throw new ArgumentNullException("handle", "handle is invalid");
+                throw new ArgumentNullException(nameof(handle), "handle is invalid");
             }
 
             bool mustRelease = false;
@@ -78,6 +78,10 @@ namespace Tizen.Applications
             {
                 handle.DangerousAddRef(ref mustRelease);
                 _handle = Interop.Bundle.DangerousClone(handle.DangerousGetHandle());
+            }
+            catch (ObjectDisposedException e)
+            {
+                throw new ArgumentNullException(nameof(handle), e.Message);
             }
             finally
             {


### PR DESCRIPTION
Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->
To prevent the common language runtime from reclaiming memory used by a handle, this patch adds calling DangerousAddRef() before calling DangerousGetHandle().
