### PR TITLE
[NUI] Spannable Module: Add FontSpan

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/VectorUnsignedInteger.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorUnsignedInteger.cs
@@ -1,0 +1,169 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.Collections.Generic;
+
+namespace Tizen.NUI
+{
+    internal class VectorUnsignedInteger : Disposable
+    {
+        internal VectorUnsignedInteger(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.VectorUnsignedInteger.DeleteVectorUnsignedInteger(swigCPtr);
+        }
+
+        public VectorUnsignedInteger() : this(Interop.VectorUnsignedInteger.NewVectorUnsignedInteger(), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public VectorUnsignedInteger(VectorUnsignedInteger vector) : this(Interop.VectorUnsignedInteger.NewVectorUnsignedInteger(VectorUnsignedInteger.getCPtr(vector)), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public VectorUnsignedInteger Assign(VectorUnsignedInteger vector)
+        {
+            VectorUnsignedInteger ret = new VectorUnsignedInteger(Interop.VectorUnsignedInteger.Assign(SwigCPtr, VectorUnsignedInteger.getCPtr(vector)), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal SWIGTYPE_p_unsigned_int Begin()
+        {
+            global::System.IntPtr cPtr = Interop.VectorUnsignedInteger.Begin(SwigCPtr);
+            SWIGTYPE_p_unsigned_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_int(cPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal SWIGTYPE_p_unsigned_int End()
+        {
+            global::System.IntPtr cPtr = Interop.VectorUnsignedInteger.End(SwigCPtr);
+            SWIGTYPE_p_unsigned_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_int(cPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal SWIGTYPE_p_unsigned_int ValueOfIndex(uint index)
+        {
+            SWIGTYPE_p_unsigned_int ret = new SWIGTYPE_p_unsigned_int(Interop.VectorUnsignedInteger.ValueOfIndex(SwigCPtr, index));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void PushBack(byte element)
+        {
+            Interop.VectorUnsignedInteger.PushBack(SwigCPtr, element);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void Insert(byte[] at, byte element)
+        {
+            Interop.VectorUnsignedInteger.Insert(SwigCPtr, at, element);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal void Insert(byte[] at, SWIGTYPE_p_unsigned_int from, SWIGTYPE_p_unsigned_int to)
+        {
+            Interop.VectorUnsignedInteger.Insert(SwigCPtr, at, SWIGTYPE_p_unsigned_int.getCPtr(from), SWIGTYPE_p_unsigned_int.getCPtr(to));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void Reserve(uint count)
+        {
+            Interop.VectorUnsignedInteger.Reserve(SwigCPtr, count);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void Resize(uint count)
+        {
+            Interop.VectorUnsignedInteger.Resize(SwigCPtr, count);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void Resize(uint count, byte item)
+        {
+            Interop.VectorUnsignedInteger.Resize(SwigCPtr, count, item);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal SWIGTYPE_p_unsigned_int Erase(byte[] iterator)
+        {
+            global::System.IntPtr cPtr = Interop.VectorUnsignedInteger.Erase(SwigCPtr, iterator);
+            SWIGTYPE_p_unsigned_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_int(cPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal SWIGTYPE_p_unsigned_int Erase(byte[] first, SWIGTYPE_p_unsigned_int last)
+        {
+            global::System.IntPtr cPtr = Interop.VectorUnsignedInteger.Erase(SwigCPtr, first, SWIGTYPE_p_unsigned_int.getCPtr(last));
+            SWIGTYPE_p_unsigned_int ret = (cPtr == global::System.IntPtr.Zero) ? null : new SWIGTYPE_p_unsigned_int(cPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void Remove(byte[] iterator)
+        {
+            Interop.VectorUnsignedInteger.Remove(SwigCPtr, iterator);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void Swap(VectorUnsignedInteger vector)
+        {
+            Interop.VectorUnsignedInteger.Swap(SwigCPtr, VectorUnsignedInteger.getCPtr(vector));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void Clear()
+        {
+            Interop.VectorUnsignedInteger.Clear(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public void Release()
+        {
+            Interop.VectorUnsignedInteger.Release(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        public int Size()
+        {
+            int size = Interop.VectorUnsignedInteger.Size(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return size;
+        }
+
+        public List<uint> GetListFromNativeVector( )
+        {
+            int count = this.Size();
+            List<uint> list = new List<uint>();
+
+            for(int i = 0; i < count; i++)
+                list.Add( uintp.frompointer(this.ValueOfIndex( (uint)i )).value());
+
+            return list;
+        }
+
+        public static readonly int BaseType = Interop.VectorUnsignedInteger.BaseTypeGet();
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseSpan.cs
@@ -1,0 +1,28 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class BaseSpan
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseSpan")]
+            public static extern void DeleteBaseSpan(global::System.Runtime.InteropServices.HandleRef refBaseSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.CharacterSequence.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.CharacterSequence.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class CharacterSequence
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CharacterSequence")]
+            public static extern void DeleteCharacterSequence(global::System.Runtime.InteropServices.HandleRef refCharacterSequence);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CharacterSequence_GetCharacters")]
+            public static extern global::System.IntPtr GetCharacters(global::System.Runtime.InteropServices.HandleRef refCharacterSequence);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CharacterSequence_GetNumberOfCharacters")]
+            public static extern uint GetNumberOfCharacters(global::System.Runtime.InteropServices.HandleRef refCharacterSequence);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CharacterSequence_ToString")]
+            public static extern string ToString(global::System.Runtime.InteropServices.HandleRef refCharacterSequence);
+
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FontSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FontSpan.cs
@@ -1,0 +1,61 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class FontSpan
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_New")]
+            public static extern global::System.IntPtr New(string argFamilyName,float argSize, int argWeight, int argWidth, int argSlant);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_GetFamilyName")]
+            public static extern string GetFamilyName(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_IsFamilyNameDefined")]
+            public static extern bool IsFamilyNameDefined(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_GetWeight")]
+            public static extern int GetWeight(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_IsWeightDefined")]
+            public static extern bool IsWeightDefined(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_GetWidth")]
+            public static extern int GetWidth(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_IsWidthDefined")]
+            public static extern bool IsWidthDefined(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_GetSlant")]
+            public static extern int GetSlant(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_IsSlantDefined")]
+            public static extern bool IsSlantDefined(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_GetSize")]
+            public static extern float GetSize(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontSpan_IsSizeDefined")]
+            public static extern bool IsSizeDefined(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FontSpan")]
+            public static extern void DeleteFontSpan(global::System.Runtime.InteropServices.HandleRef refSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ForegroundColorSpan.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class ForegroundColorSpan
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_New")]
+            public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef argColor);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_GetForegroundColor")]
+            public static extern global::System.IntPtr GetForegroundColor(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ForegroundColorSpan_IsForegroundColorDefined")]
+            public static extern bool IsForegroundColorDefined(global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ForegroundColorSpan")]
+            public static extern void DeleteForegroundColorSpan(global::System.Runtime.InteropServices.HandleRef refSpan);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Range.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Range.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class Range
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_New")]
+            public static extern global::System.IntPtr NewRange(uint argStartIndex, uint argEndIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_GetStartIndex")]
+            public static extern uint GetStartIndex(global::System.Runtime.InteropServices.HandleRef refRange);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_GetEndIndex")]
+            public static extern uint GetEndIndex(global::System.Runtime.InteropServices.HandleRef refRange);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Range_GetNumberOfIndices")]
+            public static extern uint GetNumberOfIndices(global::System.Runtime.InteropServices.HandleRef refRange);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Range")]
+            public static extern void DeleteRange(global::System.Runtime.InteropServices.HandleRef refRange);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Spannable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Spannable.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class Spannable
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_AttachSpan")]
+            public static extern bool AttachSpan(
+                global::System.Runtime.InteropServices.HandleRef refSpannable,
+                global::System.Runtime.InteropServices.HandleRef refSpan,
+                global::System.Runtime.InteropServices.HandleRef refRange);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Spannable_DetachSpan")]
+            public static extern bool DetachSpan(
+                global::System.Runtime.InteropServices.HandleRef refSpannable,
+                global::System.Runtime.InteropServices.HandleRef refSpan);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Spannable")]
+            public static extern void DeleteSpannable(global::System.Runtime.InteropServices.HandleRef refSpannable);
+
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.SpannableString.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.SpannableString.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class SpannableString
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SpannableString_New")]
+            public static extern global::System.IntPtr NewSpannableString(string refText);
+
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_SpannableString")]
+            public static extern void DeleteSpannableString(global::System.Runtime.InteropServices.HandleRef refSpannableString);
+
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Spanned.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Spanned.cs
@@ -1,0 +1,29 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class Spanned
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Spanned")]
+            public static extern void DeleteSpanned(global::System.Runtime.InteropServices.HandleRef refSpanned);
+
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextSpannable.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextSpannable.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class TextSpannable
+        {
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_SetSpannedText")]
+            public static extern void SetSpannedTextIntoTextLabel(global::System.Runtime.InteropServices.HandleRef textLabelRef, global::System.Runtime.InteropServices.HandleRef spannedRef);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextField_SetSpannedText")]
+            public static extern void SetSpannedTextIntoTextField(global::System.Runtime.InteropServices.HandleRef textFieldRef, global::System.Runtime.InteropServices.HandleRef spannedRef);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextEditor_SetSpannedText")]
+            public static extern void SetSpannedTextIntoTextEditor(global::System.Runtime.InteropServices.HandleRef textEditorRef, global::System.Runtime.InteropServices.HandleRef spannedRef);
+
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.VectorUnsignedInteger.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VectorUnsignedInteger.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class VectorUnsignedInteger
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_BaseType_get")]
+            public static extern int BaseTypeGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUnsignedInteger__SWIG_0")]
+            public static extern global::System.IntPtr NewVectorUnsignedInteger();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_VectorUnsignedInteger")]
+            public static extern void DeleteVectorUnsignedInteger(global::System.Runtime.InteropServices.HandleRef daliVector);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_VectorUnsignedInteger__SWIG_1")]
+            public static extern global::System.IntPtr NewVectorUnsignedInteger(global::System.Runtime.InteropServices.HandleRef daliVector);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Assign")]
+            public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Begin")]
+            public static extern global::System.IntPtr Begin(global::System.Runtime.InteropServices.HandleRef daliVector);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_End")]
+            public static extern global::System.IntPtr End(global::System.Runtime.InteropServices.HandleRef daliVector);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_ValueOfIndex__SWIG_0")]
+            public static extern global::System.IntPtr ValueOfIndex(global::System.Runtime.InteropServices.HandleRef daliVector, uint jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_PushBack")]
+            public static extern void PushBack(global::System.Runtime.InteropServices.HandleRef daliVector, byte jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Insert__SWIG_0")]
+            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef daliVector, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, byte jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Insert__SWIG_1")]
+            public static extern void Insert(global::System.Runtime.InteropServices.HandleRef daliVector, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Reserve")]
+            public static extern void Reserve(global::System.Runtime.InteropServices.HandleRef daliVector, uint jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Resize__SWIG_0")]
+            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef daliVector, uint jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Resize__SWIG_1")]
+            public static extern void Resize(global::System.Runtime.InteropServices.HandleRef daliVector, uint jarg2, byte jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Erase__SWIG_0")]
+            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef daliVector, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Erase__SWIG_1")]
+            public static extern global::System.IntPtr Erase(global::System.Runtime.InteropServices.HandleRef daliVector, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Remove")]
+            public static extern void Remove(global::System.Runtime.InteropServices.HandleRef daliVector, [global::System.Runtime.InteropServices.In, global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.LPArray)] byte[] jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Swap")]
+            public static extern void Swap(global::System.Runtime.InteropServices.HandleRef daliVector, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Clear")]
+            public static extern void Clear(global::System.Runtime.InteropServices.HandleRef daliVector);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Release")]
+            public static extern void Release(global::System.Runtime.InteropServices.HandleRef daliVector);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VectorUnsignedInteger_Size")]
+            public static extern int Size(global::System.Runtime.InteropServices.HandleRef daliVector);
+
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/TextSpannable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextSpannable.cs
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) 2020 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Text
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class TextSpannable
+    {
+
+        private static void CheckSWIGPendingException()
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Set the spannedText into textLabel. <br />
+        /// the spanned text contains content (text) and format (spans with ranges). <br />
+        /// the text is copied into text-controller and the spans are applied on ranges. <br />
+        /// </summary>
+        /// <note>
+        /// The TEXT in textLabel will be replaced with text from spannedText
+        /// and all the applied styles textLabel will be replaced the styles from spannedText
+        /// in-case there are styles were applied from markup-processor will be removed
+        /// </note>
+        /// <param name="textLabel"> The instance of TextLabel.</param>
+        /// <param name="spannedText">The text with spans.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetSpannedText(TextLabel textLabel, Spanned spannedText)
+        {
+            if (textLabel == null)
+            {
+                throw new ArgumentNullException(null, "textLabel object is null");
+            }
+
+            Interop.TextSpannable.SetSpannedTextIntoTextLabel(textLabel.SwigCPtr, spannedText.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Set the spannedText into textField. <br />
+        /// the spanned text contains content (text) and format (spans with ranges). <br />
+        /// the text is copied into text-controller and the spans are applied on ranges. <br />
+        /// </summary>
+        /// <note>
+        /// The TEXT in textField will be replaced with text from spannedText
+        /// and all the applied styles textField will be replaced the styles from spannedText
+        /// in-case there are styles were applied from markup-processor will be removed
+        /// </note>
+        /// <param name="textField"> The instance of TextField.</param>
+        /// <param name="spannedText">The text with spans.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetSpannedText(TextField textField, Spanned spannedText)
+        {
+            if (textField == null)
+            {
+                throw new ArgumentNullException(null, "textField object is null");
+            }
+
+            Interop.TextSpannable.SetSpannedTextIntoTextField(textField.SwigCPtr, spannedText.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+        /// <summary>
+        /// Set the spannedText into textEditor. <br />
+        /// the spanned text contains content (text) and format (spans with ranges). <br />
+        /// the text is copied into text-controller and the spans are applied on ranges. <br />
+        /// </summary>
+        /// <note>
+        /// The TEXT in textEditor will be replaced with text from spannedText
+        /// and all the applied styles textEditor will be replaced the styles from spannedText
+        /// in-case there are styles were applied from markup-processor will be removed
+        /// </note>
+        /// <param name="textEditor"> The instance of TextEditor.</param>
+        /// <param name="spannedText">The text with spans.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetSpannedText(TextEditor textEditor, Spanned spannedText)
+        {
+            if (textEditor == null)
+            {
+                throw new ArgumentNullException(null, "textEditor object is null");
+            }
+
+            Interop.TextSpannable.SetSpannedTextIntoTextEditor(textEditor.SwigCPtr, spannedText.SwigCPtr);
+            CheckSWIGPendingException();
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Common/Range.cs
+++ b/src/Tizen.NUI/src/public/Common/Range.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class Range : Disposable
+    {
+
+        /// <summary>
+        /// Creates a new Range object<br />
+        /// </summary>
+        /// <param name="startIndex">The first index of the range.</param>
+        /// <param name="endIndex">The last index of the range.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Range Create(uint startIndex, uint endIndex)
+        {
+            Range ret = new Range(Interop.Range.NewRange(startIndex, endIndex), true);
+            return ret;
+        }
+
+        internal Range(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The start-index in range.
+        /// It's the minimum bound of range.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint StartIndex
+        {
+            get
+            {
+                uint ret = Interop.Range.GetStartIndex(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The end-index in range.
+        /// It's the maximum bound of range.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint EndIndex
+        {
+            get
+            {
+                uint ret = Interop.Range.GetEndIndex(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The number of indices in range.
+        /// It's the number of indices between the minimum  and maximum bounds in range.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint NumberOfIndices
+        {
+            get
+            {
+                uint ret = Interop.Range.GetNumberOfIndices(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.Range.DeleteRange(swigCPtr);
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/CharacterSequence.cs
+++ b/src/Tizen.NUI/src/public/Text/CharacterSequence.cs
@@ -1,0 +1,81 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Text
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class CharacterSequence : Disposable
+    {
+
+        internal CharacterSequence(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.CharacterSequence.DeleteCharacterSequence(swigCPtr);
+        }
+
+        /// <summary>
+        /// Retrive the characters.
+        /// </summary>
+        /// <returns>The utf32 characters</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<uint> GetCharacters( )
+        {
+            VectorUnsignedInteger vector = new VectorUnsignedInteger(Interop.CharacterSequence.GetCharacters(this.SwigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return vector.GetListFromNativeVector();
+        }
+
+        /// <summary>
+        /// Retrive number of characters in container.
+        /// </summary>
+        /// <returns>The number of characters</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint GetNumberOfCharacters( )
+        {
+            uint ret = Interop.CharacterSequence.GetNumberOfCharacters(this.SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Retrieve constructed string form Character Sequence.
+        /// </summary>
+        /// <returns>The text </returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string ToString( )
+        {
+            string ret = Interop.CharacterSequence.ToString(this.SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spannable.cs
+++ b/src/Tizen.NUI/src/public/Text/Spannable.cs
@@ -1,0 +1,80 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Text
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class Spannable : Spanned
+    {
+
+        internal Spannable(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Add the given style span on the given range of text.
+        /// </summary>
+        /// <param name="styleSpan">The span of style to apply it on range</param>
+        /// <param name="range">The range</param>
+        /// <returns>true if the range is valid on text. Otherwise false</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AttachSpan(BaseSpan styleSpan, Range range)
+        {
+            bool ret = Interop.Spannable.AttachSpan((SwigCPtr),BaseSpan.getCPtr(styleSpan),Range.getCPtr(range));
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Remove the given style span on all ranges of text.
+        /// checks if styleSpan exists, and if it does, it's to be removed.
+        /// </summary>
+        /// <param name="styleSpan">The span of style to apply it on range</param>
+        /// <returns>true if the styleSpan was exist and removed. Otherwise false</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DetachSpan(BaseSpan styleSpan)
+        {
+            bool ret = Interop.Spannable.DetachSpan((SwigCPtr),BaseSpan.getCPtr(styleSpan));
+            if (NDalicPINVOKE.SWIGPendingException.Pending)
+                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.Spannable.DeleteSpannable(swigCPtr);
+        }
+
+
+
+
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/SpannableString.cs
+++ b/src/Tizen.NUI/src/public/Text/SpannableString.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Text
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class SpannableString : Spannable
+    {
+        // <summary>
+        /// Creates a new SpannableString object<br />
+        /// </summary>
+        /// <param name="text">The text to be formatted.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static SpannableString Create(string text)
+        {
+            SpannableString ret = new SpannableString(Interop.SpannableString.NewSpannableString(text), true);
+            return ret;
+        }
+
+        internal SpannableString(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.SpannableString.DeleteSpannableString(swigCPtr);
+        }
+
+
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spanned.cs
+++ b/src/Tizen.NUI/src/public/Text/Spanned.cs
@@ -1,0 +1,44 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Text
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class Spanned : CharacterSequence
+    {
+
+        internal Spanned(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.Spanned.DeleteSpanned(swigCPtr);
+        }
+
+
+
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/BaseSpan.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class BaseSpan : Disposable
+    {
+
+        internal BaseSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.BaseSpan.DeleteBaseSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/FontSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/FontSpan.cs
@@ -1,0 +1,206 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class FontSpan : BaseSpan
+    {
+
+        /// <summary>
+        /// Create foreground color span Set and set color for it.<br />
+        /// </summary>
+        /// <param name="familyName">The family name</param>
+        /// <param name="size">The font size</param>
+        /// <param name="weight">The font weight</param>
+        /// <param name="width">The font width</param>
+        /// <param name="slant">The font slant</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static FontSpan Create(string familyName, float size, FontWeightType weight, FontWidthType width, FontSlantType slant)
+        {
+            FontSpan ret = new FontSpan(Interop.FontSpan.New( familyName, size, (int)weight, (int)width, (int)slant), true);
+
+            return ret;
+        }
+
+        internal FontSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+                /// <summary>
+        /// The family name in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string FamilyName
+        {
+            get
+            {
+                string ret = Interop.FontSpan.GetFamilyName(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the family name is defined in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasFamilyName
+        {
+            get
+            {
+                bool ret = Interop.FontSpan.IsFamilyNameDefined(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The weight in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontWeightType WeightType
+        {
+            get
+            {
+                FontWeightType ret = (FontWeightType)Interop.FontSpan.GetWeight(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the weight is defined in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasWeight
+        {
+            get
+            {
+                bool ret = Interop.FontSpan.IsWeightDefined(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The width in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontWidthType WidthType
+        {
+            get
+            {
+                 FontWidthType ret = (FontWidthType)Interop.FontSpan.GetWidth(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the width is defined in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasWidth
+        {
+            get
+            {
+                bool ret = Interop.FontSpan.IsWidthDefined(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The slant in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public FontSlantType SlantType
+        {
+            get
+            {
+                 FontSlantType ret = (FontSlantType)Interop.FontSpan.GetSlant(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the slant is defined in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasSlant
+        {
+            get
+            {
+                bool ret = Interop.FontSpan.IsSlantDefined(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// The size in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float Size
+        {
+            get
+            {
+                float ret = Interop.FontSpan.GetSize(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the size is defined in font-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasSize
+        {
+            get
+            {
+                bool ret = Interop.FontSpan.IsSizeDefined(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.FontSpan.DeleteFontSpan(swigCPtr);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
+++ b/src/Tizen.NUI/src/public/Text/Spans/ForegroundColorSpan.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Text.Spans
+{
+    /// <summary>
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ForegroundColorSpan : BaseSpan
+    {
+
+        /// <summary>
+        /// Create foreground color span Set and set color for it.<br />
+        /// </summary>
+        /// <param name="color">The fore color</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static ForegroundColorSpan Create(Color color)
+        {
+            ForegroundColorSpan ret = new ForegroundColorSpan(Interop.ForegroundColorSpan.New(Vector4.getCPtr(color)), true);
+            return ret;
+        }
+
+        internal ForegroundColorSpan(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The fore-color in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color Color
+        {
+            get
+            {
+                Color ret = new Color(Interop.ForegroundColorSpan.GetForegroundColor(SwigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Whether the fore color is defined in color-span.
+        /// </summary>
+        /// This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasColor
+        {
+            get
+            {
+                bool ret = Interop.ForegroundColorSpan.IsForegroundColorDefined(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.ForegroundColorSpan.DeleteForegroundColorSpan(swigCPtr);
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSFontSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSFontSpan.cs
@@ -1,0 +1,434 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicFontSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanCreate()
+        {
+            tlog.Debug(tag, $"FontSpanCreate START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"FontSpanCreate END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan FamilyName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.FamilyName A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanFamilyName()
+        {
+            tlog.Debug(tag, $"FontSpanFamilyName START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual("DejaVu Sans",  testingTarget.FamilyName, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanFamilyName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan WeightType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.WeightType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanWeightType()
+        {
+            tlog.Debug(tag, $"FontSpanWeightType START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual( FontWeightType.Light, testingTarget.WeightType, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanWeightType END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan WidthType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.WidthType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanWidthType()
+        {
+            tlog.Debug(tag, $"FontSpanWidthType START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(FontWidthType.Condensed, testingTarget.WidthType, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanWidthType END (OK)");
+        }
+
+                [Test]
+        [Category("P1")]
+        [Description("FontSpan SlantType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.SlantType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanSlantType()
+        {
+            tlog.Debug(tag, $"FontSpanSlantType START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(FontSlantType.Italic, testingTarget.SlantType, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanSlantType END (OK)");
+        }
+
+                [Test]
+        [Category("P1")]
+        [Description("FontSpan Size.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.Size A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanSize()
+        {
+            tlog.Debug(tag, $"FontSpanSize START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual( 40.0f, testingTarget.Size, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanSize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasFamilyName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasFamilyName A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasFamilyName()
+        {
+            tlog.Debug(tag, $"FontSpanHasFamilyName START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasFamilyName, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasFamilyName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasWeight.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasWeight A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasWeight()
+        {
+            tlog.Debug(tag, $"FontSpanHasWeight START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasWeight, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasWeight END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasWidth.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasWidth A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasWidth()
+        {
+            tlog.Debug(tag, $"FontSpanHasWidth START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasFamilyName, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasWidth END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasSlant.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasSlant A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasSlant()
+        {
+            tlog.Debug(tag, $"FontSpanHasSlant START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasSlant, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasSlant END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasSize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasSize A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasSize()
+        {
+            tlog.Debug(tag, $"FontSpanHasSize START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasSize, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasSize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanDispose()
+        {
+            tlog.Debug(tag, $"FontSpanDispose START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"FontSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,142 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanCreate()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanCreate START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanCreate END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Color.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Color A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpan.Create(expected);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.Color;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, result), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan HasColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.HasColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanHasColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor START");
+
+            var expected = true;
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.HasColor;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannableString.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannableString.cs
@@ -1,0 +1,242 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicSpannableStringTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.SpannableString.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringCreate()
+        {
+            tlog.Debug(tag, $"SpannableStringCreate START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.SpannableString.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringDispose()
+        {
+            tlog.Debug(tag, $"SpannableStringDispose START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"SpannableStringDispose END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringAttachSpan()
+        {
+            tlog.Debug(tag, $"SpannableStringAttachSpan START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            var flagIsAttached = testingTarget.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            Assert.AreEqual(true, flagIsAttached, "Should be true!");
+
+            flagIsAttached = testingTarget.AttachSpan(
+                ForegroundColorSpan.Create(Color.Blue),
+                Range.Create(22,50)
+            );
+
+            Assert.AreEqual(false, flagIsAttached, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringAttachSpan END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringDetachSpan()
+        {
+            tlog.Debug(tag, $"SpannableStringDetachSpan START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+
+            ForegroundColorSpan span = ForegroundColorSpan.Create(Color.Green);
+
+            var flagIsDetached = testingTarget.DetachSpan(span);
+            Assert.AreEqual(false, flagIsDetached, "Should be true!");
+
+
+            var flagIsAttached = testingTarget.AttachSpan(
+                span,
+                Range.Create(2,5)
+            );
+
+            Assert.AreEqual(true, flagIsAttached, "Should be true!");
+
+            flagIsDetached = testingTarget.DetachSpan(span);
+            Assert.AreEqual(true, flagIsDetached, "Should be true!");
+
+            flagIsDetached = testingTarget.DetachSpan(span);
+            Assert.AreEqual(false, flagIsDetached, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringDetachSpan END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString GetNumberOfCharacters.")]
+        [Property("SPEC", "Tizen.NUI.Text.CharacterSequence.GetNumberOfCharacters M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringGetNumberOfCharacters()
+        {
+            tlog.Debug(tag, $"SpannableStringGetNumberOfCharacters START");
+
+            uint expected = 26;
+
+            var testingTarget = SpannableString.Create("Hello World! مرحبا بالعالم");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            uint result = testingTarget.GetNumberOfCharacters();
+            Assert.AreEqual(expected, result, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringGetNumberOfCharacters END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString ToString.")]
+        [Property("SPEC", "Tizen.NUI.Text.CharacterSequence.ToString M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringToString()
+        {
+            tlog.Debug(tag, $"SpannableStringToString START");
+
+            string expected = "Hello World! مرحبا بالعالم";
+
+            var testingTarget = SpannableString.Create(expected);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            var result = testingTarget.ToString();
+            Assert.AreEqual(expected, result, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringToString END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString GetCharacters.")]
+        [Property("SPEC", "Tizen.NUI.Text.CharacterSequence.GetCharacters M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringGetCharacters()
+        {
+            tlog.Debug(tag, $"SpannableStringGetCharacters START");
+
+             List<uint> expected = new List<uint>
+             {
+                72,
+                101,
+                108,
+                108,
+                111,
+                1605,
+                1585,
+                1581,
+                1576,
+                1575
+             };
+
+            var testingTarget = SpannableString.Create("Helloمرحبا");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            var result = testingTarget.GetCharacters();
+            Assert.AreEqual(expected, result, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringGetCharacters END (OK)");
+        }
+
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSTextSpannable.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TSTextSpannable.cs
@@ -1,0 +1,157 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicTextSpannableTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Check SetSpannedText method with TextLabel. Check whether SetSpannedText is successfully invoked or not.")]
+        [Property("SPEC", "Tizen.NUI.Text.TextSpannable.SetSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        [Property("COVPARAM", "TextLabel")]
+        public void TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTLABEL()
+        {
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTLABEL START");
+
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var spannedText = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(spannedText, "null handle");
+            Assert.IsInstanceOf<SpannableString>(spannedText, "Should return SpannableString instance.");
+
+            spannedText.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            try
+            {
+                TextSpannable.SetSpannedText(testingTarget, spannedText);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception when call TextSpannable.SetSpannedText(textLabel, spannedText) , but got: %s", ex.Message);
+            }
+
+            spannedText.Dispose();
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTLABEL END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Check SetSpannedText method with TextField. Check whether SetSpannedText is successfully invoked or not.")]
+        [Property("SPEC", "Tizen.NUI.Text.TextSpannable.SetSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        [Property("COVPARAM", "TextField")]
+        public void TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTFIELD()
+        {
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTFIELD START");
+
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var spannedText = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(spannedText, "null handle");
+            Assert.IsInstanceOf<SpannableString>(spannedText, "Should return SpannableString instance.");
+
+            spannedText.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            try
+            {
+                TextSpannable.SetSpannedText(testingTarget, spannedText);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception when call TextSpannable.SetSpannedText(textField, spannedText) , but got: %s", ex.Message);
+            }
+
+            spannedText.Dispose();
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTFIELD END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Check SetSpannedText method with TextEditor. Check whether SetSpannedText is successfully invoked or not.")]
+        [Property("SPEC", "Tizen.NUI.Text.TextSpannable.SetSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        [Property("COVPARAM", "TextEditor")]
+        public void TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTEDITOR()
+        {
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTEDITOR START");
+
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var spannedText = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(spannedText, "null handle");
+            Assert.IsInstanceOf<SpannableString>(spannedText, "Should return SpannableString instance.");
+
+            spannedText.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            try
+            {
+                TextSpannable.SetSpannedText(testingTarget, spannedText);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception when call TextSpannable.SetSpannedText(textEditor, spannedText) , but got: %s", ex.Message);
+            }
+
+            spannedText.Dispose();
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTEDITOR END (OK)");
+        }
+
+
+    }
+}

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Common/TSRange.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Common/TSRange.cs
@@ -1,0 +1,174 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Common/Range")]
+    public class PublicRangeTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Create.")]
+        [Property("SPEC", "Tizen.NUI.Range.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeCreate()
+        {
+            tlog.Debug(tag, $"RangeCreate START");
+
+            var testingTarget = Range.Create(4,5);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"RangeCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range RangeStartIndex.")]
+        [Property("SPEC", "Tizen.NUI.Range.RangeStartIndex A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeStartIndex()
+        {
+            tlog.Debug(tag, $"RangeStartIndex START");
+
+            uint expected = 10;
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                var result = testingTarget.StartIndex;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"RangeStartIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range RangeEndIndex.")]
+        [Property("SPEC", "Tizen.NUI.Range.RangeEndIndex A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeEndIndex()
+        {
+            tlog.Debug(tag, $"RangeEndIndex START");
+
+            uint expected = 27;
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                var result = testingTarget.EndIndex;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"RangeEndIndex END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range RangeNumberOfIndices.")]
+        [Property("SPEC", "Tizen.NUI.Range.RangeNumberOfIndices A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeNumberOfIndices()
+        {
+            tlog.Debug(tag, $"RangeNumberOfIndices START");
+
+            uint expected = 18;
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                var result = testingTarget.NumberOfIndices;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"RangeNumberOfIndices END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Range.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void RangeDispose()
+        {
+            tlog.Debug(tag, $"RangeDispose START");
+
+            var testingTarget = Range.Create(10,27);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<Range>(testingTarget, "Should return Range instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"RangeDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSFontSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSFontSpan.cs
@@ -1,0 +1,434 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicFontSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanCreate()
+        {
+            tlog.Debug(tag, $"FontSpanCreate START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"FontSpanCreate END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan FamilyName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.FamilyName A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanFamilyName()
+        {
+            tlog.Debug(tag, $"FontSpanFamilyName START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual("DejaVu Sans",  testingTarget.FamilyName, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanFamilyName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan WeightType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.WeightType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanWeightType()
+        {
+            tlog.Debug(tag, $"FontSpanWeightType START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual( FontWeightType.Light, testingTarget.WeightType, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanWeightType END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan WidthType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.WidthType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanWidthType()
+        {
+            tlog.Debug(tag, $"FontSpanWidthType START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(FontWidthType.Condensed, testingTarget.WidthType, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanWidthType END (OK)");
+        }
+
+                [Test]
+        [Category("P1")]
+        [Description("FontSpan SlantType.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.SlantType A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanSlantType()
+        {
+            tlog.Debug(tag, $"FontSpanSlantType START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(FontSlantType.Italic, testingTarget.SlantType, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanSlantType END (OK)");
+        }
+
+                [Test]
+        [Category("P1")]
+        [Description("FontSpan Size.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.Size A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanSize()
+        {
+            tlog.Debug(tag, $"FontSpanSize START");
+
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual( 40.0f, testingTarget.Size, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanSize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasFamilyName.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasFamilyName A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasFamilyName()
+        {
+            tlog.Debug(tag, $"FontSpanHasFamilyName START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasFamilyName, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasFamilyName END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasWeight.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasWeight A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasWeight()
+        {
+            tlog.Debug(tag, $"FontSpanHasWeight START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasWeight, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasWeight END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasWidth.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasWidth A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasWidth()
+        {
+            tlog.Debug(tag, $"FontSpanHasWidth START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasFamilyName, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasWidth END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasSlant.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasSlant A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasSlant()
+        {
+            tlog.Debug(tag, $"FontSpanHasSlant START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasSlant, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasSlant END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan HasSize.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.HasSize A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanHasSize()
+        {
+            tlog.Debug(tag, $"FontSpanHasSize START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                Assert.AreEqual(true, testingTarget.HasSize, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"FontSpanHasSize END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("FontSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.FontSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void FontSpanDispose()
+        {
+            tlog.Debug(tag, $"FontSpanDispose START");
+
+            var testingTarget = FontSpan.Create("DejaVu Sans",
+                                                 40.0f,
+                                                 FontWeightType.Light,
+                                                 FontWidthType.Condensed,
+                                                 FontSlantType.Italic );
+
+
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<FontSpan>(testingTarget, "Should return FontSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"FontSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/Spans/TSForegroundColorSpan.cs
@@ -1,0 +1,142 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text/Spans")]
+    public class PublicForegroundColorSpanTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Range Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanCreate()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanCreate START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"ForegroundColorSpanCreate END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Color.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Color A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanColor START");
+
+            Color expected = Color.Green;
+
+            var testingTarget = ForegroundColorSpan.Create(expected);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.Color;
+                Assert.AreEqual(true, TestUtils.CheckColor(expected, result), "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan HasColor.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.HasColor A")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanHasColor()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor START");
+
+            var expected = true;
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                var result = testingTarget.HasColor;
+                Assert.AreEqual(expected, result, "Should be true!");
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception: Failed!");
+            }
+
+            testingTarget.Dispose();
+            tlog.Debug(tag, $"ForegroundColorSpanHasColor END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ForegroundColorSpan Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spans.ForegroundColorSpan.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void ForegroundColorSpanDispose()
+        {
+            tlog.Debug(tag, $"ForegroundColorSpanDispose START");
+
+            var testingTarget = ForegroundColorSpan.Create(Color.Green);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<ForegroundColorSpan>(testingTarget, "Should return ForegroundColorSpan instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"ForegroundColorSpanDispose END (OK)");
+        }
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannableString.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSSpannableString.cs
@@ -1,0 +1,242 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicSpannableStringTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.SpannableString.Create M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringCreate()
+        {
+            tlog.Debug(tag, $"SpannableStringCreate START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringCreate END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Dispose.")]
+        [Property("SPEC", "Tizen.NUI.Text.SpannableString.Dispose M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR MCST")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringDispose()
+        {
+            tlog.Debug(tag, $"SpannableStringDispose START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            try
+            {
+                testingTarget.Dispose();
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Caught Exception" + e.ToString());
+            }
+
+            tlog.Debug(tag, $"SpannableStringDispose END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.AttachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringAttachSpan()
+        {
+            tlog.Debug(tag, $"SpannableStringAttachSpan START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            var flagIsAttached = testingTarget.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            Assert.AreEqual(true, flagIsAttached, "Should be true!");
+
+            flagIsAttached = testingTarget.AttachSpan(
+                ForegroundColorSpan.Create(Color.Blue),
+                Range.Create(22,50)
+            );
+
+            Assert.AreEqual(false, flagIsAttached, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringAttachSpan END (OK)");
+        }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString Create.")]
+        [Property("SPEC", "Tizen.NUI.Text.Spannable.DetachSpan M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringDetachSpan()
+        {
+            tlog.Debug(tag, $"SpannableStringDetachSpan START");
+
+            var testingTarget = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+
+            ForegroundColorSpan span = ForegroundColorSpan.Create(Color.Green);
+
+            var flagIsDetached = testingTarget.DetachSpan(span);
+            Assert.AreEqual(false, flagIsDetached, "Should be true!");
+
+
+            var flagIsAttached = testingTarget.AttachSpan(
+                span,
+                Range.Create(2,5)
+            );
+
+            Assert.AreEqual(true, flagIsAttached, "Should be true!");
+
+            flagIsDetached = testingTarget.DetachSpan(span);
+            Assert.AreEqual(true, flagIsDetached, "Should be true!");
+
+            flagIsDetached = testingTarget.DetachSpan(span);
+            Assert.AreEqual(false, flagIsDetached, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringDetachSpan END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString GetNumberOfCharacters.")]
+        [Property("SPEC", "Tizen.NUI.Text.CharacterSequence.GetNumberOfCharacters M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringGetNumberOfCharacters()
+        {
+            tlog.Debug(tag, $"SpannableStringGetNumberOfCharacters START");
+
+            uint expected = 26;
+
+            var testingTarget = SpannableString.Create("Hello World! مرحبا بالعالم");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            uint result = testingTarget.GetNumberOfCharacters();
+            Assert.AreEqual(expected, result, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringGetNumberOfCharacters END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString ToString.")]
+        [Property("SPEC", "Tizen.NUI.Text.CharacterSequence.ToString M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringToString()
+        {
+            tlog.Debug(tag, $"SpannableStringToString START");
+
+            string expected = "Hello World! مرحبا بالعالم";
+
+            var testingTarget = SpannableString.Create(expected);
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            var result = testingTarget.ToString();
+            Assert.AreEqual(expected, result, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringToString END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("SpannableString GetCharacters.")]
+        [Property("SPEC", "Tizen.NUI.Text.CharacterSequence.GetCharacters M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        public void SpannableStringGetCharacters()
+        {
+            tlog.Debug(tag, $"SpannableStringGetCharacters START");
+
+             List<uint> expected = new List<uint>
+             {
+                72,
+                101,
+                108,
+                108,
+                111,
+                1605,
+                1585,
+                1581,
+                1576,
+                1575
+             };
+
+            var testingTarget = SpannableString.Create("Helloمرحبا");
+            Assert.IsNotNull(testingTarget, "null handle");
+            Assert.IsInstanceOf<SpannableString>(testingTarget, "Should return SpannableString instance.");
+
+            var result = testingTarget.GetCharacters();
+            Assert.AreEqual(expected, result, "Should be true!");
+
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"SpannableStringGetCharacters END (OK)");
+        }
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSTextSpannable.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TSTextSpannable.cs
@@ -1,0 +1,157 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Text.Spans;
+using Tizen.NUI.Text;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Text")]
+    public class PublicTextSpannableTest
+    {
+        private const string tag = "NUITEST";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Check SetSpannedText method with TextLabel. Check whether SetSpannedText is successfully invoked or not.")]
+        [Property("SPEC", "Tizen.NUI.Text.TextSpannable.SetSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        [Property("COVPARAM", "TextLabel")]
+        public void TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTLABEL()
+        {
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTLABEL START");
+
+
+            var testingTarget = new TextLabel(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextLabel");
+            Assert.IsInstanceOf<TextLabel>(testingTarget, "Should be an instance of TextLabel type.");
+
+            var spannedText = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(spannedText, "null handle");
+            Assert.IsInstanceOf<SpannableString>(spannedText, "Should return SpannableString instance.");
+
+            spannedText.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            try
+            {
+                TextSpannable.SetSpannedText(testingTarget, spannedText);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception when call TextSpannable.SetSpannedText(textLabel, spannedText) , but got: %s", ex.Message);
+            }
+
+            spannedText.Dispose();
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTLABEL END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Check SetSpannedText method with TextField. Check whether SetSpannedText is successfully invoked or not.")]
+        [Property("SPEC", "Tizen.NUI.Text.TextSpannable.SetSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        [Property("COVPARAM", "TextField")]
+        public void TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTFIELD()
+        {
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTFIELD START");
+
+
+            var testingTarget = new TextField(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextField");
+            Assert.IsInstanceOf<TextField>(testingTarget, "Should be an instance of TextField type.");
+
+            var spannedText = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(spannedText, "null handle");
+            Assert.IsInstanceOf<SpannableString>(spannedText, "Should return SpannableString instance.");
+
+            spannedText.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            try
+            {
+                TextSpannable.SetSpannedText(testingTarget, spannedText);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception when call TextSpannable.SetSpannedText(textField, spannedText) , but got: %s", ex.Message);
+            }
+
+            spannedText.Dispose();
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTFIELD END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("Check SetSpannedText method with TextEditor. Check whether SetSpannedText is successfully invoked or not.")]
+        [Property("SPEC", "Tizen.NUI.Text.TextSpannable.SetSpannedText M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "Shrouq Sabah, s.sabah@samsung.com")]
+        [Property("COVPARAM", "TextEditor")]
+        public void TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTEDITOR()
+        {
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTEDITOR START");
+
+
+            var testingTarget = new TextEditor(true);
+            Assert.IsNotNull(testingTarget, "Can't create success object TextEditor");
+            Assert.IsInstanceOf<TextEditor>(testingTarget, "Should be an instance of TextEditor type.");
+
+            var spannedText = SpannableString.Create("Hello World!");
+            Assert.IsNotNull(spannedText, "null handle");
+            Assert.IsInstanceOf<SpannableString>(spannedText, "Should return SpannableString instance.");
+
+            spannedText.AttachSpan(
+                ForegroundColorSpan.Create(Color.Green),
+                Range.Create(2,5)
+            );
+
+            try
+            {
+                TextSpannable.SetSpannedText(testingTarget, spannedText);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Expected no exception when call TextSpannable.SetSpannedText(textEditor, spannedText) , but got: %s", ex.Message);
+            }
+
+            spannedText.Dispose();
+            testingTarget.Dispose();
+
+            tlog.Debug(tag, $"TextSpannableSetSpannedText_CALL_API_WITHOUT_EXCEPTION_WITH_TEXTEDITOR END (OK)");
+        }
+
+
+    }
+}

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Text/TestUtils.cs
@@ -1,0 +1,31 @@
+using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Tizen.NUI.Devel.Tests
+{
+
+
+    public class TestUtils
+    {
+
+        public static bool CheckColor(Color colorSrc, Color colorDst)
+        {
+            if (colorSrc.R == colorDst.R && colorSrc.G == colorDst.G && colorSrc.B == colorDst.B && colorSrc.A == colorDst.A)
+                return true;
+
+            return false;
+        }
+
+        public static bool CheckColor(Vector4 colorSrc, Vector4 colorDst)
+        {
+            if (colorSrc.X == colorDst.X && colorSrc.Y == colorDst.Y && colorSrc.Z == colorDst.Z && colorSrc.W == colorDst.W)
+                return true;
+
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Add FontSpan class
It is used in Spannable module

FontSpan is a Span to set font properties

### API Changes ###
Added:
 - public static FontSpan Create(string familyName, float size, FontWeightType weight, FontWidthType width, FontSlantType slant) // static method
 - public string FamilyName  // Readonly Property
 - public bool HasFamilyName  // Readonly Property
 - public FontWeightType WeightType  // Readonly Property
 - public bool HasWeight  // Readonly Property
 - public FontWidthType WidthType  // Readonly Property
 - public bool HasWidth  // Readonly Property
 - public FontSlantType SlantType  // Readonly Property
 - public bool HasSlant  // Readonly Property
 - public float Size  // Readonly Property
 - public bool HasSize  // Readonly Property


### Testcases ###
Added the below to (Tizen.NUI.Devel.Tests.Ubuntu) and (Tizen.NUI.Tests):
- Tizen.NUI.Devel.Tests.PublicFontSpanTest

**This PR should be preceded by the PR below:**
- https://github.com/Samsung/TizenFX/pull/4798

**This PR depends on the below patches:**
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/285495

