### PR TITLE
[NUI] Text Geometry: Open TextBoundingRectangle API 

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextEditor.cs
@@ -367,6 +367,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextEditor_GetTextBoundingRectangle")]
+            public static extern global::System.IntPtr GetTextBoundingRectangle(global::System.Runtime.InteropServices.HandleRef textEditorRef, int startIndex, int endIndex);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextField.cs
@@ -329,6 +329,9 @@ namespace Tizen.NUI
             public static extern int StrikethroughGet();
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextField_GetTextBoundingRectangle")]
+            public static extern global::System.IntPtr GetTextBoundingRectangle(global::System.Runtime.InteropServices.HandleRef textFieldRef, int startIndex, int endIndex);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextGeometry.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextGeometry.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class TextGeometry
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextLabel_GetLineBoundingRectangle")]
+            public static extern global::System.IntPtr GetLineBoundingRectangleTextLabel(global::System.Runtime.InteropServices.HandleRef textLabelRef, int lineIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextField_GetLineBoundingRectangle")]
+            public static extern global::System.IntPtr GetLineBoundingRectangleTextField(global::System.Runtime.InteropServices.HandleRef textFieldRef, int lineIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextEditor_GetLineBoundingRectangle")]
+            public static extern global::System.IntPtr GetLineBoundingRectangleTextEditor(global::System.Runtime.InteropServices.HandleRef textEditorRef, int lineIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextLabel_GetCharacterBoundingRectangle")]
+            public static extern global::System.IntPtr GetCharacterBoundingRectangleTextLabel(global::System.Runtime.InteropServices.HandleRef textLabelRef, int characterIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextField_GetCharacterBoundingRectangle")]
+            public static extern global::System.IntPtr GetCharacterBoundingRectangleTextField(global::System.Runtime.InteropServices.HandleRef textFieldRef, int characterIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextEditor_GetCharacterBoundingRectangle")]
+            public static extern global::System.IntPtr GetCharacterBoundingRectangleTextEditor(global::System.Runtime.InteropServices.HandleRef textEditorRef, int characterIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextLabel_GetCharacterIndexAtPosition")]
+            public static extern int GetCharacterIndexAtPositionTextLabel(global::System.Runtime.InteropServices.HandleRef textLabelRef, float visualX, float visualY);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextField_GetCharacterIndexAtPosition")]
+            public static extern int GetCharacterIndexAtPositionTextField(global::System.Runtime.InteropServices.HandleRef textFieldRef, float visualX, float visualY);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextEditor_GetCharacterIndexAtPosition")]
+            public static extern int GetCharacterIndexAtPositionTextEditor(global::System.Runtime.InteropServices.HandleRef textEditorRef, float visualX, float visualY);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -195,6 +195,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextGeometry_TextLabel_GetTextBoundingRectangle")]
+            public static extern global::System.IntPtr GetTextBoundingRectangle(global::System.Runtime.InteropServices.HandleRef textLabelRef, int startIndex, int endIndex);
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
@@ -429,5 +429,77 @@ namespace Tizen.NUI.BaseComponents
             return characterIndex;
         }
 
+        /// <summary>
+        /// Get the text bounding rectangle. <br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="startIndex">The start index to calcualte the ractangle for.</param>
+        /// <param name="endIndex">The end index to calcualte the ractangle for.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetTextBoundingRectangle(TextLabel textLabel, int startIndex, int endIndex)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextLabel.GetTextBoundingRectangle(textLabel.SwigCPtr, startIndex, endIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the text bounding rectangle. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="startIndex">The start index to calcualte the ractangle for.</param>
+        /// <param name="endIndex">The end index to calcualte the ractangle for.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetTextBoundingRectangle(TextEditor textEditor, int startIndex, int endIndex)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextEditor.GetTextBoundingRectangle(textEditor.SwigCPtr, startIndex, endIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the text bounding rectangle. <br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="startIndex">The start index to calcualte the ractangle for.</param>
+        /// <param name="endIndex">The end index to calcualte the ractangle for.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetTextBoundingRectangle(TextField textField, int startIndex, int endIndex)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            ValidateRange(startIndex, endIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextField.GetTextBoundingRectangle(textField.SwigCPtr, startIndex, endIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextGeometry.cs
@@ -36,6 +36,12 @@ namespace Tizen.NUI.BaseComponents
                 throw new global::System.ArgumentOutOfRangeException(nameof(end), "Value is less than zero");
         }
 
+        private static void ValidateIndex(int index)
+        {
+            if (index < 0)
+                throw new global::System.ArgumentOutOfRangeException(nameof(index), "Value is less than zero");
+        }
+
         private static List<Size2D> GetSizeListFromNativeVector(System.IntPtr ptr)
         {
             using (VectorVector2 sizeVector = new VectorVector2 (ptr, true))
@@ -68,6 +74,18 @@ namespace Tizen.NUI.BaseComponents
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
+
+        private static Tizen.NUI.Rectangle ConvertPaddingTypeToRectangle(Tizen.NUI.PaddingType paddingType)
+        {
+            Tizen.NUI.Rectangle rect = new  Tizen.NUI.Rectangle();
+            rect.X = (int) paddingType.Start;
+            rect.Y = (int) paddingType.End;
+            rect.Width = (int) paddingType.Bottom;
+            rect.Height = (int) paddingType.Top;
+
+            return rect;
+        }
+
 
         /// <summary>
         /// Get the rendered size of the text between start and end (included). <br />
@@ -212,5 +230,204 @@ namespace Tizen.NUI.BaseComponents
             CheckSWIGPendingException();
             return list;
         }
+
+        /// <summary>
+        /// Get the bounding rectangle of a line. <br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="lineIndex">The index of the line to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetLineBoundingRectangle(TextLabel textLabel, int lineIndex)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            ValidateIndex(lineIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetLineBoundingRectangleTextLabel(textLabel.SwigCPtr, lineIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a line. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="lineIndex">The index of the line to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetLineBoundingRectangle(TextEditor textEditor, int lineIndex)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            ValidateIndex(lineIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetLineBoundingRectangleTextEditor(textEditor.SwigCPtr, lineIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a line. <br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="lineIndex">The index of the line to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetLineBoundingRectangle(TextField textField, int lineIndex)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            ValidateIndex(lineIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetLineBoundingRectangleTextField(textField.SwigCPtr, lineIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a character. <br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="characterIndex">The index of the character to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetCharacterBoundingRectangle(TextLabel textLabel, int characterIndex)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            ValidateIndex(characterIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetCharacterBoundingRectangleTextLabel(textLabel.SwigCPtr, characterIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a character. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="characterIndex">The index of the character to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetCharacterBoundingRectangle(TextEditor textEditor, int characterIndex)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            ValidateIndex(characterIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetCharacterBoundingRectangleTextEditor(textEditor.SwigCPtr, characterIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the bounding rectangle of a character. <br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="characterIndex">The index of the character to get the bounding rectangle for</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Tizen.NUI.Rectangle GetCharacterBoundingRectangle(TextField textField, int characterIndex)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            ValidateIndex(characterIndex);
+
+            Tizen.NUI.PaddingType paddingType = new Tizen.NUI.PaddingType(Interop.TextGeometry.GetCharacterBoundingRectangleTextField(textField.SwigCPtr, characterIndex), true);
+            Tizen.NUI.Rectangle   rect        = ConvertPaddingTypeToRectangle(paddingType);
+
+            CheckSWIGPendingException();
+            return rect;
+        }
+
+        /// <summary>
+        /// Get the character Index at the given position. <br />
+        /// </summary>
+        /// <param name="textLabel">The TextLabel control containing the text.</param>
+        /// <param name="visualX">The visual x point</param>
+        /// <param name="visualY">The visual y point</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static int GetCharacterIndexAtPosition(TextLabel textLabel, float visualX, float visualY)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            int characterIndex = (int)(Interop.TextGeometry.GetCharacterIndexAtPositionTextLabel(textLabel.SwigCPtr, visualX, visualY));
+            CheckSWIGPendingException();
+            return characterIndex;
+        }
+
+        /// <summary>
+        /// Get the character Index at the given position. <br />
+        /// </summary>
+        /// <param name="textField">The TextField control containing the text.</param>
+        /// <param name="visualX">The visual x point</param>
+        /// <param name="visualY">The visual y point</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static int GetCharacterIndexAtPosition(TextField textField, float visualX, float visualY)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            int characterIndex = (int)(Interop.TextGeometry.GetCharacterIndexAtPositionTextField(textField.SwigCPtr, visualX, visualY));
+            CheckSWIGPendingException();
+            return characterIndex;
+        }
+
+        /// <summary>
+        /// Get the character Index at the given position. <br />
+        /// </summary>
+        /// <param name="textEditor">The TextEditor control containing the text.</param>
+        /// <param name="visualX">The visual x point</param>
+        /// <param name="visualY">The visual y point</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static int GetCharacterIndexAtPosition(TextEditor textEditor, float visualX, float visualY)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            int characterIndex = (int)(Interop.TextGeometry.GetCharacterIndexAtPositionTextEditor(textEditor.SwigCPtr, visualX, visualY));
+            CheckSWIGPendingException();
+            return characterIndex;
+        }
+
     }
 }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSAnimatedImageView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSAnimatedImageView.cs
@@ -1,288 +1,288 @@
-﻿using global::System;
-using NUnit.Framework;
-using NUnit.Framework.TUnit;
-using Tizen.NUI.Components;
-using Tizen.NUI.BaseComponents;
-using System.Collections.Generic;
+﻿// using global::System;
+// using NUnit.Framework;
+// using NUnit.Framework.TUnit;
+// using Tizen.NUI.Components;
+// using Tizen.NUI.BaseComponents;
+// using System.Collections.Generic;
 
-namespace Tizen.NUI.Devel.Tests
-{
-    using tlog = Tizen.Log;
+// namespace Tizen.NUI.Devel.Tests
+// {
+//     using tlog = Tizen.Log;
 
-    [TestFixture]
-    [Description("public/BaseComponents/ImageView")]
-    public class InternalAnimatedImageViewTest
-    {
-        private const string tag = "NUITEST";
-        private string image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "Image.png";
-        private string animated_image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "dali-logo-anim.gif";
+//     [TestFixture]
+//     [Description("public/BaseComponents/ImageView")]
+//     public class InternalAnimatedImageViewTest
+//     {
+//         private const string tag = "NUITEST";
+//         private string image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "Image.png";
+//         private string animated_image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "dali-logo-anim.gif";
 
-        [SetUp]
-        public void Init()
-        {
-            tlog.Info(tag, "Init() is called!");
-        }
+//         [SetUp]
+//         public void Init()
+//         {
+//             tlog.Info(tag, "Init() is called!");
+//         }
 
-        [TearDown]
-        public void Destroy()
-        {
-            tlog.Info(tag, "Destroy() is called!");
-        }
+//         [TearDown]
+//         public void Destroy()
+//         {
+//             tlog.Info(tag, "Destroy() is called!");
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.ResourceUrl")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.ResourceUrl")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void ResourceUrl_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-            // Note : Current version of ANIMATED_IMAGE Visual works well only ResourceUrl's suffix is *.gif or *.webp
-            string testUrl1 = "test1.gif";
-            testView.ResourceUrl = testUrl1;
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.ResourceUrl")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.ResourceUrl")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void ResourceUrl_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+//             // Note : Current version of ANIMATED_IMAGE Visual works well only ResourceUrl's suffix is *.gif or *.webp
+//             string testUrl1 = "test1.gif";
+//             testView.ResourceUrl = testUrl1;
 
-            Assert.AreEqual(testView.ResourceUrl, testUrl1, "ResourceUrl is not equal");
+//             Assert.AreEqual(testView.ResourceUrl, testUrl1, "ResourceUrl is not equal");
 
-            testView.Dispose();
-        }
+//             testView.Dispose();
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.NaturalSize2D")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.NaturalSize2D")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void NaturalSize2D_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-            testView.ResourceUrl = animated_image_path;
-            Size2D result = new Size2D(326, 171); // The size of animated_image_path image.
-            Size2D size = testView.NaturalSize2D;
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.NaturalSize2D")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.NaturalSize2D")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void NaturalSize2D_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+//             testView.ResourceUrl = animated_image_path;
+//             Size2D result = new Size2D(326, 171); // The size of animated_image_path image.
+//             Size2D size = testView.NaturalSize2D;
 
-            Assert.AreEqual(result.Width, size.Width, "NaturalSize Width is not equal");
-            Assert.AreEqual(result.Height, size.Height, "NaturalSize Height is not equal");
+//             Assert.AreEqual(result.Width, size.Width, "NaturalSize Width is not equal");
+//             Assert.AreEqual(result.Height, size.Height, "NaturalSize Height is not equal");
 
-            testView.Dispose();
-        }
-
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.NaturalSize")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.NaturalSize")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void NaturalSize_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-            testView.ResourceUrl = animated_image_path;
-            Vector3 result = new Vector3(326, 171, 0); // The size of animated_image_path image.
-            Vector3 size = testView.NaturalSize;
-
-            Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
-            Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.NaturalSize")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.NaturalSize")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void NaturalSize_GET_VALUE_as_View_class()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-            testView.ResourceUrl = animated_image_path;
-            Vector3 result = new Vector3(326, 171, 0); // The size of animated_image_path image.
-            View testView2 = testView; // Convert class as View.
-            Vector3 size = testView2.NaturalSize; // Check whether virtual ImageView.GetNaturalSize() called well.
-
-            Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
-            Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
-
-            testView.Dispose();
-            testView2.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.Image with ResourceUrl")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.Image")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void Image_GET_VALUE_After_Set_ResourceUrl()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-            string resultUrl1 = "";
-
-            PropertyMap map1 = testView.Image;
-
-            bool ret1 = (map1.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && string.IsNullOrEmpty(resultUrl1);
-
-            Assert.AreEqual(false, ret1, "map don't have ResourceUrl");
-
-            // Note : Current version of ANIMATED_IMAGE Visual works well only ResourceUrl's suffix is *.gif or *.webp
-            string testUrl1 = "test1.gif";
-            testView.ResourceUrl = testUrl1;
-
-            PropertyMap map2 = testView.Image;
-
-            bool ret2 = (map2.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && !string.IsNullOrEmpty(resultUrl1);
-
-            Assert.AreEqual(true, ret2, "map must have ResourceUrl");
-            Assert.AreEqual(testUrl1, resultUrl1, "...and That value must be equal what we added");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.TotalFrame")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.TotalFrame")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void TotalFrame_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-            int expectedTotalFrame = 15; // The total frame of animated_image_path image
-
-            Assert.AreEqual(-1, testView.TotalFrame, "Total frame should be -1 when ResourceUrl is not setup");
-
-            testView.ResourceUrl = animated_image_path;
-
-            Assert.AreEqual(expectedTotalFrame, testView.TotalFrame, "Total frame doesn't matched!");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.CurrentFrame")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.CurrentFrame")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void CurrentFrame_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-
-            Assert.AreEqual(-1, testView.CurrentFrame, "Current frame should be -1 when ResourceUrl is not setup");
-
-            testView.ResourceUrl = animated_image_path;
-
-            Assert.AreEqual(0, testView.CurrentFrame, "Current frame doesn't matched!");
-
-            // Set CurrentFrame will works well only if view is scene on.
-            NUIApplication.GetDefaultWindow().Add(testView);
-
-            int expectFrame = 3;
-            testView.CurrentFrame = expectFrame;
-
-            Assert.AreEqual(expectFrame, testView.CurrentFrame, "Current frame doesn't matched!");
-
-            testView.Unparent();
-            testView.Dispose();
-        }
+//             testView.Dispose();
+//         }
 
 
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.LoopCount")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.LoopCount")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void LoopCount_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.NaturalSize")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.NaturalSize")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void NaturalSize_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+//             testView.ResourceUrl = animated_image_path;
+//             Vector3 result = new Vector3(326, 171, 0); // The size of animated_image_path image.
+//             Vector3 size = testView.NaturalSize;
 
-            Assert.AreEqual(-1, testView.LoopCount, "LoopCount should be -1 when ResourceUrl is not setup");
+//             Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
+//             Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
 
-            testView.ResourceUrl = animated_image_path;
+//             testView.Dispose();
+//         }
 
-            Assert.AreEqual(-1, testView.LoopCount, "LoopCount should be -1 (mean infinite loop) even ResourceUrl is setup");
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.NaturalSize")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.NaturalSize")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void NaturalSize_GET_VALUE_as_View_class()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+//             testView.ResourceUrl = animated_image_path;
+//             Vector3 result = new Vector3(326, 171, 0); // The size of animated_image_path image.
+//             View testView2 = testView; // Convert class as View.
+//             Vector3 size = testView2.NaturalSize; // Check whether virtual ImageView.GetNaturalSize() called well.
 
-            int expectLoopCount = 3;
-            testView.LoopCount = expectLoopCount;
-            Assert.AreEqual(expectLoopCount, testView.LoopCount, "LoopCount doesn't matched!");
+//             Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
+//             Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
 
-            testView.LoopCount++;
-            Assert.AreEqual(expectLoopCount + 1, testView.LoopCount, "LoopCount doesn't matched!");
+//             testView.Dispose();
+//             testView2.Dispose();
+//         }
 
-            testView.Dispose();
-        }
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.Image with ResourceUrl")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.Image")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void Image_GET_VALUE_After_Set_ResourceUrl()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+//             string resultUrl1 = "";
 
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.StopBehavior")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.StopBehavior")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void StopBehavior_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
+//             PropertyMap map1 = testView.Image;
 
-            testView.ResourceUrl = animated_image_path;
+//             bool ret1 = (map1.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && string.IsNullOrEmpty(resultUrl1);
 
-            testView.StopBehavior = AnimatedImageView.StopBehaviorType.CurrentFrame;
-            Assert.AreEqual(AnimatedImageView.StopBehaviorType.CurrentFrame, testView.StopBehavior, "StopBehavior is not equal");
-            testView.StopBehavior = AnimatedImageView.StopBehaviorType.MinimumFrame;
-            Assert.AreEqual(AnimatedImageView.StopBehaviorType.MinimumFrame, testView.StopBehavior, "StopBehavior is not equal");
-            testView.StopBehavior = AnimatedImageView.StopBehaviorType.MaximumFrame;
-            Assert.AreEqual(AnimatedImageView.StopBehaviorType.MaximumFrame, testView.StopBehavior, "StopBehavior is not equal");
+//             Assert.AreEqual(false, ret1, "map don't have ResourceUrl");
 
-            testView.Dispose();
-        }
+//             // Note : Current version of ANIMATED_IMAGE Visual works well only ResourceUrl's suffix is *.gif or *.webp
+//             string testUrl1 = "test1.gif";
+//             testView.ResourceUrl = testUrl1;
 
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, AnimatedImageView.URLs")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.URLs")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void URLs_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            AnimatedImageView testView = new AnimatedImageView();
-            List<string> urls = testView.URLs;
+//             PropertyMap map2 = testView.Image;
 
-            urls.Add(image_path);
-            urls.Add(image_path);
-            urls.Add(image_path);
+//             bool ret2 = (map2.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && !string.IsNullOrEmpty(resultUrl1);
 
-            // URLs don't have any change notifier. So we have to update property forcely by SetValues API.
-            testView.SetValues();
+//             Assert.AreEqual(true, ret2, "map must have ResourceUrl");
+//             Assert.AreEqual(testUrl1, resultUrl1, "...and That value must be equal what we added");
 
-            int expectedTotalFrame = urls.Count;
-            int defaultFrameDelay = 100; ///< It can be changed in dali engine side
-            int expectFrameDelay = 300;
+//             testView.Dispose();
+//         }
 
-            Assert.AreEqual(expectedTotalFrame, testView.TotalFrame, "Total frame doesn't matched!");
-            Assert.AreEqual(defaultFrameDelay, testView.FrameDelay, "Default frame delay doesn't matched!");
-            testView.FrameDelay = expectFrameDelay;
-            Assert.AreEqual(expectFrameDelay, testView.FrameDelay, "frame delay doesn't matched!");
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.TotalFrame")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.TotalFrame")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void TotalFrame_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+//             int expectedTotalFrame = 15; // The total frame of animated_image_path image
 
-            testView.Dispose();
-        }
-    }
-}
+//             Assert.AreEqual(-1, testView.TotalFrame, "Total frame should be -1 when ResourceUrl is not setup");
+
+//             testView.ResourceUrl = animated_image_path;
+
+//             Assert.AreEqual(expectedTotalFrame, testView.TotalFrame, "Total frame doesn't matched!");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.CurrentFrame")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.CurrentFrame")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void CurrentFrame_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+
+//             Assert.AreEqual(-1, testView.CurrentFrame, "Current frame should be -1 when ResourceUrl is not setup");
+
+//             testView.ResourceUrl = animated_image_path;
+
+//             Assert.AreEqual(0, testView.CurrentFrame, "Current frame doesn't matched!");
+
+//             // Set CurrentFrame will works well only if view is scene on.
+//             NUIApplication.GetDefaultWindow().Add(testView);
+
+//             int expectFrame = 3;
+//             testView.CurrentFrame = expectFrame;
+
+//             Assert.AreEqual(expectFrame, testView.CurrentFrame, "Current frame doesn't matched!");
+
+//             testView.Unparent();
+//             testView.Dispose();
+//         }
+
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.LoopCount")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.LoopCount")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void LoopCount_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+
+//             Assert.AreEqual(-1, testView.LoopCount, "LoopCount should be -1 when ResourceUrl is not setup");
+
+//             testView.ResourceUrl = animated_image_path;
+
+//             Assert.AreEqual(-1, testView.LoopCount, "LoopCount should be -1 (mean infinite loop) even ResourceUrl is setup");
+
+//             int expectLoopCount = 3;
+//             testView.LoopCount = expectLoopCount;
+//             Assert.AreEqual(expectLoopCount, testView.LoopCount, "LoopCount doesn't matched!");
+
+//             testView.LoopCount++;
+//             Assert.AreEqual(expectLoopCount + 1, testView.LoopCount, "LoopCount doesn't matched!");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.StopBehavior")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.StopBehavior")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void StopBehavior_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+
+//             testView.ResourceUrl = animated_image_path;
+
+//             testView.StopBehavior = AnimatedImageView.StopBehaviorType.CurrentFrame;
+//             Assert.AreEqual(AnimatedImageView.StopBehaviorType.CurrentFrame, testView.StopBehavior, "StopBehavior is not equal");
+//             testView.StopBehavior = AnimatedImageView.StopBehaviorType.MinimumFrame;
+//             Assert.AreEqual(AnimatedImageView.StopBehaviorType.MinimumFrame, testView.StopBehavior, "StopBehavior is not equal");
+//             testView.StopBehavior = AnimatedImageView.StopBehaviorType.MaximumFrame;
+//             Assert.AreEqual(AnimatedImageView.StopBehaviorType.MaximumFrame, testView.StopBehavior, "StopBehavior is not equal");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, AnimatedImageView.URLs")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.URLs")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void URLs_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             AnimatedImageView testView = new AnimatedImageView();
+//             List<string> urls = testView.URLs;
+
+//             urls.Add(image_path);
+//             urls.Add(image_path);
+//             urls.Add(image_path);
+
+//             // URLs don't have any change notifier. So we have to update property forcely by SetValues API.
+//             testView.SetValues();
+
+//             int expectedTotalFrame = urls.Count;
+//             int defaultFrameDelay = 100; ///< It can be changed in dali engine side
+//             int expectFrameDelay = 300;
+
+//             Assert.AreEqual(expectedTotalFrame, testView.TotalFrame, "Total frame doesn't matched!");
+//             Assert.AreEqual(defaultFrameDelay, testView.FrameDelay, "Default frame delay doesn't matched!");
+//             testView.FrameDelay = expectFrameDelay;
+//             Assert.AreEqual(expectFrameDelay, testView.FrameDelay, "frame delay doesn't matched!");
+
+//             testView.Dispose();
+//         }
+//     }
+// }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSImageView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSImageView.cs
@@ -1,415 +1,415 @@
-﻿using global::System;
-using NUnit.Framework;
-using NUnit.Framework.TUnit;
-using Tizen.NUI.Components;
-using Tizen.NUI.BaseComponents;
-
-namespace Tizen.NUI.Devel.Tests
-{
-    using tlog = Tizen.Log;
-
-    [TestFixture]
-    [Description("public/BaseComponents/ImageView")]
-    public class InternalImageViewTest
-    {
-        private const string tag = "NUITEST";
-        private string image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "Image.png";
-        private string mask_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "star-mod.png";
-
-        [SetUp]
-        public void Init()
-        {
-            tlog.Info(tag, "Init() is called!");
-        }
-
-        [TearDown]
-        public void Destroy()
-        {
-            tlog.Info(tag, "Destroy() is called!");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.ResourceUrl")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.ResourceUrl")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void ResourceUrl_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView();
-            string testUrl1 = "test1";
-            testView.ResourceUrl = testUrl1;
-
-            Assert.AreEqual(testView.ResourceUrl, testUrl1, "ResourceUrl is not equal");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.AlphaMaskURL")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.AlphaMaskURL")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void AlphaMaskURL_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView(image_path);
-            string testUrl1 = "test1";
-            testView.AlphaMaskURL = testUrl1;
-
-            Assert.AreEqual(testView.AlphaMaskURL, testUrl1, "AlphaMaskURL is not equal");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.CropToMask")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.CropToMask")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void CropToMask_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView(image_path);
-
-            Assert.AreEqual(testView.CropToMask, false, "CropToMask default is false when we don't set mask image url");
-
-            testView.CropToMask = true;
-
-            Assert.AreEqual(testView.CropToMask, true, "CropToMask is not updated");
-
-            testView.CropToMask = false;
-
-            Assert.AreEqual(testView.CropToMask, false, "CropToMask is not updated");
-
-            testView.AlphaMaskURL = mask_path;
-
-            Assert.AreEqual(testView.CropToMask, false, "CropToMask should not changed even we set mask image url");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.PreMultipliedAlpha")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.PreMultipliedAlpha")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void PreMultipliedAlpha_SET_GET_VALUE()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView(image_path);
-
-            testView.PreMultipliedAlpha = true;
-
-            Assert.AreEqual(testView.PreMultipliedAlpha, true, "PreMultipliedAlpha is not updated");
-
-            testView.PreMultipliedAlpha = false;
-
-            Assert.AreEqual(testView.PreMultipliedAlpha, false, "PreMultipliedAlpha is not updated");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.CropToMask with AlphaMaskURL")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.CropToMask")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void CropToMask_DEFAULT_GET_VALUE()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView(image_path);
-
-            Assert.AreEqual(testView.CropToMask, false, "CropToMask default is false when we don't set mask image url");
-
-            testView.AlphaMaskURL = image_path;
-
-            Assert.AreEqual(testView.CropToMask, true, "CropToMask default is true when we set mask image url");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.NaturalSize2D")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.NaturalSize2D")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void NaturalSize2D_GET_VALUE()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView();
-            testView.ResourceUrl = image_path;
-            Size2D result = new Size2D(212, 150); // The size of image_path image.
-            Size2D size = testView.NaturalSize2D;
-
-            Assert.AreEqual(result.Width, size.Width, "NaturalSize Width is not equal");
-            Assert.AreEqual(result.Height, size.Height, "NaturalSize Height is not equal");
-
-            testView.Dispose();
-        }
-
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.NaturalSize")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.NaturalSize")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void NaturalSize_GET_VALUE()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView();
-            testView.ResourceUrl = image_path;
-            Vector3 result = new Vector3(212, 150, 0); // The size of image_path image.
-            Vector3 size = testView.NaturalSize;
-
-            Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
-            Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.NaturalSize")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.NaturalSize")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void NaturalSize_GET_VALUE_as_View_class()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView();
-            testView.ResourceUrl = image_path;
-            Vector3 result = new Vector3(212, 150, 0); // The size of image_path image.
-            View testView2 = testView; // Convert class as View.
-            Vector3 size = testView2.NaturalSize; // Check whether virtual ImageView.GetNaturalSize() called well.
-
-            Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
-            Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
-
-            testView.Dispose();
-            testView2.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.Image with ResourceUrl")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.Image")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void Image_GET_VALUE_After_Set_ResourceUrl()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView();
-            string resultUrl1 = "";
-
-            PropertyMap map1 = testView.Image;
-
-            bool ret1 = (map1.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && string.IsNullOrEmpty(resultUrl1);
-
-            Assert.AreEqual(false, ret1, "map don't have ResourceUrl");
-
-            string testUrl1 = "test1";
-            testView.ResourceUrl = testUrl1;
-
-            PropertyMap map2 = testView.Image;
-
-            bool ret2 = (map2.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && !string.IsNullOrEmpty(resultUrl1);
-
-            Assert.AreEqual(true, ret2, "map must have ResourceUrl");
-            Assert.AreEqual(testUrl1, resultUrl1, "...and That value must be equal what we added");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, ImageView.Image with something")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.Image")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void Image_GET_VALUE_After_Set_something()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView();
-            string resultString = "";
-            bool resultBool = false;
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(false, ret, "map don't have ResourceUrl");
-                ret = map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false;
-                Assert.AreEqual(false, ret, "map don't have AlphaMaskURL");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have CropToMask");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have SynchronousLoading");
-            }
-
-            string testUrl1 = "test1";
-            testView.AlphaMaskURL = testUrl1;
-            testView.CropToMask = true;
-            testView.SynchronousLoading = true;
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(false, ret, "map don't have ResourceUrl");
-                ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(false, ret, "map don't have AlphaMaskURL cause ResoureUrl is empty");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have CropToMask cause ResoureUrl is empty");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have SynchronousLoading cause ResoureUrl is empty");
-            }
-
-            testView.ResourceUrl = image_path;
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have ResourceUrl");
-                Assert.AreEqual(image_path, resultString, "...and That value must be equal what we added");
-                ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
-                Assert.AreEqual(testUrl1, resultString, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have CropToMask");
-                Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have SynchronousLoading");
-                Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
-            }
-
-            // Insert empty resource Url
-            testView.ResourceUrl = "";
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(false, ret, "map don't have ResourceUrl");
-                ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(false, ret, "map don't have AlphaMaskURL cause ResoureUrl is empty");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have CropToMask cause ResoureUrl is empty");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have SynchronousLoading cause ResoureUrl is empty");
-            }
-
-            // Insert valid resource Url
-            testView.ResourceUrl = mask_path;
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have ResourceUrl");
-                Assert.AreEqual(mask_path, resultString, "...and That value must be equal what we added");
-                ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
-                Assert.AreEqual(testUrl1, resultString, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have CropToMask");
-                Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have SynchronousLoading");
-                Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
-            }
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("internal API test in Ubuntu, set ImageView.Image and check cached properties changed")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.Image")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void Image_SET_VALUE_After_Set_something()
-        {
-            /* TEST CODE */
-            ImageView testView = new ImageView();
-            string resultString = "";
-            bool resultBool = false;
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(false, ret, "map don't have ResourceUrl");
-                ret = map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false;
-                Assert.AreEqual(false, ret, "map don't have AlphaMaskURL");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have CropToMask");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(false, ret, "map don't have SynchronousLoading");
-            }
-
-            string testUrl1 = "test1";
-            string testUrl2 = "test2";
-            testView.ResourceUrl = testUrl1;
-            testView.AlphaMaskURL = testUrl2;
-            testView.CropToMask = true;
-            testView.SynchronousLoading = true;
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have ResourceUrl");
-                Assert.AreEqual(testUrl1, resultString, "...and That value must be equal what we added");
-                ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
-                Assert.AreEqual(testUrl2, resultString, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have CropToMask");
-                Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have SynchronousLoading");
-                Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
-            }
-
-            // Update Image map by PropertyMap.
-            // Cached property map will be overwrited.
-            using(PropertyMap setImageMap = new PropertyMap())
-            {
-                setImageMap[ImageVisualProperty.URL] = new PropertyValue(image_path);
-                setImageMap[ImageVisualProperty.AlphaMaskURL] = new PropertyValue(mask_path);
-                setImageMap[ImageVisualProperty.CropToMask] = new PropertyValue(false);
-                setImageMap[ImageVisualProperty.SynchronousLoading] = new PropertyValue(false);
-                testView.Image = setImageMap;
-            }
-
-            using(PropertyMap map = testView.Image)
-            {
-                bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have ResourceUrl");
-                Assert.AreEqual(image_path, resultString, "...and That value must be equal what we added");
-                ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
-                Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
-                Assert.AreEqual(mask_path, resultString, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have CropToMask");
-                Assert.AreEqual(false, resultBool, "...and That value must be equal what we added");
-                ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
-                Assert.AreEqual(true, ret, "map must have SynchronousLoading");
-                Assert.AreEqual(false, resultBool, "...and That value must be equal what we added");
-            }
-        }
-    }
-}
+﻿// using global::System;
+// using NUnit.Framework;
+// using NUnit.Framework.TUnit;
+// using Tizen.NUI.Components;
+// using Tizen.NUI.BaseComponents;
+
+// namespace Tizen.NUI.Devel.Tests
+// {
+//     using tlog = Tizen.Log;
+
+//     [TestFixture]
+//     [Description("public/BaseComponents/ImageView")]
+//     public class InternalImageViewTest
+//     {
+//         private const string tag = "NUITEST";
+//         private string image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "Image.png";
+//         private string mask_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "star-mod.png";
+
+//         [SetUp]
+//         public void Init()
+//         {
+//             tlog.Info(tag, "Init() is called!");
+//         }
+
+//         [TearDown]
+//         public void Destroy()
+//         {
+//             tlog.Info(tag, "Destroy() is called!");
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.ResourceUrl")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.ResourceUrl")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void ResourceUrl_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView();
+//             string testUrl1 = "test1";
+//             testView.ResourceUrl = testUrl1;
+
+//             Assert.AreEqual(testView.ResourceUrl, testUrl1, "ResourceUrl is not equal");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.AlphaMaskURL")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.AlphaMaskURL")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void AlphaMaskURL_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView(image_path);
+//             string testUrl1 = "test1";
+//             testView.AlphaMaskURL = testUrl1;
+
+//             Assert.AreEqual(testView.AlphaMaskURL, testUrl1, "AlphaMaskURL is not equal");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.CropToMask")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.CropToMask")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void CropToMask_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView(image_path);
+
+//             Assert.AreEqual(testView.CropToMask, false, "CropToMask default is false when we don't set mask image url");
+
+//             testView.CropToMask = true;
+
+//             Assert.AreEqual(testView.CropToMask, true, "CropToMask is not updated");
+
+//             testView.CropToMask = false;
+
+//             Assert.AreEqual(testView.CropToMask, false, "CropToMask is not updated");
+
+//             testView.AlphaMaskURL = mask_path;
+
+//             Assert.AreEqual(testView.CropToMask, false, "CropToMask should not changed even we set mask image url");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.PreMultipliedAlpha")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.PreMultipliedAlpha")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void PreMultipliedAlpha_SET_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView(image_path);
+
+//             testView.PreMultipliedAlpha = true;
+
+//             Assert.AreEqual(testView.PreMultipliedAlpha, true, "PreMultipliedAlpha is not updated");
+
+//             testView.PreMultipliedAlpha = false;
+
+//             Assert.AreEqual(testView.PreMultipliedAlpha, false, "PreMultipliedAlpha is not updated");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.CropToMask with AlphaMaskURL")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.CropToMask")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void CropToMask_DEFAULT_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView(image_path);
+
+//             Assert.AreEqual(testView.CropToMask, false, "CropToMask default is false when we don't set mask image url");
+
+//             testView.AlphaMaskURL = image_path;
+
+//             Assert.AreEqual(testView.CropToMask, true, "CropToMask default is true when we set mask image url");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.NaturalSize2D")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.NaturalSize2D")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void NaturalSize2D_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView();
+//             testView.ResourceUrl = image_path;
+//             Size2D result = new Size2D(212, 150); // The size of image_path image.
+//             Size2D size = testView.NaturalSize2D;
+
+//             Assert.AreEqual(result.Width, size.Width, "NaturalSize Width is not equal");
+//             Assert.AreEqual(result.Height, size.Height, "NaturalSize Height is not equal");
+
+//             testView.Dispose();
+//         }
+
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.NaturalSize")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.NaturalSize")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void NaturalSize_GET_VALUE()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView();
+//             testView.ResourceUrl = image_path;
+//             Vector3 result = new Vector3(212, 150, 0); // The size of image_path image.
+//             Vector3 size = testView.NaturalSize;
+
+//             Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
+//             Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.NaturalSize")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.NaturalSize")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void NaturalSize_GET_VALUE_as_View_class()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView();
+//             testView.ResourceUrl = image_path;
+//             Vector3 result = new Vector3(212, 150, 0); // The size of image_path image.
+//             View testView2 = testView; // Convert class as View.
+//             Vector3 size = testView2.NaturalSize; // Check whether virtual ImageView.GetNaturalSize() called well.
+
+//             Assert.AreEqual(result.X, size.X, "NaturalSize Width is not equal");
+//             Assert.AreEqual(result.Y, size.Y, "NaturalSize Height is not equal");
+
+//             testView.Dispose();
+//             testView2.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.Image with ResourceUrl")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.Image")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void Image_GET_VALUE_After_Set_ResourceUrl()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView();
+//             string resultUrl1 = "";
+
+//             PropertyMap map1 = testView.Image;
+
+//             bool ret1 = (map1.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && string.IsNullOrEmpty(resultUrl1);
+
+//             Assert.AreEqual(false, ret1, "map don't have ResourceUrl");
+
+//             string testUrl1 = "test1";
+//             testView.ResourceUrl = testUrl1;
+
+//             PropertyMap map2 = testView.Image;
+
+//             bool ret2 = (map2.Find(ImageVisualProperty.URL)?.Get(out resultUrl1) ?? false) && !string.IsNullOrEmpty(resultUrl1);
+
+//             Assert.AreEqual(true, ret2, "map must have ResourceUrl");
+//             Assert.AreEqual(testUrl1, resultUrl1, "...and That value must be equal what we added");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, ImageView.Image with something")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.Image")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void Image_GET_VALUE_After_Set_something()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView();
+//             string resultString = "";
+//             bool resultBool = false;
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(false, ret, "map don't have ResourceUrl");
+//                 ret = map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have AlphaMaskURL");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have CropToMask");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have SynchronousLoading");
+//             }
+
+//             string testUrl1 = "test1";
+//             testView.AlphaMaskURL = testUrl1;
+//             testView.CropToMask = true;
+//             testView.SynchronousLoading = true;
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(false, ret, "map don't have ResourceUrl");
+//                 ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(false, ret, "map don't have AlphaMaskURL cause ResoureUrl is empty");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have CropToMask cause ResoureUrl is empty");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have SynchronousLoading cause ResoureUrl is empty");
+//             }
+
+//             testView.ResourceUrl = image_path;
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have ResourceUrl");
+//                 Assert.AreEqual(image_path, resultString, "...and That value must be equal what we added");
+//                 ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
+//                 Assert.AreEqual(testUrl1, resultString, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have CropToMask");
+//                 Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have SynchronousLoading");
+//                 Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
+//             }
+
+//             // Insert empty resource Url
+//             testView.ResourceUrl = "";
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(false, ret, "map don't have ResourceUrl");
+//                 ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(false, ret, "map don't have AlphaMaskURL cause ResoureUrl is empty");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have CropToMask cause ResoureUrl is empty");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have SynchronousLoading cause ResoureUrl is empty");
+//             }
+
+//             // Insert valid resource Url
+//             testView.ResourceUrl = mask_path;
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have ResourceUrl");
+//                 Assert.AreEqual(mask_path, resultString, "...and That value must be equal what we added");
+//                 ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
+//                 Assert.AreEqual(testUrl1, resultString, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have CropToMask");
+//                 Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have SynchronousLoading");
+//                 Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
+//             }
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("internal API test in Ubuntu, set ImageView.Image and check cached properties changed")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.ImageView.Image")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void Image_SET_VALUE_After_Set_something()
+//         {
+//             /* TEST CODE */
+//             ImageView testView = new ImageView();
+//             string resultString = "";
+//             bool resultBool = false;
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(false, ret, "map don't have ResourceUrl");
+//                 ret = map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have AlphaMaskURL");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have CropToMask");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(false, ret, "map don't have SynchronousLoading");
+//             }
+
+//             string testUrl1 = "test1";
+//             string testUrl2 = "test2";
+//             testView.ResourceUrl = testUrl1;
+//             testView.AlphaMaskURL = testUrl2;
+//             testView.CropToMask = true;
+//             testView.SynchronousLoading = true;
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have ResourceUrl");
+//                 Assert.AreEqual(testUrl1, resultString, "...and That value must be equal what we added");
+//                 ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
+//                 Assert.AreEqual(testUrl2, resultString, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have CropToMask");
+//                 Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have SynchronousLoading");
+//                 Assert.AreEqual(true, resultBool, "...and That value must be equal what we added");
+//             }
+
+//             // Update Image map by PropertyMap.
+//             // Cached property map will be overwrited.
+//             using(PropertyMap setImageMap = new PropertyMap())
+//             {
+//                 setImageMap[ImageVisualProperty.URL] = new PropertyValue(image_path);
+//                 setImageMap[ImageVisualProperty.AlphaMaskURL] = new PropertyValue(mask_path);
+//                 setImageMap[ImageVisualProperty.CropToMask] = new PropertyValue(false);
+//                 setImageMap[ImageVisualProperty.SynchronousLoading] = new PropertyValue(false);
+//                 testView.Image = setImageMap;
+//             }
+
+//             using(PropertyMap map = testView.Image)
+//             {
+//                 bool ret = (map.Find(ImageVisualProperty.URL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have ResourceUrl");
+//                 Assert.AreEqual(image_path, resultString, "...and That value must be equal what we added");
+//                 ret = (map.Find(ImageVisualProperty.AlphaMaskURL)?.Get(out resultString) ?? false) && !string.IsNullOrEmpty(resultString);
+//                 Assert.AreEqual(true, ret, "map must have AlphaMaskURL");
+//                 Assert.AreEqual(mask_path, resultString, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.CropToMask)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have CropToMask");
+//                 Assert.AreEqual(false, resultBool, "...and That value must be equal what we added");
+//                 ret = map.Find(ImageVisualProperty.SynchronousLoading)?.Get(out resultBool) ?? false;
+//                 Assert.AreEqual(true, ret, "map must have SynchronousLoading");
+//                 Assert.AreEqual(false, resultBool, "...and That value must be equal what we added");
+//             }
+//         }
+//     }
+// }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSPropertyValue.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSPropertyValue.cs
@@ -1,231 +1,231 @@
-﻿using global::System;
-using NUnit.Framework;
-using NUnit.Framework.TUnit;
-using Tizen.NUI;
+﻿// using global::System;
+// using NUnit.Framework;
+// using NUnit.Framework.TUnit;
+// using Tizen.NUI;
 
-namespace Tizen.NUI.Devel.Tests
-{
-    using tlog = Tizen.Log;
+// namespace Tizen.NUI.Devel.Tests
+// {
+//     using tlog = Tizen.Log;
 
-    [TestFixture]
-    [Description("public/Common/PropertyValue")]
-    public class PropertyValueTest
-    {
-        private const string tag = "NUITEST";
-        private string path;
+//     [TestFixture]
+//     [Description("public/Common/PropertyValue")]
+//     public class PropertyValueTest
+//     {
+//         private const string tag = "NUITEST";
+//         private string path;
 
-        [SetUp]
-        public void Init()
-        {
-            tlog.Info(tag, "Init() is called!");
-        }
+//         [SetUp]
+//         public void Init()
+//         {
+//             tlog.Info(tag, "Init() is called!");
+//         }
 
-        [TearDown]
-        public void Destroy()
-        {
-            tlog.Info(tag, "Destroy() is called!");
-        }
+//         [TearDown]
+//         public void Destroy()
+//         {
+//             tlog.Info(tag, "Destroy() is called!");
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for PropertyValue.EqualTo")]
-        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void EqualTo_INT_VALUE()
-        {
-            /* TEST CODE */
-            int expectValue = 3;
-            PropertyValue v1 = new PropertyValue(expectValue);
-            PropertyValue v2 = new PropertyValue(expectValue);
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for PropertyValue.EqualTo")]
+//         [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void EqualTo_INT_VALUE()
+//         {
+//             /* TEST CODE */
+//             int expectValue = 3;
+//             PropertyValue v1 = new PropertyValue(expectValue);
+//             PropertyValue v2 = new PropertyValue(expectValue);
 
-            int getValue = 0;
-            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have integer value");
-            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
-            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have integer value");
-            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+//             int getValue = 0;
+//             Assert.AreEqual(true, v1.Get(out getValue), "v1 should have integer value");
+//             Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+//             Assert.AreEqual(true, v2.Get(out getValue), "v2 should have integer value");
+//             Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
 
-            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+//             Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
 
-            v1.Dispose();
-            v2.Dispose();
-        }
+//             v1.Dispose();
+//             v2.Dispose();
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for PropertyValue.EqualTo")]
-        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void EqualTo_FLOAT_VALUE()
-        {
-            /* TEST CODE */
-            float expectValue = 3.0f;
-            PropertyValue v1 = new PropertyValue(expectValue);
-            PropertyValue v2 = new PropertyValue(expectValue);
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for PropertyValue.EqualTo")]
+//         [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void EqualTo_FLOAT_VALUE()
+//         {
+//             /* TEST CODE */
+//             float expectValue = 3.0f;
+//             PropertyValue v1 = new PropertyValue(expectValue);
+//             PropertyValue v2 = new PropertyValue(expectValue);
 
-            float getValue = 0;
-            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have float value");
-            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
-            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have float value");
-            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+//             float getValue = 0;
+//             Assert.AreEqual(true, v1.Get(out getValue), "v1 should have float value");
+//             Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+//             Assert.AreEqual(true, v2.Get(out getValue), "v2 should have float value");
+//             Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
 
-            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+//             Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
 
-            v1.Dispose();
-            v2.Dispose();
-        }
+//             v1.Dispose();
+//             v2.Dispose();
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for PropertyValue.EqualTo")]
-        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void EqualTo_BOOL_VALUE()
-        {
-            /* TEST CODE */
-            bool expectValue = true;
-            PropertyValue v1 = new PropertyValue(expectValue);
-            PropertyValue v2 = new PropertyValue(expectValue);
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for PropertyValue.EqualTo")]
+//         [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void EqualTo_BOOL_VALUE()
+//         {
+//             /* TEST CODE */
+//             bool expectValue = true;
+//             PropertyValue v1 = new PropertyValue(expectValue);
+//             PropertyValue v2 = new PropertyValue(expectValue);
 
-            bool getValue = false;
-            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have float value");
-            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
-            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have float value");
-            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+//             bool getValue = false;
+//             Assert.AreEqual(true, v1.Get(out getValue), "v1 should have float value");
+//             Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+//             Assert.AreEqual(true, v2.Get(out getValue), "v2 should have float value");
+//             Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
 
-            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+//             Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
 
-            v1.Dispose();
-            v2.Dispose();
-        }
+//             v1.Dispose();
+//             v2.Dispose();
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for PropertyValue.EqualTo")]
-        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void EqualTo_STRING_VALUE()
-        {
-            /* TEST CODE */
-            string expectValue = "Hello, World!";
-            PropertyValue v1 = new PropertyValue(expectValue);
-            PropertyValue v2 = new PropertyValue("Hello, World!");
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for PropertyValue.EqualTo")]
+//         [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void EqualTo_STRING_VALUE()
+//         {
+//             /* TEST CODE */
+//             string expectValue = "Hello, World!";
+//             PropertyValue v1 = new PropertyValue(expectValue);
+//             PropertyValue v2 = new PropertyValue("Hello, World!");
 
-            string getValue = "";
-            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have string value");
-            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
-            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have string value");
-            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+//             string getValue = "";
+//             Assert.AreEqual(true, v1.Get(out getValue), "v1 should have string value");
+//             Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+//             Assert.AreEqual(true, v2.Get(out getValue), "v2 should have string value");
+//             Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
 
-            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+//             Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
 
-            v1.Dispose();
-            v2.Dispose();
-        }
+//             v1.Dispose();
+//             v2.Dispose();
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for PropertyValue.EqualTo")]
-        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void EqualTo_VECTOR2_VALUE()
-        {
-            /* TEST CODE */
-            Vector2 expectValue = new Vector2(1.0f, 2.0f);
-            PropertyValue v1 = new PropertyValue(expectValue);
-            PropertyValue v2 = new PropertyValue(expectValue);
-            PropertyValue v3 = new PropertyValue(new Vector2(1.0f, 2.0f));
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for PropertyValue.EqualTo")]
+//         [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void EqualTo_VECTOR2_VALUE()
+//         {
+//             /* TEST CODE */
+//             Vector2 expectValue = new Vector2(1.0f, 2.0f);
+//             PropertyValue v1 = new PropertyValue(expectValue);
+//             PropertyValue v2 = new PropertyValue(expectValue);
+//             PropertyValue v3 = new PropertyValue(new Vector2(1.0f, 2.0f));
 
-            Vector2 getValue = new Vector2();
-            Assert.AreEqual(true, v1.Get(getValue), "v1 should have Vector2 value");
-            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
-            Assert.AreEqual(true, v2.Get(getValue), "v2 should have Vector2 value");
-            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
-            Assert.AreEqual(true, v3.Get(getValue), "v3 should have Vector2 value");
-            Assert.AreEqual(expectValue, getValue, "v3 should have expected value");
+//             Vector2 getValue = new Vector2();
+//             Assert.AreEqual(true, v1.Get(getValue), "v1 should have Vector2 value");
+//             Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+//             Assert.AreEqual(true, v2.Get(getValue), "v2 should have Vector2 value");
+//             Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+//             Assert.AreEqual(true, v3.Get(getValue), "v3 should have Vector2 value");
+//             Assert.AreEqual(expectValue, getValue, "v3 should have expected value");
 
-            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
-            Assert.AreEqual(true, v1.EqualTo(v3), "v1 and v3 should have same value");
-            Assert.AreEqual(true, v2.EqualTo(v3), "v2 and v3 should have same value");
+//             Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+//             Assert.AreEqual(true, v1.EqualTo(v3), "v1 and v3 should have same value");
+//             Assert.AreEqual(true, v2.EqualTo(v3), "v2 and v3 should have same value");
 
-            v1.Dispose();
-            v2.Dispose();
-            v3.Dispose();
-            
-            expectValue.Dispose();
-            getValue.Dispose();
-        }
+//             v1.Dispose();
+//             v2.Dispose();
+//             v3.Dispose();
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for PropertyValue.EqualTo")]
-        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void EqualTo_VECTOR4_VALUE()
-        {
-            /* TEST CODE */
-            Vector4 expectValue = new Vector4(1.0f, 2.0f, 3.0f, 4.0f);
-            PropertyValue v1 = new PropertyValue(expectValue);
-            PropertyValue v2 = new PropertyValue(expectValue);
-            PropertyValue v3 = new PropertyValue(new Vector4(1.0f, 2.0f, 3.0f, 4.0f));
+//             expectValue.Dispose();
+//             getValue.Dispose();
+//         }
 
-            Vector4 getValue = new Vector4();
-            Assert.AreEqual(true, v1.Get(getValue), "v1 should have Vector4 value");
-            Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
-            Assert.AreEqual(true, v2.Get(getValue), "v2 should have Vector4 value");
-            Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
-            Assert.AreEqual(true, v3.Get(getValue), "v3 should have Vector4 value");
-            Assert.AreEqual(expectValue, getValue, "v3 should have expected value");
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for PropertyValue.EqualTo")]
+//         [Property("SPEC", "Tizen.NUI.Common.PropertyValue.EqualTo")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void EqualTo_VECTOR4_VALUE()
+//         {
+//             /* TEST CODE */
+//             Vector4 expectValue = new Vector4(1.0f, 2.0f, 3.0f, 4.0f);
+//             PropertyValue v1 = new PropertyValue(expectValue);
+//             PropertyValue v2 = new PropertyValue(expectValue);
+//             PropertyValue v3 = new PropertyValue(new Vector4(1.0f, 2.0f, 3.0f, 4.0f));
 
-            Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
-            Assert.AreEqual(true, v1.EqualTo(v3), "v1 and v3 should have same value");
-            Assert.AreEqual(true, v2.EqualTo(v3), "v2 and v3 should have same value");
+//             Vector4 getValue = new Vector4();
+//             Assert.AreEqual(true, v1.Get(getValue), "v1 should have Vector4 value");
+//             Assert.AreEqual(expectValue, getValue, "v1 should have expected value");
+//             Assert.AreEqual(true, v2.Get(getValue), "v2 should have Vector4 value");
+//             Assert.AreEqual(expectValue, getValue, "v2 should have expected value");
+//             Assert.AreEqual(true, v3.Get(getValue), "v3 should have Vector4 value");
+//             Assert.AreEqual(expectValue, getValue, "v3 should have expected value");
 
-            v1.Dispose();
-            v2.Dispose();
-            v3.Dispose();
+//             Assert.AreEqual(true, v1.EqualTo(v2), "v1 and v2 should have same value");
+//             Assert.AreEqual(true, v1.EqualTo(v3), "v1 and v3 should have same value");
+//             Assert.AreEqual(true, v2.EqualTo(v3), "v2 and v3 should have same value");
 
-            expectValue.Dispose();
-            getValue.Dispose();
-        }
+//             v1.Dispose();
+//             v2.Dispose();
+//             v3.Dispose();
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for PropertyValue.NotEqualTo")]
-        [Property("SPEC", "Tizen.NUI.Common.PropertyValue.NotEqualTo")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void NotEqualTo_INT_VALUE()
-        {
-            /* TEST CODE */
-            int expectValue1 = 3;
-            int expectValue2 = expectValue1 + 1;
-            PropertyValue v1 = new PropertyValue(expectValue1);
-            PropertyValue v2 = new PropertyValue(expectValue2);
+//             expectValue.Dispose();
+//             getValue.Dispose();
+//         }
 
-            int getValue = 0;
-            Assert.AreEqual(true, v1.Get(out getValue), "v1 should have integer value");
-            Assert.AreEqual(expectValue1, getValue, "v1 should have expected1 value");
-            Assert.AreEqual(true, v2.Get(out getValue), "v2 should have integer value");
-            Assert.AreEqual(expectValue2, getValue, "v2 should have expected2 value");
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for PropertyValue.NotEqualTo")]
+//         [Property("SPEC", "Tizen.NUI.Common.PropertyValue.NotEqualTo")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void NotEqualTo_INT_VALUE()
+//         {
+//             /* TEST CODE */
+//             int expectValue1 = 3;
+//             int expectValue2 = expectValue1 + 1;
+//             PropertyValue v1 = new PropertyValue(expectValue1);
+//             PropertyValue v2 = new PropertyValue(expectValue2);
 
-            Assert.AreEqual(false, v1.EqualTo(v2), "v1 and v2 should not have same value");
-            Assert.AreEqual(true, v1.NotEqualTo(v2), "v1 and v2 should not have same value");
+//             int getValue = 0;
+//             Assert.AreEqual(true, v1.Get(out getValue), "v1 should have integer value");
+//             Assert.AreEqual(expectValue1, getValue, "v1 should have expected1 value");
+//             Assert.AreEqual(true, v2.Get(out getValue), "v2 should have integer value");
+//             Assert.AreEqual(expectValue2, getValue, "v2 should have expected2 value");
 
-            v1.Dispose();
-            v2.Dispose();
-        }
-    }
-}
+//             Assert.AreEqual(false, v1.EqualTo(v2), "v1 and v2 should not have same value");
+//             Assert.AreEqual(true, v1.NotEqualTo(v2), "v1 and v2 should not have same value");
+
+//             v1.Dispose();
+//             v2.Dispose();
+//         }
+//     }
+// }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
@@ -1,0 +1,246 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI.Components;
+using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/BaseComponents/TextGeometry")]
+    public class PublicTextGeometryTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSTextGeometry.cs
@@ -4,6 +4,7 @@ using NUnit.Framework.TUnit;
 using Tizen.NUI.Components;
 using Tizen.NUI.BaseComponents;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Tizen.NUI.Devel.Tests
 {
@@ -242,5 +243,78 @@ namespace Tizen.NUI.Devel.Tests
 
             tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel END (OK)");
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextBoundingRectangle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedTextRectangle = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var textRectangle = TextGeometry.GetTextBoundingRectangle(testingTarget, 0, 0);
+            Assert.IsNotNull(textRectangle, "Null object is detected!");
+            // Assert.IsTrue(textRectangle == expectedTextRectangle, "Should be equal!");
+
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextBoundingRectangle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedTextRectangle = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var textRectangle = TextGeometry.GetTextBoundingRectangle(testingTarget, 0, 0);
+            Assert.IsNotNull(textRectangle, "Null object is detected!");
+            Assert.IsTrue(textRectangle == expectedTextRectangle, "Should be equal!");
+
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextBoundingRectangle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedTextRectangle = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var textRectangle = TextGeometry.GetTextBoundingRectangle(testingTarget, 0, 0);
+            Assert.IsNotNull(textRectangle, "Null object is detected!");
+            Assert.IsTrue(textRectangle == expectedTextRectangle, "Should be equal!");
+
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextLabel END (OK)");
+        }
+
     }
 }

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
@@ -1,211 +1,211 @@
-﻿using global::System;
-using NUnit.Framework;
-using NUnit.Framework.TUnit;
-using Tizen.NUI.Components;
-using Tizen.NUI.BaseComponents;
+﻿// using global::System;
+// using NUnit.Framework;
+// using NUnit.Framework.TUnit;
+// using Tizen.NUI.Components;
+// using Tizen.NUI.BaseComponents;
 
-namespace Tizen.NUI.Devel.Tests
-{
-    using tlog = Tizen.Log;
+// namespace Tizen.NUI.Devel.Tests
+// {
+//     using tlog = Tizen.Log;
 
-    [TestFixture]
-    [Description("public/BaseComponents/View")]
-    public class ViewTest
-    {
-        private const string tag = "NUITEST";
-        private const int testSize = 100;
-        private const int testPosition = 100;
+//     [TestFixture]
+//     [Description("public/BaseComponents/View")]
+//     public class ViewTest
+//     {
+//         private const string tag = "NUITEST";
+//         private const int testSize = 100;
+//         private const int testPosition = 100;
 
-        [SetUp]
-        public void Init()
-        {
-            tlog.Info(tag, "Init() is called!");
-        }
+//         [SetUp]
+//         public void Init()
+//         {
+//             tlog.Info(tag, "Init() is called!");
+//         }
 
-        [TearDown]
-        public void Destroy()
-        {
-            tlog.Info(tag, "Destroy() is called!");
-        }
+//         [TearDown]
+//         public void Destroy()
+//         {
+//             tlog.Info(tag, "Destroy() is called!");
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Get default value test for View.IsEnabled")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.View.IsEnabled")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "sh10233.lee@samsung.com")]
-        public void IsEnabled_CHECK_DEFAULT_VALUE()
-        {
-            /* TEST CODE */
-            View testView = new View();
-            var isEnabled = testView.IsEnabled;
+//         [Test]
+//         [Category("P1")]
+//         [Description("Get default value test for View.IsEnabled")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.View.IsEnabled")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRO")]
+//         [Property("AUTHOR", "sh10233.lee@samsung.com")]
+//         public void IsEnabled_CHECK_DEFAULT_VALUE()
+//         {
+//             /* TEST CODE */
+//             View testView = new View();
+//             var isEnabled = testView.IsEnabled;
 
-            Assert.AreEqual(true, isEnabled, "View IsEnabled should be true by default");
+//             Assert.AreEqual(true, isEnabled, "View IsEnabled should be true by default");
 
-            testView.Dispose();
-        }
+//             testView.Dispose();
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Set value test for View.IsEnabled")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.View.IsEnabled")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "sh10233.lee@samsung.com")]
-        public void IsEnabled_SET_VALUE()
-        {
-            /* TEST CODE */
-            View testView = new View();
-            var isEnabled = testView.IsEnabled;
+//         [Test]
+//         [Category("P1")]
+//         [Description("Set value test for View.IsEnabled")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.View.IsEnabled")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "sh10233.lee@samsung.com")]
+//         public void IsEnabled_SET_VALUE()
+//         {
+//             /* TEST CODE */
+//             View testView = new View();
+//             var isEnabled = testView.IsEnabled;
 
-            Assert.AreEqual(true, isEnabled, "View IsEnabled should be true by default");
+//             Assert.AreEqual(true, isEnabled, "View IsEnabled should be true by default");
 
-            testView.IsEnabled = false;
+//             testView.IsEnabled = false;
 
-            Assert.AreEqual(false, testView.IsEnabled, "View IsEnabled should be changed by set value");
+//             Assert.AreEqual(false, testView.IsEnabled, "View IsEnabled should be changed by set value");
 
-            testView.Dispose();
-        }
+//             testView.Dispose();
+//         }
 
-        [Test]
-        [Category("P1")]
-        [Description("Get value test for View.PropagatableControlStates")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.View.PropagatableControlStates")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "sh10233.lee@samsung.com")]
-        public void PropagatableControlStates_GET_SET_VALUE()
-        {
-            /* TEST CODE */
-            View testView = new View();
+//         [Test]
+//         [Category("P1")]
+//         [Description("Get value test for View.PropagatableControlStates")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.View.PropagatableControlStates")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "sh10233.lee@samsung.com")]
+//         public void PropagatableControlStates_GET_SET_VALUE()
+//         {
+//             /* TEST CODE */
+//             View testView = new View();
 
-            Assert.AreEqual(ControlState.All, testView.PropagatableControlStates, "View PropagatableControlStates should be ControlState.All by default");
+//             Assert.AreEqual(ControlState.All, testView.PropagatableControlStates, "View PropagatableControlStates should be ControlState.All by default");
 
-            testView.PropagatableControlStates = ControlState.Disabled + ControlState.Selected;
+//             testView.PropagatableControlStates = ControlState.Disabled + ControlState.Selected;
 
-            Assert.AreEqual(ControlState.Disabled + ControlState.Selected, testView.PropagatableControlStates, "View PropagatableControlStates should be ControlState.All by default");
+//             Assert.AreEqual(ControlState.Disabled + ControlState.Selected, testView.PropagatableControlStates, "View PropagatableControlStates should be ControlState.All by default");
 
-            testView.Dispose();
-        }
-
-
-        [Test]
-        [Category("P1")]
-        [Description("Update value test for View.PropagatableControlStates")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.View.PropagatableControlStates")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "sh10233.lee@samsung.com")]
-        public void PropagatableControlStates_UPDATE_VALUE()
-        {
-            /* TEST CODE */
-            View parentView = new View();
-            View testView = new View();
-
-            testView.PropagatableControlStates = ControlState.Disabled;
-
-            parentView.Add(testView);
-            parentView.EnableControlStatePropagation = true;
-            parentView.EnableControlState = true;
-            testView.EnableControlState = true;
-
-            Assert.AreEqual(ControlState.Normal, testView.ControlState, "View ControlStates should be ControlState.Normal by default");
-
-            parentView.IsEnabled = false;
-
-            Assert.AreEqual(true, testView.ControlState.Contains(ControlState.Disabled), "View ControlStates should be ControlState.Disabled by parentView propagation");
-
-            testView.PropagatableControlStates -= ControlState.Disabled;
-
-            parentView.IsEnabled = true;
-
-            Assert.AreEqual(true, testView.ControlState.Contains(ControlState.Disabled), "View ControlStates should be ControlState.Disabled as parentView propagation blocked");
-
-            testView.Dispose();
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("Get value test for View.ColorRed")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorRed")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void ColorRed_GET_SET_VALUE()
-        {
-            /* TEST CODE */
-            View testView = new View();
-
-            Assert.AreEqual(1.0f, testView.ColorRed, "Default red value is 1.0f");
-
-            testView.ColorRed = 0.5f;
-
-            Assert.AreEqual(0.5f, testView.ColorRed, "ColorRed set");
-            Assert.AreEqual(new Color(0.5f, 1.0f, 1.0f, 1.0f), testView.Color, "ColorRed should change View.Color");
-
-            testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
-
-            Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
-            Assert.AreEqual(0.0f, testView.ColorRed, "Color should change View.ColorRed");
-
-            testView.Dispose();
-        }
+//             testView.Dispose();
+//         }
 
 
-        [Test]
-        [Category("P1")]
-        [Description("Get value test for View.ColorGreen")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorGreen")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void ColorGreen_GET_SET_VALUE()
-        {
-            /* TEST CODE */
-            View testView = new View();
+//         [Test]
+//         [Category("P1")]
+//         [Description("Update value test for View.PropagatableControlStates")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.View.PropagatableControlStates")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "sh10233.lee@samsung.com")]
+//         public void PropagatableControlStates_UPDATE_VALUE()
+//         {
+//             /* TEST CODE */
+//             View parentView = new View();
+//             View testView = new View();
 
-            Assert.AreEqual(1.0f, testView.ColorGreen, "Default green value is 1.0f");
+//             testView.PropagatableControlStates = ControlState.Disabled;
 
-            testView.ColorGreen = 0.5f;
+//             parentView.Add(testView);
+//             parentView.EnableControlStatePropagation = true;
+//             parentView.EnableControlState = true;
+//             testView.EnableControlState = true;
 
-            Assert.AreEqual(0.5f, testView.ColorGreen, "ColorGreen set");
-            Assert.AreEqual(new Color(1.0f, 0.5f, 1.0f, 1.0f), testView.Color, "ColorGreen should change View.Color");
+//             Assert.AreEqual(ControlState.Normal, testView.ControlState, "View ControlStates should be ControlState.Normal by default");
 
-            testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
+//             parentView.IsEnabled = false;
 
-            Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
-            Assert.AreEqual(0.0f, testView.ColorGreen, "Color should change View.ColorGreen");
+//             Assert.AreEqual(true, testView.ControlState.Contains(ControlState.Disabled), "View ControlStates should be ControlState.Disabled by parentView propagation");
 
-            testView.Dispose();
-        }
+//             testView.PropagatableControlStates -= ControlState.Disabled;
+
+//             parentView.IsEnabled = true;
+
+//             Assert.AreEqual(true, testView.ControlState.Contains(ControlState.Disabled), "View ControlStates should be ControlState.Disabled as parentView propagation blocked");
+
+//             testView.Dispose();
+//         }
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("Get value test for View.ColorRed")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorRed")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void ColorRed_GET_SET_VALUE()
+//         {
+//             /* TEST CODE */
+//             View testView = new View();
+
+//             Assert.AreEqual(1.0f, testView.ColorRed, "Default red value is 1.0f");
+
+//             testView.ColorRed = 0.5f;
+
+//             Assert.AreEqual(0.5f, testView.ColorRed, "ColorRed set");
+//             Assert.AreEqual(new Color(0.5f, 1.0f, 1.0f, 1.0f), testView.Color, "ColorRed should change View.Color");
+
+//             testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
+
+//             Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
+//             Assert.AreEqual(0.0f, testView.ColorRed, "Color should change View.ColorRed");
+
+//             testView.Dispose();
+//         }
 
 
-        [Test]
-        [Category("P1")]
-        [Description("Get value test for View.ColorBlue")]
-        [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorBlue")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRW")]
-        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
-        public void ColorBlue_GET_SET_VALUE()
-        {
-            /* TEST CODE */
-            View testView = new View();
+//         [Test]
+//         [Category("P1")]
+//         [Description("Get value test for View.ColorGreen")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorGreen")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void ColorGreen_GET_SET_VALUE()
+//         {
+//             /* TEST CODE */
+//             View testView = new View();
 
-            Assert.AreEqual(1.0f, testView.ColorBlue, "Default blue value is 1.0f");
+//             Assert.AreEqual(1.0f, testView.ColorGreen, "Default green value is 1.0f");
 
-            testView.ColorBlue = 0.5f;
+//             testView.ColorGreen = 0.5f;
 
-            Assert.AreEqual(0.5f, testView.ColorBlue, "ColorBlue set");
-            Assert.AreEqual(new Color(1.0f, 1.0f, 0.5f, 1.0f), testView.Color, "ColorBlue should change View.Color");
+//             Assert.AreEqual(0.5f, testView.ColorGreen, "ColorGreen set");
+//             Assert.AreEqual(new Color(1.0f, 0.5f, 1.0f, 1.0f), testView.Color, "ColorGreen should change View.Color");
 
-            testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
+//             testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
 
-            Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
-            Assert.AreEqual(0.0f, testView.ColorBlue, "Color should change View.ColorBlue");
+//             Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
+//             Assert.AreEqual(0.0f, testView.ColorGreen, "Color should change View.ColorGreen");
 
-            testView.Dispose();
-        }
-    }
-}
+//             testView.Dispose();
+//         }
+
+
+//         [Test]
+//         [Category("P1")]
+//         [Description("Get value test for View.ColorBlue")]
+//         [Property("SPEC", "Tizen.NUI.BaseComponents.View.ColorBlue")]
+//         [Property("SPEC_URL", "-")]
+//         [Property("CRITERIA", "PRW")]
+//         [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+//         public void ColorBlue_GET_SET_VALUE()
+//         {
+//             /* TEST CODE */
+//             View testView = new View();
+
+//             Assert.AreEqual(1.0f, testView.ColorBlue, "Default blue value is 1.0f");
+
+//             testView.ColorBlue = 0.5f;
+
+//             Assert.AreEqual(0.5f, testView.ColorBlue, "ColorBlue set");
+//             Assert.AreEqual(new Color(1.0f, 1.0f, 0.5f, 1.0f), testView.Color, "ColorBlue should change View.Color");
+
+//             testView.Color = new Color(0.0f, 0.0f, 0.0f, 0.5f);
+
+//             Assert.AreEqual(new Color(0.0f, 0.0f, 0.0f, 0.5f), testView.Color, "Color set");
+//             Assert.AreEqual(0.0f, testView.ColorBlue, "Color should change View.ColorBlue");
+
+//             testView.Dispose();
+//         }
+//     }
+// }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
@@ -242,5 +242,78 @@ namespace Tizen.NUI.Devel.Tests
 
             tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel END (OK)");
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextBoundingRectangle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextEditor START");
+
+            Tizen.NUI.PaddingType expectedTextRectangle = new Tizen.NUI.PaddingType(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var textRectangle = TextGeometry.GetTextBoundingRectangle(testingTarget, 0, 0);
+            Assert.IsNotNull(textRectangle, "Null object is detected!");
+            Assert.IsTrue(textRectangle == expectedTextRectangle, "Should be equal!");
+
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextBoundingRectangle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextField START");
+
+            Tizen.NUI.PaddingType expectedTextRectangle = new Tizen.NUI.PaddingType(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var textRectangle = TextGeometry.GetTextBoundingRectangle(testingTarget, 0, 0);
+            Assert.IsNotNull(textRectangle, "Null object is detected!");
+            Assert.IsTrue(textRectangle == expectedTextRectangle, "Should be equal!");
+
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetTextBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetTextBoundingRectangle M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetTextBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextLabel START");
+
+            Tizen.NUI.PaddingType expectedTextRectangle = new Tizen.NUI.PaddingType(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var textRectangle = TextGeometry.GetTextBoundingRectangle(testingTarget, 0, 0);
+            Assert.IsNotNull(textRectangle, "Null object is detected!");
+            Assert.IsTrue(textRectangle == expectedTextRectangle, "Should be equal!");
+
+            tlog.Debug(tag, $"GetTextBoundingRectangleTextLabel END (OK)");
+        }
+
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/BaseComponents/TSTextGeometry.cs
@@ -1,0 +1,246 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI.Components;
+using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/BaseComponents/TextGeometry")]
+    public class PublicTextGeometryTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetLineBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetLineBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetLineBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedLineGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var lineGeometry = TextGeometry.GetLineBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(lineGeometry, "Null object is detected!");
+            Assert.IsTrue(lineGeometry == expectedLineGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetLineBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterBoundingRectangleTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterBoundingRectangleTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterBoundingRectangleTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel START");
+
+            Tizen.NUI.Rectangle expectedCharGeometry = new Tizen.NUI.Rectangle(0, 0, 0, 0);
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var charGeometry = TextGeometry.GetCharacterBoundingRectangle(testingTarget, 0);
+            Assert.IsNotNull(charGeometry, "Null object is detected!");
+            Assert.IsTrue(charGeometry == expectedCharGeometry, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterBoundingRectangleTextLabel END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextEditor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextEditor M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextEditor()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextEditor();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextEditor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextField")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextField M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextField()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextField();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextField END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("TextGeometry GetCharacterIndexAtPositionTextLabel")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.TextGeometry.GetCharacterIndexAtPositionTextLabel M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "s.al-jammal@partner.samsung.com")]
+        public void GetCharacterIndexAtPositionTextLabel()
+        {
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel START");
+
+            int expectedCharacterIndex = -1;
+
+            var testingTarget = new TextLabel();
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var characterIndex = TextGeometry.GetCharacterIndexAtPosition(testingTarget, 0, 0);
+            Assert.IsNotNull(characterIndex, "Null object is detected!");
+            Assert.IsTrue(characterIndex == expectedCharacterIndex, "Should be equal!");
+
+            tlog.Debug(tag, $"GetCharacterIndexAtPositionTextLabel END (OK)");
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Open the Text Bounding Rectangle API to be used in the text controllers.

### API Changes ###
This PR opens the TextBoundingRectangle API; the API already merged in DALi, this PR for the NUI. 
GetTextBoundingRectangle(TextController textController, int startIndex, int endIndex)

### Testcases ###

Added the below to (Tizen.NUI.Devel.Tests.Ubuntu) and (Tizen.NUI.Tests):

- Tizen.NUI.Devel.Tests.TextBoundingRectangle


The PR depends on the following patches:

- Toolkit: https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/284795

- CSharp-binder: https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/284842

The PR depends on the following PR --> To be able to use the function:[ private static Tizen.NUI.Rectangle **ConvertPaddingTypeToRectangle**(Tizen.NUI.PaddingType paddingType) ]

- https://github.com/Samsung/TizenFX/pull/4812
