### PR TITLE
[NUI] Pass SelectionChangedEventArgs by default as SelectionChangedCommandParameter.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/CollectionView.cs
@@ -47,8 +47,8 @@ namespace Tizen.NUI.Components
 
                     oldValue = colView.selectedItem;
                     colView.selectedItem = newValue;
-                    var args = new SelectionChangedEventArgs(oldValue, newValue);
 
+                    var args = new SelectionChangedEventArgs(oldValue, newValue);
                     foreach (RecyclerViewItem item in colView.ContentContainer.Children.Where((item) => item is RecyclerViewItem))
                     {
                         if (item.BindingContext == null)
@@ -1234,6 +1234,10 @@ namespace Tizen.NUI.Components
             if (command != null)
             {
                 var commandParameter = colView.SelectionChangedCommandParameter;
+                if (commandParameter == null)
+                {
+                    commandParameter = args;
+                }
 
                 if (command.CanExecute(commandParameter))
                 {

--- a/test/NUITizenGallery/Examples/CollectionViewTest/AnimalGridPage.xaml
+++ b/test/NUITizenGallery/Examples/CollectionViewTest/AnimalGridPage.xaml
@@ -26,7 +26,8 @@
               ScrollingDirection="Vertical"
               ItemsSource="{Binding Source}"
               HideScrollbar="true"
-              SelectionMode="None">
+              SelectionMode="SingleAlways"
+              SelectionChangedCommand="{Binding SelectedAnimalChangedCommand}">
 
                 <CollectionView.ItemsLayouter>
                       <GridLayouter />

--- a/test/NUITizenGallery/Examples/CollectionViewTest/AnimalListPage.xaml
+++ b/test/NUITizenGallery/Examples/CollectionViewTest/AnimalListPage.xaml
@@ -26,7 +26,8 @@
               ScrollingDirection="Vertical"
               ItemsSource="{Binding Source}"
               HideScrollbar="true"
-              SelectionMode="None">
+              SelectionMode="Single"
+              SelectionChangedCommand="{Binding SelectedAnimalChangedCommand}">
 
                 <CollectionView.ItemsLayouter>
                       <LinearLayouter />

--- a/test/NUITizenGallery/Examples/CollectionViewTest/Animals.cs
+++ b/test/NUITizenGallery/Examples/CollectionViewTest/Animals.cs
@@ -19,7 +19,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using Tizen.NUI;
+using Tizen.NUI.Components;
 using Tizen.NUI.Binding;
 
 public class Animal : INotifyPropertyChanged
@@ -29,7 +31,7 @@ public class Animal : INotifyPropertyChanged
     private string _imageUrl = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "/images/animals/";
 
     public event PropertyChangedEventHandler PropertyChanged;
-    private void OnPropertyChanged(string propertyName) { PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName)); }
+    private void OnPropertyChanged([CallerMemberName] string propertyName="") { PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName)); }
 
 
     public Animal(string name, string scientificName)
@@ -44,7 +46,7 @@ public class Animal : INotifyPropertyChanged
         set
         {
             _name = value;
-            OnPropertyChanged("Name");
+            OnPropertyChanged();
         }
     }
 
@@ -54,7 +56,7 @@ public class Animal : INotifyPropertyChanged
         set
         {
             _scientificName = value;
-            OnPropertyChanged("ScientificName");
+            OnPropertyChanged();
         }
     }
 
@@ -70,7 +72,7 @@ public class Animal : INotifyPropertyChanged
 }
 
 
-public class Animals
+public class Animals : INotifyPropertyChanged
 {
     (string Name,string ScientificName)[] namePool = {
     ("Bald Eagle", "Haliaeetus leucocephalus"),
@@ -97,12 +99,39 @@ public class Animals
     ("Tiger", "Panthera tigris"),
     ("Wolf", "Canis lupus"),
     ("Zebra", "Hippotigris"),
-};
+    };
+
+    public event PropertyChangedEventHandler PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string propertyName="") { PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName)); }
+
     public ObservableCollection<Animal> Source {get; private set; } = new ObservableCollection<Animal>();
 
     public Animals()
     {
         for (int i = 0; i < namePool.Length; i++)
             Source.Add(new Animal(namePool[i].Name, namePool[i].ScientificName));
+
+        SelectedAnimalChangedCommand = new Command<SelectionChangedEventArgs>((param) =>
+        {
+            if (param == null) return;
+
+            Animal animal = null;
+            // Single Selection Only have 1 or nil object in the list.
+            foreach (object item in param.PreviousSelection)
+            {
+                animal = item as Animal;
+                if (animal == null) break;
+
+                Console.WriteLine($"Previous selected item {animal.Name}");
+            }
+            foreach (object item in param.CurrentSelection)
+            {
+                animal = item as Animal;
+                if (animal == null) break;
+
+                Console.WriteLine($"Current selected item {animal.Name}");
+        }       });
     }
+
+    public Command<SelectionChangedEventArgs> SelectedAnimalChangedCommand { get; }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

In SelectionChangedCommand,
SelectionChangedCommandParamater is the only accessible value for changing selection.
if user sets SelectionChangedCommandParamater to SelectedItem of CollectionView,
Parameter will be updated after SelectedItemProperty is updated,
So SelectionChangedCommand which calls in the SelectedItemProperty,
cannot get updated SelectedItem value.

Here is a simple solution for that.
If nothing exist in SelectionChangedCommandParameter,
CollectionView will pass SelectionChangedEventArgs by default.
So user can get PreviousSelection and CurrentSelection in the model.

This change makes the model dependent on SelectionChangedEventArgs,
which I wish to avoid but we don't have a proper solution for now.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
