### PR TITLE
[NUI] Add ActionsProperty to AlertDialog to support xaml

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -346,6 +346,19 @@ namespace Tizen.NUI.Components
         {
             get
             {
+                return GetValue(ActionsProperty) as IEnumerable<View>;
+            }
+            set
+            {
+                SetValue(ActionsProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        private IEnumerable<View> InternalActions
+        {
+            get
+            {
                 return actionContentViews;
             }
             set

--- a/src/Tizen.NUI.Components/Controls/AlertDialogBindableProperty.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialogBindableProperty.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Collections.Generic;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
 
@@ -76,6 +77,24 @@ namespace Tizen.NUI.Components
         {
             var instance = (AlertDialog)bindable;
             return instance.InternalContent;
+        });
+
+        /// <summary>
+        /// ActionsProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty ActionsProperty = BindableProperty.Create(nameof(Actions), typeof(IEnumerable<View>), typeof(AlertDialog), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (AlertDialog)bindable;
+            if (newValue != null)
+            {
+                instance.InternalActions = newValue as IEnumerable<View>;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (AlertDialog)bindable;
+            return instance.InternalActions;
         });
 
         /// <summary>

--- a/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestDialogPage.xaml
+++ b/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestDialogPage.xaml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<DialogPage x:Class="NUITizenGallery.AlertDialogTestDialogPage"
+  xmlns="http://tizen.org/Tizen.NUI/2018/XAML"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  xmlns:sys="clr-namespace:System.Collections.Generic;assembly=netstandard">
+
+    <!-- Content is main placeholder of DialogPage. Add your dialog into this view. -->
+    <DialogPage.Content>
+        <AlertDialog x:Name="alertDialog" Title="Title" Message="Message">
+            <AlertDialog.Actions>
+                <sys:List x:TypeArguments="View">
+                    <Button x:Name="cancelButton" Text="Cancel"/>
+                    <Button x:Name="okButton" Text="OK"/>
+                </sys:List>
+            </AlertDialog.Actions>
+        </AlertDialog>
+    </DialogPage.Content>
+
+</DialogPage>

--- a/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestDialogPage.xaml.cs
+++ b/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestDialogPage.xaml.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+//using Tizen.NUI;
+//using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUITizenGallery
+{
+    public partial class AlertDialogTestDialogPage : DialogPage
+    {
+        public AlertDialogTestDialogPage()
+        {
+            InitializeComponent();
+
+            cancelButton.Clicked += CancelButtonClicked;
+            okButton.Clicked += OkButtonClicked;
+        }
+
+        private void CancelButtonClicked(object sender, ClickedEventArgs args)
+        {
+            Navigator?.Pop();
+        }
+
+        private void OkButtonClicked(object sender, ClickedEventArgs args)
+        {
+            Navigator?.Pop();
+        }
+    }
+}

--- a/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestPage.xaml
+++ b/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestPage.xaml
@@ -19,6 +19,10 @@
                 <LinearLayout LinearOrientation="Vertical" CellPadding="0,20"/>
             </View.Layout>
 
+            <Button x:Name="buttonWithXaml"
+                        Text="Show AlertDialog with xaml"
+                        WidthSpecification="{Static LayoutParamPolicies.MatchParent}" />
+
             <Button x:Name="buttonOneAction"
                         Text="Show AlertDialog with one button"
                         WidthSpecification="{Static LayoutParamPolicies.MatchParent}" />

--- a/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestPage.xaml.cs
+++ b/test/NUITizenGallery/Examples/AlertDialogTest/AlertDialogTestPage.xaml.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2022 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ namespace NUITizenGallery
         {
             InitializeComponent();
 
+            buttonWithXaml.Clicked += ButtonWithXamlClicked;
             buttonOneAction.Clicked += ButtonOneActionClicked;
             buttonTwoActions.Clicked += ButtonTwoActionsClicked;
             buttonNoTitle.Clicked += ButtonNoTitleClicked;
@@ -36,6 +37,11 @@ namespace NUITizenGallery
         }
 
         private int count;
+
+        private void ButtonWithXamlClicked(object sender, ClickedEventArgs args)
+        {
+            NUIApplication.GetDefaultWindow().GetDefaultNavigator().Push(new AlertDialogTestDialogPage());
+        }
 
         private void ButtonOneActionClicked(object sender, ClickedEventArgs args)
         {


### PR DESCRIPTION
To support Actions property of AlertDialog in xaml, the bindable property ActionsProperty has been added to AlertDialog.

The AlertDialog example with xaml has been added to NUITizenGallery.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
