### PR TITLE
[NUI] Fix Navigator to enable multiple Pop()

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -393,6 +393,9 @@ namespace Tizen.NUI.Components
             //Duplicate page is not pushed.
             if (navigationPages.Contains(page)) return;
 
+            //TODO: The following transition codes will be replaced with view transition.
+            InitializeAnimation();
+
             var curTop = Peek();
 
             if (!curTop)
@@ -410,9 +413,6 @@ namespace Tizen.NUI.Components
             curTop.InvokeDisappearing();
 
             curTop.SaveKeyFocus();
-
-            //TODO: The following transition codes will be replaced with view transition.
-            InitializeAnimation();
 
             if (page is DialogPage == false)
             {
@@ -475,6 +475,9 @@ namespace Tizen.NUI.Components
                 throw new InvalidOperationException("There is no page in Navigator.");
             }
 
+            //TODO: The following transition codes will be replaced with view transition.
+            InitializeAnimation();
+
             var curTop = Peek();
 
             if (navigationPages.Count == 1)
@@ -493,9 +496,6 @@ namespace Tizen.NUI.Components
             newTop.InvokeAppearing();
             curTop.InvokeDisappearing();
             curTop.SaveKeyFocus();
-
-            //TODO: The following transition codes will be replaced with view transition.
-            InitializeAnimation();
 
             if (curTop is DialogPage == false)
             {
@@ -1071,17 +1071,50 @@ namespace Tizen.NUI.Components
         //TODO: The following transition codes will be replaced with view transition.
         private void InitializeAnimation()
         {
+            bool isCurAnimPlaying = false;
+            bool isNewAnimPlaying = false;
+
             if (curAnimation != null)
             {
-                curAnimation.Stop();
-                curAnimation.Clear();
-                curAnimation = null;
+                if (curAnimation.State == Animation.States.Playing)
+                {
+                    isCurAnimPlaying = true;
+                    curAnimation.Stop();
+                }
             }
 
             if (newAnimation != null)
             {
-                newAnimation.Stop();
+                if (newAnimation.State == Animation.States.Playing)
+                {
+                    isNewAnimPlaying = true;
+                    newAnimation.Stop();
+                }
+            }
+
+            if (isCurAnimPlaying)
+            {
+                // To enable multiple Pop(), animation's Finished callback is required.
+                // To call animation's Finished callback, FinishedSignal is emitted.
+                curAnimation.FinishedSignal().Emit(curAnimation);
+                curAnimation.Clear();
+
+                // InitializeAnimation() can be called by FinishedSignal().Emit().
+                // Not to cause null pointer dereference by calling InitializeAnimation() in InitializeAnimation(),
+                // animation handle is assigned to be null only if the animation is playing.
+                curAnimation = null;
+            }
+
+            if (isNewAnimPlaying)
+            {
+                // To enable multiple Pop(), animation's Finished callback is required.
+                // To call animation's Finished callback, FinishedSignal is emitted.
+                newAnimation.FinishedSignal().Emit(newAnimation);
                 newAnimation.Clear();
+
+                // InitializeAnimation() can be called by FinishedSignal().Emit().
+                // Not to cause null pointer dereference by calling InitializeAnimation() in InitializeAnimation(),
+                // animation handle is assigned to be null only if the animation is playing.
                 newAnimation = null;
             }
         }


### PR DESCRIPTION
A popped page is removed in the Pop() animation's Finished callback.

Previously, Navigator could not support multiple Pop().
Because Pop() simply stopped the previous Pop() animation without
calling the animation's Finished callback.

Now, Pop() stops the previous Pop() animation with calling the
animation's Finished callback by emitting FinishedSignal().
Consequently, Navigator can support multiple Pop() now.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
