### PR TITLE
[NUI] fix tct block issue in text field and editor

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -2544,6 +2544,8 @@ namespace Tizen.NUI.BaseComponents
             }
 
             TextChanged -= TextEditorTextChanged;
+            GetInputMethodContext()?.DestroyContext();
+
             base.Dispose(type);
         }
 
@@ -2551,8 +2553,6 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            // In order to speed up IME hide, temporarily add
-            GetInputMethodContext()?.DestroyContext();
             Interop.TextEditor.DeleteTextEditor(swigCPtr);
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -2550,6 +2550,7 @@ namespace Tizen.NUI.BaseComponents
             }
 
             TextChanged -= TextFieldTextChanged;
+            GetInputMethodContext()?.DestroyContext();
 
             base.Dispose(type);
         }
@@ -2558,8 +2559,6 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            // In order to speed up IME hide, temporarily add
-            GetInputMethodContext()?.DestroyContext();
             Interop.TextField.DeleteTextField(swigCPtr);
         }
 


### PR DESCRIPTION
GetInputMethodContext() in ReleaseSwigCPtr crashes due to current changes in BaseHandle.
Move DestroyContext() to Dispose to avoid this.

Signed-off-by: Bowon Ryu <bowon.ryu@samsung.com>
