### PR TITLE
[NUI] Fix FlexLayout OnMeasure to calculate size correctly

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -773,8 +773,16 @@ namespace Tizen.NUI
 
             NUILog.Debug("FlexLayout OnMeasure width:" + flexLayoutWidth.AsRoundedValue() + " height:" + flexLayoutHeight.AsRoundedValue());
 
-            SetMeasuredDimensions(GetDefaultSize(flexLayoutWidth, widthMeasureSpec),
-                                   GetDefaultSize(flexLayoutHeight, heightMeasureSpec));
+            // If flexLayoutWidth or flexLayoutHeight is 0,
+            // then the measured width or height can be assigned with parent's width or height.
+            // e.g. Let flexLayoutHeight be 0.
+            //      Let heightMeasureSpec.Mode be AtMost.
+            //      Then GetDefaultSize(flexLayoutHeight, heightMeasureSpec) returns the parent's height.
+            // Not to break backward compatibility of GetDefaultSize(), ResolveSizeAndState() is used instead.
+            Tizen.NUI.MeasuredSize widthMeasuredSize = ResolveSizeAndState(flexLayoutWidth, widthMeasureSpec, Tizen.NUI.MeasuredSize.StateType.MeasuredSizeOK);
+            Tizen.NUI.MeasuredSize heightMeasuredSize = ResolveSizeAndState(flexLayoutHeight, heightMeasureSpec, Tizen.NUI.MeasuredSize.StateType.MeasuredSizeOK);
+
+            SetMeasuredDimensions(widthMeasuredSize, heightMeasuredSize);
         }
 
         /// <summary>

--- a/test/Tizen.NUI.StyleGuide/Examples/DialogAndAlertDialogExample.cs
+++ b/test/Tizen.NUI.StyleGuide/Examples/DialogAndAlertDialogExample.cs
@@ -26,7 +26,7 @@ namespace Tizen.NUI.StyleGuide
     internal class DialogAndAlertDialogExample : ContentPage, IExample
     {
         private View rootContent;
-        private Button buttonOneAction, buttonTwoAction, buttonNoTitle, buttonNoMessage;
+        private Button buttonNoAction, buttonOneAction, buttonTwoAction, buttonNoTitle, buttonNoMessage;
 
         public void Activate()
         {
@@ -61,6 +61,19 @@ namespace Tizen.NUI.StyleGuide
                     VerticalAlignment = VerticalAlignment.Center,
                     CellPadding = new Size2D(10, 20),
                 },
+            };
+
+            buttonNoAction = new Button
+            {
+                Name = "buttonNoAction",
+                Text = "Show AlertDialog without button",
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+            };
+            rootContent.Add(buttonNoAction);
+
+            buttonNoAction.Clicked += (s, e) =>
+            {
+                DialogPage.ShowAlertDialog("Title", "Message", null);
             };
 
             buttonOneAction = new Button


### PR DESCRIPTION
Previously, the measured size of FlexLayout with WrapContent could be calculated like MatchParent.
The above issue happened in the following case.
Tizen.NUI.Components.DialogPage.ShowAlertDialog("Title", "Message", null);

To resolve the above issue without breaking backward compatibility, FlexLayout OnMeasure has been fixed to use ResolveSizeAndState() instead of GetDefaultSize() when calculating the measured size.

To test the issue, showing a dialog without action button case has been added to Tizen.NUI.StyleGuide.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
