### PR TITLE
[NUI] fix group remove error.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -858,6 +858,7 @@ namespace Tizen.NUI.Components
                     // Remove Group
                     // groupInfo.Dispose();
                     groups.Remove(groupInfo);
+                    parentIndex--;
                 }
                 else
                 {

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -961,6 +961,7 @@ namespace Tizen.NUI.Components
                     // Remove Group
                     // groupInfo.Dispose();
                     groups.Remove(groupInfo);
+                    parentIndex--;
                 }
                 else
                 {


### PR DESCRIPTION
when Nth empty item group is removed,
we didn't restore parentIndex while searching group item,
so N+1 group is not updated, as it changed Nth.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
