### PR TITLE
[NUI] Make PixelBuffer & PixelData as Disposable

### DIFF
--- a/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
@@ -71,6 +71,9 @@ namespace Tizen.NUI
         /// Note : the url lifecycle is same as ImageUrl and it's internal usage.
         /// Store only ImageUrl.ToString() result and re-use that url is Undefined Behavior.
         /// </summary>
+        /// <remarks>
+        /// This API should not be called at worker thread.
+        /// </remarks>
         /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ImageUrl GenerateUrl()

--- a/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
@@ -100,6 +100,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Generate Url from native image queue.
         /// </summary>
+        /// <remarks>
+        /// This API should not be called at worker thread.
+        /// </remarks>
         /// <returns>The ImageUrl of NativeImageQueue.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ImageUrl GenerateUrl()

--- a/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
@@ -40,6 +40,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Generate Url from native image source.
         /// </summary>
+        /// <remarks>
+        /// This API should not be called at worker thread.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ImageUrl GenerateUrl()
         {

--- a/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI
     /// <since_tizen> 5 </since_tizen>
     /// This will be released at Tizen.NET API Level 5. Therefore, currently this would be used as an in-house API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class PixelBuffer : BaseHandle
+    public class PixelBuffer : Disposable
     {
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Images/PixelData.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelData.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI
     /// <since_tizen> 5 </since_tizen>
     /// This will be released at Tizen.NET API Level 5, so currently this would be used as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class PixelData : BaseHandle
+    public class PixelData : Disposable
     {
 
         /// <summary>
@@ -98,6 +98,9 @@ namespace Tizen.NUI
         /// <summary>
         /// Generate Url from pixel data.
         /// </summary>
+        /// <remarks>
+        /// This API should not be called at worker thread.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ImageUrl GenerateUrl()
         {


### PR DESCRIPTION
Since they were BaseHandle, there was some Fatal log printed when we try to use them at worker thread.

For example, PixelBuffer buffer = ImageLoader.LoadImageFromFile() was invalid.

This patch make them as Disposable.
So they will not be registed into Registry.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
