### PR TITLE
[NUI.Scene3D] Remove useless default property setter on Model

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -78,9 +78,6 @@ namespace Tizen.NUI.Scene3D
     {
         internal Model(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
-            // Currenly, Model don't have API to access it's child. So, we make it false.
-            this.ChildrenSensitive = false;
-            this.FocusableChildren = false;
         }
 
         /// <summary>
@@ -121,31 +118,6 @@ namespace Tizen.NUI.Scene3D
             Model ret = new Model(Interop.Model.ModelAssign(SwigCPtr, Model.getCPtr(model)), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
-        }
-
-        /// <summary>
-        /// Set/Get whether allow this model's children allow to use touch events.
-        /// This property doesn't change Model itself's Sensitive info.
-        /// If this property is true, event can traversal this models children.
-        /// If this property is false, event traversal blocked.
-        /// Default is false.
-        /// </summary>
-        /// <remarks>
-        /// If ChildrenSensitive is true, it could decrease performance but we can connect events into it's children.
-        /// If ChildrenSensitive is false, the performance becomes better but we cannot connect events into it's children.
-        ///
-        /// Currenly, Model don't have API to access it's child. So, we make it as private.
-        /// </remarks>
-        private bool ChildrenSensitive
-        {
-            set
-            {
-                SetChildrenSensitive(value);
-            }
-            get
-            {
-                return GetChildrenSensitive();
-            }
         }
 
         /// <summary>
@@ -239,19 +211,6 @@ namespace Tizen.NUI.Scene3D
             View ret = new View(Interop.Model.GetModelRoot(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
-        }
-
-        internal void SetChildrenSensitive(bool enable)
-        {
-            Interop.Model.SetChildrenSensitive(SwigCPtr, enable);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        internal bool GetChildrenSensitive()
-        {
-            bool result = Interop.Model.GetChildrenSensitive(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR don't make FocusableChildren as false in default. Now we can add focusable children under the Model as default.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>