### PR TITLE
[NUI] add AutomationId on NavigationContent for automation support.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -848,6 +848,25 @@ namespace Tizen.NUI.Components
         }
         private float stepScrollDistance = 0f;
 
+        /// <summary>
+        /// Wheel scroll move distance.
+        /// This value decide how long distance will it moves in wheel event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float WheelScrollDistance
+        {
+            get
+            {
+                return (float)GetValue(WheelScrollDistanceProperty);
+            }
+            set
+            {
+                SetValue(WheelScrollDistanceProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+        private float wheelScrollDistance = 50f;
+
 
         // Let's consider more whether this needs to be set as protected.
         private float finalTargetPosition;
@@ -941,6 +960,8 @@ namespace Tizen.NUI.Components
                 ParentOrigin = NUI.ParentOrigin.CenterRight,
                 PivotPoint = NUI.PivotPoint.CenterRight,
             };
+
+            WheelEvent += OnWheelEvent;
 
             AccessibilityManager.Instance.SetAccessibilityAttribute(this, AccessibilityManager.AccessibilityAttribute.Trait, "ScrollableBase");
 
@@ -1362,6 +1383,8 @@ namespace Tizen.NUI.Components
                 propertyNotification.Dispose();
                 propertyNotification = null;
             }
+
+            WheelEvent -= OnWheelEvent;
 
             if (type == DisposeTypes.Explicit)
             {
@@ -2148,6 +2171,22 @@ namespace Tizen.NUI.Components
 
             return true;
         }
+
+
+        private bool OnWheelEvent(object o, WheelEventArgs e)
+        {
+            Wheel wheel = e?.Wheel;
+            if (wheel == null)
+            {
+                return false;
+            }
+
+            float currentScrollPosition = -(ScrollingDirection == Direction.Horizontal ? ContentContainer.CurrentPosition.X : ContentContainer.CurrentPosition.Y);
+            ScrollTo(currentScrollPosition + (wheelScrollDistance * wheel.Z), false);
+
+            return true;
+        }
+
     }
 
 } // namespace

--- a/src/Tizen.NUI.Components/Controls/ScrollableBaseBindableProperty.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBaseBindableProperty.cs
@@ -312,6 +312,24 @@ namespace Tizen.NUI.Components
         });
 
         /// <summary>
+        /// WheelScrollDistanceProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty WheelScrollDistanceProperty = BindableProperty.Create(nameof(WheelScrollDistance), typeof(float), typeof(ScrollableBase), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (ScrollableBase)bindable;
+            if (newValue != null)
+            {
+                instance.wheelScrollDistance = (float)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (ScrollableBase)bindable;
+            return instance.stepScrollDistance;
+        });
+
+        /// <summary>
         /// FadeScrollbarProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

NavigationContent is essential element for browsing automation test.
Key event can also usable for finding out NavigationContent,
but if we have AutomationId for NavigationContent,
user can easily find out NaviagationContent.
this is prototype suggestions,
and I think it would be better to distinguish general navigationContent and default(backbutton).
so we need more discussion on this yet.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
