### PR TITLE
[NUI] Add GetSystemFonts in FontClient

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
@@ -90,7 +90,7 @@ namespace Tizen.NUI
             public static extern void GetDefaultPlatformFontDescription(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetSystemFonts")]
-            public static extern void GetSystemFonts(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            public static extern global::System.IntPtr GetSystemFonts(global::System.Runtime.InteropServices.HandleRef fontClient);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_GetDescription")]
             public static extern void GetDescription(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextConstants.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextConstants.cs
@@ -801,4 +801,70 @@ namespace Tizen.NUI.Text
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => (LeftImageUrl, RightImageUrl).GetHashCode();
     }
+
+    /// <summary>
+    /// A struct to pass data of FontInfo PropertyMap.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct FontInfo : IEquatable<FontInfo>
+    {
+        /// <summary>
+        /// The FontFamily of the font.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Family { get; set; }
+
+        /// <summary>
+        /// The FontPath of the font.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Path { get; set; }
+
+        /// <summary>
+        /// The FontStyle of the font.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontStyle Style { get; set; }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>true if equal FontInfo, else false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => obj is FontInfo other && this.Equals(other);
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="other">The FontInfo to compare with the current FontInfo.</param>
+        /// <returns>true if equal FontInfo, else false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Equals(FontInfo other) => Family == other.Family && Path == other.Path && Style == other.Style;
+
+        /// <summary>
+        /// The == operator.
+        /// </summary>
+        /// <param name="lhsFontInfo">FontInfo to compare</param>
+        /// <param name="rhsFontInfo">FontInfo to be compared</param>
+        /// <returns>true if FontInfos are equal</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator ==(FontInfo lhsFontInfo, FontInfo rhsFontInfo) => lhsFontInfo.Equals(rhsFontInfo);
+
+        /// <summary>
+        /// The != operator.
+        /// </summary>
+        /// <param name="lhsFontInfo">FontInfo to compare</param>
+        /// <param name="rhsFontInfo">FontInfo to be compared</param>
+        /// <returns>true if FontInfos are not equal</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !=(FontInfo lhsFontInfo, FontInfo rhsFontInfo) => !lhsFontInfo.Equals(rhsFontInfo);
+
+        /// <summary>
+        /// Gets the hash code of this FontInfo.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => (Family, Path, Style).GetHashCode();
+    }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -32,17 +32,17 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class TextEditor : View
     {
+        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextEditor";
         static private string defaultFontFamily = "TizenSans";
-        private string fontFamily = defaultFontFamily;
-        private bool hasSystemFontTypeChanged = false;
         private string textEditorTextSid = null;
         private string textEditorPlaceHolderTextSid = null;
-        private bool systemlangTextFlag = false;
         private InputMethodContext inputMethodContext = null;
+        private string fontFamily = defaultFontFamily;
         private float fontSizeScale = 1.0f;
-        private bool hasFontSizeChangedCallback = false;
+        private bool hasSystemLanguageChanged = false;
+        private bool hasSystemFontSizeChanged = false;
+        private bool hasSystemFontTypeChanged = false;
         private bool isSettingTextInCSharp = false;
-        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextEditor";
 
         private Color internalPlaceholderTextColor = null;
         private Vector4 internalPrimaryCursorColor = null;
@@ -2257,12 +2257,12 @@ namespace Tizen.NUI.BaseComponents
                         systemSettingsFontSize = SystemSettingsFontSize.Normal;
                     }
                     newFontSizeScale = TextUtils.GetFontSizeScale(systemSettingsFontSize);
-                    addFontSizeChangedCallback();
+                    AddSystemSettingsFontSizeChanged();
                 }
                 else
                 {
                     newFontSizeScale = fontSizeScale;
-                    removeFontSizeChangedCallback();
+                    RemoveSystemSettingsFontSizeChanged();
                 }
 
                 SetInternalFontSizeScale(newFontSizeScale);
@@ -2498,14 +2498,13 @@ namespace Tizen.NUI.BaseComponents
             internalTextColor?.Dispose();
             internalGrabHandleColor?.Dispose();
 
-            if (systemlangTextFlag)
+            if (hasSystemLanguageChanged)
             {
                 SystemSettings.LocaleLanguageChanged -= SystemSettings_LocaleLanguageChanged;
             }
 
             RemoveSystemSettingsFontTypeChanged();
-
-            removeFontSizeChangedCallback();
+            RemoveSystemSettingsFontSizeChanged();
 
             //Release your own unmanaged resources here.
             //You should not access any managed member here except static instance.
@@ -2575,10 +2574,10 @@ namespace Tizen.NUI.BaseComponents
             translatableText = NUIApplication.MultilingualResourceManager?.GetString(textEditorSid, new CultureInfo(SystemSettings.LocaleLanguage.Replace("_", "-")));
             if (translatableText != null)
             {
-                if (systemlangTextFlag == false)
+                if (hasSystemLanguageChanged == false)
                 {
                     SystemSettings.LocaleLanguageChanged += SystemSettings_LocaleLanguageChanged;
-                    systemlangTextFlag = true;
+                    hasSystemLanguageChanged = true;
                 }
                 return translatableText;
             }
@@ -2607,36 +2606,36 @@ namespace Tizen.NUI.BaseComponents
             SetInternalFontSizeScale(newFontSizeScale);
         }
 
-        private void addFontSizeChangedCallback()
+        private void AddSystemSettingsFontSizeChanged()
         {
-            if (hasFontSizeChangedCallback != true)
+            if (hasSystemFontSizeChanged != true)
             {
                 try
                 {
                     SystemSettings.FontSizeChanged += SystemSettingsFontSizeChanged;
-                    hasFontSizeChangedCallback = true;
+                    hasSystemFontSizeChanged = true;
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine("{0} Exception caught.", e);
-                    hasFontSizeChangedCallback = false;
+                    hasSystemFontSizeChanged = false;
                 }
             }
         }
 
-        private void removeFontSizeChangedCallback()
+        private void RemoveSystemSettingsFontSizeChanged()
         {
-            if (hasFontSizeChangedCallback == true)
+            if (hasSystemFontSizeChanged == true)
             {
                 try
                 {
                     SystemSettings.FontSizeChanged -= SystemSettingsFontSizeChanged;
-                    hasFontSizeChangedCallback = false;
+                    hasSystemFontSizeChanged = false;
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine("{0} Exception caught.", e);
-                    hasFontSizeChangedCallback = true;
+                    hasSystemFontSizeChanged = true;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -74,15 +74,13 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
             if (newValue != null)
             {
-
-                Object.InternalSetPropertyString(textEditor.SwigCPtr, TextEditor.Property.FontFamily, (string)newValue);
+                textEditor.InternalFontFamily = (string)newValue;
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textEditor = (TextEditor)bindable;
-
-            return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.FontFamily);
+            return textEditor.InternalFontFamily;
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -31,19 +31,18 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class TextField : View
     {
+        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextField";
         static private string defaultFontFamily = "TizenSans";
-        private string fontFamily = defaultFontFamily;
-        private bool hasSystemFontTypeChanged = false;
         private string textFieldTextSid = null;
         private string textFieldPlaceHolderTextSid = null;
         private string textFieldPlaceHolderTextFocusedSid = null;
-        private bool systemlangTextFlag = false;
         private InputMethodContext inputMethodCotext = null;
+        private string fontFamily = defaultFontFamily;
         private float fontSizeScale = 1.0f;
-        private bool hasFontSizeChangedCallback = false;
+        private bool hasSystemLanguageChanged = false;
+        private bool hasSystemFontSizeChanged = false;
+        private bool hasSystemFontTypeChanged = false;
         private bool isSettingTextInCSharp = false;
-        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextField";
-
 
         private Vector4 internalPlaceholderTextColor = null;
         private Vector4 internalPrimaryCursorColor = null;
@@ -2377,12 +2376,12 @@ namespace Tizen.NUI.BaseComponents
                         systemSettingsFontSize = SystemSettingsFontSize.Normal;
                     }
                     newFontSizeScale = TextUtils.GetFontSizeScale(systemSettingsFontSize);
-                    addFontSizeChangedCallback();
+                    AddSystemSettingsFontSizeChanged();
                 }
                 else
                 {
                     newFontSizeScale = fontSizeScale;
-                    removeFontSizeChangedCallback();
+                    RemoveSystemSettingsFontSizeChanged();
                 }
 
                 SetInternalFontSizeScale(newFontSizeScale);
@@ -2499,14 +2498,13 @@ namespace Tizen.NUI.BaseComponents
             internalTextColor?.Dispose();
             internalGrabHandleColor?.Dispose();
 
-            if (systemlangTextFlag)
+            if (hasSystemLanguageChanged)
             {
-                SystemSettings.LocaleLanguageChanged -= SystemSettings_LocaleLanguageChanged;
+                SystemSettings.LocaleLanguageChanged -= SystemSettingsLocaleLanguageChanged;
             }
 
             RemoveSystemSettingsFontTypeChanged();
-
-            removeFontSizeChangedCallback();
+            RemoveSystemSettingsFontSizeChanged();
 
             if (type == DisposeTypes.Explicit)
             {
@@ -2583,10 +2581,10 @@ namespace Tizen.NUI.BaseComponents
             translatableText = NUIApplication.MultilingualResourceManager?.GetString(textFieldSid, new CultureInfo(SystemSettings.LocaleLanguage.Replace("_", "-")));
             if (translatableText != null)
             {
-                if (systemlangTextFlag == false)
+                if (hasSystemLanguageChanged == false)
                 {
-                    SystemSettings.LocaleLanguageChanged += SystemSettings_LocaleLanguageChanged;
-                    systemlangTextFlag = true;
+                    SystemSettings.LocaleLanguageChanged += SystemSettingsLocaleLanguageChanged;
+                    hasSystemLanguageChanged = true;
                 }
                 return translatableText;
             }
@@ -2597,7 +2595,7 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private void SystemSettings_LocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
+        private void SystemSettingsLocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
         {
             if (textFieldTextSid != null)
             {
@@ -2619,36 +2617,36 @@ namespace Tizen.NUI.BaseComponents
             SetInternalFontSizeScale(newFontSizeScale);
         }
 
-        private void addFontSizeChangedCallback()
+        private void AddSystemSettingsFontSizeChanged()
         {
-            if (hasFontSizeChangedCallback != true)
+            if (hasSystemFontSizeChanged != true)
             {
                 try
                 {
                     SystemSettings.FontSizeChanged += SystemSettingsFontSizeChanged;
-                    hasFontSizeChangedCallback = true;
+                    hasSystemFontSizeChanged = true;
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine("{0} Exception caught.", e);
-                    hasFontSizeChangedCallback = false;
+                    hasSystemFontSizeChanged = false;
                 }
             }
         }
 
-        private void removeFontSizeChangedCallback()
+        private void RemoveSystemSettingsFontSizeChanged()
         {
-            if (hasFontSizeChangedCallback == true)
+            if (hasSystemFontSizeChanged == true)
             {
                 try
                 {
                     SystemSettings.FontSizeChanged -= SystemSettingsFontSizeChanged;
-                    hasFontSizeChangedCallback = false;
+                    hasSystemFontSizeChanged = false;
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine("{0} Exception caught.", e);
-                    hasFontSizeChangedCallback = true;
+                    hasSystemFontSizeChanged = true;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -31,6 +31,9 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class TextField : View
     {
+        static private string defaultFontFamily = "TizenSans";
+        private string fontFamily = defaultFontFamily;
+        private bool hasSystemFontTypeChanged = false;
         private string textFieldTextSid = null;
         private string textFieldPlaceHolderTextSid = null;
         private string textFieldPlaceHolderTextFocusedSid = null;
@@ -112,6 +115,11 @@ namespace Tizen.NUI.BaseComponents
         {
             ExceedPolicyOriginal,
             ExceedPolicyClip
+        }
+
+        private bool HasStyle()
+        {
+            return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
         }
 
         /// <summary>
@@ -296,6 +304,50 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(FontFamilyProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        private string InternalFontFamily
+        {
+            get
+            {
+                if (HasStyle())
+                    return fontFamily;
+                else
+                    return Object.InternalGetPropertyString(this.SwigCPtr, TextField.Property.FontFamily);
+            }
+            set
+            {
+                string newFontFamily;
+
+                if (string.Equals(fontFamily, value)) return;
+
+                fontFamily = value;
+                if (fontFamily == Tizen.NUI.FontFamily.UseSystemSetting)
+                {
+                    try
+                    {
+                        newFontFamily = SystemSettings.FontType;
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine("{0} Exception caught.", e);
+                        newFontFamily = defaultFontFamily;
+                    }
+                    AddSystemSettingsFontTypeChanged();
+                }
+                else
+                {
+                    newFontFamily = fontFamily;
+                    RemoveSystemSettingsFontTypeChanged();
+                }
+
+                SetInternalFontFamily(newFontFamily);
+            }
+        }
+
+        private void SetInternalFontFamily(string fontFamily)
+        {
+            Object.InternalSetPropertyString(this.SwigCPtr, TextField.Property.FontFamily, (string)fontFamily);
         }
 
         /// <summary>
@@ -2452,6 +2504,8 @@ namespace Tizen.NUI.BaseComponents
                 SystemSettings.LocaleLanguageChanged -= SystemSettings_LocaleLanguageChanged;
             }
 
+            RemoveSystemSettingsFontTypeChanged();
+
             removeFontSizeChangedCallback();
 
             if (type == DisposeTypes.Explicit)
@@ -2595,6 +2649,45 @@ namespace Tizen.NUI.BaseComponents
                 {
                     Console.WriteLine("{0} Exception caught.", e);
                     hasFontSizeChangedCallback = true;
+                }
+            }
+        }
+
+        private void SystemSettingsFontTypeChanged(object sender, FontTypeChangedEventArgs e)
+        {
+            SetInternalFontFamily(e.Value);
+        }
+
+        private void AddSystemSettingsFontTypeChanged()
+        {
+            if (HasStyle() && !hasSystemFontTypeChanged)
+            {
+                try
+                {
+                    SystemSettings.FontTypeChanged += SystemSettingsFontTypeChanged;
+                    hasSystemFontTypeChanged = true;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemFontTypeChanged = false;
+                }
+            }
+        }
+        
+        private void RemoveSystemSettingsFontTypeChanged()
+        {
+            if (hasSystemFontTypeChanged)
+            {
+                try
+                {
+                    SystemSettings.FontTypeChanged -= SystemSettingsFontTypeChanged;
+                    hasSystemFontTypeChanged = false;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemFontTypeChanged = true;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -137,15 +137,13 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
             if (newValue != null)
             {
-
-                Object.InternalSetPropertyString(textField.SwigCPtr, TextField.Property.FontFamily, (string)newValue);
+                textField.InternalFontFamily = (string)newValue;
             }
         }),
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textField = (TextField)bindable;
-
-            return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.FontFamily);
+            return textField.InternalFontFamily;
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -81,15 +81,15 @@ namespace Tizen.NUI.BaseComponents
 
         static TextLabel() { }
 
-        static private string defaultFontFamily = "TizenSans";
-        private string fontFamily = defaultFontFamily;
-        private bool hasSystemFontTypeChanged = false;
-        private string textLabelSid = null;
-        private bool systemlangTextFlag = false;
-        private TextLabelSelectorData selectorData;
-        private float fontSizeScale = 1.0f;
-        private bool hasFontSizeChangedCallback = false;
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextLabel";
+        static private string defaultFontFamily = "BreezeSans";
+        private string textLabelSid = null;
+        private TextLabelSelectorData selectorData;
+        private string fontFamily = defaultFontFamily;
+        private float fontSizeScale = 1.0f;
+        private bool hasSystemLanguageChanged = false;
+        private bool hasSystemFontSizeChanged = false;
+        private bool hasSystemFontTypeChanged = false;
 
         private Color internalTextColor;
 
@@ -211,10 +211,10 @@ namespace Tizen.NUI.BaseComponents
                 if (translatableText != null)
                 {
                     Text = translatableText;
-                    if (systemlangTextFlag == false)
+                    if (hasSystemLanguageChanged == false)
                     {
-                        SystemSettings.LocaleLanguageChanged += SystemSettings_LocaleLanguageChanged;
-                        systemlangTextFlag = true;
+                        SystemSettings.LocaleLanguageChanged += SystemSettingsLocaleLanguageChanged;
+                        hasSystemLanguageChanged = true;
                     }
                 }
                 else
@@ -1487,12 +1487,12 @@ namespace Tizen.NUI.BaseComponents
                         systemSettingsFontSize = SystemSettingsFontSize.Normal;
                     }
                     newFontSizeScale = TextUtils.GetFontSizeScale(systemSettingsFontSize);
-                    addFontSizeChangedCallback();
+                    AddSystemSettingsFontSizeChanged();
                 }
                 else
                 {
                     newFontSizeScale = fontSizeScale;
-                    removeFontSizeChangedCallback();
+                    RemoveSystemSettingsFontSizeChanged();
                 }
 
                 SetInternalFontSizeScale(newFontSizeScale);
@@ -1561,14 +1561,13 @@ namespace Tizen.NUI.BaseComponents
 
             internalTextColor?.Dispose();
 
-            if (systemlangTextFlag)
+            if (hasSystemLanguageChanged)
             {
-                SystemSettings.LocaleLanguageChanged -= SystemSettings_LocaleLanguageChanged;
+                SystemSettings.LocaleLanguageChanged -= SystemSettingsLocaleLanguageChanged;
             }
 
             RemoveSystemSettingsFontTypeChanged();
-
-            removeFontSizeChangedCallback();
+            RemoveSystemSettingsFontSizeChanged();
 
             if (type == DisposeTypes.Explicit)
             {
@@ -1618,7 +1617,7 @@ namespace Tizen.NUI.BaseComponents
             base.OnBindingContextChanged();
         }
 
-        private void SystemSettings_LocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
+        private void SystemSettingsLocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
         {
             Text = NUIApplication.MultilingualResourceManager?.GetString(textLabelSid, new CultureInfo(e.Value.Replace("_", "-")));
         }
@@ -1629,36 +1628,36 @@ namespace Tizen.NUI.BaseComponents
             SetInternalFontSizeScale(newFontSizeScale);
         }
 
-        private void addFontSizeChangedCallback()
+        private void AddSystemSettingsFontSizeChanged()
         {
-            if (hasFontSizeChangedCallback != true)
+            if (hasSystemFontSizeChanged != true)
             {
                 try
                 {
                     SystemSettings.FontSizeChanged += SystemSettingsFontSizeChanged;
-                    hasFontSizeChangedCallback = true;
+                    hasSystemFontSizeChanged = true;
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine("{0} Exception caught.", e);
-                    hasFontSizeChangedCallback = false;
+                    hasSystemFontSizeChanged = false;
                 }
             }
         }
 
-        private void removeFontSizeChangedCallback()
+        private void RemoveSystemSettingsFontSizeChanged()
         {
-            if (hasFontSizeChangedCallback == true)
+            if (hasSystemFontSizeChanged == true)
             {
                 try
                 {
                     SystemSettings.FontSizeChanged -= SystemSettingsFontSizeChanged;
-                    hasFontSizeChangedCallback = false;
+                    hasSystemFontSizeChanged = false;
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine("{0} Exception caught.", e);
-                    hasFontSizeChangedCallback = true;
+                    hasSystemFontSizeChanged = true;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -81,6 +81,9 @@ namespace Tizen.NUI.BaseComponents
 
         static TextLabel() { }
 
+        static private string defaultFontFamily = "TizenSans";
+        private string fontFamily = defaultFontFamily;
+        private bool hasSystemFontTypeChanged = false;
         private string textLabelSid = null;
         private bool systemlangTextFlag = false;
         private TextLabelSelectorData selectorData;
@@ -164,6 +167,11 @@ namespace Tizen.NUI.BaseComponents
             {
                 SetVisible(false);
             }
+        }
+
+        private bool HasStyle()
+        {
+            return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
         }
 
         /// <summary>
@@ -251,6 +259,51 @@ namespace Tizen.NUI.BaseComponents
                 SetValue(FontFamilyProperty, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        private string InternalFontFamily
+        {
+            get
+            {
+                if (HasStyle())
+                    return fontFamily;
+                else
+                    return Object.InternalGetPropertyString(this.SwigCPtr, TextLabel.Property.FontFamily);
+            }
+            set
+            {
+                string newFontFamily;
+
+                if (string.Equals(fontFamily, value)) return;
+
+                fontFamily = value;
+                if (fontFamily == Tizen.NUI.FontFamily.UseSystemSetting)
+                {
+                    try
+                    {
+                        newFontFamily = SystemSettings.FontType;
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine("{0} Exception caught.", e);
+                        newFontFamily = defaultFontFamily;
+                    }
+                    AddSystemSettingsFontTypeChanged();
+                }
+                else
+                {
+                    newFontFamily = fontFamily;
+                    RemoveSystemSettingsFontTypeChanged();
+                }
+
+                SetInternalFontFamily(newFontFamily);
+            }
+        }
+
+        private void SetInternalFontFamily(string fontFamily)
+        {
+            Object.InternalSetPropertyString(this.SwigCPtr, TextLabel.Property.FontFamily, (string)fontFamily);
+            RequestLayout();
         }
 
         /// <summary>
@@ -1513,6 +1566,8 @@ namespace Tizen.NUI.BaseComponents
                 SystemSettings.LocaleLanguageChanged -= SystemSettings_LocaleLanguageChanged;
             }
 
+            RemoveSystemSettingsFontTypeChanged();
+
             removeFontSizeChangedCallback();
 
             if (type == DisposeTypes.Explicit)
@@ -1604,6 +1659,45 @@ namespace Tizen.NUI.BaseComponents
                 {
                     Console.WriteLine("{0} Exception caught.", e);
                     hasFontSizeChangedCallback = true;
+                }
+            }
+        }
+
+        private void SystemSettingsFontTypeChanged(object sender, FontTypeChangedEventArgs e)
+        {
+            SetInternalFontFamily(e.Value);
+        }
+
+        private void AddSystemSettingsFontTypeChanged()
+        {
+            if (HasStyle() && !hasSystemFontTypeChanged)
+            {
+                try
+                {
+                    SystemSettings.FontTypeChanged += SystemSettingsFontTypeChanged;
+                    hasSystemFontTypeChanged = true;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemFontTypeChanged = false;
+                }
+            }
+        }
+        
+        private void RemoveSystemSettingsFontTypeChanged()
+        {
+            if (hasSystemFontTypeChanged)
+            {
+                try
+                {
+                    SystemSettings.FontTypeChanged -= SystemSettingsFontTypeChanged;
+                    hasSystemFontTypeChanged = false;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemFontTypeChanged = true;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -92,8 +92,7 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
         {
             var textLabel = (TextLabel)bindable;
-
-            return Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.FontFamily);
+            return textLabel.InternalFontFamily;
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -909,9 +908,7 @@ namespace Tizen.NUI.BaseComponents
         {
             if (value != null)
             {
-
-                Object.InternalSetPropertyString(SwigCPtr, TextLabel.Property.FontFamily, value);
-                RequestLayout();
+                InternalFontFamily = (string)value;
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -19,6 +19,8 @@ extern alias TizenSystemSettings;
 using TizenSystemSettings.Tizen.System;
 using System;
 using System.ComponentModel;
+using System.Collections.Generic;
+using Tizen.NUI.Text;
 
 namespace Tizen.NUI.BaseComponents
 {
@@ -1081,6 +1083,43 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.PropertyArray ret = new Tizen.NUI.PropertyArray(Interop.TextUtils.GetLastCharacterIndex(RendererParameters.getCPtr(textParameters)), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        /// <summary>
+        /// This method converts a FontInfo property array to a list and returns it.
+        /// <param name="fontArray">The FontInfo PropertyArray.</param>
+        /// <returns> A list of FontInfo struct. </returns>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static List<FontInfo> GetFontInfoList(PropertyArray fontArray)
+        {
+            var fontList = new List<FontInfo>();
+            if (fontArray != null)
+            {
+                for (uint i = 0 ; i < fontArray.Count(); i ++)
+                {
+                    using (var fontInfoMap = new PropertyMap())
+                    using (var propertyValue = fontArray[i])
+                    {
+                        propertyValue.Get(fontInfoMap);
+
+                        if (fontInfoMap.Count() > 0)
+                        {
+                            var fontInfo = new FontInfo();
+                            fontInfo.Family = TextMapHelper.GetStringFromMap(fontInfoMap, "family", "TizenSans");
+                            fontInfo.Path = TextMapHelper.GetStringFromMap(fontInfoMap, "path", "");
+                            fontInfo.Style = new FontStyle()
+                            {
+                                Width = (FontWidthType)TextMapHelper.GetIntFromMap(fontInfoMap, "width", 0),
+                                Weight = (FontWeightType)TextMapHelper.GetIntFromMap(fontInfoMap, "weight", 0),
+                                Slant = (FontSlantType)TextMapHelper.GetIntFromMap(fontInfoMap, "slant", 0),
+                            };
+                            fontList.Add(fontInfo);
+                        }
+                    }
+                }
+            }
+            return fontList;
         }
 
 #if PROFILE_TV

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -1973,6 +1973,19 @@ namespace Tizen.NUI
     }
 
     /// <summary>
+    /// FontFamily constant.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct FontFamily
+    {
+        /// <summary>
+        /// UseSystemSetting
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly string UseSystemSetting = string.Empty;
+    }
+
+    /// <summary>
     /// Offset has left, right, bottom, top value.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
@@ -38,7 +38,7 @@ namespace Tizen.NUI
             // TextLabel style.
             theme.AddStyleWithoutClone("Tizen.NUI.BaseComponents.TextLabel", new TextLabelStyle()
             {
-                FontFamily = "TizenSans",
+                FontFamily = Tizen.NUI.FontFamily.UseSystemSetting,
                 PixelSize = 24,
                 TextColor = new Color(0.04f, 0.05f, 0.13f, 1),
                 FontStyle = new PropertyMap().Add("weight", new PropertyValue("regular")),
@@ -51,7 +51,7 @@ namespace Tizen.NUI
             // TextField style.
             theme.AddStyleWithoutClone("Tizen.NUI.BaseComponents.TextField", new TextFieldStyle()
             {
-                FontFamily = "TizenSans",
+                FontFamily = Tizen.NUI.FontFamily.UseSystemSetting,
                 PixelSize = 24,
                 TextColor = new Color(0.04f, 0.05f, 0.13f, 1),
                 PlaceholderTextColor = new Vector4(0.79f, 0.79f, 0.79f, 1),
@@ -88,7 +88,7 @@ namespace Tizen.NUI
             // TextEditor style.
             theme.AddStyleWithoutClone("Tizen.NUI.BaseComponents.TextEditor", new TextEditorStyle()
             {
-                FontFamily = "TizenSans",
+                FontFamily = Tizen.NUI.FontFamily.UseSystemSetting,
                 PixelSize = 24,
                 TextColor = new Color(0.04f, 0.05f, 0.13f, 1),
                 PlaceholderTextColor = new Color(0.79f, 0.79f, 0.79f, 1),

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -15,6 +15,9 @@
  *
  */
 using System.ComponentModel;
+using System.Collections.Generic;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Text;
 
 namespace Tizen.NUI
 {
@@ -209,6 +212,38 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// Retrieve the list of font info supported by the system.
+        /// </summary>
+        /// <returns>The list of FontInfo</returns>
+        /// <remarks>
+        /// <see cref="Tizen.NUI.Text.FontInfo"/>
+        /// </remarks>
+        /// <example>
+        /// The following example demonstrates how to use the GetSystemFonts method.
+        /// <code>
+        /// var fontList = FontClient.Instance.GetSystemFonts();
+        /// foreach(Tizen.NUI.Text.FontInfo fontInfo in fontList)
+        /// {
+        ///    string fontFamily = fontInfo.Family;
+        ///    string fontPath = fontInfo.Path;
+        ///    FontWidthType fontWidth = fontInfo.Style.Width;
+        ///    FontWeightType fontWeight = fontInfo.Style.Weight;
+        ///    FontSlantType fontSlant = fontInfo.Style.Slant;
+        /// }
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<FontInfo> GetSystemFonts()
+        {
+            using PropertyArray fontArray = new PropertyArray(Interop.FontClient.GetSystemFonts(SwigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            List<FontInfo> fontInfoList;
+            fontInfoList = TextUtils.GetFontInfoList(fontArray);
+            return fontInfoList;
+        }
+
         internal static FontClient Get()
         {
             FontClient ret = new FontClient(Interop.FontClient.Get(), true);
@@ -251,12 +286,6 @@ namespace Tizen.NUI
         internal void GetDefaultPlatformFontDescription(FontDescription fontDescription)
         {
             Interop.FontClient.GetDefaultPlatformFontDescription(SwigCPtr, FontDescription.getCPtr(fontDescription));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        internal void GetSystemFonts(SWIGTYPE_p_std__vectorT_Dali__TextAbstraction__FontDescription_t systemFonts)
-        {
-            Interop.FontClient.GetSystemFonts(SwigCPtr, SWIGTYPE_p_std__vectorT_Dali__TextAbstraction__FontDescription_t.getCPtr(systemFonts));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
user can get a list of system fonts

sample code:
https://github.com/wonrst/NUI-Test/blob/main/text-font-list/font_list.cs

dali-csharp-binder:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/284941/