### PR TITLE
[Applications.PackageManager] Add ClearUserData(package, path)

### DIFF
--- a/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManager.cs
@@ -141,6 +141,9 @@ internal static partial class Interop
         [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_data_dir")]
         internal static extern ErrorCode PackageManagerClearDataDir(string packageId);
 
+        [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_clear_user_data_with_path")]
+        internal static extern ErrorCode PackageManagerClearUserDataWithPath(string packageId, String filePath);
+
         [DllImport(Libraries.PackageManager, EntryPoint = "package_manager_filter_create")]
         internal static extern ErrorCode PackageManagerFilterCreate(out IntPtr handle);
 

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -353,6 +353,31 @@ namespace Tizen.Applications
         }
 
         /// <summary>
+        /// Clears the application's user file or directory from the file path.
+        /// </summary>
+        /// <remarks>
+        /// A file or directory under user data folder in the internal storage is removed.
+        /// </remarks>
+        /// <param name="packageId">ID of the package.</param>
+        /// <param name="filePath">The path of the file or directory in the package user data folder.</param>
+        /// <exception cref="OutOfMemoryException">Thrown when there is not enough memory to continue the execution of the method.</exception>
+        /// <exception cref="System.IO.IOException">Thrown when the method failed due to an internal IO error.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when an application does not have the privilege to access this method.</exception>
+        /// <exception cref="SystemException">Thrown when the method failed due to an internal system error.</exception>
+        /// <privilege>http://tizen.org/privilege/packagemanager.admin</privilege>
+        /// <privlevel>platform</privlevel>
+        /// <since_tizen> 11 </since_tizen>
+        public static void ClearUserData(string packageId, string filePath)
+        {
+            Interop.PackageManager.ErrorCode err = Interop.PackageManager.PackageManagerClearUserDataWithPath(packageId, filePath);
+            if (err != Interop.PackageManager.ErrorCode.None)
+            {
+                Log.Warn(LogTag, string.Format("Failed to clear user data for {0} of {1}. err = {2}", filePath, packageId, err));
+                throw PackageManagerErrorFactory.GetException(err, "Failed to clear user data");
+            }
+        }
+
+        /// <summary>
         /// Retrieves the package information of all installed packages.
         /// </summary>
         /// <returns>Returns the list of packages.</returns>

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -353,13 +353,13 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// Clears the application's user file or directory from the file path.
+        /// Removes a file or directory specified with <paramref name="path"/> from user data internal storage for the application
         /// </summary>
         /// <remarks>
         /// A file or directory under user data folder in the internal storage is removed.
         /// </remarks>
         /// <param name="packageId">ID of the package.</param>
-        /// <param name="filePath">The path of the file or directory in the package user data folder.</param>
+        /// <param name="path">The path of the file or directory in the package user data folder.</param>
         /// <exception cref="OutOfMemoryException">Thrown when there is not enough memory to continue the execution of the method.</exception>
         /// <exception cref="System.IO.IOException">Thrown when the method failed due to an internal IO error.</exception>
         /// <exception cref="UnauthorizedAccessException">Thrown when an application does not have the privilege to access this method.</exception>
@@ -367,12 +367,12 @@ namespace Tizen.Applications
         /// <privilege>http://tizen.org/privilege/packagemanager.admin</privilege>
         /// <privlevel>platform</privlevel>
         /// <since_tizen> 11 </since_tizen>
-        public static void ClearUserData(string packageId, string filePath)
+        public static void ClearUserData(string packageId, string path)
         {
-            Interop.PackageManager.ErrorCode err = Interop.PackageManager.PackageManagerClearUserDataWithPath(packageId, filePath);
+            Interop.PackageManager.ErrorCode err = Interop.PackageManager.PackageManagerClearUserDataWithPath(packageId, path);
             if (err != Interop.PackageManager.ErrorCode.None)
             {
-                Log.Warn(LogTag, string.Format("Failed to clear user data for {0} of {1}. err = {2}", filePath, packageId, err));
+                Log.Warn(LogTag, string.Format("Failed to clear user data for {0} of {1}. err = {2}", path, packageId, err));
                 throw PackageManagerErrorFactory.GetException(err, "Failed to clear user data");
             }
         }

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -355,9 +355,6 @@ namespace Tizen.Applications
         /// <summary>
         /// Removes a file or directory specified with <paramref name="path"/> from user data internal storage for the application
         /// </summary>
-        /// <remarks>
-        /// A file or directory under user data folder in the internal storage is removed.
-        /// </remarks>
         /// <param name="packageId">ID of the package.</param>
         /// <param name="path">The path of the file or directory in the package user data folder.</param>
         /// <exception cref="OutOfMemoryException">Thrown when there is not enough memory to continue the execution of the method.</exception>

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -353,7 +353,7 @@ namespace Tizen.Applications
         }
 
         /// <summary>
-        /// Removes a file or directory specified with <paramref name="path"/> from user data internal storage for the application
+        /// Removes a file or directory specified with <paramref name="path"/> from user data internal storage for the application.
         /// </summary>
         /// <param name="packageId">ID of the package.</param>
         /// <param name="path">The path of the file or directory in the package user data folder.</param>


### PR DESCRIPTION
Adds:
 - ClearUserData(packageId, filePath)

Signed-off-by: ChangGyu Choi <uppletaste@gmail.com>

### Description of Change ###
PackageManager has an API that removes all user data from a specific package.
There is a requirement to remove only certain file or directory
Data management becomes more detailed because only specific data can be removed by adding this API.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: TCSACR-522

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
