### PR TITLE
[NUI][API10] Animated view's size cache into NUI

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -732,6 +732,13 @@ namespace Tizen.NUI.BaseComponents
                     view.internalSize2D = new Size2D(view.OnSize2DChanged, 0, 0);
                 }
                 Object.InternalRetrievingPropertyVector2ActualVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize2D.SwigCPtr);
+
+                // Update NUI stored internal size informations only both widthPolicy and heightPolicy are fixed.
+                if(view.widthPolicy >= 0 && view.heightPolicy >= 0)
+                {
+                    view.widthPolicy = view.internalSize2D.Width;
+                    view.heightPolicy = view.internalSize2D.Height;
+                }
                 return view.internalSize2D;
             }
         );
@@ -1572,6 +1579,13 @@ namespace Tizen.NUI.BaseComponents
                     view.internalSize = new Size(view.OnSizeChanged, 0, 0, 0);
                 }
                 Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize.SwigCPtr);
+
+                // Update NUI stored internal size informations only both widthPolicy and heightPolicy are fixed.
+                if(view.WidthSpecification >= 0 && view.HeightSpecification >= 0)
+                {
+                    view.WidthSpecification = (int)System.Math.Ceiling(view.internalSize.Width);
+                    view.HeightSpecification = (int)System.Math.Ceiling(view.internalSize.Height);
+                }
                 return view.internalSize;
             }
         );


### PR DESCRIPTION
When view's size animated, the DALi known size and NUI stored size (mean, userSizeWidth and widthPolicy like) will not be matched.

If NUI use fixed size policy (mean, It "May" not use NUI.Layout system so can use animation feature.) Let we make NUI keep dali-side size's information and keep it.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
