### PR TITLE
[Applications.Common] Remove log prints in the thread

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -115,7 +115,7 @@ namespace Tizen.Applications
         /// The backend instance.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        protected ICoreBackend Backend { get { return _backend; } }      
+        protected ICoreBackend Backend { get { return _backend; } }
 
         /// <summary>
         /// Runs the application's main loop.
@@ -173,7 +173,7 @@ namespace Tizen.Applications
             if (_task != null)
             {
                 TizenUISynchronizationContext.Initialize();
-            }            
+            }
 
             if (!GlobalizationMode.Invariant)
             {
@@ -381,11 +381,6 @@ namespace Tizen.Applications
             if (cultureInfo != null)
             {
                 CultureInfo.CurrentCulture = cultureInfo;
-                Thread thread = new Thread(() =>
-                {
-                    Log.Info(LogTag, "Locale: " + locale.ToLower(cultureInfo) + ", " + locale.ToUpper(cultureInfo));
-                });
-                thread.Start();
             }
             else
             {
@@ -399,11 +394,6 @@ namespace Tizen.Applications
             if (cultureInfo != null)
             {
                 CultureInfo.CurrentUICulture = cultureInfo;
-                Thread thread = new Thread(() =>
-                {
-                    Log.Info(LogTag, "Locale: " + locale.ToLower(cultureInfo) + ", " + locale.ToUpper(cultureInfo));
-                });
-                thread.Start();
             }
             else
             {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Currently, the CoreApplication prints the log for improving the performance of ToLower() and ToUpper().
This causes the resource contention. Because creating the thread needs the resource as like the fork() in the linux system.
This request removes the thread creation for removing the resource contention.

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>
