### PR TITLE
[NUI][NUI.Components] Fix SVACE issue in CollectionView.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -1360,11 +1360,11 @@ namespace Tizen.NUI.Components
 
             if (ScrollingDirection == Direction.Horizontal)
             {
-                ContentContainer.SizeWidth = ItemsLayouter.CalculateLayoutOrientationSize();
+                ContentContainer.SizeWidth = (float)ItemsLayouter?.CalculateLayoutOrientationSize();
             }
             else
             {
-                ContentContainer.SizeHeight = ItemsLayouter.CalculateLayoutOrientationSize();
+                ContentContainer.SizeHeight = (float)ItemsLayouter?.CalculateLayoutOrientationSize();
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
DF221104-01088
[Reported] Value ItemsLayouter, which is result of method invocation with possible null return value, is dereferenced in method call ItemsLayouter.CaculateLayoutOrientationSize()

Solution:
Add the null check operator '?.'


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
