### PR TITLE
[NUI] Use smaller NearPlaneDistance and bigger FarPlaneDistance during Camera Transition

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -355,8 +355,9 @@ namespace Tizen.NUI.Scene3D
         /// Camera Position, Orientation and FieldOfView are smoothly animated.
         /// </summary>
         /// <remarks>
-        /// The selected camera is switched when the transition is started.
-        /// During camera transition, Selected Camera cannot be changed by using SelectCamera() or CameraTransition() method.
+        /// The selected camera is switched to the Camera of the index when the transition is started.
+        /// During camera transition, Selected Camera should not be changed by using SelectCamera() or CameraTransition() method.
+        /// During camera transition, Camera properties of Selected Camera should not be changed.
         /// </remarks>
         /// <param name="index"> Index of destination Camera of Camera transition.</param>
         /// <param name="durationMilliSeconds">The duration in milliseconds.</param>
@@ -364,7 +365,7 @@ namespace Tizen.NUI.Scene3D
         /// <since_tizen> 10 </since_tizen>
         public void CameraTransition(uint index, int durationMilliSeconds, AlphaFunction alphaFunction = null)
         {
-            if(inCameraTransition)
+            if(inCameraTransition || GetSelectedCamera() == GetCamera(index))
             {
                 return;
             }
@@ -381,8 +382,9 @@ namespace Tizen.NUI.Scene3D
         /// Camera Position, Orientation and FieldOfView are smoothly animated.
         /// </summary>
         /// <remarks>
-        /// The selected camera is switched when the transition is started.
-        /// During camera transition, Selected Camera cannot be changed by using SelectCamera() or CameraTransition() method.
+        /// The selected camera is switched to the Camera of the input name when the transition is started.
+        /// During camera transition, Selected Camera should not be changed by using SelectCamera() or CameraTransition() method.
+        /// During camera transition, Camera properties of Selected Camera should not be changed.
         /// </remarks>
         /// <param name="name"> string keyword of destination Camera of Camera transition.</param>
         /// <param name="durationMilliSeconds">The duration in milliseconds.</param>
@@ -390,7 +392,7 @@ namespace Tizen.NUI.Scene3D
         /// <since_tizen> 10 </since_tizen>
         public void CameraTransition(string name, int durationMilliSeconds, AlphaFunction alphaFunction = null)
         {
-            if(inCameraTransition)
+            if(inCameraTransition || GetSelectedCamera() == GetCamera(name))
             {
                 return;
             }
@@ -614,8 +616,15 @@ namespace Tizen.NUI.Scene3D
                 orthographicSizeKeyFrames.Dispose();
             }
 
+            float destinationNearPlaneDistance = destinationCamera.NearPlaneDistance;
+            float destinationFarPlaneDistance = destinationCamera.FarPlaneDistance;
+            destinationCamera.NearPlaneDistance = Math.Min(sourceCamera.NearPlaneDistance, destinationCamera.NearPlaneDistance);
+            destinationCamera.FarPlaneDistance = Math.Max(sourceCamera.FarPlaneDistance, destinationCamera.FarPlaneDistance);
+
             cameraTransition.Finished += (s, e) =>
             {
+                this.GetSelectedCamera().NearPlaneDistance = destinationNearPlaneDistance;
+                this.GetSelectedCamera().FarPlaneDistance = destinationFarPlaneDistance;
                 inCameraTransition = false;
                 CameraTransitionFinished?.Invoke(this, EventArgs.Empty);
             };


### PR DESCRIPTION
 - To do not cull fragments during camera transition

Signed-off-by: seungho baek <sbsh.baek@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
