### PR TITLE
[Packagemanager] Use ToLowerInvariant instead of ToLower

### DIFF
--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -683,7 +683,7 @@ namespace Tizen.Applications
             {
                 if (type != PackageType.UNKNOWN)
                 {
-                    err = Interop.PackageManager.PackageManagerRequestSetType(RequestHandle, type.ToString().ToLower());
+                    err = Interop.PackageManager.PackageManagerRequestSetType(RequestHandle, type.ToString().ToLowerInvariant());
                     if (err != Interop.PackageManager.ErrorCode.None)
                     {
                         Log.Warn(LogTag, string.Format("Failed to install packages. Error in setting request package type. err = {0}", err));
@@ -893,7 +893,7 @@ namespace Tizen.Applications
 
             try
             {
-                err = Interop.PackageManager.PackageManagerRequestSetType(RequestHandle, type.ToString().ToLower());
+                err = Interop.PackageManager.PackageManagerRequestSetType(RequestHandle, type.ToString().ToLowerInvariant());
                 if (err != Interop.PackageManager.ErrorCode.None)
                 {
                     Log.Warn(LogTag, string.Format("Failed to uninstall package {0}. Error in setting request package type. err = {1}", packageId, err));
@@ -1024,7 +1024,7 @@ namespace Tizen.Applications
             try
             {
                 bool result = true;
-                err = Interop.PackageManager.PackageManagerRequestSetType(RequestHandle, type.ToString().ToLower());
+                err = Interop.PackageManager.PackageManagerRequestSetType(RequestHandle, type.ToString().ToLowerInvariant());
                 if (err != Interop.PackageManager.ErrorCode.None)
                 {
                     Log.Warn(LogTag, string.Format("Failed to move package. Error in setting request package type. err = {0}", err));

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageType.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageType.cs
@@ -52,7 +52,7 @@ namespace Tizen.Applications
                 throw PackageManagerErrorFactory.GetException(Interop.PackageManager.ErrorCode.InvalidParameter, "type can't be null or empty");
             }
 
-            string lowerType = type.ToLower();
+            string lowerType = type.ToLowerInvariant();
             if (lowerType == "tpk")
             {
                 return PackageType.TPK;


### PR DESCRIPTION
### Description of Change ###
ToLower can cause unexpected error when system is busy.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
