### PR TITLE
[NUI] Add GetOverlayLayer in NUI window.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -209,6 +209,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetRootLayer")]
             public static extern global::System.IntPtr GetRootLayer(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetOverlayLayer")]
+            public static extern global::System.IntPtr GetOverlayLayer(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyEventSignal")]
             public static extern global::System.IntPtr KeyEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -36,6 +36,7 @@ namespace Tizen.NUI
     {
         private HandleRef stageCPtr;
         private Layer rootLayer;
+        private Layer overlayLayer;
         private Layer borderLayer;
         private string windowTitle;
         private List<Layer> childLayers = new List<Layer>();
@@ -928,6 +929,24 @@ namespace Tizen.NUI
         public Layer GetDefaultLayer()
         {
             return this.GetRootLayer();
+        }
+
+        /// <summary>
+        /// Gets the overlay layer.
+        /// </summary>
+        /// <returns>The overlay layer.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Layer GetOverlayLayer()
+        {
+            // Window.IsInstalled() is actually true only when called from event thread and
+            // Core has been initialized, not when Stage is ready.
+            if (overlayLayer == null && Window.IsInstalled())
+            {
+                overlayLayer = new Layer(Interop.Window.GetOverlayLayer(SwigCPtr), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                overlayLayer.SetWindow(this);
+            }
+            return overlayLayer;
         }
 
         /// <summary>


### PR DESCRIPTION
 - The overlay layer is rendered at the end of rendering order

Signed-off-by: seungho baek <sbsh.baek@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
