### PR TITLE
[NUI] fix DefaultGridItem image to fill available area.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/DefaultGridItem.cs
@@ -336,6 +336,8 @@ namespace Tizen.NUI.Components
             RelativeLayout.SetRightTarget(itemImage, this);
             RelativeLayout.SetRightRelativeOffset(itemImage, 1.0F);
             RelativeLayout.SetHorizontalAlignment(itemImage, RelativeLayout.Alignment.Center);
+            RelativeLayout.SetFillHorizontal(itemImage, true);
+            RelativeLayout.SetFillVertical(itemImage, true);
 
             if (itemLabel != null)
             {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

DefaultGridItem need to fill image on availableArea by default.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
