### PR TITLE
[NUI] add ImageUrl property on DefaultGridItem.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
@@ -164,23 +164,32 @@ namespace Tizen.NUI.Components
             }
         }
 
-        /* open when ImageView using Uri not string
-                /// <summary>
-                /// Image image's resource url in DefaultGridItem.
-                /// </summary>
-                [EditorBrowsable(EditorBrowsableState.Never)]
-                public string ImageUrl
-                {
-                    get
-                    {
-                        return Image.ResourceUrl;
-                    }
-                    set
-                    {
-                        Image.ResourceUrl = value;
-                    }
-                }
-        */
+        /// <summary>
+        /// Image image's resource url in DefaultGridItem.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string ImageUrl
+        {
+            get => GetValue(ImageUrlProperty) as string;
+            set
+            {
+                SetValue(ImageUrlProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        internal string InternalImageUrl
+        {
+            get
+            {
+                return Image.ResourceUrl;
+            }
+            set
+            {
+                Image.ResourceUrl = value;
+            }
+        }
+
 
         /// <summary>
         /// DefaultGridItem's text part.

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
@@ -165,20 +165,20 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
-        /// Image image's resource url in DefaultGridItem.
+        /// Image resource url in DefaultGridItem.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public string ImageUrl
+        public string ResourceUrl
         {
-            get => GetValue(ImageUrlProperty) as string;
+            get => GetValue(ResourceUrlProperty) as string;
             set
             {
-                SetValue(ImageUrlProperty, value);
+                SetValue(ResourceUrlProperty, value);
                 NotifyPropertyChanged();
             }
         }
 
-        internal string InternalImageUrl
+        internal string InternalResourceUrl
         {
             get
             {

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItemBindableProperty.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItemBindableProperty.cs
@@ -44,21 +44,21 @@ namespace Tizen.NUI.Components
 
 
         /// <summary>
-        /// ImageUrlProperty
+        /// ResourceUrlProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ImageUrlProperty = BindableProperty.Create(nameof(ImageUrl), typeof(string), typeof(DefaultGridItem), default(string), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ResourceUrlProperty = BindableProperty.Create(nameof(ResourceUrl), typeof(string), typeof(DefaultGridItem), default(string), propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (DefaultGridItem)bindable;
             if (newValue != null)
             {
-                instance.InternalImageUrl = newValue as string;
+                instance.InternalResourceUrl = newValue as string;
             }
         },
         defaultValueCreator: (bindable) =>
         {
             var instance = (DefaultGridItem)bindable;
-            return instance.InternalImageUrl;
+            return instance.InternalResourceUrl;
         });
 
         /// <summary>

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItemBindableProperty.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItemBindableProperty.cs
@@ -42,6 +42,25 @@ namespace Tizen.NUI.Components
             return instance.InternalText;
         });
 
+
+        /// <summary>
+        /// ImageUrlProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ImageUrlProperty = BindableProperty.Create(nameof(ImageUrl), typeof(string), typeof(DefaultGridItem), default(string), propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (DefaultGridItem)bindable;
+            if (newValue != null)
+            {
+                instance.InternalImageUrl = newValue as string;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (DefaultGridItem)bindable;
+            return instance.InternalImageUrl;
+        });
+
         /// <summary>
         /// LabelOrientationTypeProperty
         /// </summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Add ImageUrl Property on DefaultGridItem.
DefaultGridItem Image is readonly property,
so in XAML ResourceUrl is unaccessible.
this patch will fix those issue by directly binding resourceUrl on ImageUrl of DefaultGridItem.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
