### PR TITLE
[NUI] Fix WidthSpecification and HeightSpecification not to set Size2D

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2605,11 +2605,7 @@ namespace Tizen.NUI.BaseComponents
                 widthPolicy = value;
                 if (widthPolicy >= 0)
                 {
-                    if (heightPolicy >= 0) // Policy an exact value
-                    {
-                        // Create Size2D only both _widthPolicy and _heightPolicy are set.
-                        Size2D = new Size2D(widthPolicy, heightPolicy);
-                    }
+                    SizeWidth = widthPolicy;
                 }
                 layout?.RequestLayout();
             }
@@ -2662,11 +2658,7 @@ namespace Tizen.NUI.BaseComponents
                 heightPolicy = value;
                 if (heightPolicy >= 0)
                 {
-                    if (widthPolicy >= 0) // Policy an exact value
-                    {
-                        // Create Size2D only both _widthPolicy and _heightPolicy are set.
-                        Size2D = new Size2D(widthPolicy, heightPolicy);
-                    }
+                    SizeHeight = heightPolicy;
                 }
                 layout?.RequestLayout();
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -733,12 +733,6 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector2ActualVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize2D.SwigCPtr);
 
-                // Update NUI stored internal size informations only both widthPolicy and heightPolicy are fixed.
-                if(view.widthPolicy >= 0 && view.heightPolicy >= 0)
-                {
-                    view.widthPolicy = view.internalSize2D.Width;
-                    view.heightPolicy = view.internalSize2D.Height;
-                }
                 return view.internalSize2D;
             }
         );
@@ -1580,12 +1574,6 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize.SwigCPtr);
 
-                // Update NUI stored internal size informations only both widthPolicy and heightPolicy are fixed.
-                if(view.WidthSpecification >= 0 && view.HeightSpecification >= 0)
-                {
-                    view.WidthSpecification = (int)System.Math.Ceiling(view.internalSize.Width);
-                    view.HeightSpecification = (int)System.Math.Ceiling(view.internalSize.Height);
-                }
                 return view.internalSize;
             }
         );


### PR DESCRIPTION
We don't need to change the width value when we try to set the height. Also, widthPolicy might not matched with SizeWidth when we use NUI.Animation

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
