### PR TITLE
[NUI] Spannable Module: Add BaseSpan and ForegroundColorSpan

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class BaseSpan
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseSpan")]
+            public static extern void DeleteBaseSpan(global::System.Runtime.InteropServices.HandleRef refBaseSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class ForegroundColorSpan
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_New")]
+            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef argColor);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_GetForegroundColor")]
+            public static extern global::System.IntPtr GetForegroundColor(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_IsForegroundColorDefined")]
+            public static extern bool IsForegroundColorDefined(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ForegroundColorSpan")]
+            public static extern void DeleteForegroundColorSpan(global::System.Runtime.InteropServices.HandleRef refSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Range.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Range.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class Range
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_New")]
+            public static extern global::System.IntPtr NewRange(uint argStartIndex, uint argEndIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_GetStartIndex")]
+            public static extern uint GetStartIndex(global::System.Runtime.InteropServices.HandleRef refRange);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_GetEndIndex")]
+            public static extern uint GetEndIndex(global::System.Runtime.InteropServices.HandleRef refRange);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_GetNumberOfIndices")]
+            public static extern uint GetNumberOfIndices(global::System.Runtime.InteropServices.HandleRef refRange);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Range")]
+            public static extern void DeleteRange(global::System.Runtime.InteropServices.HandleRef refRange);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Common/Range.cs
+++ b/src/Tizen.NUI/src/public/Common/Range.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class Range : Disposable
+    {
+
+        /// <summary>
+        /// Creates a new Range object<br />
+        /// </summary>
+        /// <param name="startIndex">The first index of the range.</param>
+        /// <param name="endIndex">The last index of the range.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Range Create(uint startIndex, uint endIndex)
+        {
+            Range ret = new Range(Interop.Range.NewRange(startIndex, endIndex), true);
+            return ret;
+        }
+
+        internal Range(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The start-index in range.
+        /// It's the minimum bound of range.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint StartIndex
+        {
+            get
+            {
+                uint ret = Interop.Range.GetStartIndex(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The end-index in range.
+        /// It's the maximum bound of range.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint EndIndex
+        {
+            get
+            {
+                uint ret = Interop.Range.GetEndIndex(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The number of indices in range.
+        /// It's the number of indices between the minimum  and maximum bounds in range.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint NumberOfIndices
+        {
+            get
+            {
+                uint ret = Interop.Range.GetNumberOfIndices(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.Range.DeleteRange(swigCPtr);
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class BaseSpan : Disposable
+    {
+
+        internal BaseSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.BaseSpan.DeleteBaseSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ForegroundColorSpan : BaseSpan
+    {
+
+        /// <summary>
+        /// Create foreground color span Set and set color for it.<br />
+        /// </summary>
+        /// <param name="color">The fore color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ForegroundColorSpan Create(Color color)
+        {
+            ForegroundColorSpan ret = new ForegroundColorSpan(Interop.ForegroundColorSpan.New(Vector4.getCPtr(color)), true);
+            return ret;
+        }
+
+        internal ForegroundColorSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The fore-color in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color Color
+        {
+            get
+            {
+                Color ret = new Color(Interop.ForegroundColorSpan.GetForegroundColor(SwigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the fore color is defined in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasColor
+        {
+            get
+            {
+                bool ret = Interop.ForegroundColorSpan.IsForegroundColorDefined(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.ForegroundColorSpan.DeleteForegroundColorSpan(swigCPtr);
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,142 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanCreate()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanCreate START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanCreate END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Color.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Color A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpan.Create(expected);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.Color;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, result), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan HasColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.HasColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanHasColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor START");
+
+            var expected = true;
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.HasColor;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Common/TSRange.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Common/TSRange.cs
@@ -1,0 +1,174 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Common/Range")]
+    public class PublicRangeTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Create.")]
+        [Property("SPEC", "Tizen.NUI.Range.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeCreate()
+        {
+            tlog.Debug(tag, $"RangeCreate START");
+
+            var testingTarget = Range.Create(4,5);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"RangeCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range RangeStartIndex.")]
+        [Property("SPEC", "Tizen.NUI.Range.RangeStartIndex A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeStartIndex()
+        {
+            tlog.Debug(tag, $"RangeStartIndex START");
+
+            uint expected = 10;
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                var result = testingTarget.StartIndex;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"RangeStartIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range RangeEndIndex.")]
+        [Property("SPEC", "Tizen.NUI.Range.RangeEndIndex A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeEndIndex()
+        {
+            tlog.Debug(tag, $"RangeEndIndex START");
+
+            uint expected = 27;
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                var result = testingTarget.EndIndex;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"RangeEndIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range RangeNumberOfIndices.")]
+        [Property("SPEC", "Tizen.NUI.Range.RangeNumberOfIndices A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeNumberOfIndices()
+        {
+            tlog.Debug(tag, $"RangeNumberOfIndices START");
+
+            uint expected = 18;
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                var result = testingTarget.NumberOfIndices;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"RangeNumberOfIndices END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Range.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeDispose()
+        {
+            tlog.Debug(tag, $"RangeDispose START");
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"RangeDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,142 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanCreate()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanCreate START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanCreate END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Color.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Color A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpan.Create(expected);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.Color;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, result), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan HasColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.HasColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanHasColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor START");
+
+            var expected = true;
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.HasColor;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Add BaseSpan and ForegroundColorSpan classes
They are used in Spannable module

BaseSpan is an abstract class for all Span classes
ForegroundColorSpan is a Span to set foreground color

### API Changes ###
Added:
 - BaseSpan // Abstract Class
 - ForegroundColorSpan // Class
 - public static ForegroundColorSpan Create(Color color); // static method
 - public Color Color; // Readonly Property 
 - public bool HasColor; // Readonly Property 


### Testcases ###
Added the below to (Tizen.NUI.Devel.Tests.Ubuntu) and (Tizen.NUI.Tests):
- Tizen.NUI.Devel.Tests.PublicForegroundColorSpanTest

**This PR should be preceded by the PR below:**

- https://github.com/Samsung/TizenFX/pull/4779

**This PR depends on the below patches:**
 -  https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/284792
