### PR TITLE
[NUI] Move Matrix API as public (hidden)

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Matrix.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Matrix.cs
@@ -91,9 +91,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_OrthoNormalize")]
             public static extern void OrthoNormalize(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_AsFloat__SWIG_0")]
-            public static extern global::System.IntPtr AsFloat(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_0")]
             public static extern void Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
@@ -101,7 +98,13 @@ namespace Tizen.NUI
             public static extern void MultiplyQuaternion(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_2")]
+            public static extern global::System.IntPtr MultiplyVector4(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_Multiply__SWIG_4")]
             public static extern global::System.IntPtr Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_MultiplyAssign")]
+            public static extern global::System.IntPtr MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_EqualTo")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
@@ -122,6 +125,18 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_GetTransformComponents")]
             public static extern void GetTransformComponents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_ValueOfIndex__SWIG_0")]
+            public static extern float ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_ValueOfIndex__SWIG_1")]
+            public static extern float ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetValueAtIndex__SWIG_0")]
+            public static extern void SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, float val);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix_SetValueAtIndex__SWIG_1")]
+            public static extern void SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn, float val);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Matrix")]
             public static extern void DeleteMatrix(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -184,6 +199,27 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply")]
             public static extern void Matrix3Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply__SWIG_1")]
+            public static extern global::System.IntPtr Matrix3MultiplyVector3(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_Multiply__SWIG_3")]
+            public static extern global::System.IntPtr Matrix3Multiply(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_MultiplyAssign")]
+            public static extern global::System.IntPtr Matrix3MultiplyAssign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ValueOfIndex__SWIG_0")]
+            public static extern float Matrix3ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_ValueOfIndex__SWIG_1")]
+            public static extern float Matrix3ValueOfIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetValueAtIndex__SWIG_0")]
+            public static extern void Matrix3SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint index, float val);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Matrix3_SetValueAtIndex__SWIG_1")]
+            public static extern void Matrix3SetValueAtIndex(global::System.Runtime.InteropServices.HandleRef jarg1, uint indexRow, uint indexColumn, float val);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/Matrix.cs
+++ b/src/Tizen.NUI/src/public/Common/Matrix.cs
@@ -15,9 +15,13 @@
  *
  */
 
+using System;
+using System.ComponentModel;
+
 namespace Tizen.NUI
-{
-    internal class Matrix : Disposable
+{    /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class Matrix : Disposable
     {
         internal Matrix(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -26,12 +30,6 @@ namespace Tizen.NUI
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Matrix.DeleteMatrix(swigCPtr);
-        }
-
-
-        public static Vector4 operator *(Matrix arg1, Vector4 arg2)
-        {
-            return arg1.Multiply(arg2);
         }
 
         public Matrix() : this(Interop.Matrix.NewMatrix(), true)
@@ -75,6 +73,35 @@ namespace Tizen.NUI
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
+        }
+
+        public float this[uint index]
+        {
+            set
+            {
+                SetValueAtIndex(index, value);
+            }
+            get
+            {
+                return ValueOfIndex(index);
+            }
+        }
+
+        public static Vector4 operator *(Matrix arg1, Vector4 arg2)
+        {
+            return arg1?.Multiply(arg2);
+        }
+
+        public static Matrix operator *(Matrix arg1, Rotation arg2)
+        {
+            Matrix ret = new Matrix(false);
+            Matrix.Multiply(ret, arg1, arg2);
+            return ret;
+        }
+
+        public static Matrix operator *(Matrix arg1, Matrix arg2)
+        {
+            return arg1?.Multiply(arg2);
         }
 
         public void SetIdentity()
@@ -179,14 +206,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        public SWIGTYPE_p_float AsFloat()
-        {
-            global::System.IntPtr cPtr = Interop.Matrix.AsFloat(SwigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
         public static void Multiply(Matrix result, Matrix lhs, Matrix rhs)
         {
             Interop.Matrix.Multiply(Matrix.getCPtr(result), Matrix.getCPtr(lhs), Matrix.getCPtr(rhs));
@@ -201,9 +220,27 @@ namespace Tizen.NUI
 
         public Vector4 Multiply(Vector4 rhs)
         {
-            Vector4 ret = new Vector4(Interop.Matrix.Multiply(SwigCPtr, Vector4.getCPtr(rhs)), true);
+            Vector4 ret = new Vector4(Interop.Matrix.MultiplyVector4(SwigCPtr, Vector4.getCPtr(rhs)), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        public Matrix Multiply(Matrix rhs)
+        {
+            Matrix ret = new Matrix(Interop.Matrix.Multiply(SwigCPtr, Matrix.getCPtr(rhs)), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void MultiplyAssign(Matrix rhs)
+        {
+            Interop.Matrix.MultiplyAssign(SwigCPtr, Matrix.getCPtr(rhs));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public override int GetHashCode()
+        {
+            return SwigCPtr.Handle.GetHashCode();
         }
 
         public bool EqualTo(Matrix rhs)
@@ -241,6 +278,32 @@ namespace Tizen.NUI
         public void GetTransformComponents(Vector3 position, Rotation rotation, Vector3 scale)
         {
             Interop.Matrix.GetTransformComponents(SwigCPtr, Vector3.getCPtr(position), Rotation.getCPtr(rotation), Vector3.getCPtr(scale));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public float ValueOfIndex(uint index)
+        {
+            float ret = Interop.Matrix.ValueOfIndex(SwigCPtr, index);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public float ValueOfIndex(uint indexRow, uint indexColumn)
+        {
+            float ret = Interop.Matrix.ValueOfIndex(SwigCPtr, indexRow, indexColumn);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void SetValueAtIndex(uint index, float val)
+        {
+            Interop.Matrix.SetValueAtIndex(SwigCPtr, index, val);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void SetValueAtIndex(uint indexRow, uint indexColumn, float val)
+        {
+            Interop.Matrix.SetValueAtIndex(SwigCPtr, indexRow, indexColumn, val);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }

--- a/src/Tizen.NUI/src/public/Common/Matrix3.cs
+++ b/src/Tizen.NUI/src/public/Common/Matrix3.cs
@@ -15,9 +15,14 @@
  *
  */
 
+using System;
+using System.ComponentModel;
+
 namespace Tizen.NUI
 {
-    internal class Matrix3 : Disposable
+    /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class Matrix3 : Disposable
     {
         internal Matrix3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -73,6 +78,33 @@ namespace Tizen.NUI
             return ret;
         }
 
+        public float this[uint index]
+        {
+            set
+            {
+                SetValueAtIndex(index, value);
+            }
+            get
+            {
+                return ValueOfIndex(index);
+            }
+        }
+
+        public static Vector3 operator *(Matrix3 arg1, Vector3 arg2)
+        {
+            return arg1?.Multiply(arg2);
+        }
+
+        public static Matrix3 operator *(Matrix3 arg1, Matrix3 arg2)
+        {
+            return arg1?.Multiply(arg2);
+        }
+
+        public override int GetHashCode()
+        {
+            return SwigCPtr.Handle.GetHashCode();
+        }
+
         public bool EqualTo(Matrix3 rhs)
         {
             bool ret = Interop.Matrix.Matrix3EqualTo(SwigCPtr, Matrix3.getCPtr(rhs));
@@ -91,14 +123,6 @@ namespace Tizen.NUI
         {
             Interop.Matrix.Matrix3SetIdentity(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        public SWIGTYPE_p_float AsFloat()
-        {
-            global::System.IntPtr cPtr = Interop.Matrix.Matrix3AsFloat(SwigCPtr);
-            SWIGTYPE_p_float ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_float(cPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         public bool Invert()
@@ -138,6 +162,52 @@ namespace Tizen.NUI
         public static void Multiply(Matrix3 result, Matrix3 lhs, Matrix3 rhs)
         {
             Interop.Matrix.Matrix3Multiply(Matrix3.getCPtr(result), Matrix3.getCPtr(lhs), Matrix3.getCPtr(rhs));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public Vector3 Multiply(Vector3 rhs)
+        {
+            Vector3 ret = new Vector3(Interop.Matrix.Matrix3MultiplyVector3(SwigCPtr, Vector3.getCPtr(rhs)), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public Matrix3 Multiply(Matrix3 rhs)
+        {
+            Matrix3 ret = new Matrix3(Interop.Matrix.Matrix3Multiply(SwigCPtr, Matrix3.getCPtr(rhs)), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void MultiplyAssign(Matrix3 rhs)
+        {
+            Interop.Matrix.Matrix3MultiplyAssign(SwigCPtr, Matrix3.getCPtr(rhs));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public float ValueOfIndex(uint index)
+        {
+            float ret = Interop.Matrix.Matrix3ValueOfIndex(SwigCPtr, index);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public float ValueOfIndex(uint indexRow, uint indexColumn)
+        {
+            float ret = Interop.Matrix.Matrix3ValueOfIndex(SwigCPtr, indexRow, indexColumn);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void SetValueAtIndex(uint index, float val)
+        {
+            Interop.Matrix.Matrix3SetValueAtIndex(SwigCPtr, index, val);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void SetValueAtIndex(uint indexRow, uint indexColumn, float val)
+        {
+            Interop.Matrix.Matrix3SetValueAtIndex(SwigCPtr, indexRow, indexColumn, val);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/Program.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/Program.cs
@@ -47,6 +47,7 @@ namespace Tizen.NUI.Devel.Tests
         public static int mainTid;
         Timer timer;
         private EventThreadCallback eventThreadCallback;
+        private EventThreadCallback.CallbackDelegate callbackDelegate;
         private NUnitLite.TUnit.TRunner trunner;
         private ManualResetEvent methodExecutionResetEvent;
         private TAsyncThreadMgr asyncThreadMgr;
@@ -104,7 +105,8 @@ namespace Tizen.NUI.Devel.Tests
                     methodExecutionResetEvent.Set();
                 });
 
-            eventThreadCallback = new EventThreadCallback(new EventThreadCallback.CallbackDelegate(ProcessTest));
+            callbackDelegate = new EventThreadCallback.CallbackDelegate(ProcessTest);
+            eventThreadCallback = new EventThreadCallback(callbackDelegate);
             eventThreadCallback.Trigger();
         }
 

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Common/TSMatrix.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Common/TSMatrix.cs
@@ -1,16 +1,15 @@
 ﻿using global::System;
 using NUnit.Framework;
 using NUnit.Framework.TUnit;
-using Tizen.NUI.Components;
-using Tizen.NUI.BaseComponents;
+using Tizen.NUI;
 
 namespace Tizen.NUI.Devel.Tests
 {
     using tlog = Tizen.Log;
 
     [TestFixture]
-    [Description("internal/Common/Matrix")]
-    public class InternalMatrixTest
+    [Description("public/Common/Matrix")]
+    public class MatrixTest
     {
         private const string tag = "NUITEST";
 
@@ -75,7 +74,11 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"MatrixConstructorWithFloatArray START");
 
-            float[] arr = new float[3] { 0.1f, 0.4f, 0.2f };
+            float[] arr = new float[16]
+            { 0.0f, 1.0f, 2.0f, 3.0f,
+              0.1f, 1.1f, 2.1f, 3.1f,
+              0.2f, 1.2f, 2.2f, 3.2f,
+              0.3f, 1.3f, 2.3f, 3.3f};
 
             var testingTarget = new Matrix(arr);
             Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
@@ -204,6 +207,7 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.Fail("Caught Exception : Failed!");
             }
 
+            testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixSetIdentity END (OK)");
         }
 
@@ -235,6 +239,7 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.Fail("Caught Exception : Failed!");
             }
 
+            testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixSetIdentityAndScale END (OK)");
         }
 
@@ -249,7 +254,14 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"MatrixInvert START");
 
-            var testingTarget = new Matrix();
+            // Initialize as invertable matrix
+            float[] arr = new float[16]
+            { 0.0f, 2.0f, 0.0f, 0.0f,
+              1.0f, 0.0f, 0.0f, 0.0f,
+              0.0f, 0.0f, 0.0f, 4.0f,
+              0.0f, 0.0f, 3.0f, 0.0f};
+
+            var testingTarget = new Matrix(arr);
             Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
             Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
 
@@ -257,6 +269,7 @@ namespace Tizen.NUI.Devel.Tests
             {
                 var result = testingTarget.Invert();
                 tlog.Debug(tag, "Invert : " + result);
+                Assert.AreEqual(true, result, "Invert should be successed");
             }
             catch (Exception e)
             {
@@ -264,6 +277,7 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.Fail("Caught Exception : Failed!");
             }
 
+            testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixInvert END (OK)");
         }
 
@@ -292,6 +306,7 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.Fail("Caught Exception : Failed!");
             }
 
+            testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixTranspose END (OK)");
         }
 
@@ -321,6 +336,7 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.AreEqual(3.0f, result.Z, "Should be equal!");
             }
 
+            testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixSetXAxis END (OK)");
         }
 
@@ -350,6 +366,7 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.AreEqual(3.0f, result.Z, "Should be equal!");
             }
 
+            testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixSetYAxis END (OK)");
         }
 
@@ -379,6 +396,7 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.AreEqual(3.0f, result.Z, "Should be equal!");
             }
 
+            testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixSetZAxis END (OK)");
         }
 
@@ -471,34 +489,6 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("Matrix AsFloat.")]
-        [Property("SPEC", "Tizen.NUI.Matrix.AsFloat M")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "MR")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void MatrixAsFloat()
-        {
-            tlog.Debug(tag, $"MatrixAsFloat START");
-
-            var testingTarget = new Matrix();
-            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
-            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
-
-            try
-            {
-                testingTarget.AsFloat();
-            }
-            catch (Exception e)
-            {
-                tlog.Debug(tag, e.Message.ToString());
-                Assert.Fail("Caught Exception : Failed!");
-            }
-
-            tlog.Debug(tag, $"MatrixAsFloat END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
         [Description("Matrix Multiply.")]
         [Property("SPEC", "Tizen.NUI.Matrix.Multiply M")]
         [Property("SPEC_URL", "-")]
@@ -530,6 +520,38 @@ namespace Tizen.NUI.Devel.Tests
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixMultiply END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix MultiplyAssign.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.MultiplyAssign M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void MatrixMultiplyAssign()
+        {
+            tlog.Debug(tag, $"MatrixMultiplyAssign START");
+
+            var testingTarget = new Matrix();
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            using (Matrix rhs = new Matrix(false))
+            {
+                try
+                {
+                    testingTarget.MultiplyAssign(rhs);
+                }
+                catch (Exception e)
+                {
+                    tlog.Debug(tag, e.Message.ToString());
+                    Assert.Fail("Caught Exception : Failed!");
+                }
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixMultiplyAssign END (OK)");
         }
 
         [Test]
@@ -586,7 +608,8 @@ namespace Tizen.NUI.Devel.Tests
             {
                 try
                 {
-                    testingTarget.Multiply(vector);
+                    var ret = testingTarget.Multiply(vector);
+                    ret.Dispose();
                 }
                 catch (Exception e)
                 {
@@ -618,6 +641,7 @@ namespace Tizen.NUI.Devel.Tests
             {
                 var result = testingTarget.EqualTo(matrix);
                 tlog.Debug(tag, "EqualTo : " + result);
+                Assert.AreEqual(true, result, "EqualTo should be true");
             }
 
             testingTarget.Dispose();
@@ -643,6 +667,7 @@ namespace Tizen.NUI.Devel.Tests
             {
                 var result = testingTarget.NotEqualTo(matrix);
                 tlog.Debug(tag, "NotEqualTo : " + result);
+                Assert.AreEqual(false, result, "NotEqualTo should be false");
             }
 
             testingTarget.Dispose();
@@ -810,6 +835,244 @@ namespace Tizen.NUI.Devel.Tests
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"MatrixGetTransformComponents END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix ValueOfIndex with signle index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.ValueOfIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void MatrixValueOfIndexSingleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"MatrixValueOfIndexSingleIndex START");
+
+            float[] arr = new float[16]
+            { 0.0f, 1.0f, 2.0f, 3.0f,
+              0.1f, 1.1f, 2.1f, 3.1f,
+              0.2f, 1.2f, 2.2f, 3.2f,
+              0.3f, 1.3f, 2.3f, 3.3f};
+
+            Matrix testingTarget = new Matrix(arr);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            for(uint index = 0; index < 16; ++index)
+            {
+                float expectResult = (index / 4) * 0.1f + (index % 4) * 1.0f;
+                Assert.AreEqual(expectResult, testingTarget.ValueOfIndex(index), "The value of index is not correct!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixValueOfIndexSingleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix ValueOfIndex with double index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.ValueOfIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void MatrixValueOfIndexDoubleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"MatrixValueOfIndexDoubleIndex START");
+            float[] arr = new float[16]
+            { 0.0f, 1.0f, 2.0f, 3.0f,
+              0.1f, 1.1f, 2.1f, 3.1f,
+              0.2f, 1.2f, 2.2f, 3.2f,
+              0.3f, 1.3f, 2.3f, 3.3f};
+
+            Matrix testingTarget = new Matrix(arr);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            for(uint indexRow = 0; indexRow < 4; ++indexRow)
+            {
+                for(uint indexColumn = 0; indexColumn < 4; ++indexColumn)
+                {
+                    float expectResult = indexColumn * 0.1f + indexRow * 1.0f;
+                    Assert.AreEqual(expectResult, testingTarget.ValueOfIndex(indexRow, indexColumn), "The value of index is not correct!");
+                }
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixValueOfIndexDoubleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix SetValueAtIndex with signle index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.SetValueAtIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void MatrixSetValueAtIndexSingleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"MatrixSetValueAtIndexSingleIndex START");
+            Matrix testingTarget = new Matrix(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            for(uint index = 0; index < 16; ++index)
+            {
+                float expectResult = (index / 4) * 0.1f + (index % 4) * 1.0f;
+                testingTarget.SetValueAtIndex(index, expectResult);
+                Assert.AreEqual(expectResult, testingTarget[index], "The value of index is not correct!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixSetValueAtIndexSingleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix SetValueAtIndex with double index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.SetValueAtIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void MatrixSetValueAtIndexDoubleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"MatrixSetValueAtIndexDoubleIndex START");
+            Matrix testingTarget = new Matrix(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            for(uint indexRow = 0; indexRow < 4; ++indexRow)
+            {
+                for(uint indexColumn = 0; indexColumn < 4; ++indexColumn)
+                {
+                    float expectResult = indexColumn * 0.1f + indexRow * 1.0f;
+                    testingTarget.SetValueAtIndex(indexRow, indexColumn, expectResult);
+                    Assert.AreEqual(expectResult, testingTarget.ValueOfIndex(indexRow, indexColumn), "The value of index is not correct!");
+                }
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixSetValueAtIndexDoubleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Test Tizen.NUI.Matrix.operator * with Matrix.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.operator *() A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void MatrixMultiplyOperator()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"MatrixMultiplyOperator START");
+            Matrix testingTarget = new Matrix(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            try
+            {
+                Matrix rhs = new Matrix(false);
+                Matrix ret = testingTarget * rhs;
+                rhs.Dispose();
+                ret.Dispose();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixMultiplyOperator END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Test Tizen.NUI.Matrix.operator * with Rotation.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.operator *() A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void MatrixMultiplyOperatorWithRotation()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"MatrixMultiplyOperatorWithRotation START");
+            Matrix testingTarget = new Matrix(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            try
+            {
+                Rotation rhs = new Rotation();
+                Matrix ret = testingTarget * rhs;
+                rhs.Dispose();
+                ret.Dispose();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixMultiplyOperatorWithRotation END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Test Tizen.NUI.Matrix.operator * with Vector4.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.operator *() A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void MatrixMultiplyOperatorWithVector4()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"MatrixMultiplyOperatorWithVector4 START");
+            Matrix testingTarget = new Matrix(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix>(testingTarget, "Should return Matrix instance.");
+
+            try
+            {
+                Vector4 rhs = new Vector4();
+                Vector4 ret = testingTarget * rhs;
+                rhs.Dispose();
+                ret.Dispose();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"MatrixMultiplyOperatorWithVector4 END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Test this[uint index]. Check whether this[uint index] returns expected value or not.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.this[uint] A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void this_SET_GET_VALUE()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrixthis_SET_GET_VALUE START");
+            Matrix testingTarget = new Matrix(true);
+            try
+            {
+                testingTarget[0] = 100.0f;
+                testingTarget[1] = 200.0f;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+            Assert.AreEqual(100.0f, testingTarget[0], "The value of index[0] is not correct!");
+            Assert.AreEqual(200.0f, testingTarget[1], "The value of index[1] is not correct!");
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrixthis_SET_GET_VALUE END (OK)");
         }
     }
 }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Common/TSMatrix3.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Common/TSMatrix3.cs
@@ -1,16 +1,15 @@
 ﻿using global::System;
 using NUnit.Framework;
 using NUnit.Framework.TUnit;
-using Tizen.NUI.Components;
-using Tizen.NUI.BaseComponents;
+using Tizen.NUI;
 
 namespace Tizen.NUI.Devel.Tests
 {
     using tlog = Tizen.Log;
 
     [TestFixture]
-    [Description("internal/Common/Matrix3")]
-    public class InternalMatrix3Test
+    [Description("public/Common/Matrix3")]
+    public class Matrix3Test
     {
         private const string tag = "NUITEST";
 
@@ -184,6 +183,7 @@ namespace Tizen.NUI.Devel.Tests
             {
                 var result = testingTarget.EqualTo(matrix3);
                 tlog.Debug(tag, "EqualTo : " + result);
+                Assert.AreEqual(false, result, "EqualTo should be false");
             }
 
             testingTarget.Dispose();
@@ -209,6 +209,7 @@ namespace Tizen.NUI.Devel.Tests
             {
                 var result = testingTarget.NotEqualTo(matrix3);
                 tlog.Debug(tag, "NotEqualTo : " + result);
+                Assert.AreEqual(true, result, "NotEqualTo should be true");
             }
 
             testingTarget.Dispose();
@@ -246,35 +247,6 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("Matrix3 AsFloat.")]
-        [Property("SPEC", "Tizen.NUI.Matrix3.AsFloat M")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "MR")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void Matrix3AsFloat()
-        {
-            tlog.Debug(tag, $"Matrix3AsFloat START");
-
-            var testingTarget = new Matrix3();
-            Assert.IsNotNull(testingTarget, "Can't create success object Matrix3.");
-            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix3 instance.");
-
-            try
-            {
-                testingTarget.AsFloat();
-            }
-            catch (Exception e)
-            {
-                tlog.Debug(tag, e.Message.ToString());
-                Assert.Fail("Caught Exception : Failed!");
-            }
-
-            testingTarget.Dispose();
-            tlog.Debug(tag, $"Matrix3AsFloat END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
         [Description("Matrix3 Invert.")]
         [Property("SPEC", "Tizen.NUI.Matrix3.Invert M")]
         [Property("SPEC_URL", "-")]
@@ -284,12 +256,14 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"Matrix3Invert START");
 
-            var testingTarget = new Matrix3();
+            // Initialize as invertable matrix
+            var testingTarget = new Matrix3(1.0f, 0.0f, 0.0f, 0.0f, 2.0f, 0.0f, 0.0f, 0.0f, 3.0f);
             Assert.IsNotNull(testingTarget, "Can't create success object Matrix3.");
             Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix3 instance.");
 
             var result = testingTarget.Invert();
             tlog.Debug(tag, "Invert :" + result);
+            Assert.AreEqual(true, result, "Invert should be successed");
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"Matrix3Invert END (OK)");
@@ -423,6 +397,235 @@ namespace Tizen.NUI.Devel.Tests
 
             testingTarget.Dispose();
             tlog.Debug(tag, $"Matrix3Multiply END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix3 MultiplyAssign.")]
+        [Property("SPEC", "Tizen.NUI.Matrix3.MultiplyAssign M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void Matrix3MultiplyAssign()
+        {
+            tlog.Debug(tag, $"Matrix3MultiplyAssign START");
+
+            var testingTarget = new Matrix3();
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix3.");
+            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix3 instance.");
+
+            using (Matrix3 rhs = new Matrix3(0.0f, 0.1f, 0.2f, 1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f))
+            {
+                try
+                {
+                    testingTarget.MultiplyAssign(rhs);
+                }
+                catch (Exception e)
+                {
+                    tlog.Debug(tag, e.Message.ToString());
+                    Assert.Fail("Caught Exception : Failed!");
+                }
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3MultiplyAssign END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix ValueOfIndex with signle index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix.ValueOfIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void Matrix3ValueOfIndexSingleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrix3ValueOfIndexSingleIndex START");
+
+            Matrix3 testingTarget = new Matrix3(0.0f, 1.0f, 2.0f, 0.1f, 1.1f, 2.1f, 0.2f, 1.2f, 2.2f);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix instance.");
+
+            for(uint index = 0; index < 9; ++index)
+            {
+                float expectResult = (index / 3) * 0.1f + (index % 3) * 1.0f;
+                Assert.AreEqual(expectResult, testingTarget.ValueOfIndex(index), "The value of index is not correct!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3ValueOfIndexSingleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix3 ValueOfIndex with double index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix3.ValueOfIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void Matrix3ValueOfIndexDoubleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrix3ValueOfIndexDoubleIndex START");
+
+            Matrix3 testingTarget = new Matrix3(0.0f, 1.0f, 2.0f, 0.1f, 1.1f, 2.1f, 0.2f, 1.2f, 2.2f);
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix instance.");
+
+            for(uint indexRow = 0; indexRow < 3; ++indexRow)
+            {
+                for(uint indexColumn = 0; indexColumn < 3; ++indexColumn)
+                {
+                    float expectResult = indexColumn * 0.1f + indexRow * 1.0f;
+                    Assert.AreEqual(expectResult, testingTarget.ValueOfIndex(indexRow, indexColumn), "The value of index is not correct!");
+                }
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3ValueOfIndexDoubleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix3 SetValueAtIndex with signle index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix3.SetValueAtIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void Matrix3SetValueAtIndexSingleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrix3SetValueAtIndexSingleIndex START");
+            Matrix3 testingTarget = new Matrix3();
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix instance.");
+
+            for(uint index = 0; index < 9; ++index)
+            {
+                float expectResult = (index / 3) * 0.1f + (index % 3) * 1.0f;
+                testingTarget.SetValueAtIndex(index, expectResult);
+                Assert.AreEqual(expectResult, testingTarget[index], "The value of index is not correct!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3SetValueAtIndexSingleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Matrix3 SetValueAtIndex with double index.")]
+        [Property("SPEC", "Tizen.NUI.Matrix3.SetValueAtIndex M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void Matrix3SetValueAtIndexDoubleIndex()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrix3SetValueAtIndexDoubleIndex START");
+            Matrix3 testingTarget = new Matrix3();
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix instance.");
+
+            for(uint indexRow = 0; indexRow < 3; ++indexRow)
+            {
+                for(uint indexColumn = 0; indexColumn < 3; ++indexColumn)
+                {
+                    float expectResult = indexColumn * 0.1f + indexRow * 1.0f;
+                    testingTarget.SetValueAtIndex(indexRow, indexColumn, expectResult);
+                    Assert.AreEqual(expectResult, testingTarget.ValueOfIndex(indexRow, indexColumn), "The value of index is not correct!");
+                }
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3SetValueAtIndexDoubleIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Test Tizen.NUI.Matrix3.operator * with Matrix3.")]
+        [Property("SPEC", "Tizen.NUI.Matrix3.operator *() A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void Matrix3MultiplyOperator()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrix3MultiplyOperator START");
+            Matrix3 testingTarget = new Matrix3();
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix instance.");
+
+            try
+            {
+                Matrix3 rhs = new Matrix3(1.0f, 0.0f, 0.0f, 0.0f, 2.0f, 0.0f, 0.0f, 0.0f, 3.0f);
+                Matrix3 ret = testingTarget * rhs;
+                rhs.Dispose();
+                ret.Dispose();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3MultiplyOperator END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Test Tizen.NUI.Matrix3.operator * with Vector3.")]
+        [Property("SPEC", "Tizen.NUI.Matrix3.operator *() A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void Matrix3MultiplyOperatorWithVector3()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrix3MultiplyOperatorWithVector3 START");
+            Matrix3 testingTarget = new Matrix3();
+            Assert.IsNotNull(testingTarget, "Can't create success object Matrix.");
+            Assert.IsInstanceOf<Matrix3>(testingTarget, "Should return Matrix instance.");
+
+            try
+            {
+                Vector3 rhs = new Vector3();
+                Vector3 ret = testingTarget * rhs;
+                rhs.Dispose();
+                ret.Dispose();
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3MultiplyOperatorWithVector4 END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Test this[uint index]. Check whether this[uint index] returns expected value or not.")]
+        [Property("SPEC", "Tizen.NUI.Matrix3.this[uint] A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Eunki Hong, eunkiki.hong@samsung.com")]
+        public void this_SET_GET_VALUE()
+        {
+            /* TEST CODE */
+            tlog.Debug(tag, $"Matrix3this_SET_GET_VALUE START");
+            Matrix3 testingTarget = new Matrix3();
+            try
+            {
+                testingTarget[0] = 100.0f;
+                testingTarget[1] = 200.0f;
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+            Assert.AreEqual(100.0f, testingTarget[0], "The value of index[0] is not correct!");
+            Assert.AreEqual(200.0f, testingTarget[1], "The value of index[1] is not correct!");
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"Matrix3this_SET_GET_VALUE END (OK)");
         }
     }
 }


### PR DESCRIPTION
Add and bind some matrix operator + remove useless items

And also, move this matrix class under public
so normal NUI Apps also can use this feature

Removed :
 * AsFloat() : Due to ignore unsafe float point accesser.

Added :
 * operator * override.
 * MultiplyAssign (static Matrix.Multiply API cannot do something like this.)
 * Value setter/getter by index (mat[9] == mat.ValueOfIndex(9) == mat.ValueOfIndex(1, 2). Set by mat.SetValueAtIndex(1, 2, 3.0f)
   * Since NUI.Matrix system is column-major, we need to some help for App developer to know the row/column index.

More detail : https://github.com/dalihub/dali-core/blob/master/dali/public-api/math/matrix.h#L38-L58
TODO : Apply comments on this classes. It might be doing on another patches.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

Required dali patch : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/283173