### PR TITLE
[NUI.Scene3D] Support SkyboxImageType

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.SceneView.cs
@@ -82,6 +82,9 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_SetSkybox")]
             public static extern void SetSkybox(global::System.Runtime.InteropServices.HandleRef sceneView, string skyboxUrl);
 
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_SetSkyboxWithType")]
+            public static extern void SetSkybox(global::System.Runtime.InteropServices.HandleRef sceneView, string skyboxUrl, int skyboxType);
+
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_SetSkyboxIntensity")]
             public static extern void SetSkyboxIntensity(global::System.Runtime.InteropServices.HandleRef sceneView, float intensity);
 

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -67,9 +67,16 @@ namespace Tizen.NUI.Scene3D
     /// <since_tizen> 10 </since_tizen>
     public class SceneView : View
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum SkyboxType
+        {
+            CUBEMAP, ///< Skybox in cubemap
+            EQUIRECTANGULAR ///< Skybox in equirectangular projection
+        }
         private bool inCameraTransition = false;
         private Animation cameraTransition;
         private string skyboxUrl;
+        private SkyboxType skyboxType = SkyboxType.CUBEMAP;
 
         internal SceneView(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -170,6 +177,24 @@ namespace Tizen.NUI.Scene3D
             get
             {
                 return skyboxUrl;
+            }
+        }
+
+        /// <summary>
+        /// Set/Get SkyboxImageType.
+        /// Skybox texture is asynchronously loaded. When loading is finished, ResourcesLoaded is emitted.
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SkyboxType SkyboxImageType
+        {
+            set
+            {
+                SetSkyboxType(value);
+            }
+            get
+            {
+                return skyboxType;
             }
         }
 
@@ -481,15 +506,46 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
-        /// Set the Skybox from cube map image.
+        /// Set the Skybox image with image type.
         /// Skybox texture is asynchronously loaded. When loading is finished, ResourcesLoaded is emitted.
         /// </summary>
-        /// <param name="skyboxUrl">Cube map image url for skybox.</param>
+        /// <param name="skyboxUrl">Image url for skybox.</param>
+        /// <param name="skyboxType">Type for skybox.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetSkybox(string skyboxUrl, SkyboxType skyboxType)
+        {
+            this.skyboxUrl = skyboxUrl;
+            this.skyboxType = skyboxType;
+            Interop.SceneView.SetSkybox(SwigCPtr, skyboxUrl, (int)skyboxType);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Set the Skybox from image.
+        /// Skybox texture is asynchronously loaded. When loading is finished, ResourcesLoaded is emitted.
+        /// </summary>
+        /// <param name="skyboxUrl">Image url for skybox.</param>
         private void SetSkybox(string skyboxUrl)
         {
             this.skyboxUrl = skyboxUrl;
-            Interop.SceneView.SetSkybox(SwigCPtr, skyboxUrl);
+            Interop.SceneView.SetSkybox(SwigCPtr, skyboxUrl, (int)this.skyboxType);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Set the Skybox image type.
+        /// Skybox texture is asynchronously loaded. When loading is finished, ResourcesLoaded is emitted.
+        /// </summary>
+        /// <param name="skyboxType">Type url for skybox.</param>
+        private void SetSkyboxType(SkyboxType skyboxType)
+        {
+            this.skyboxType = skyboxType;
+            if(!string.IsNullOrEmpty(this.skyboxUrl))
+            {
+                Interop.SceneView.SetSkybox(SwigCPtr, this.skyboxUrl, (int)skyboxType);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Support to select the image type of skybox.
Default is cubemap image.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
