### PR TITLE
[NUI] Fix Navigator & GridLayouter svace issues.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -155,13 +155,19 @@ namespace Tizen.NUI.Components
         private void OnAddedToWindow(object sender, EventArgs e)
         {
             parentWindow = Window.Get(this);
-            parentWindow.KeyEvent += OnWindowKeyEvent;
+            if (null != parentWindow)
+            {
+                parentWindow.KeyEvent += OnWindowKeyEvent;
+            }
         }
 
         private void OnRemovedFromWindow(object sender, EventArgs e)
         {
-            parentWindow.KeyEvent -= OnWindowKeyEvent;
-            parentWindow = null;
+            if (null != parentWindow)
+            {
+                parentWindow.KeyEvent -= OnWindowKeyEvent;
+                parentWindow = null;
+            }
         }
 
         private void Initialize()

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -1445,9 +1445,10 @@ namespace Tizen.NUI.Components
                         ScrollContentSize - Padding.Bottom - footerSize + footerMargin.Top;
                 return (xPos, yPos);
             }
-            if (isGrouped)
+
+            GroupInfo myGroup = GetGroupInfo(index);
+            if (isGrouped && null != myGroup)
             {
-                GroupInfo myGroup = GetGroupInfo(index);
                 if (colView.InternalItemSource.IsGroupHeader(index))
                 {
                     spaceStartX+= groupHeaderMargin.Start;


### PR DESCRIPTION
### Description of Change ###
**WID:52614003** [STATISTICAL] Value **_parentWindow_**, which is result of method invocation with possible null return value, is dereferenced in member access expression **_parentWindow.KeyEvent_**
                _parentWindow.KeyEvent += OnWindowKeyEvent;_
/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs **line158**


**WID:52613990** [STATISTICAL] Value **_myGroup_**, which is result of method invocation with possible null return value, is dereferenced in member access expression **_myGroup.GroupPosition_**
                                _myGroup.GroupPosition + groupHeaderMargin.Start:_
src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs **line 1456**




### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
