### PR TITLE
[NUI] Make PixelBuffer & PixelData operator checked by BaseHandle

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Disposable.cs
+++ b/src/Tizen.NUI/src/internal/Common/Disposable.cs
@@ -61,6 +61,195 @@ namespace Tizen.NUI
         /// <since_tizen> 6 </since_tizen>
         ~Disposable() => Dispose(false);
 
+
+        /// <summary>
+        /// Returns the bool value true to indicate that an operand is true and returns false otherwise.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator true(Disposable disposable)
+        {
+            // if the C# object is null, return false
+            if (Disposable.ReferenceEquals(disposable, null))
+            {
+                return false;
+            }
+            // returns true if the handle has a body, false otherwise
+            return disposable.HasBody();
+        }
+
+        /// <summary>
+        /// Returns the bool false  to indicate that an operand is false and returns true otherwise.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator false(Disposable disposable)
+        {
+            // if the C# object is null, return true
+            if (Disposable.ReferenceEquals(disposable, null))
+            {
+                return true;
+            }
+            return !disposable.HasBody();
+        }
+
+        /// <summary>
+        /// Explicit conversion from Disposable to bool.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static explicit operator bool(Disposable disposable)
+        {
+            // if the C# object is null, return false
+            if (Disposable.ReferenceEquals(disposable, null))
+            {
+                return false;
+            }
+            // returns true if the handle has a body, false otherwise
+            return disposable.HasBody();
+        }
+
+        /// <summary>
+        /// Equality operator
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator ==(Disposable x, Disposable y)
+        {
+            // if the C# objects are the same return true
+            if (Disposable.ReferenceEquals(x, y))
+            {
+                return true;
+            }
+            if (!Disposable.ReferenceEquals(x, null) && !Disposable.ReferenceEquals(y, null))
+            {
+                // drop into native code to see if both Disposable point to the same body
+                return x.IsEqual(y);
+            }
+
+            if (Disposable.ReferenceEquals(x, null) && !Disposable.ReferenceEquals(y, null))
+            {
+                if (y.HasBody()) return false;
+                else return true;
+            }
+            if (!Disposable.ReferenceEquals(x, null) && Disposable.ReferenceEquals(y, null))
+            {
+                if (x.HasBody()) return false;
+                else return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Inequality operator. Returns Null if either operand is Null
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !=(Disposable x, Disposable y)
+        {
+            return !(x == y);
+        }
+
+        /// <summary>
+        /// Logical AND operator.<br />
+        /// It's possible when doing a  operator this function (opBitwiseAnd) is never called due to short circuiting.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Disposable operator &(Disposable x, Disposable y)
+        {
+            if (x == y)
+            {
+                return x;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Logical OR operator for ||.<br />
+        /// It's possible when doing a || this function (opBitwiseOr) is never called due to short circuiting.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Disposable operator |(Disposable x, Disposable y)
+        {
+            if (!Disposable.ReferenceEquals(x, null) || !Disposable.ReferenceEquals(y, null))
+            {
+                if (x != null && x.HasBody())
+                {
+                    return x;
+                }
+                if (y != null && y.HasBody())
+                {
+                    return y;
+                }
+                return null;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Logical ! operator
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !(Disposable x)
+        {
+            // if the C# object is null, return true
+            if (Disposable.ReferenceEquals(x, null))
+            {
+                return true;
+            }
+            if (x.HasBody())
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Equals
+        /// </summary>
+        /// <param name="o">The object should be compared.</param>
+        /// <returns>True if equal.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object o)
+        {
+            return base.Equals(o);
+        }
+
+        /// <summary>
+        /// Gets the hash code of this Disposable.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+
+        /// <summary>
+        /// To check the Disposable instance has body or not.
+        /// </summary>
+        /// <remark>
+        /// Since Disposable it self done't have data ownership, just return true.
+        /// If some detail operation required, override it.
+        /// </remark>
+        /// <returns>True If the Disposable instance has body.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual bool HasBody()
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// To check the Disposable instance is equal or not.
+        /// </summary>
+        /// <param name="rhs">The Disposable instance.</param>
+        /// <remark>
+        /// Since Disposable it self done't have data ownership, just return false.
+        /// If some detail operation required, override it.
+        /// </remark>
+        /// <returns>True If equal.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual bool IsEqual(Disposable rhs)
+        {
+            return false;
+        }
+
         /// <summary>
         /// Dispose.
         /// </summary>
@@ -185,6 +374,11 @@ namespace Tizen.NUI
             {
                 swigCPtr = value;
             }
+        }
+
+        internal bool IsNativeHandleInvalid()
+        {
+            return swigCPtr.Handle == IntPtr.Zero;
         }
 
         internal bool SwigCMemOwn => swigCMemOwn;

--- a/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
@@ -61,6 +61,43 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Since this class is BaseHandle internally, return BaseHandle.HasBody
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool HasBody()
+        {
+            if (IsNativeHandleInvalid())
+            {
+                return false;
+            }
+
+            if (Disposed)
+            {
+                return false;
+            }
+            bool ret = Interop.BaseHandle.HasBody(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Since this class is BaseHandle internally, return BaseHandle.IsEqual
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool IsEqual(Disposable _rhs)
+        {
+            PixelBuffer rhs = _rhs as PixelBuffer;
+            if (Disposed == true || rhs == null || !rhs.HasBody())
+            {
+                return false;
+            }
+
+            bool ret = Interop.BaseHandle.IsEqual(SwigCPtr, PixelBuffer.getCPtr(rhs));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
         /// Convert to a pixel data and release the object of the pixelBuffer.
         /// This handle is left empty.
         /// Any other handles that keep a reference to this object

--- a/src/Tizen.NUI/src/public/Images/PixelData.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelData.cs
@@ -77,6 +77,43 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Since this class is BaseHandle internally, return BaseHandle.HasBody
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool HasBody()
+        {
+            if (IsNativeHandleInvalid())
+            {
+                return false;
+            }
+
+            if (Disposed)
+            {
+                return false;
+            }
+            bool ret = Interop.BaseHandle.HasBody(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Since this class is BaseHandle internally, return BaseHandle.IsEqual
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool IsEqual(Disposable _rhs)
+        {
+            PixelData rhs = _rhs as PixelData;
+            if (Disposed == true || rhs == null || !rhs.HasBody())
+            {
+                return false;
+            }
+
+            bool ret = Interop.BaseHandle.IsEqual(SwigCPtr, PixelData.getCPtr(rhs));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
         /// Enumeration for function to release the pixel buffer.
         /// </summary>
         /// <since_tizen> 5 </since_tizen>

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Images/TSImageLoader.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/Images/TSImageLoader.cs
@@ -1,0 +1,98 @@
+﻿using global::System;
+using NUnit.Framework;
+using NUnit.Framework.TUnit;
+using Tizen.NUI;
+
+namespace Tizen.NUI.Devel.Tests
+{
+    using tlog = Tizen.Log;
+
+    [TestFixture]
+    [Description("public/Images/ImageLoader")]
+    public class ImageLoaderTest
+    {
+        private const string tag = "NUITEST";
+        private string image_path = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "Image.png";
+
+        [SetUp]
+        public void Init()
+        {
+            tlog.Info(tag, "Init() is called!");
+        }
+
+        [TearDown]
+        public void Destroy()
+        {
+            tlog.Info(tag, "Destroy() is called!");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ImageLoader LoadImageFromFile.")]
+        [Property("SPEC", "Tizen.NUI.ImageLoader.LoadImageFromFile M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ImageLoaderLoadImageFromFile()
+        {
+            tlog.Debug(tag, $"ImageLoaderLoadImageFromFile START");
+
+            {
+                var testingTarget = ImageLoader.LoadImageFromFile(image_path);
+                Assert.IsNotNull(testingTarget, "Can't create success object PixelBuffer.");
+                Assert.IsInstanceOf<PixelBuffer>(testingTarget, "Should return PixelBuffer instance.");
+
+                Assert.AreEqual(false, PixelBuffer.ReferenceEquals(testingTarget, null), "Valid image's load result should not be null!");
+                Assert.AreEqual(false, testingTarget == null, "Valid image's load result compare with null should be false!");
+                Assert.AreEqual(true, (bool)testingTarget, "Valid image's load result bool operator should be true!");
+                Assert.AreEqual(false, !testingTarget, "Valid image's load result not operator should be false!");
+
+                testingTarget.Dispose();
+            }
+
+            {
+                var testingTarget = ImageLoader.LoadImageFromFile("invalid.jpg");
+                Assert.AreEqual(false, PixelBuffer.ReferenceEquals(testingTarget, null), "Invalid image's load result should not be null!");
+                Assert.AreEqual(true, testingTarget == null, "Invalid image's load result compare with null should be true!");
+                Assert.AreEqual(false, (bool)testingTarget, "Invalid image's load result bool operator should be false!");
+                Assert.AreEqual(true, !testingTarget, "Invalid image's load result not operator should be true!");
+
+                testingTarget.Dispose();
+            }
+            tlog.Debug(tag, $"ImageLoaderLoadImageFromFile END (OK)");
+        }
+
+        [Test]
+        [Category("P1")]
+        [Description("ImageLoader LoadImageFromFile. With Size.")]
+        [Property("SPEC", "Tizen.NUI.ImageLoader.LoadImageFromFile M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        [Property("AUTHOR", "guowei.wang@samsung.com")]
+        public void ImageLoaderLoadImageFromFileWithSize()
+        {
+            tlog.Debug(tag, $"ImageLoaderLoadImageFromFileWithSize START");
+
+            using (Size2D size2d = new Size2D(NUIApplication.GetDefaultWindow().WindowSize.Width, NUIApplication.GetDefaultWindow().WindowSize.Height))
+            {
+                var testingTarget = ImageLoader.LoadImageFromFile(image_path, size2d);
+                Assert.IsNotNull(testingTarget, "Can't create success object PixelBuffer.");
+                Assert.IsInstanceOf<PixelBuffer>(testingTarget, "Should return PixelBuffer instance.");
+
+                testingTarget.Dispose();
+            }
+
+            // size is null
+            try
+            {
+                var testingTarget = ImageLoader.LoadImageFromFile(image_path, null);
+                Assert.Fail("Didn't through exception. Failed!");
+            }
+            catch (ArgumentNullException)
+            {
+                tlog.Debug(tag, $"ImageLoaderLoadImageFromFileWithSize END (OK)");
+                Assert.Pass("Catch ArgumentNullException, Pass!");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since PR #4897 change the behavior && they requied to check BaseHandle's operation, Some NUI App behavior also be changed.

We'd better revert that patch, or make specialized operation for these two class.

TODO : We'd better seperate "Registry-registed BaseHandle" and "Don't need to registry-registed BaseHandle" in future.

Signed-off-by: Eunki, Hong <eunkiki.hong@samsung.com>

