### PR TITLE
[NUI] Reorder Disposable's ReleaseSwigCPtr + Allow to dispose seperat…

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Disposable.cs
+++ b/src/Tizen.NUI/src/internal/Common/Disposable.cs
@@ -106,21 +106,6 @@ namespace Tizen.NUI
                 // TODO: dispose managed state (managed objects).
                 // Explicit call. user calls Dispose()
 
-                //Throw exception if Dispose() is called in separate thread.
-                if (!Window.IsInstalled())
-                {
-                    var process = global::System.Diagnostics.Process.GetCurrentProcess().Id;
-                    var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
-                    var me = this.GetType().FullName;
-
-                    Tizen.Log.Fatal("NUI", $"[NUI][Disposable]This API called from separate thread. This API must be called from MainThread. \n" +
-                        $" process:{process} thread:{thread}, disposing:{disposing}, isDisposed:{this.disposed}, isDisposeQueued:{this.isDisposeQueued}, me:{me}\n");
-
-                    //to fix ArtApp black screen issue. this will be enabled after talking with ArtApp team and fixing it.
-                    // throw new global::System.InvalidOperationException("[NUI][Disposable]This API called from separate thread. This API must be called from MainThread. \n" +
-                    //     $" process:{process} thread:{thread}, disposing:{disposing}, isDisposed:{this.disposed}, isDisposeQueued:{this.isDisposeQueued}, me:{me}\n");
-                }
-
                 if (isDisposeQueued)
                 {
                     Tizen.Log.Fatal("NUI", $"[Disposable]should not be here! (dead code) this will be removed!");
@@ -171,12 +156,13 @@ namespace Tizen.NUI
             //because the execution order of Finalizes is non-deterministic.
             if (swigCPtr.Handle != global::System.IntPtr.Zero)
             {
-                if (SwigCMemOwn)
+                var nativeSwigCPtr = swigCPtr.Handle;
+                swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+                if (swigCMemOwn)
                 {
                     swigCMemOwn = false;
-                    ReleaseSwigCPtr(swigCPtr);
+                    ReleaseSwigCPtr(new global::System.Runtime.InteropServices.HandleRef(this, nativeSwigCPtr));
                 }
-                swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
             }
 
             disposed = true;

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/etc/DisposeTest.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/etc/DisposeTest.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI.Devel.Tests
         private const string tag = "NUITEST";
         private const int testSize = 100;
         private const int testPosition = 100;
-        private const int RefCountWhenNew = 2;
+        private const int RefCountWhenNew = 1;
         private const int RefCountWhenAdd = 1;
         private const int RefCountWhenRemoveOrUnparent = -1;
         private const int RefCountWhenAddedInList = 0;


### PR DESCRIPTION
…e thread

Reorder the `ReleaseSwigCPtr` call time and `SwigCPtr` value setup. It will be matched as `BaseHandle.cs` doing now.

Plus

Make we don't print any fatal log when we try to dispose `Disposable` class. For example, `Vector2` or `Uint16Pair` don't need to be used only for main thread. Only some UI releative things has some dependency issue of Main / UI thread.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>
