### PR TITLE
[Applications.AppControl] Add new internal APIs

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
@@ -154,5 +154,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_auto_restart")]
         internal static extern ErrorCode SetAutoRestart(SafeAppControlHandle handle);
+
+        [DllImport(Libraries.AppControl, EntryPoint = "app_control_send_launch_request_with_timeout")]
+        internal static extern ErrorCode SendLaunchRequestWithTimeout(SafeAppControlHandle handle, uint timeout, ReplyCallback callback, IntPtr userData);
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -669,6 +669,89 @@ namespace Tizen.Applications
         }
 
         /// <summary>
+        /// Sends the launch request with setting timeout
+        /// </summary>
+        /// <remarks>
+        /// This is the extension of AppControl.SendLaunchRequest() API.<br/>
+        /// The operation is mandatory information for the launch request.
+        /// If the operation is not specified, AppControlOperations.Default is used by default.
+        /// If the operation is AppControlOperations.Default, the application ID is mandatory to explicitly launch the application.<br/>
+        /// To launch a service application, an explicit launch request with the application ID given by property ApplicationId MUST be sent.<br/>
+        /// It can set receiving timeout interval using timeout parameter.
+        /// If there is an error that is not related to timeout, the error is returned immediately regardless of the timeout value.
+        /// </remarks>
+        /// <param name="launchRequest">The AppControl.</param>
+        /// <param name="timeout">The timeout in milliseconds, the timeout range is 5000 to 30000.</param>
+        /// <param name="replyAfterLaunching">The callback function to be called when the reply is delivered.</param>
+        /// <exception cref="ArgumentException">Thrown when failed because of the argument is invalid.</exception>
+        /// <exception cref="Exceptions.AppNotFoundException">Thrown when the application to run is not found.</exception>
+        /// <exception cref="Exceptions.LaunchFailedException">Thrown when the request failed to launch the application.</exception>
+        /// <exception cref="Exceptions.LaunchRejectedException">Thrown when the launch request is rejected.</exception>
+        /// <exception cref="Exceptions.OutOfMemoryException">Thrown when the memory is insufficient.</exception>
+        /// <exception cref="Exceptions.PermissionDeniedException">Thrown when the permission is denied.</exception>
+        /// <exception cref="TimeoutException">Thrown when failed because of timeout. The timeout interval is set by timeout parameter.</exception>
+        /// <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
+        /// <example>
+        /// <code>
+        /// AppControl appControl = new AppControl();
+        /// appControl.ApplicationId = "org.tizen.calculator";
+        /// AppControl.SendLaunchRequestWithTimeout(appControl, 10000, (launchRequest, replyRequest, result) => {
+        ///     // ...
+        /// });
+        /// </code>
+        /// </example>
+        /// <since_tizen> 7.5 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SendLaunchRequestWithTimeout(AppControl launchRequest, uint timeout, AppControlReplyCallback replyAfterLaunching)
+        {
+            if (launchRequest == null)
+            {
+                throw new ArgumentNullException("launchRequest");
+            }
+
+            Interop.AppControl.ErrorCode err;
+
+            if (replyAfterLaunching != null)
+            {
+                int id = 0;
+                lock (s_replyCallbackMaps)
+                {
+                    id = s_reaustId++;
+                    s_replyCallbackMaps[id] = replyAfterLaunching;
+                }
+                err = Interop.AppControl.SendLaunchRequestWithTimeout(launchRequest._handle, timeout, s_replyNativeCallback, (IntPtr)id);
+            }
+            else
+            {
+                err = Interop.AppControl.SendLaunchRequestWithTimeout(launchRequest._handle, timeout, null, IntPtr.Zero);
+            }
+
+            if (err != Interop.AppControl.ErrorCode.None)
+            {
+                switch (err)
+                {
+                    case Interop.AppControl.ErrorCode.InvalidParameter:
+                        throw new ArgumentException("Invalid Arguments");
+                    case Interop.AppControl.ErrorCode.TimedOut:
+                        throw new TimeoutException("Timed out");
+                    case Interop.AppControl.ErrorCode.OutOfMemory:
+                        throw new Exceptions.OutOfMemoryException("Out-of-memory");
+                    case Interop.AppControl.ErrorCode.AppNotFound:
+                        throw new Exceptions.AppNotFoundException("App(" + launchRequest.ApplicationId + ") not found. Operation(" + launchRequest.Operation + ")");
+                    case Interop.AppControl.ErrorCode.LaunchRejected:
+                        throw new Exceptions.LaunchRejectedException("Launch rejected");
+                    case Interop.AppControl.ErrorCode.LaunchFailed:
+                        throw new Exceptions.LaunchFailedException("Launch failed");
+                    case Interop.AppControl.ErrorCode.PermissionDenied:
+                        throw new Exceptions.PermissionDeniedException("Permission denied");
+
+                    default:
+                        throw new Exceptions.LaunchRejectedException("Launch rejected");
+                }
+            }
+        }
+
+        /// <summary>
         /// Sends the terminate request to the application that is launched by AppControl.
         /// </summary>
         /// <remarks>

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -672,7 +672,6 @@ namespace Tizen.Applications
         /// Sends the launch request with setting timeout
         /// </summary>
         /// <remarks>
-        /// This is the extension of AppControl.SendLaunchRequest() API.<br/>
         /// The operation is mandatory information for the launch request.
         /// If the operation is not specified, AppControlOperations.Default is used by default.
         /// If the operation is AppControlOperations.Default, the application ID is mandatory to explicitly launch the application.<br/>
@@ -695,7 +694,7 @@ namespace Tizen.Applications
         /// <code>
         /// AppControl appControl = new AppControl();
         /// appControl.ApplicationId = "org.tizen.calculator";
-        /// AppControl.SendLaunchRequestWithTimeout(appControl, 10000, (launchRequest, replyRequest, result) => {
+        /// AppControl.SendLaunchRequest(appControl, 10000, (launchRequest, replyRequest, result) => {
         ///     // ...
         /// });
         /// </code>

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -702,7 +702,7 @@ namespace Tizen.Applications
         /// </example>
         /// <since_tizen> 7.5 </since_tizen>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void SendLaunchRequestWithTimeout(AppControl launchRequest, uint timeout, AppControlReplyCallback replyAfterLaunching)
+        public static void SendLaunchRequest(AppControl launchRequest, uint timeout, AppControlReplyCallback replyAfterLaunching)
         {
             if (launchRequest == null)
             {

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -589,6 +589,37 @@ namespace Tizen.Applications
         }
 
         /// <summary>
+        /// Sends the launch request with setting timeout.
+        /// </summary>
+        /// <remarks>
+        /// The operation is mandatory information for the launch request.
+        /// If the operation is not specified, AppControlOperations.Default is used by default.
+        /// If the operation is AppControlOperations.Default, the application ID is mandatory to explicitly launch the application.<br/>
+        /// To launch a service application, an explicit launch request with the application ID given by property ApplicationId MUST be sent.<br/>
+        /// It can set receiving timeout interval using timeout parameter.
+        /// If there is an error that is not related to timeout, the error is returned immediately regardless of the timeout value.
+        /// </remarks>
+        /// <param name="launchRequest">The AppControl.</param>
+        /// <param name="timeout">The timeout in milliseconds, the timeout range is 5000 to 30000.</param>
+        /// <exception cref="ArgumentNullException">Thrown when failed because of a null argument.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
+        /// <exception cref="TimeoutException">Thrown when failed because of timeout.</exception>
+        /// <privilege>http://tizen.org/privilege/appmanager.launch</privilege>
+        /// <example>
+        /// <code>
+        /// AppControl appControl = new AppControl();
+        /// appControl.ApplicationId = "org.tizen.calculator";
+        /// AppControl.SendLaunchRequest(appControl, 10000);
+        /// </code>
+        /// </example>
+        /// <since_tizen> 7.5 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SendLaunchRequest(AppControl launchRequest, uint timeout)
+        {
+            SendLaunchRequest(launchRequest, timeout, null);
+        }
+
+        /// <summary>
         /// Sends the launch request.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This patch adds the API below to set the timeout interval when sending an app launch request.

Adds:
 - `AppControl.SendLaunchRequest(appControl, timeout)`
 - `AppControl.SendLaunchRequest(appControl, timeout, replyAfterLaunching)`

Signed-off-by: ChangGyu Choi <uppletaste@gmail.com>


