### PR TITLE
[NUI] Fix Layouter to handle empty group case.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -210,7 +210,8 @@ namespace Tizen.NUI.Components
 
             bool failed = false;
             //Final Check of FirstIndex
-            if (colView.InternalItemSource.Count - 1 < firstIndex)
+            if ((colView.InternalItemSource.Count - 1 < firstIndex) ||
+                (colView.InternalItemSource.IsFooter(firstIndex) && (colView.InternalItemSource.Count - 1) == firstIndex))
             {
                 StepCandidate = 0F;
                 failed = true;
@@ -517,7 +518,7 @@ namespace Tizen.NUI.Components
             // Insert Single item.
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (colView == null) return;
-            if (isSourceEmpty || StepCandidate == 0)
+            if (isSourceEmpty || StepCandidate <= 1)
             {
                 Initialize(colView);
             }
@@ -669,7 +670,7 @@ namespace Tizen.NUI.Components
              // Insert Group
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (colView == null) return;
-            if (isSourceEmpty || StepCandidate == 0)
+            if (isSourceEmpty || StepCandidate <= 1)
             {
                 Initialize(colView);
             }

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -210,11 +210,19 @@ namespace Tizen.NUI.Components
 
             bool failed = false;
             //Final Check of FirstIndex
-            while (colView.InternalItemSource.IsHeader(firstIndex) ||
-                    colView.InternalItemSource.IsGroupHeader(firstIndex) ||
-                    colView.InternalItemSource.IsGroupFooter(firstIndex))
+            if (colView.InternalItemSource.Count - 1 < firstIndex)
             {
-                if (colView.InternalItemSource.IsFooter(firstIndex))
+                StepCandidate = 0F;
+                failed = true;
+            }
+
+            while (!failed &&
+                   (colView.InternalItemSource.IsHeader(firstIndex) ||
+                    colView.InternalItemSource.IsGroupHeader(firstIndex) ||
+                    colView.InternalItemSource.IsGroupFooter(firstIndex)))
+            {
+                if (colView.InternalItemSource.IsFooter(firstIndex)
+                    || ((colView.InternalItemSource.Count - 1) <= firstIndex))
                 {
                     StepCandidate = 0F;
                     failed = true;
@@ -509,7 +517,7 @@ namespace Tizen.NUI.Components
             // Insert Single item.
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (colView == null) return;
-            if (isSourceEmpty)
+            if (isSourceEmpty || StepCandidate == 0)
             {
                 Initialize(colView);
             }
@@ -661,7 +669,7 @@ namespace Tizen.NUI.Components
              // Insert Group
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (colView == null) return;
-            if (isSourceEmpty)
+            if (isSourceEmpty || StepCandidate == 0)
             {
                 Initialize(colView);
             }

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -204,8 +204,8 @@ namespace Tizen.NUI.Components
             bool failed = false;
 
             //Final Check of FirstIndex
-
-            if (colView.InternalItemSource.Count - 1 < firstIndex)
+            if ((colView.InternalItemSource.Count - 1 < firstIndex) ||
+                (colView.InternalItemSource.IsFooter(firstIndex) && (colView.InternalItemSource.Count - 1) == firstIndex))
             {
                 StepCandidate = 0F;
                 failed = true;

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -204,10 +204,19 @@ namespace Tizen.NUI.Components
             bool failed = false;
 
             //Final Check of FirstIndex
-            while (colView.InternalItemSource.IsHeader(firstIndex) ||
-                    colView.InternalItemSource.IsGroupHeader(firstIndex) ||
-                    colView.InternalItemSource.IsGroupFooter(firstIndex))
+
+            if (colView.InternalItemSource.Count - 1 < firstIndex)
             {
+                StepCandidate = 0F;
+                failed = true;
+            }
+
+            while (!failed &&
+                   (colView.InternalItemSource.IsHeader(firstIndex) ||
+                    colView.InternalItemSource.IsGroupHeader(firstIndex) ||
+                    colView.InternalItemSource.IsGroupFooter(firstIndex)))
+            {
+
                 if (colView.InternalItemSource.IsFooter(firstIndex)
                     || ((colView.InternalItemSource.Count - 1) <= firstIndex))
                 {
@@ -557,7 +566,7 @@ namespace Tizen.NUI.Components
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (colView == null) return;
 
-            if (isSourceEmpty)
+            if (isSourceEmpty || StepCandidate == 0)
             {
                 Initialize(colView);
             }
@@ -725,7 +734,7 @@ namespace Tizen.NUI.Components
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (colView == null) return;
 
-            if (isSourceEmpty)
+            if (isSourceEmpty || StepCandidate == 0)
             {
                 Initialize(colView);
             }


### PR DESCRIPTION
If we create empty group it gets crash and moreover,
if we add more items in the group item didn't show correctly.
this patch will fix by re-initialize when new item added.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
