### PR TITLE
[NUI] Add FontSizeScale in TextStyle

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -162,6 +162,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_New")]
             public static extern global::System.IntPtr New();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_New_With_Style")]
+            public static extern global::System.IntPtr New(bool hasStyle);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextEditor__SWIG_0")]
             public static extern global::System.IntPtr NewTextEditor();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -171,6 +171,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_New")]
             public static extern global::System.IntPtr New();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_New_With_Style")]
+            public static extern global::System.IntPtr New(bool hasStyle);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextField__SWIG_0")]
             public static extern global::System.IntPtr NewTextField();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -88,7 +88,13 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr New();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New__SWIG_1")]
-            public static extern global::System.IntPtr New(string jarg1);
+            public static extern global::System.IntPtr New(string text);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_Style")]
+            public static extern global::System.IntPtr New(bool hasStyle);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_String_Style")]
+            public static extern global::System.IntPtr New(string text, bool hasStyle);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextLabel__SWIG_0")]
             public static extern global::System.IntPtr NewTextLabel();

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
@@ -277,6 +277,18 @@ namespace Tizen.NUI.BaseComponents
         });
 
         [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textEditorStyle = (TextEditorStyle)bindable;
+            textEditorStyle.fontSizeScale = (float?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textEditorStyle = (TextEditorStyle)bindable;
+            return textEditorStyle.fontSizeScale;
+        });
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionPopupStyleProperty = BindableProperty.Create(nameof(SelectionPopupStyle), typeof(PropertyMap), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textEditorStyle = (TextEditorStyle)bindable;
@@ -326,6 +338,7 @@ namespace Tizen.NUI.BaseComponents
         private float? lineSpacing;
         private float? minLineSize;
         private float? relativeLineHeight;
+        private float? fontSizeScale;
 
         static TextEditorStyle() { }
 
@@ -710,6 +723,13 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (float?)GetValue(RelativeLineHeightProperty);
             set => SetValue(RelativeLineHeightProperty, value);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float? FontSizeScale
+        {
+            get => (float?)GetValue(FontSizeScaleProperty);
+            set => SetValue(FontSizeScaleProperty, value);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
@@ -50,6 +50,17 @@ namespace Tizen.NUI.BaseComponents
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.pointSize;
         });
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textFieldStyle = (TextFieldStyle)bindable;
+            textFieldStyle.fontSizeScale = (float?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textFieldStyle = (TextFieldStyle)bindable;
+            return textFieldStyle.fontSizeScale;
+        });
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -545,6 +556,7 @@ namespace Tizen.NUI.BaseComponents
         private string fontFamily;
         private Color textColor;
         private float? pointSize;
+        private float? fontSizeScale;
         private Vector4 placeholderTextColor;
         private Vector4 primaryCursorColor;
         private PropertyMap fontStyle;
@@ -843,6 +855,13 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (float?)GetValue(PointSizeProperty);
             set => SetValue(PointSizeProperty, value);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float? FontSizeScale
+        {
+            get => (float?)GetValue(FontSizeScaleProperty);
+            set => SetValue(FontSizeScaleProperty, value);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
@@ -303,6 +303,17 @@ namespace Tizen.NUI.BaseComponents
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.characterSpacing;
         });
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            textLabelStyle.fontSizeScale = (float?)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            return textLabelStyle.fontSizeScale;
+        });
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -365,6 +376,7 @@ namespace Tizen.NUI.BaseComponents
         private Selector<TextShadow> textShadow;
         private PropertyMap fontStyle;
         private float? characterSpacing;
+        private float? fontSizeScale;
 
         static TextLabelStyle() { }
 
@@ -552,6 +564,13 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (float?)GetValue(CharacterSpacingProperty);
             set => SetValue(CharacterSpacingProperty, value);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float? FontSizeScale
+        {
+            get => (float?)GetValue(FontSizeScaleProperty);
+            set => SetValue(FontSizeScaleProperty, value);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -39,6 +39,7 @@ namespace Tizen.NUI.BaseComponents
         private float fontSizeScale = 1.0f;
         private bool hasFontSizeChangedCallback = false;
         private bool isSettingTextInCSharp = false;
+        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextEditor";
 
 #if NUI_PROPERTY_CHANGE_2
         private Color internalPlaceholderTextColor = null;
@@ -57,7 +58,7 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextEditor control.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TextEditor() : this(Interop.TextEditor.New(), true)
+        public TextEditor() : this(Interop.TextEditor.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -66,7 +67,7 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextEditor with specified style.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextEditor(TextEditorStyle style) : this(Interop.TextLabel.New(), true, style: style)
+        public TextEditor(TextEditorStyle style) : this(Interop.TextEditor.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true, style: style)
         {
         }
 
@@ -76,7 +77,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextEditor(bool shown) : this(Interop.TextEditor.New(), true)
+        public TextEditor(bool shown) : this(Interop.TextEditor.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -2170,6 +2171,19 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+                return (float)GetValue(FontSizeScaleProperty);
+            }
+            set
+            {
+                SetValue(FontSizeScaleProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        private float InternalFontSizeScale
+        {
+            get
+            {
                 return fontSizeScale;
             }
             set
@@ -2201,9 +2215,20 @@ namespace Tizen.NUI.BaseComponents
                     removeFontSizeChangedCallback();
                 }
 
-                SetValue(FontSizeScaleProperty, newFontSizeScale);
-                NotifyPropertyChanged();
+                SetInternalFontSizeScale(newFontSizeScale);
             }
+        }
+
+        private void SetInternalFontSizeScale(float fontSizeScale)
+        {
+#if NUI_PROPERTY_CHANGE_2
+            Object.InternalSetPropertyFloat(this.SwigCPtr, TextEditor.Property.FontSizeScale, (float)fontSizeScale);
+#else
+            using (var property = new Tizen.NUI.PropertyValue((float)fontSizeScale))
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)this.SwigCPtr, TextEditor.Property.FontSizeScale, property);
+            }
+#endif
         }
 
         /// <summary>
@@ -2535,8 +2560,7 @@ namespace Tizen.NUI.BaseComponents
         private void SystemSettingsFontSizeChanged(object sender, FontSizeChangedEventArgs e)
         {
             float newFontSizeScale = TextUtils.GetFontSizeScale(e.Value);
-            SetValue(FontSizeScaleProperty, newFontSizeScale);
-            NotifyPropertyChanged();
+            SetInternalFontSizeScale(newFontSizeScale);
         }
 
         private void addFontSizeChangedCallback()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -1364,26 +1364,13 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             if (newValue != null)
             {
-#if NUI_PROPERTY_CHANGE_2
-                Object.InternalSetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.FontSizeScale, (float)newValue);
-#else
-                using (var property = new Tizen.NUI.PropertyValue((float)newValue))
-                {
-                    Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.FontSizeScale, property);
-                }
-#endif
+                textEditor.InternalFontSizeScale = (float)newValue;
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textEditor = (TextEditor)bindable;
-#if NUI_PROPERTY_CHANGE_2
-            return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.FontSizeScale);
-#else
-            float temp;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.FontSizeScale).Get(out temp);
-            return temp;
-#endif
+            return textEditor.InternalFontSizeScale;
         }));
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -39,6 +39,7 @@ namespace Tizen.NUI.BaseComponents
         private float fontSizeScale = 1.0f;
         private bool hasFontSizeChangedCallback = false;
         private bool isSettingTextInCSharp = false;
+        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextField";
 
 #if NUI_PROPERTY_CHANGE_2
         private Vector4 internalPlaceholderTextColor = null;
@@ -57,7 +58,7 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextField control.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TextField() : this(Interop.TextField.New(), true)
+        public TextField() : this(Interop.TextField.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -68,7 +69,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextField(bool shown) : this(Interop.TextField.New(), true)
+        public TextField(bool shown) : this(Interop.TextField.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -2289,6 +2290,19 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+                return (float)GetValue(FontSizeScaleProperty);
+            }
+            set
+            {
+                SetValue(FontSizeScaleProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        private float InternalFontSizeScale
+        {
+            get
+            {
                 return fontSizeScale;
             }
             set
@@ -2320,9 +2334,20 @@ namespace Tizen.NUI.BaseComponents
                     removeFontSizeChangedCallback();
                 }
 
-                SetValue(FontSizeScaleProperty, newFontSizeScale);
-                NotifyPropertyChanged();
+                SetInternalFontSizeScale(newFontSizeScale);
             }
+        }
+
+        private void SetInternalFontSizeScale(float fontSizeScale)
+        {
+#if NUI_PROPERTY_CHANGE_2
+            Object.InternalSetPropertyFloat(this.SwigCPtr, TextField.Property.FontSizeScale, (float)fontSizeScale);
+#else
+            using (var property = new Tizen.NUI.PropertyValue((float)fontSizeScale))
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)this.SwigCPtr, TextField.Property.FontSizeScale, property);
+            }
+#endif
         }
 
         /// <summary>
@@ -2545,8 +2570,7 @@ namespace Tizen.NUI.BaseComponents
         private void SystemSettingsFontSizeChanged(object sender, FontSizeChangedEventArgs e)
         {
             float newFontSizeScale = TextUtils.GetFontSizeScale(e.Value);
-            SetValue(FontSizeScaleProperty, newFontSizeScale);
-            NotifyPropertyChanged();
+            SetInternalFontSizeScale(newFontSizeScale);
         }
 
         private void addFontSizeChangedCallback()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -1373,26 +1373,13 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             if (newValue != null)
             {
-#if NUI_PROPERTY_CHANGE_2
-                Object.InternalSetPropertyFloat(textField.SwigCPtr, TextField.Property.FontSizeScale, (float)newValue);
-#else
-                using (var property = new Tizen.NUI.PropertyValue((float)newValue))
-                {
-                    Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.FontSizeScale, property);
-                }
-#endif
+                textField.InternalFontSizeScale = (float)newValue;
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textField = (TextField)bindable;
-#if NUI_PROPERTY_CHANGE_2
-            return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.FontSizeScale);
-#else
-            float temp;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.FontSizeScale).Get(out temp);
-            return temp;
-#endif
+            return textField.InternalFontSizeScale;
         }));
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -86,6 +86,7 @@ namespace Tizen.NUI.BaseComponents
         private TextLabelSelectorData selectorData;
         private float fontSizeScale = 1.0f;
         private bool hasFontSizeChangedCallback = false;
+        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextLabel";
 
 #if NUI_PROPERTY_CHANGE_2
         private Color internalTextColor;
@@ -95,14 +96,14 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextLabel control.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TextLabel() : this(Interop.TextLabel.New(), true)
+        public TextLabel() : this(Interop.TextLabel.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextLabel(TextLabelStyle viewStyle) : this(Interop.TextLabel.New(), true, viewStyle)
+        public TextLabel(TextLabelStyle viewStyle) : this(Interop.TextLabel.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true, viewStyle)
         {
         }
 
@@ -112,7 +113,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextLabel(bool shown) : this(Interop.TextLabel.New(), true)
+        public TextLabel(bool shown) : this(Interop.TextLabel.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -123,7 +124,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="text">The text to display</param>
         /// <since_tizen> 3 </since_tizen>
-        public TextLabel(string text) : this(Interop.TextLabel.New(text), true)
+        public TextLabel(string text) : this(Interop.TextLabel.New(text, ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -135,7 +136,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextLabel(string text, bool shown) : this(Interop.TextLabel.New(text), true)
+        public TextLabel(string text, bool shown) : this(Interop.TextLabel.New(text, ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -1399,6 +1400,19 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
+                return (float)GetValue(FontSizeScaleProperty);
+            }
+            set
+            {
+                SetValue(FontSizeScaleProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        private float InternalFontSizeScale
+        {
+            get
+            {
                 return fontSizeScale;
             }
             set
@@ -1430,9 +1444,21 @@ namespace Tizen.NUI.BaseComponents
                     removeFontSizeChangedCallback();
                 }
 
-                SetValue(FontSizeScaleProperty, newFontSizeScale);
-                NotifyPropertyChanged();
+                SetInternalFontSizeScale(newFontSizeScale);
             }
+        }
+
+        private void SetInternalFontSizeScale(float fontSizeScale)
+        {
+#if NUI_PROPERTY_CHANGE_2
+            Object.InternalSetPropertyFloat(this.SwigCPtr, TextLabel.Property.FontSizeScale, (float)fontSizeScale);
+#else
+            using (var property = new Tizen.NUI.PropertyValue((float)fontSizeScale))
+            {
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)this.SwigCPtr, TextLabel.Property.FontSizeScale, property);
+            }
+#endif
+            RequestLayout();
         }
 
         /// <summary>
@@ -1555,7 +1581,7 @@ namespace Tizen.NUI.BaseComponents
         private void SystemSettingsFontSizeChanged(object sender, FontSizeChangedEventArgs e)
         {
             float newFontSizeScale = TextUtils.GetFontSizeScale(e.Value);
-            SetValue(FontSizeScaleProperty, newFontSizeScale);
+            SetInternalFontSizeScale(newFontSizeScale);
         }
 
         private void addFontSizeChangedCallback()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -856,28 +856,13 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-#if NUI_PROPERTY_CHANGE_2
-                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.FontSizeScale, (float)newValue);
-                textLabel.RequestLayout();
-#else
-                using (var property = new Tizen.NUI.PropertyValue((float)newValue))
-                {
-                    Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.FontSizeScale, property);
-                    textLabel.RequestLayout();
-                }
-#endif                
+                textLabel.InternalFontSizeScale = (float)newValue;
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textLabel = (TextLabel)bindable;
-#if NUI_PROPERTY_CHANGE_2
-            return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.FontSizeScale);
-#else
-            float temp;
-            Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.FontSizeScale).Get(out temp);
-            return temp;
-#endif
+            return textLabel.InternalFontSizeScale;
         }));
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
@@ -45,6 +45,7 @@ namespace Tizen.NUI
                 AutoScrollLoopCount = 2,
                 AutoScrollGap = 50.0f,
                 AutoScrollSpeed = 80,
+                FontSizeScale = Tizen.NUI.FontSizeScale.UseSystemSetting,
             });
 
             // TextField style.
@@ -58,6 +59,7 @@ namespace Tizen.NUI
                 PrimaryCursorColor = new Vector4(0.04f, 0.05f, 0.13f, 1),
                 SecondaryCursorColor = new Vector4(0.04f, 0.05f, 0.13f, 1),
                 CursorWidth = 2,
+                FontSizeScale = Tizen.NUI.FontSizeScale.UseSystemSetting,
                 SelectionHighlightColor = new Vector4(1.00f, 0.38f, 0.00f, 0.30f),
                 GrabHandleColor = new Color(1.00f, 1.00f, 1.00f, 1),
                 GrabHandleImage = FrameworkInformation.ResourcePath + "IoT_handler_center_downW.png",
@@ -94,6 +96,7 @@ namespace Tizen.NUI
                 PrimaryCursorColor = new Vector4(0.04f, 0.05f, 0.13f, 1),
                 SecondaryCursorColor = new Vector4(0.04f, 0.05f, 0.13f, 1),
                 CursorWidth = 2,
+                FontSizeScale = Tizen.NUI.FontSizeScale.UseSystemSetting,
                 SelectionHighlightColor = new Vector4(1.00f, 0.38f, 0.00f, 0.30f),
                 GrabHandleColor = new Color(1.00f, 1.00f, 1.00f, 1),
                 GrabHandleImage = FrameworkInformation.ResourcePath + "IoT_handler_center_downW.png",


### PR DESCRIPTION
Setting FontSizeScale to UseSystemSetting in Theme, the default font scale follows the properties of system.

- Added new argument to New(bool hasStlye)
- If true, DALi's json is no longer used in Text components
- If false, use DALi's json.

- Fixed previous incorrect bindable property structure.

- This must be sync merged with patches below.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/284113/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/284127/

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>