### PR TITLE
[NUI] make BaseHandle.Reset() not work

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseHandle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseHandle.cs
@@ -47,9 +47,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_GetBaseObject__SWIG_0")]
             public static extern global::System.IntPtr GetBaseObject(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_Reset")]
-            public static extern void Reset(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BaseHandle_EqualTo")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool EqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -432,10 +432,12 @@ namespace Tizen.NUI
         /// Resets the handle.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        /// <remark>
+        /// This will be deprecated, please use Dispose() instead.
+        /// </remark>
         public void Reset()
         {
-            Interop.BaseHandle.Reset(swigCPtrCopy);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            NUILog.Error("[ERROR] This(BaseHandle.Reset) will be deprecated, please use Dispose() instead!");
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
[NUI] make BaseHandle.Reset() not work

- this came from native dali and it is not appropriate for nui.
- it makes BaseHandle's reference count as 0, but this action could cause memory leak in nui side.
- in nui side, calling Dispose() explicitly or doing nothing to delegate disposing action to the DisposeQueue is recommended.

### API Changes ###
none