### PR TITLE
[NUI] Support device and window orientation event

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -24,16 +24,12 @@ using Tizen.NUI.Binding;
 
 namespace Tizen.NUI
 {
-    /**
-      * @brief Event arguments that passed via NUIApplicationInit signal
-      */
+    // Event arguments that passed via NUIApplicationInit signal
     internal class NUIApplicationInitEventArgs : EventArgs
     {
         private Application application;
 
-        /**
-          * @brief Application - is the application that is being initialized
-          */
+        // Application - is the application that is being initialized
         public Application Application
         {
             get
@@ -47,15 +43,12 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationTerminate signal
-      */
+    // Event arguments that passed via NUIApplicationTerminate signal
     internal class NUIApplicationTerminatingEventArgs : EventArgs
     {
         private Application application;
-        /**
-          * @brief Application - is the application that is being Terminated
-          */
+
+        // Application - is the application that is being Terminated
         public Application Application
         {
             get
@@ -69,15 +62,12 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationPause signal
-      */
+    // Event arguments that passed via NUIApplicationPause signal
     internal class NUIApplicationPausedEventArgs : EventArgs
     {
         private Application application;
-        /**
-          * @brief Application - is the application that is being Paused
-          */
+
+        // Application - is the application that is being Paused
         public Application Application
         {
             get
@@ -91,15 +81,11 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationResume signal
-      */
+    // Event arguments that passed via NUIApplicationResume signal
     internal class NUIApplicationResumedEventArgs : EventArgs
     {
         private Application application;
-        /**
-          * @brief Application - is the application that is being Resumed
-          */
+        // Application - is the application that is being Resumed
         public Application Application
         {
             get
@@ -113,15 +99,12 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationReset signal
-      */
+    // Event arguments that passed via NUIApplicationReset signal
     internal class NUIApplicationResetEventArgs : EventArgs
     {
         private Application application;
-        /**
-          * @brief Application - is the application that is being Reset
-          */
+
+        // Application - is the application that is being Reset
         public Application Application
         {
             get
@@ -135,15 +118,12 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationLanguageChanged signal
-      */
+    // Event arguments that passed via NUIApplicationLanguageChanged signal
     internal class NUIApplicationLanguageChangedEventArgs : EventArgs
     {
         private Application application;
-        /**
-          * @brief Application - is the application that is being affected with Device's language change
-          */
+
+        // Application - is the application that is being affected with Device's language change
         public Application Application
         {
             get
@@ -157,15 +137,12 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationRegionChanged signal
-      */
+    // Event arguments that passed via NUIApplicationRegionChanged signal
     internal class NUIApplicationRegionChangedEventArgs : EventArgs
     {
         private Application application;
-        /**
-          * @brief Application - is the application that is being affected with Device's region change
-          */
+
+        // Application - is the application that is being affected with Device's region change
         public Application Application
         {
             get
@@ -179,15 +156,12 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationBatteryLow signal
-      */
+    // Event arguments that passed via NUIApplicationBatteryLow signal
     internal class NUIApplicationBatteryLowEventArgs : EventArgs
     {
         private Application.BatteryStatus status;
-        /**
-          * @brief Application - is the application that is being affected when the battery level of the device is low
-          */
+
+        // Application - is the application that is being affected when the battery level of the device is low
         public Application.BatteryStatus BatteryStatus
         {
             get
@@ -201,15 +175,12 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationMemoryLow signal
-      */
+    // Event arguments that passed via NUIApplicationMemoryLow signal
     internal class NUIApplicationMemoryLowEventArgs : EventArgs
     {
         private Application.MemoryStatus status;
-        /**
-          * @brief Application - is the application that is being affected when the memory level of the device is low
-          */
+
+        // Application - is the application that is being affected when the memory level of the device is low
         public Application.MemoryStatus MemoryStatus
         {
             get
@@ -223,16 +194,32 @@ namespace Tizen.NUI
         }
     }
 
-    /**
-      * @brief Event arguments that passed via NUIApplicationAppControl	 signal
-      */
+    // Event arguments that passed via NUIApplicationDeviceOrientationChanged signal
+    internal class NUIApplicationDeviceOrientationChangedEventArgs : EventArgs
+    {
+        private Application.DeviceOrientationStatus status;
+
+        // Application - is the application that is being affected when the device orientation is changed.
+        public Application.DeviceOrientationStatus DeviceOrientationStatus
+        {
+            get
+            {
+                return status;
+            }
+            set
+            {
+                status = value;
+            }
+        }
+    }
+
+    // Event arguments that passed via NUIApplicationAppControl	 signal
     internal class NUIApplicationAppControlEventArgs : EventArgs
     {
         private Application application;
         private IntPtr voidp;
-        /**
-          * @brief Application - is the application that is receiving the launch request from another application
-          */
+
+        // Application - is the application that is receiving the launch request from another application
         public Application Application
         {
             get
@@ -244,9 +231,8 @@ namespace Tizen.NUI
                 application = value;
             }
         }
-        /**
-          * @brief VoidP - contains the information about why the application is launched
-          */
+
+        // VoidP - contains the information about why the application is launched
         public IntPtr VoidP
         {
             get
@@ -456,6 +442,13 @@ namespace Tizen.NUI
                 memoryLowSignal = null;
             }
 
+            if (applicationDeviceOrientationChangedEventCallback != null)
+            {
+                deviceOrientationChangedSignal?.Disconnect(applicationDeviceOrientationChangedEventCallback);
+                deviceOrientationChangedSignal?.Dispose();
+                deviceOrientationChangedSignal = null;
+            }
+
             if (applicationAppControlEventCallbackDelegate != null)
             {
                 appControlSignal?.Disconnect(applicationAppControlEventCallbackDelegate);
@@ -506,6 +499,13 @@ namespace Tizen.NUI
                 taskMemoryLowSignal = null;
             }
 
+            if (applicationTaskDeviceOrientationChangedEventCallback != null)
+            {
+                taskDeviceOrientationChangedSignal?.Disconnect(applicationTaskDeviceOrientationChangedEventCallback);
+                taskDeviceOrientationChangedSignal?.Dispose();
+                taskDeviceOrientationChangedSignal = null;
+            }
+
             if (applicationTaskAppControlEventCallbackDelegate != null)
             {
                 taskAppControlSignal?.Disconnect(applicationTaskAppControlEventCallbackDelegate);
@@ -535,6 +535,14 @@ namespace Tizen.NUI
             Normal,
             Low,
             CriticallyLow
+        };
+
+        public enum DeviceOrientationStatus
+        {
+            Orientation_0 = 0,
+            Orientation_90 = 90,
+            Orientation_180 = 180,
+            Orientation_270 = 270
         };
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -593,6 +601,12 @@ namespace Tizen.NUI
         private LowMemorySignalType memoryLowSignal;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void NUIApplicationDeviceOrientationChangedEventCallback(DeviceOrientationStatus status);
+        private DaliEventHandler<object, NUIApplicationDeviceOrientationChangedEventArgs> applicationDeviceOrientationChangedEventHandler;
+        private NUIApplicationDeviceOrientationChangedEventCallback applicationDeviceOrientationChangedEventCallback;
+        private DeviceOrientationChangedSignalType deviceOrientationChangedSignal;
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void NUIApplicationAppControlEventCallbackDelegate(IntPtr application, IntPtr voidp);
         private DaliEventHandler<object, NUIApplicationAppControlEventArgs> applicationAppControlEventHandler;
         private NUIApplicationAppControlEventCallbackDelegate applicationAppControlEventCallbackDelegate;
@@ -622,16 +636,18 @@ namespace Tizen.NUI
         private NUIApplicationMemoryLowEventCallbackDelegate applicationTaskMemoryLowEventCallbackDelegate;
         private LowMemorySignalType taskMemoryLowSignal;
 
+        private DaliEventHandler<object, NUIApplicationDeviceOrientationChangedEventArgs> applicationTaskDeviceOrientationChangedEventHandler;
+        private NUIApplicationDeviceOrientationChangedEventCallback applicationTaskDeviceOrientationChangedEventCallback;
+        private DeviceOrientationChangedSignalType taskDeviceOrientationChangedSignal;
+
         private DaliEventHandler<object, NUIApplicationAppControlEventArgs> applicationTaskAppControlEventHandler;
         private NUIApplicationAppControlEventCallbackDelegate applicationTaskAppControlEventCallbackDelegate;
         private ApplicationControlSignal taskAppControlSignal;
 
         private Window window;
 
-        /**
-          * @brief Event for Initialized signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. Initialized signal is emitted when application is initialized
-          */
+        // Event for Initialized signal which can be used to subscribe/unsubscribe the event handler
+        // provided by the user. Initialized signal is emitted when application is initialized
         public event DaliEventHandler<object, NUIApplicationInitEventArgs> Initialized
         {
             add
@@ -682,10 +698,8 @@ namespace Tizen.NUI
 
         }
 
-        /**
-          * @brief Event for Terminated signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. Terminated signal is emitted when application is terminating
-          */
+        // Event for Terminated signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. Terminated signal is emitted when application is terminating
         public event DaliEventHandler<object, NUIApplicationTerminatingEventArgs> Terminating
         {
             add
@@ -731,10 +745,8 @@ namespace Tizen.NUI
             }
         }
 
-        /**
-          * @brief Event for Paused signal which can be used to subscribe/unsubscribe the event handler
-          * provided by the user. Paused signal is emitted when application is paused
-          */
+        // Event for Paused signal which can be used to subscribe/unsubscribe the event handler
+        // provided by the user. Paused signal is emitted when application is paused
         public event DaliEventHandler<object, NUIApplicationPausedEventArgs> Paused
         {
             add
@@ -774,10 +786,8 @@ namespace Tizen.NUI
             }
         }
 
-        /**
-          * @brief Event for Resumed signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. Resumed signal is emitted when application is resumed
-          */
+        // Event for Resumed signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. Resumed signal is emitted when application is resumed
         public event DaliEventHandler<object, NUIApplicationResumedEventArgs> Resumed
         {
             add
@@ -817,10 +827,8 @@ namespace Tizen.NUI
             }
         }
 
-        /**
-          * @brief Event for Reset signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. Reset signal is emitted when application is reset
-          */
+        // Event for Reset signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. Reset signal is emitted when application is reset
         public new event DaliEventHandler<object, NUIApplicationResetEventArgs> Reset
         {
             add
@@ -860,10 +868,8 @@ namespace Tizen.NUI
             }
         }
 
-        /**
-          * @brief Event for LanguageChanged signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. LanguageChanged signal is emitted when the region of the device is changed.
-          */
+        // Event for LanguageChanged signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. LanguageChanged signal is emitted when the region of the device is changed.
         public event DaliEventHandler<object, NUIApplicationLanguageChangedEventArgs> LanguageChanged
         {
             add
@@ -903,10 +909,8 @@ namespace Tizen.NUI
             }
         }
 
-        /**
-          * @brief Event for RegionChanged signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. RegionChanged signal is emitted when the region of the device is changed.
-          */
+        // Event for RegionChanged signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. RegionChanged signal is emitted when the region of the device is changed.
         public event DaliEventHandler<object, NUIApplicationRegionChangedEventArgs> RegionChanged
         {
             add
@@ -946,10 +950,8 @@ namespace Tizen.NUI
             }
         }
 
-        /**
-          * @brief Event for BatteryLow signal which can be used to subscribe/unsubscribe the event handler
-          * provided by the user. BatteryLow signal is emitted when the battery level of the device is low.
-          */
+        // Event for BatteryLow signal which can be used to subscribe/unsubscribe the event handler
+        // provided by the user. BatteryLow signal is emitted when the battery level of the device is low.
         public event DaliEventHandler<object, NUIApplicationBatteryLowEventArgs> BatteryLow
         {
             add
@@ -988,10 +990,8 @@ namespace Tizen.NUI
             applicationBatteryLowEventHandler?.Invoke(this, e);
         }
 
-        /**
-          * @brief Event for MemoryLow signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. MemoryLow signal is emitted when the memory level of the device is low.
-          */
+        // Event for MemoryLow signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. MemoryLow signal is emitted when the memory level of the device is low.
         public event DaliEventHandler<object, NUIApplicationMemoryLowEventArgs> MemoryLow
         {
             add
@@ -1030,10 +1030,47 @@ namespace Tizen.NUI
             applicationMemoryLowEventHandler?.Invoke(this, e);
         }
 
-        /**
-          * @brief Event for AppControl signal which can be used to subscribe/unsubscribe the event handler
-          *  provided by the user. AppControl signal is emitted when another application sends a launch request to the application.
-          */
+        // Event for changing Device orientation signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. DeviceOrientationChanged signal is emitted when the device orientation is changed.
+        public event DaliEventHandler<object, NUIApplicationDeviceOrientationChangedEventArgs> DeviceOrientationChanged
+        {
+            add
+            {
+                // Restricted to only one listener
+                if (applicationDeviceOrientationChangedEventHandler == null)
+                {
+                    applicationDeviceOrientationChangedEventHandler += value;
+
+                    applicationDeviceOrientationChangedEventCallback = new NUIApplicationDeviceOrientationChangedEventCallback(OnNUIApplicationDeviceOrientationChanged);
+                    deviceOrientationChangedSignal = this.DeviceOrientationChangedSignal();
+                    deviceOrientationChangedSignal?.Connect(applicationDeviceOrientationChangedEventCallback);
+                }
+            }
+
+            remove
+            {
+                if (applicationDeviceOrientationChangedEventHandler != null)
+                {
+                    deviceOrientationChangedSignal?.Disconnect(applicationDeviceOrientationChangedEventCallback);
+                    deviceOrientationChangedSignal?.Dispose();
+                    deviceOrientationChangedSignal = null;
+                }
+
+                applicationDeviceOrientationChangedEventHandler -= value;
+            }
+        }
+
+        // Callback for Application DeviceOrientationChangedSignal
+        private void OnNUIApplicationDeviceOrientationChanged(DeviceOrientationStatus status)
+        {
+            NUIApplicationDeviceOrientationChangedEventArgs e = new NUIApplicationDeviceOrientationChangedEventArgs();
+
+            e.DeviceOrientationStatus = status;
+            applicationDeviceOrientationChangedEventHandler?.Invoke(this, e);
+        }
+
+        // Event for AppControl signal which can be used to subscribe/unsubscribe the event handler
+        //  provided by the user. AppControl signal is emitted when another application sends a launch request to the application.
         public event DaliEventHandler<object, NUIApplicationAppControlEventArgs> AppControl
         {
             add
@@ -1075,7 +1112,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// @brief Event for Initialized signal which can be used to subscribe/unsubscribe the event handler
+        /// Event for Initialized signal which can be used to subscribe/unsubscribe the event handler
         ///  provided by the user. Initialized signal is emitted when application is initialized
         /// </summary>
         public event DaliEventHandler<object, NUIApplicationInitEventArgs> TaskInitialized
@@ -1118,7 +1155,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// @brief Event for Terminated signal which can be used to subscribe/unsubscribe the event handler
+        /// Event for Terminated signal which can be used to subscribe/unsubscribe the event handler
         ///  provided by the user. Terminated signal is emitted when application is terminating
         /// </summary>
         public event DaliEventHandler<object, NUIApplicationTerminatingEventArgs> TaskTerminating
@@ -1160,7 +1197,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// @brief Event for TaskLanguageChanged signal which can be used to subscribe/unsubscribe the event handler
+        /// Event for TaskLanguageChanged signal which can be used to subscribe/unsubscribe the event handler
         ///  provided by the user. TaskLanguageChanged signal is emitted when the region of the device is changed.
         /// </summary>
         public event DaliEventHandler<object, NUIApplicationLanguageChangedEventArgs> TaskLanguageChanged
@@ -1202,7 +1239,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// @brief Event for TaskRegionChanged signal which can be used to subscribe/unsubscribe the event handler
+        /// Event for TaskRegionChanged signal which can be used to subscribe/unsubscribe the event handler
         ///  provided by the user. TaskRegionChanged signal is emitted when the region of the device is changed.
         /// </summary>
         public event DaliEventHandler<object, NUIApplicationRegionChangedEventArgs> TaskRegionChanged
@@ -1244,7 +1281,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// @brief Event for TaskBatteryLow signal which can be used to subscribe/unsubscribe the event handler
+        /// Event for TaskBatteryLow signal which can be used to subscribe/unsubscribe the event handler
         /// provided by the user. TaskBatteryLow signal is emitted when the battery level of the device is low.
         /// </summary>
         public event DaliEventHandler<object, NUIApplicationBatteryLowEventArgs> TaskBatteryLow
@@ -1285,7 +1322,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// @brief Event for TaskMemoryLow signal which can be used to subscribe/unsubscribe the event handler
+        /// Event for TaskMemoryLow signal which can be used to subscribe/unsubscribe the event handler
         /// provided by the user. TaskMemoryLow signal is emitted when the memory level of the device is low.
         /// </summary>
         public event DaliEventHandler<object, NUIApplicationMemoryLowEventArgs> TaskMemoryLow
@@ -1326,7 +1363,46 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// @brief Event for TaskAppControl signal which can be used to subscribe/unsubscribe the event handler
+        /// Event for TaskDeviceOrientationChanged signal which can be used to subscribe/unsubscribe the event handler
+        /// provided by the user. TaskDeviceOrientationChanged signal is emitted when the device orientation is changed.
+        /// </summary>
+        public event DaliEventHandler<object, NUIApplicationDeviceOrientationChangedEventArgs> TaskDeviceOrientationChanged
+        {
+            add
+            {
+                if (applicationTaskDeviceOrientationChangedEventHandler == null)
+                {
+                    applicationTaskDeviceOrientationChangedEventHandler += value;
+
+                    applicationTaskDeviceOrientationChangedEventCallback = new NUIApplicationDeviceOrientationChangedEventCallback(OnNUIApplicationTaskDeviceOrientationChanged);
+                    taskDeviceOrientationChangedSignal = this.TaskDeviceOrientationChangedSignal();
+                    taskDeviceOrientationChangedSignal?.Connect(applicationTaskDeviceOrientationChangedEventCallback);
+                }
+            }
+
+            remove
+            {
+                if (applicationTaskDeviceOrientationChangedEventHandler != null)
+                {
+                    taskDeviceOrientationChangedSignal?.Disconnect(applicationTaskDeviceOrientationChangedEventCallback);
+                    taskDeviceOrientationChangedSignal?.Dispose();
+                    taskDeviceOrientationChangedSignal = null;
+                }
+
+                applicationTaskDeviceOrientationChangedEventHandler -= value;
+            }
+        }
+
+        private void OnNUIApplicationTaskDeviceOrientationChanged(DeviceOrientationStatus status)
+        {
+            NUIApplicationDeviceOrientationChangedEventArgs e = new NUIApplicationDeviceOrientationChangedEventArgs();
+
+            e.DeviceOrientationStatus = status;
+            applicationTaskDeviceOrientationChangedEventHandler?.Invoke(this, e);
+        }
+
+        /// <summary>
+        /// Event for TaskAppControl signal which can be used to subscribe/unsubscribe the event handler
         /// provided by the user. TaskAppControl signal is emitted when another application sends a launch request to the application.
         /// </summary>
         public event DaliEventHandler<object, NUIApplicationAppControlEventArgs> TaskAppControl
@@ -1803,6 +1879,13 @@ namespace Tizen.NUI
             return ret;
         }
 
+        internal DeviceOrientationChangedSignalType DeviceOrientationChangedSignal()
+        {
+            DeviceOrientationChangedSignalType ret = new DeviceOrientationChangedSignalType(NDalicPINVOKE.ApplicationDeviceOrientationChangedSignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         //Task
         internal ApplicationSignal TaskInitSignal()
         {
@@ -1849,6 +1932,13 @@ namespace Tizen.NUI
         internal LowMemorySignalType TaskMemoryLowSignal()
         {
             LowMemorySignalType ret = new LowMemorySignalType(NDalicPINVOKE.ApplicationTaskLowMemorySignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal DeviceOrientationChangedSignalType TaskDeviceOrientationChangedSignal()
+        {
+            DeviceOrientationChangedSignalType ret = new DeviceOrientationChangedSignalType(NDalicPINVOKE.ApplicationTaskDeviceOrientationChangedSignal(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
@@ -211,6 +211,7 @@ namespace Tizen.NUI
             application.LanguageChanged += OnLanguageChanged;
             application.MemoryLow += OnMemoryLow;
             application.RegionChanged += OnRegionChanged;
+            application.DeviceOrientationChanged += OnDeviceOrientationChanged;
 
             application.Initialized += OnInitialized;
             application.Resumed += OnResumed;
@@ -227,6 +228,7 @@ namespace Tizen.NUI
                 application.TaskLanguageChanged += OnTaskLanguageChanged;
                 application.TaskMemoryLow += OnTaskMemoryLow;
                 application.TaskRegionChanged += OnTaskRegionChanged;
+                application.TaskDeviceOrientationChanged += OnTaskDeviceOrientationChanged;
 
                 application.TaskInitialized += OnTaskInitialized;
                 application.TaskTerminating += OnTaskTerminated;
@@ -326,6 +328,41 @@ namespace Tizen.NUI
                 case Application.BatteryStatus.PowerOff:
                     {
                         handler?.Invoke(new LowBatteryEventArgs(LowBatteryStatus.PowerOff));
+                        break;
+                    }
+            }
+        }
+
+        /// <summary>
+        /// The Device Orientation changed event callback function.
+        /// </summary>
+        /// <param name="source">The application instance.</param>
+        /// <param name="e">The event argument for DeviceOrientationChanged.</param>
+        private void OnDeviceOrientationChanged(object source, NUIApplicationDeviceOrientationChangedEventArgs e)
+        {
+            Log.Info("NUI", "NUICorebackend OnDeviceOrientationChanged Called");
+            var handler = Handlers[EventType.DeviceOrientationChanged] as Action<DeviceOrientationEventArgs>;
+
+            switch (e.DeviceOrientationStatus)
+            {
+                case Application.DeviceOrientationStatus.Orientation_0:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_0));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_90:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_90));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_180:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_180));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_270:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_270));
                         break;
                     }
             }
@@ -486,6 +523,39 @@ namespace Tizen.NUI
                 case Application.BatteryStatus.PowerOff:
                     {
                         coreTask?.OnLowBattery(new LowBatteryEventArgs(LowBatteryStatus.PowerOff));
+                        break;
+                    }
+            }
+        }
+
+        /// <summary>
+        /// The Orientation Changed event callback function. The callback is emitted on the main thread.
+        /// </summary>
+        /// <param name="source">The application instance.</param>
+        /// <param name="e">The event argument for changing device orientation.</param>
+        private void OnTaskDeviceOrientationChanged(object source, NUIApplicationDeviceOrientationChangedEventArgs e)
+        {
+            Log.Info("NUI", "NUICorebackend OnTaskBatteryLow Called");
+            switch (e.DeviceOrientationStatus)
+            {
+                case Application.DeviceOrientationStatus.Orientation_0:
+                    {
+                        coreTask?.OnDeviceOrientationChanged(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_0));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_90:
+                    {
+                        coreTask?.OnDeviceOrientationChanged(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_90));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_180:
+                    {
+                        coreTask?.OnDeviceOrientationChanged(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_180));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_270:
+                    {
+                        coreTask?.OnDeviceOrientationChanged(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_270));
                         break;
                     }
             }

--- a/src/Tizen.NUI/src/internal/Application/NUIWidgetCoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUIWidgetCoreBackend.cs
@@ -116,7 +116,8 @@ namespace Tizen.NUI
             application.BatteryLow += OnBatteryLow;
             application.LanguageChanged += OnLanguageChanged;
             application.MemoryLow += OnMemoryLow;
-            application.RegionChanged += OnRegionChanged; ;
+            application.RegionChanged += OnRegionChanged;
+            application.DeviceOrientationChanged += OnDeviceOrientationChanged;
             application.Initialized += OnInitialized;
             application.Terminating += OnTerminated;
 
@@ -224,6 +225,40 @@ namespace Tizen.NUI
                 case Application.BatteryStatus.PowerOff:
                     {
                         handler?.Invoke(new LowBatteryEventArgs(LowBatteryStatus.PowerOff));
+                        break;
+                    }
+            }
+        }
+
+        /// <summary>
+        /// The Device Orientation changed event callback function.
+        /// </summary>
+        /// <param name="source">The application instance.</param>
+        /// <param name="e">The event argument for DeviceOrientationChanged.</param>
+        private void OnDeviceOrientationChanged(object source, NUIApplicationDeviceOrientationChangedEventArgs e)
+        {
+            var handler = handlers[EventType.DeviceOrientationChanged] as Action<DeviceOrientationEventArgs>;
+
+            switch (e.DeviceOrientationStatus)
+            {
+                case Application.DeviceOrientationStatus.Orientation_0:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_0));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_90:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_90));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_180:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_180));
+                        break;
+                    }
+                case Application.DeviceOrientationStatus.Orientation_270:
+                    {
+                        handler?.Invoke(new DeviceOrientationEventArgs(DeviceOrientation.Orientation_270));
                         break;
                     }
             }

--- a/src/Tizen.NUI/src/internal/Common/DeviceOrientationChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/DeviceOrientationChangedSignalType.cs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal class DeviceOrientationChangedSignalType : Disposable
+    {
+        internal DeviceOrientationChangedSignalType(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.DeviceOrientationChangedSignalType.DeleteDeviceOrientationChangedSignalType(swigCPtr);
+        }
+
+        public bool Empty()
+        {
+            bool ret = Interop.DeviceOrientationChangedSignalType.Empty(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public uint GetConnectionCount()
+        {
+            uint ret = Interop.DeviceOrientationChangedSignalType.GetConnectionCount(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
+            {
+                Interop.DeviceOrientationChangedSignalType.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(func);
+            {
+                Interop.DeviceOrientationChangedSignalType.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        internal void Emit(Application.MemoryStatus arg)
+        {
+            Interop.DeviceOrientationChangedSignalType.Emit(SwigCPtr, (int)arg);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public DeviceOrientationChangedSignalType() : this(Interop.DeviceOrientationChangedSignalType.NewDeviceOrientationChangedSignalType(), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DeviceOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DeviceOrientationChangedSignal.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class DeviceOrientationChangedSignalType
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Empty")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_GetConnectionCount")]
+            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Connect")]
+            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Disconnect")]
+            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignalType_Emit")]
+            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_new_DeviceOrientationChangedSignalType")]
+            public static extern global::System.IntPtr NewDeviceOrientationChangedSignalType();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_delete_DeviceOrientationChangedSignalType")]
+            public static extern void DeleteDeviceOrientationChangedSignalType(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowOrientationChangedSignal.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WindowOrientationChangedSignal
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_Orientation_Changed_Signal")]
+            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Empty")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_GetConnectionCount")]
+            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Connect")]
+            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Orientation_Changed_Signal_Disconnect")]
+            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Orientation_Changed_Signal_Emit")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Emit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Orientation_Changed_Signal")]
+            public static extern global::System.IntPtr NewSignal();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Orientation_Changed_Signal")]
+            public static extern void DeleteSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -277,6 +277,9 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_LowMemorySignal")]
         public static extern global::System.IntPtr ApplicationLowMemorySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_DeviceOrientationChangedSignal")]
+        public static extern global::System.IntPtr ApplicationDeviceOrientationChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
         //Task
         [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_TaskInitSignal")]
         public static extern global::System.IntPtr ApplicationTaskInitSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -299,6 +302,8 @@ namespace Tizen.NUI
         [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_TaskLowMemorySignal")]
         public static extern global::System.IntPtr ApplicationTaskLowMemorySignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+        [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_TaskDeviceOrientationChangedSignal")]
+        public static extern global::System.IntPtr ApplicationTaskDeviceOrientationChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
         [Obsolete("This has been deprecated in API9 and will be removed in API11. Use NDalicPINVOKE.DeleteBaseHandle(...) instead.")]
         [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle")]

--- a/src/Tizen.NUI/src/internal/Window/WindowOrientationChangedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowOrientationChangedSignal.cs
@@ -1,0 +1,77 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal class WindowOrientationChangedSignal : Disposable
+    {
+        internal WindowOrientationChangedSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WindowOrientationChangedSignal.DeleteSignal(swigCPtr);
+        }
+
+        public bool Empty()
+        {
+            bool ret = Interop.WindowOrientationChangedSignal.Empty(SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public uint GetConnectionCount()
+        {
+            uint ret = Interop.WindowOrientationChangedSignal.GetConnectionCount(SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowOrientationChangedSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowOrientationChangedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        public bool Emit(Window window, int orientation)
+        {
+            bool ret = Interop.WindowOrientationChangedSignal.Emit(SwigCPtr, Window.getCPtr(window), orientation);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public WindowOrientationChangedSignal(Window window) : this(Interop.WindowOrientationChangedSignal.GetSignal(Window.getCPtr(window)), false)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -508,6 +508,20 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// This method is to handle behavior when the device orientation is changed.
+        ///
+        /// When device is rotated to ccw or cw, this event occurs.
+        /// In addition, this event is different to window orientation changed event.
+        /// The window orientation event is for per a window and occurs when some flags should be set before.
+        /// </summary>
+        /// <param name="e">The device orientation changed event argument</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
+        {
+            base.OnDeviceOrientationChanged(e);
+        }
+
+        /// <summary>
         /// Overrides this method if you want to handle behavior.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.NUI/src/public/Application/NUIWidgetApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIWidgetApplication.cs
@@ -165,6 +165,21 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// This method is to handle behavior when the device orientation is changed.
+        ///
+        /// When device is rotated to ccw or cw, this event occurs.
+        /// In addition, this event is different to window orientation changed event.
+        /// The window orientation event is for per a window and occurs when some flags should be set before.
+        /// </summary>
+        /// <param name="e">The device orientation changed event argument</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
+        {
+            Log.Fatal("NUI", "OnDeviceOrientationChanged() is called!");
+            base.OnDeviceOrientationChanged(e);
+        }
+
+        /// <summary>
         /// Overrides this method if want to handle OnTerminate behavior.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>

--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -47,6 +47,7 @@ namespace Tizen.NUI
         private WindowFocusChangedEventCallbackType windowFocusChangedEventCallback2;
         private TransitionEffectEventCallbackType transitionEffectEventCallback;
         private MovedEventCallbackType movedEventCallback;
+        private OrientationChangedEventCallbackType orientationChangedEventCallback;
         private KeyboardRepeatSettingsChangedEventCallbackType keyboardRepeatSettingsChangedEventCallback;
         private AuxiliaryMessageEventCallbackType auxiliaryMessageEventCallback;
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -63,6 +64,8 @@ namespace Tizen.NUI
         private delegate void TransitionEffectEventCallbackType(IntPtr window, int state, int type);
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void MovedEventCallbackType(IntPtr window, IntPtr position);
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        private delegate void OrientationChangedEventCallbackType(IntPtr window, int orientation);
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate void KeyboardRepeatSettingsChangedEventCallbackType();
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -415,6 +418,38 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Window Orientation Changed event
+        /// This event is for per windows
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<WindowOrientationChangedEventArgs> OrientationChanged
+        {
+            add
+            {
+                if (orientationChangedHandler == null)
+                {
+                    orientationChangedEventCallback = OnOrientationChanged;
+                    using WindowOrientationChangedSignal signal = new WindowOrientationChangedSignal(Interop.WindowOrientationChangedSignal.GetSignal(SwigCPtr), false);
+                    signal?.Connect(orientationChangedEventCallback);
+                }
+                orientationChangedHandler += value;
+            }
+            remove
+            {
+                orientationChangedHandler -= value;
+                if (orientationChangedHandler == null && orientationChangedEventCallback != null)
+                {
+                    using WindowOrientationChangedSignal signal = new WindowOrientationChangedSignal(Interop.WindowOrientationChangedSignal.GetSignal(SwigCPtr), false);
+                    signal?.Disconnect(orientationChangedEventCallback);
+                    if (signal?.Empty() == true)
+                    {
+                        orientationChangedEventCallback = null;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Keyboard Repeat Settings Changed
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -463,6 +498,7 @@ namespace Tizen.NUI
         private event EventHandler<FocusChangedEventArgs> windowFocusChangedEventHandler2;
         private event EventHandler<TransitionEffectEventArgs> transitionEffectHandler;
         private event EventHandler<WindowMovedEventArgs> movedHandler;
+        private event EventHandler<WindowOrientationChangedEventArgs> orientationChangedHandler;
         private event EventHandler keyboardRepeatSettingsChangedHandler;
         private event EventHandler<AuxiliaryMessageEventArgs> auxiliaryMessageEventHandler;
 
@@ -704,6 +740,13 @@ namespace Tizen.NUI
                 movedEventCallback = null;
             }
 
+            if (orientationChangedEventCallback != null)
+            {
+                using WindowOrientationChangedSignal signal = new WindowOrientationChangedSignal(Interop.WindowOrientationChangedSignal.GetSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(orientationChangedEventCallback);
+                orientationChangedEventCallback = null;
+            }
+
             if (keyboardRepeatSettingsChangedEventCallback != null)
             {
                 using KeyboardRepeatSettingsChangedSignal signal = new KeyboardRepeatSettingsChangedSignal(Interop.KeyboardRepeatSettingsChangedSignal.GetSignal(GetBaseHandleCPtrHandleRef), false);
@@ -912,6 +955,22 @@ namespace Tizen.NUI
                 WindowMovedEventArgs e = new WindowMovedEventArgs();
                 e.WindowPosition = this.WindowPosition;
                 movedHandler(this, e);
+            }
+            return;
+        }
+
+        private void OnOrientationChanged(IntPtr window, int orientation)
+        {
+            if (window == global::System.IntPtr.Zero)
+            {
+                return;
+            }
+
+            if (orientationChangedHandler != null)
+            {
+                WindowOrientationChangedEventArgs e = new WindowOrientationChangedEventArgs();
+                e.WindowOrientation = (WindowOrientation)orientation;
+                orientationChangedHandler(this, e);
             }
             return;
         }
@@ -1402,6 +1461,28 @@ namespace Tizen.NUI
             set
             {
                 position = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// OrientationChangedArgs
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WindowOrientationChangedEventArgs : EventArgs
+    {
+        private Window.WindowOrientation orientation;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Window.WindowOrientation WindowOrientation
+        {
+            get
+            {
+                return orientation;
+            }
+            set
+            {
+                orientation = value;
             }
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowEventsTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowEventsTest.cs
@@ -45,6 +45,8 @@ namespace Tizen.NUI.Samples
             Window.Instance.GetDefaultLayer().Add(parent1);
             Window.Instance.GetDefaultLayer().Add(parent2);
 
+            Window.Instance.OrientationChanged += OnWindowOrientationChangedEvent;
+
             parent1.LeftFocusableView = parent2;
             parent2.RightFocusableView = parent1;
 
@@ -53,6 +55,17 @@ namespace Tizen.NUI.Samples
 
             FocusManager.Instance.SetCurrentFocusView(parent1);
             Window.Instance.BackgroundColor = new Color(1.0f, 0.92f, 0.80f, 1.0f);
+
+            Window.Instance.AddAvailableOrientation(Window.WindowOrientation.Portrait);
+            Window.Instance.AddAvailableOrientation(Window.WindowOrientation.Landscape);
+            Window.Instance.AddAvailableOrientation(Window.WindowOrientation.PortraitInverse);
+            Window.Instance.AddAvailableOrientation(Window.WindowOrientation.LandscapeInverse);
+        }
+
+        private void OnWindowOrientationChangedEvent(object sender, WindowOrientationChangedEventArgs e)
+        {
+            Window.WindowOrientation orientation = e.WindowOrientation;
+            log.Fatal(tag, $"OnWindowOrientationChangedEvent() called!, orientation:{orientation}");
         }
 
         private void OnParentFocusGained(object sender, EventArgs e)

--- a/test/Tizen.NUI.UIThread/Tizen.NUI.UIThread.cs
+++ b/test/Tizen.NUI.UIThread/Tizen.NUI.UIThread.cs
@@ -42,6 +42,11 @@ namespace UIThreadApp
         {
             Tizen.Log.Info("UIThreadApp", "CoreTask OnRegionFormatChanged " + e.Region);
         }
+
+        public override void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
+        {
+            Tizen.Log.Info("UIThreadApp", "CoreTask OnDeviceOrientationChanged " + e.DeviceOrientation);
+        }
     }
 
     class Program : NUIApplication
@@ -78,6 +83,11 @@ namespace UIThreadApp
         protected override void OnRegionFormatChanged(RegionFormatChangedEventArgs e)
         {
             Tizen.Log.Info("UIThreadApp", "NUIApplication OnRegionFormatChanged " + e.Region);
+        }
+
+        protected override void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
+        {
+            Tizen.Log.Info("UIThreadApp", "NUIApplication OnDeviceOrientationChanged " + e.DeviceOrientation);
         }
 
         protected override void OnTerminate()


### PR DESCRIPTION
Supporting  Device orientation and Window Orienation event when device orientation is changed or window orientation is changed. Window orientation event is emitted by display server. To emit the Window Orientation event, AddAvailableOrientation() or SetPreferredOrientation() should be called before the device is rotated. Otherwise, Device Orientation event is emitted by Application framework and any condition is not needed.

This PR should be sync merged with the below patches.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/283622/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/283830/
