### PR TITLE
[NUI] Add Text Geometry APIs

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextGeometry.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextGeometry.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class TextGeometry
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextLabel_GetLineBoundingRectangle")]
+            public static extern global::System.IntPtr GetLineBoundingRectangleTextLabel(global::System.Runtime.InteropServices.HandleRef textLabelRef, int lineIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextField_GetLineBoundingRectangle")]
+            public static extern global::System.IntPtr GetLineBoundingRectangleTextField(global::System.Runtime.InteropServices.HandleRef textFieldRef, int lineIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextEditor_GetLineBoundingRectangle")]
+            public static extern global::System.IntPtr GetLineBoundingRectangleTextEditor(global::System.Runtime.InteropServices.HandleRef textEditorRef, int lineIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextLabel_GetCharacterBoundingRectangle")]
+            public static extern global::System.IntPtr GetCharacterBoundingRectangleTextLabel(global::System.Runtime.InteropServices.HandleRef textLabelRef, int characterIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextField_GetCharacterBoundingRectangle")]
+            public static extern global::System.IntPtr GetCharacterBoundingRectangleTextField(global::System.Runtime.InteropServices.HandleRef textFieldRef, int characterIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextEditor_GetCharacterBoundingRectangle")]
+            public static extern global::System.IntPtr GetCharacterBoundingRectangleTextEditor(global::System.Runtime.InteropServices.HandleRef textEditorRef, int characterIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextLabel_GetCharacterIndexAtPosition")]
+            public static extern int GetCharacterIndexAtPositionTextLabel(global::System.Runtime.InteropServices.HandleRef textLabelRef, float visualX, float visualY);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextField_GetCharacterIndexAtPosition")]
+            public static extern int GetCharacterIndexAtPositionTextField(global::System.Runtime.InteropServices.HandleRef textFieldRef, float visualX, float visualY);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextEditor_GetCharacterIndexAtPosition")]
+            public static extern int GetCharacterIndexAtPositionTextEditor(global::System.Runtime.InteropServices.HandleRef textEditorRef, float visualX, float visualY);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
@@ -36,6 +36,12 @@ namespace Tizen.NUI.BaseComponents
                 throw new global::System.ArgumentOutOfRangeException(nameof(end), "Value is less than zero");
         }
 
+        private static void ValidateIndex(int index)
+        {
+            if (index < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(index), "Value is less than zero");
+        }
+
         private static List<Size2D> GetSizeListFromNativeVector(System.IntPtr ptr)
         {
             using (VectorVector2 sizeVector = new VectorVector2 (ptr, true))
@@ -68,6 +74,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
+
+        private static Tizen.NUI.Rectangle ConvertPaddingTypeToRectangle(Tizen.NUI.PaddingType paddingType)
+        {
+            Tizen.NUI.Rectangle rect = new  Tizen.NUI.Rectangle();
+            rect.X = (int) paddingType.Start;
+            rect.Y = (int) paddingType.End;
+            rect.Width = (int) paddingType.Bottom;
+            rect.Height = (int) paddingType.Top;
+
+            return rect;
+        }
+
 
         /// <summary>
         /// Get the rendered size of the text between start and end (included). <br />
@@ -212,5 +230,204 @@ namespace Tizen.NUI.BaseComponents
             CheckSWIGPendingException();
             return list;
         }
+
+        /// <summary>
+        /// Get the bounding rectangle of a line. <br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="lineIndex">The index of the line to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetLineBoundingRectangle(TextLabel textLabel, int lineIndex)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            ValidateIndex(lineIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetLineBoundingRectangleTextLabel(textLabel.SwigCPtr, lineIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a line. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="lineIndex">The index of the line to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetLineBoundingRectangle(TextEditor textEditor, int lineIndex)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            ValidateIndex(lineIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetLineBoundingRectangleTextEditor(textEditor.SwigCPtr, lineIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a line. <br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="lineIndex">The index of the line to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetLineBoundingRectangle(TextField textField, int lineIndex)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            ValidateIndex(lineIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetLineBoundingRectangleTextField(textField.SwigCPtr, lineIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a character. <br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="characterIndex">The index of the character to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetCharacterBoundingRectangle(TextLabel textLabel, int characterIndex)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            ValidateIndex(characterIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetCharacterBoundingRectangleTextLabel(textLabel.SwigCPtr, characterIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a character. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="characterIndex">The index of the character to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetCharacterBoundingRectangle(TextEditor textEditor, int characterIndex)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            ValidateIndex(characterIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetCharacterBoundingRectangleTextEditor(textEditor.SwigCPtr, characterIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a character. <br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="characterIndex">The index of the character to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetCharacterBoundingRectangle(TextField textField, int characterIndex)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            ValidateIndex(characterIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetCharacterBoundingRectangleTextField(textField.SwigCPtr, characterIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the character Index at the given position. <br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="visualX">The visual x point</param>
+        /// <param name="visualY">The visual y point</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static int GetCharacterIndexAtPosition(TextLabel textLabel, float visualX, float visualY)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            int characterIndex = (int)(Interop.TextGeometry.GetCharacterIndexAtPositionTextLabel(textLabel.SwigCPtr, visualX, visualY));
+            CheckSWIGPendingException();
+            return characterIndex;
+        }
+
+        /// <summary>
+        /// Get the character Index at the given position. <br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="visualX">The visual x point</param>
+        /// <param name="visualY">The visual y point</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static int GetCharacterIndexAtPosition(TextField textField, float visualX, float visualY)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            int characterIndex = (int)(Interop.TextGeometry.GetCharacterIndexAtPositionTextField(textField.SwigCPtr, visualX, visualY));
+            CheckSWIGPendingException();
+            return characterIndex;
+        }
+
+        /// <summary>
+        /// Get the character Index at the given position. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="visualX">The visual x point</param>
+        /// <param name="visualY">The visual y point</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static int GetCharacterIndexAtPosition(TextEditor textEditor, float visualX, float visualY)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            int characterIndex = (int)(Interop.TextGeometry.GetCharacterIndexAtPositionTextEditor(textEditor.SwigCPtr, visualX, visualY));
+            CheckSWIGPendingException();
+            return characterIndex;
+        }
+
     }
 }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
@@ -1,0 +1,246 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI.Components;
+using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/BaseComponents/TextGeometry")]
+    public class PublicTextGeometryTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
@@ -1,0 +1,246 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI.Components;
+using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/BaseComponents/TextGeometry")]
+    public class PublicTextGeometryTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel END (OK)");
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Add Text Geometry APIs:

- GetLineBoundedRectangle. //API
- GetCharacterBoundedRectangle. //API
- GetCharacterIndexAtPostion //API

### API Changes ###

This PR contains 3 Text Geometry APIs: 
Added:
 - Rectangle GetLineBoundingRectangle(TextController textController, int lineIndex) 
 - Rectangle GetCharacterBoundingRectangle(TextController textController, int characterIndex)
 - int GetCharacterIndexAtPosition(TextController textController, float visualX, float visualY)


### Testcases ###

Added the below to (Tizen.NUI.Devel.Tests.Ubuntu) and (Tizen.NUI.Tests):

- Tizen.NUI.Devel.Tests.TexGeometry


The PR depends on the following patches: 

- Toolkit: https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/284604
- CSharp-binder: https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/284814

