### PR TITLE
[NUI][XamlBuild] Fix namespace confused issue. 

### DIFF
--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NUIXamlCTask.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NUIXamlCTask.cs
@@ -419,7 +419,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             }
 
             CustomAttribute xamlFilePathAttr;
-            var xamlFilePath = typeDef.HasCustomAttributes && (xamlFilePathAttr = typeDef.CustomAttributes.FirstOrDefault(ca => ca.AttributeType.FullName == "Tizen.NUI.Xaml.XamlFilePathAttribute")) != null ?
+            var xamlFilePath = typeDef.HasCustomAttributes && (xamlFilePathAttr = typeDef.CustomAttributes.FirstOrDefault(ca => ca.AttributeType.FullName.Contains("Tizen.NUI.Xaml.XamlFilePathAttribute"))) != null ?
                                       (string)xamlFilePathAttr.ConstructorArguments[0].Value :
                                       resource.Name;
 
@@ -517,7 +517,7 @@ namespace Tizen.NUI.Xaml.Build.Tasks
             ModuleDefinition module = typeDef.Module;
 
             CustomAttribute xamlFilePathAttr;
-            var xamlFilePath = typeDef.HasCustomAttributes && (xamlFilePathAttr = typeDef.CustomAttributes.FirstOrDefault(ca => ca.AttributeType.FullName == "Tizen.NUI.Xaml.XamlFilePathAttribute")) != null ?
+            var xamlFilePath = typeDef.HasCustomAttributes && (xamlFilePathAttr = typeDef.CustomAttributes.FirstOrDefault(ca => ca.AttributeType.FullName.Contains("Tizen.NUI.Xaml.XamlFilePathAttribute"))) != null ?
                                       (string)xamlFilePathAttr.ConstructorArguments[0].Value :
                                       resource.Name;
 

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/XamlGenerator.cs
@@ -323,13 +323,13 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                 IsPartial = true,
                 TypeAttributes = GetTypeAttributes(classModifier),
                 CustomAttributes = {
-                    new CodeAttributeDeclaration(new CodeTypeReference(NUIXamlCTask.xamlNameSpace + ".XamlFilePathAttribute"),
+                    new CodeAttributeDeclaration(new CodeTypeReference($"global::{NUIXamlCTask.xamlNameSpace}.XamlFilePathAttribute"),
                          new CodeAttributeArgument(new CodePrimitiveExpression(XamlFile))),
                 }
             };
             if (AddXamlCompilationAttribute)
                 declType.CustomAttributes.Add(
-                    new CodeAttributeDeclaration(new CodeTypeReference(NUIXamlCTask.xamlNameSpace + ".XamlCompilationAttribute"),
+                    new CodeAttributeDeclaration(new CodeTypeReference($"global::{NUIXamlCTask.xamlNameSpace}.XamlCompilationAttribute"),
                                                  new CodeAttributeArgument(new CodeSnippetExpression($"global::{typeof(XamlCompilationOptions).FullName}.Compile"))));
             if (HideFromIntellisense)
                 declType.CustomAttributes.Add(


### PR DESCRIPTION
### Description of Change ###
Fix conflicts of PR:4825

==========

During the task of replace Xamarin.Forms with NUI.Xaml of Tizen-CSharp-Samples, The samples' namespace always contains "Tizen", and we would got the error : "NUI" could not be found in Tizen. The solution is, add global when constructing related parameters, such as ：
new CodeAttributeDeclaration(new CodeTypeReference($"global::{NUIXamlCTask.xamlNameSpace}.XamlFilePathAttribute"),


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
