### PR TITLE
[NUI] Fix WidthSpecification and HeightSpecification not to set Size2D

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2605,11 +2605,7 @@ namespace Tizen.NUI.BaseComponents
                 widthPolicy = value;
                 if (widthPolicy >= 0)
                 {
-                    if (heightPolicy >= 0) // Policy an exact value
-                    {
-                        // Create Size2D only both _widthPolicy and _heightPolicy are set.
-                        Size2D = new Size2D(widthPolicy, heightPolicy);
-                    }
+                    SizeWidth = widthPolicy;
                 }
                 layout?.RequestLayout();
             }
@@ -2662,11 +2658,7 @@ namespace Tizen.NUI.BaseComponents
                 heightPolicy = value;
                 if (heightPolicy >= 0)
                 {
-                    if (widthPolicy >= 0) // Policy an exact value
-                    {
-                        // Create Size2D only both _widthPolicy and _heightPolicy are set.
-                        Size2D = new Size2D(widthPolicy, heightPolicy);
-                    }
+                    SizeHeight = heightPolicy;
                 }
                 layout?.RequestLayout();
             }


### PR DESCRIPTION
Not to change SizeWidth or SizeHeight by setting Size2D, WidthSpecification and HeightSpecification have been fixed not to set Size2D.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
