### PR TITLE
[NUI] Make ReleaseSwigCPtr didn't check HasBody()

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Uint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Common/Uint16Pair.cs
@@ -37,13 +37,6 @@ namespace Tizen.NUI
 
         protected override void ReleaseSwigCPtr(HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero)
-            {
-                //Log.Fatal("NUI", "Error! NUI.Uint16Pair's native DALi object is already disposed! OR the native DALi object handle of NUI.Uint16Pair's became null by unknown reason!");
-                //Log.Fatal("NUI", "Error! just return here! this can cause unknown error or crash in next step");
-                //return false;
-                throw new InvalidOperationException("Error! NUI.Uint16Pair's native DALi object is already disposed! OR the native DALi object handle of NUI.Uint16Pair's became null by unknown reason!");
-            }
             Interop.Uint16Pair.DeleteUint16Pair(swigCPtr);
         }
 

--- a/src/Tizen.NUI/src/internal/Transition/FadeTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/FadeTransitionItem.cs
@@ -70,9 +70,9 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero || this.HasBody() == false)
+            if (swigCPtr.Handle == IntPtr.Zero || Disposed)
             {
-                Tizen.Log.Fatal("NUI", $"[ERROR] FadeTransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} HasBody={this.HasBody()}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] FadeTransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} Disposed={Disposed}");
                 return;
             }
             Interop.FadeTransitionItem.Delete(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Transition/ScaleTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/ScaleTransitionItem.cs
@@ -81,9 +81,9 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero || this.HasBody() == false)
+            if (swigCPtr.Handle == IntPtr.Zero || Disposed)
             {
-                Tizen.Log.Fatal("NUI", $"[ERROR] ScaleTransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} HasBody={this.HasBody()}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] ScaleTransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} Disposed={Disposed}");
                 return;
             }
             Interop.ScaleTransitionItem.Delete(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Transition/SlideTransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/SlideTransitionItem.cs
@@ -70,9 +70,9 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero || this.HasBody() == false)
+            if (swigCPtr.Handle == IntPtr.Zero || Disposed)
             {
-                Tizen.Log.Fatal("NUI", $"[ERROR] SlideTransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} HasBody={this.HasBody()}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] SlideTransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} Disposed={Disposed}");
                 return;
             }
             Interop.SlideTransitionItem.Delete(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Transition/TransitionItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionItem.cs
@@ -69,9 +69,9 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero || this.HasBody() == false)
+            if (swigCPtr.Handle == IntPtr.Zero || Disposed)
             {
-                Tizen.Log.Fatal("NUI", $"[ERROR] TransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} HasBody={this.HasBody()}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] TransitionItem ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} Disposed={Disposed}");
                 return;
             }
             Interop.TransitionItem.Delete(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Transition/TransitionItemBase.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionItemBase.cs
@@ -153,9 +153,9 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero || this.HasBody() == false)
+            if (swigCPtr.Handle == IntPtr.Zero || Disposed)
             {
-                Tizen.Log.Fatal("NUI", $"[ERROR] TransitionItemBase ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} HasBody={this.HasBody()}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] TransitionItemBase ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} Disposed={Disposed}");
                 return;
             }
             Interop.TransitionItemBase.Delete(swigCPtr);

--- a/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
@@ -197,9 +197,9 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero || this.HasBody() == false)
+            if (swigCPtr.Handle == IntPtr.Zero || Disposed)
             {
-                Tizen.Log.Fatal("NUI", $"[ERROR] TransitionSet ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} HasBody={this.HasBody()}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] TransitionSet ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} Disposed={Disposed}");
                 return;
             }
             Interop.TransitionSet.Delete(swigCPtr);

--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -1744,9 +1744,9 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (swigCPtr.Handle == IntPtr.Zero || this.HasBody() == false)
+            if (swigCPtr.Handle == IntPtr.Zero || Disposed)
             {
-                Tizen.Log.Fatal("NUI", $"[ERROR] Animation ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} HasBody={this.HasBody()}");
+                Tizen.Log.Fatal("NUI", $"[ERROR] Animation ReleaseSwigCPtr()! IntPtr=0x{swigCPtr.Handle:X} Disposed={Disposed}");
                 return;
             }
             Interop.Animation.DeleteAnimation(swigCPtr);

--- a/src/Tizen.NUI/src/public/Utility/Capture.cs
+++ b/src/Tizen.NUI/src/public/Utility/Capture.cs
@@ -305,7 +305,7 @@ namespace Tizen.NUI
             {
                 if (finishedEventHandler == null && disposed == false)
                 {
-                    finishedSignal = new CaptureSignal(Interop.Capture.Get(SwigCPtr), false);
+                    finishedSignal = new CaptureSignal(Interop.Capture.Get(SwigCPtr));
                     finishedCallback = onFinished;
                     finishedSignal.Connect(finishedCallback);
                 }
@@ -363,16 +363,13 @@ namespace Tizen.NUI
 
     internal class CaptureSignal : Disposable
     {
-        internal CaptureSignal(IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal CaptureSignal(IntPtr cPtr) : base(cPtr, false)
         {
         }
 
         protected override void ReleaseSwigCPtr(HandleRef swigCPtr)
         {
-            if (SwigCMemOwn)
-            {
-                Interop.Capture.DeleteSignal(swigCPtr);
-            }
+            // Do nothing because native didn't create new signal handle.
         }
 
         public bool Empty()


### PR DESCRIPTION
After PR #4892 `HasBody()` can be false in `ReleaseSwigCPtr`. So, some class who check double-released might not release native memory. It might occure some leak.

This patch make them to check `Disposed` instead of `HasBody()`.

+

Clean up some codes of `ReleaseSwigCPtr`.

TODO : Also need to check `Disposable.Dispose` function

TODO : Need to check third-party library implementation who use their custom `ReleaseSwigCPtr`

Signed-off-by: Eunki Hong <eunkiki.hong@samsung.com>