### PR TITLE
[NUI] Add method to DisposeRecursively. + Fix DisposeTest demo works

### DIFF
--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -228,6 +228,34 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Dispose itself and all children recursively.
+        /// We can call this even itself is disposed.
+        /// </summary>
+        /// <remarks>
+        /// Note that Container.DisposeIncludeChildren() disposed only if it created by xaml.
+        /// </remarks>
+        /// <remarks>
+        /// This is a hidden API(inhouse API) only for internal purpose.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void DisposeRecursively()
+        {
+            // To avoid useless "OnChildRemoved" callback invoke, Dispose itself before children.
+            if(!Disposed && !IsDisposeQueued)
+            {
+                Dispose();
+            }
+
+            foreach (View child in Children)
+            {
+                child.DisposeRecursively();
+            }
+
+            // Make sure that itself don't have children anymore.
+            childViews?.Clear();
+        }
+
+        /// <summary>
         /// Adds a child view to this Container.
         /// </summary>
         /// <pre>This Container (the parent) has been initialized. The child view has been initialized. The child view is not the same as the parent view.</pre>

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSImageView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSImageView.cs
@@ -411,5 +411,33 @@ namespace Tizen.NUI.Devel.Tests
                 Assert.AreEqual(false, resultBool, "...and That value must be equal what we added");
             }
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("internal API test in Ubuntu, Container.DisposeRecursively")]
+        [Property("SPEC", "Tizen.NUI.Common.Container.DisposeRecursively M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void DisposeRecursively_VALUE()
+        {
+            /* TEST CODE */
+            View testParent = new View();
+            View testChildL0 = new View();
+            View testChildL1 = new View();
+
+            testParent.Add(testChildL0);
+            testChildL0.Add(testChildL1);
+
+            Assert.AreEqual(false, testParent.Disposed, "View should not disposed yet.");
+            Assert.AreEqual(false, testChildL0.Disposed, "View should not disposed yet.");
+            Assert.AreEqual(false, testChildL1.Disposed, "View should not disposed yet.");
+
+            testParent.DisposeRecursively();
+
+            Assert.AreEqual(true, testParent.Disposed, "View should be disposed now.");
+            Assert.AreEqual(true, testChildL0.Disposed, "View should be disposed now.");
+            Assert.AreEqual(true, testChildL1.Disposed, "View should be disposed now.");
+        }
     }
 }


### PR DESCRIPTION
Previous Container.cs can dispose recursively only if it is created by xaml. (DisposeIncludeChildren)
And also, that API only for internal.

Now we add some useful API that user can dispose all connected children recursively by one button.

```
View a = new View();
View b = new View();

a.Add(b);
a.DisposeRecursively();

// Now both a and b are disposed.
```

Signed-off-by: Eunki Hong <h.pichulia@gmail.com>
