### PR TITLE
[NUI] Reorder DeleteBaseHandle and SwigCPtrCopy = null;

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.BaseHandle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BaseHandle.cs
@@ -27,6 +27,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle")]
             public static extern void DeleteBaseHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_BaseHandle")]
+            public static extern void DeleteBaseHandle(global::System.IntPtr jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_BaseHandle__SWIG_2")]
             public static extern global::System.IntPtr NewBaseHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -568,8 +568,11 @@ namespace Tizen.NUI
             if (swigCPtrCopy.Handle != global::System.IntPtr.Zero)
             {
                 swigCMemOwn = false;
-                Interop.BaseHandle.DeleteBaseHandle(swigCPtrCopy);
+                var nativeSwigCPtr = swigCPtrCopy.Handle;
+
+                // Remove swigCPtrCopy first. Now HasBody() return false.
                 swigCPtrCopy = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+                Interop.BaseHandle.DeleteBaseHandle(nativeSwigCPtr);
             }
             else
             {


### PR DESCRIPTION
Now HasBody() become false during DeleteBaseHandle() emitted signals

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
