### PR TITLE
[NUI] Add CameraTransitionFinished in SceneView

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -107,6 +107,13 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// An event emitted when Camera Transition is finished.
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler CameraTransitionFinished;
+
+        /// <summary>
         /// Set/Get the ImageBasedLight ScaleFactor.
         /// Scale factor controls light source intensity in [0.0f, 1.0f]
         /// </summary>
@@ -576,13 +583,14 @@ namespace Tizen.NUI.Scene3D
             cameraTransition.Finished += (s, e) =>
             {
                 inCameraTransition = false;
+                CameraTransitionFinished?.Invoke(this, EventArgs.Empty);
             };
             cameraTransition.Play();
 
             sourceFieldOfView.Dispose();
             positionKeyFrames.Dispose();
             orientationKeyFrames.Dispose();
-            orientationKeyFrames.Dispose();
+            fieldOfViewKeyFrames.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
Adds CameraTransitionFinished signal to notice whether the Camera Transition is finished or not.

Signed-off-by: seunghobaek <sbsh.baek@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
