### PR TITLE
[NUI] Add EmitScrollStartedEvent and EmitScrollFinishedEvent

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1158,6 +1158,7 @@ namespace Tizen.NUI.Components
         {
             ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollDragStarted?.Invoke(this, eventArgs);
+            EmitScrollStartedEvent();
 
             if (!hideScrollbar && fadeScrollbar)
             {
@@ -1169,6 +1170,7 @@ namespace Tizen.NUI.Components
         {
             ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollDragEnded?.Invoke(this, eventArgs);
+            EmitScrollFinishedEvent();
 
             if (!hideScrollbar && fadeScrollbar)
             {
@@ -1180,6 +1182,7 @@ namespace Tizen.NUI.Components
         {
             ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollAnimationStarted?.Invoke(this, eventArgs);
+            EmitScrollStartedEvent();
 
             if (!hideScrollbar && fadeScrollbar)
             {
@@ -1194,6 +1197,7 @@ namespace Tizen.NUI.Components
 
             ScrollEventArgs eventArgs = new ScrollEventArgs(ContentContainer.CurrentPosition);
             ScrollAnimationEnded?.Invoke(this, eventArgs);
+            EmitScrollFinishedEvent();
 
             if (!hideScrollbar && fadeScrollbar)
             {

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -130,6 +130,14 @@ namespace Tizen.NUI
             public static extern IntPtr DaliAccessibilityEmitTextCursorMovedEvent(HandleRef arg1, int arg2_pos);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitScrollStartedEvent")]
+            public static extern IntPtr DaliAccessibilityEmitScrollStartedEvent(HandleRef arg1_actor);
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_EmitScrollFinishedEvent")]
+            public static extern IntPtr DaliAccessibilityEmitScrollFinishedEvent(HandleRef arg1_actor);
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_IsSuppressedEvent")]
             public static extern bool DaliAccessibilityIsSuppressedEvent(HandleRef arg1, int accessibilityEvent);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -320,6 +320,26 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Emits accessibility scroll started event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void EmitScrollStartedEvent()
+        {
+            Interop.ControlDevel.DaliAccessibilityEmitScrollStartedEvent(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Emits accessibility scroll finished event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void EmitScrollFinishedEvent()
+        {
+            Interop.ControlDevel.DaliAccessibilityEmitScrollFinishedEvent(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Modifiable collection of suppressed AT-SPI events (D-Bus signals).
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
This allows the user to know scrollable object scroll is started or finished.

Requires:
https://review.tizen.org/gerrit/284124/
https://review.tizen.org/gerrit/284126/
