### PR TITLE
[NUI] Remove build warning messages in NUI Samples 

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AllAppsSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AllAppsSample.cs
@@ -180,7 +180,7 @@ namespace Tizen.NUI.Samples
           ResourceUrl = imagePath + "download2.jpeg",
           Layout = new LinearLayout()
           {
-              LinearAlignment = LinearLayout.Alignment.CenterHorizontal,
+              HorizontalAlignment = HorizontalAlignment.Center,
               LinearOrientation = LinearLayout.Orientation.Horizontal,
               CellPadding = new Size(10, 10),
           }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AnimatedImageViewTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AnimatedImageViewTest.cs
@@ -136,7 +136,7 @@ namespace Tizen.NUI.Samples
             root.BackgroundColor = Color.Green;
             root.Size2D = new Size2D(NUIApplication.GetDefaultWindow().Size.Width, NUIApplication.GetDefaultWindow().Size.Height);
             var layer = new LinearLayout();
-            layer.LinearAlignment = LinearLayout.Alignment.CenterHorizontal;
+            layer.HorizontalAlignment = HorizontalAlignment.Center;
             layer.LinearOrientation = LinearLayout.Orientation.Vertical;
             root.Layout = layer;
             NUIApplication.GetDefaultWindow().GetDefaultLayer().Add(root);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/BorderWindowTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/BorderWindowTest.cs
@@ -67,7 +67,7 @@ namespace Tizen.NUI.Samples
         topView.Layout = new LinearLayout()
         {
           LinearOrientation = LinearLayout.Orientation.Horizontal, 
-          LinearAlignment = LinearLayout.Alignment.CenterVertical,
+          VerticalAlignment = VerticalAlignment.Center,
           CellPadding = new Size2D(20, 20),
         };
         title = new TextLabel()
@@ -389,10 +389,11 @@ namespace Tizen.NUI.Samples
             return false;
         };
 
-        var root = new View(){
+        var root = new View()
+        {
           Layout = new LinearLayout()
           {
-              LinearAlignment = LinearLayout.Alignment.CenterHorizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
           },
           WidthResizePolicy = ResizePolicyType.FillToParent,
           HeightResizePolicy = ResizePolicyType.FillToParent,

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/BorderWindowTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/BorderWindowTest.cs
@@ -431,7 +431,7 @@ namespace Tizen.NUI.Samples
           ResourceUrl = imagePath + "gallery-large-14.jpg",
           Layout = new LinearLayout()
           {
-              LinearAlignment = LinearLayout.Alignment.CenterHorizontal,
+              HorizontalAlignment = HorizontalAlignment.Center,
               LinearOrientation = LinearLayout.Orientation.Horizontal,
               CellPadding = new Size(10, 10),
           }
@@ -450,7 +450,7 @@ namespace Tizen.NUI.Samples
           CornerRadiusPolicy = VisualTransformPolicyType.Relative,
           Layout = new LinearLayout()
           {
-              LinearAlignment = LinearLayout.Alignment.CenterHorizontal,
+              HorizontalAlignment = HorizontalAlignment.Center,
               LinearOrientation = LinearLayout.Orientation.Horizontal,
               CellPadding = new Size(10, 10),
               Padding = new Extents(10, 10, 10 , 10),
@@ -463,7 +463,8 @@ namespace Tizen.NUI.Samples
           Size = new Size(150, 180),
           Layout = new LinearLayout()
           {
-              LinearAlignment = LinearLayout.Alignment.Center,
+              HorizontalAlignment = HorizontalAlignment.Center,
+              VerticalAlignment = VerticalAlignment.Center,
               LinearOrientation = LinearLayout.Orientation.Vertical,
           },
           AccessibilityHighlightable = true,
@@ -503,7 +504,8 @@ namespace Tizen.NUI.Samples
           Size = new Size(150, 180),
           Layout = new LinearLayout()
           {
-              LinearAlignment = LinearLayout.Alignment.Center,
+              HorizontalAlignment = HorizontalAlignment.Center,
+              VerticalAlignment = VerticalAlignment.Center,
               LinearOrientation = LinearLayout.Orientation.Vertical,
           },
           AccessibilityHighlightable = true,

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CameraViewTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CameraViewTest.cs
@@ -9,7 +9,6 @@ namespace Tizen.NUI.Samples
 
     public class CameraViewTest : IExample
     {
-
         Window win;
         CameraView overlayCameraView;
         CameraView imageCameraView;
@@ -50,7 +49,6 @@ namespace Tizen.NUI.Samples
             sizeButton.Clicked += sizeButtonClicked;
             win.Add(sizeButton);
 
-
             rotationButton = new Button();
             rotationButton.Text = "Rotation";
             rotationButton.Size = new Size(100, 100);
@@ -60,17 +58,15 @@ namespace Tizen.NUI.Samples
 
             OverlayCamera();
             // ImageCamera();
-
         }
 
         private int rotationCnt = 0;
         private void rotationButtonClicked(object sender, ClickedEventArgs e)
         {
             int rotation = rotationCnt % 4;
-            Vector3 axis;
-            Degree degree;
-            if(overlayCamera != null) {
-                switch(rotation)
+            if (overlayCamera != null) 
+            {
+                switch (rotation)
                 {
                     case 0 :
                         overlayCamera.DisplaySettings.Rotation = Tizen.Multimedia.Rotation.Rotate0;
@@ -99,14 +95,14 @@ namespace Tizen.NUI.Samples
 
         private void OverlayButtonClicked(object sender, ClickedEventArgs e)
         {
-            if(imageCamera != null)
+            if (imageCamera != null)
             {
                 imageCamera.StopPreview();
                 imageCamera.Dispose();
                 imageCamera = null;
                 win.Remove(imageCameraView);
             }
-            if(overlayCamera == null)
+            if (overlayCamera == null)
             {
                 OverlayCamera();
             }
@@ -114,14 +110,14 @@ namespace Tizen.NUI.Samples
 
         private void NativeButtonClicked(object sender, ClickedEventArgs e)
         {
-            if(overlayCamera != null)
+            if (overlayCamera != null)
             {
                 overlayCamera.StopPreview();
                 overlayCamera.Dispose();
                 overlayCamera = null;
                 win.Remove(overlayCameraView);
             }
-            if(imageCamera == null)
+            if (imageCamera == null)
             {
                 ImageCamera();
             }
@@ -164,10 +160,14 @@ namespace Tizen.NUI.Samples
         private int size = 300;
         private void sizeButtonClicked(object sender, ClickedEventArgs e)
         {
-            if(overlayCameraView != null)
+            if (overlayCameraView != null)
+            {
                 overlayCameraView.Size = new Size(size, size);
-            if(imageCameraView != null)
+            }
+            if (imageCameraView != null)
+            {
                 imageCameraView.Size = new Size(size, size);
+            }
             size += 20;
         }
 
@@ -176,9 +176,8 @@ namespace Tizen.NUI.Samples
         {
             win.KeyEvent -= Win_KeyEvent;
 
-             if(imageCamera != null)
+            if (imageCamera != null)
             {
-
                 imageCamera.StopPreview();
                 imageCamera.Dispose();
                 imageCamera = null;
@@ -187,7 +186,7 @@ namespace Tizen.NUI.Samples
                 imageCameraView.Dispose();
             }
 
-            if(overlayCamera != null)
+            if (overlayCamera != null)
             {
                 overlayCamera.StopPreview();
                 overlayCamera.Dispose();
@@ -195,7 +194,6 @@ namespace Tizen.NUI.Samples
                 win.Remove(overlayCameraView);
                 overlayCameraView.Dispose();
             }
-
 
             tlog.Fatal(tag, $"Deactivate()! cameraView disposed");
         }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CheckBoxSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CheckBoxSample.cs
@@ -47,7 +47,7 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
                     CellPadding = new Size(40, 40),
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                 }
             };
             window.Add(root);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CircularTextSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CircularTextSample.cs
@@ -135,7 +135,6 @@ namespace Tizen.NUI.Samples
                 default:
                 return 4;
             }
-            return 0;
         }
 
         TextureSet CreateTextureSet( RendererParameters textParameters, List<string> embeddedItems )

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ClippedImage.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ClippedImage.cs
@@ -107,9 +107,7 @@ namespace Tizen.NUI.Samples
                     float rad = percent * 2.0f * (float)Math.PI;
 
                     // Vertex position
-                    Vector2 tmpvec = new Vector2(0, 0);
-                    tmpvec.X = (float)(center.X + radius * Math.Cos(rad));
-                    tmpvec.Y = (float)(center.Y + radius * Math.Sin(rad));
+                    Vector2 tmpvec = new Vector2((float)(center.X + radius * Math.Cos(rad)), (float)(center.Y + radius * Math.Sin(rad)));
 
                     circleBuffer[idx++] = tmpvec;
                 }
@@ -141,35 +139,37 @@ namespace Tizen.NUI.Samples
                 Vector2 outer = new Vector2(0.5f, 0.0f);
                 quadBuffer[idx++] = new Vector2(outer.X, outer.Y);
                 float incrementPerBuffer = 1.0f / (float)(vertsPerSide);
+                float x = outer.X;
+                float y = outer.Y;
 
-                for (int i = 0; i < vertsPerSide && outer.Y < 0.5f; ++i)
+                for (int i = 0; i < vertsPerSide && y < 0.5f; ++i)
                 {
-                    outer.Y += incrementPerBuffer;
-                    quadBuffer[idx++] = new Vector2(outer.X, outer.Y);
+                    y += incrementPerBuffer;
+                    quadBuffer[idx++] = new Vector2(x, y);
                 }
 
-                for (int i = 0; i < vertsPerSide && outer.X > -0.5f; ++i)
+                for (int i = 0; i < vertsPerSide && x > -0.5f; ++i)
                 {
-                    outer.X -= incrementPerBuffer;
-                    quadBuffer[idx++] = new Vector2(outer.X, outer.Y);
+                    x -= incrementPerBuffer;
+                    quadBuffer[idx++] = new Vector2(x, y);
                 }
 
-                for (int i = 0; i < vertsPerSide && outer.Y > -0.5f; ++i)
+                for (int i = 0; i < vertsPerSide && y > -0.5f; ++i)
                 {
-                    outer.Y -= incrementPerBuffer;
-                    quadBuffer[idx++] = new Vector2(outer.X, outer.Y);
+                    y -= incrementPerBuffer;
+                    quadBuffer[idx++] = new Vector2(x, y);
                 }
 
-                for (int i = 0; i < vertsPerSide && outer.X < 0.5f; ++i)
+                for (int i = 0; i < vertsPerSide && x < 0.5f; ++i)
                 {
-                    outer.X += incrementPerBuffer;
-                    quadBuffer[idx++] = new Vector2(outer.X, outer.Y);
+                    x += incrementPerBuffer;
+                    quadBuffer[idx++] = new Vector2(x, y);
                 }
 
-                for (int i = 0; i < vertsPerSide && outer.Y < 0.0f; ++i)
+                for (int i = 0; i < vertsPerSide && y < 0.0f; ++i)
                 {
-                    outer.Y += incrementPerBuffer;
-                    quadBuffer[idx++] = new Vector2(outer.X, outer.Y);
+                    y += incrementPerBuffer;
+                    quadBuffer[idx++] = new Vector2(x, y);
                 }
 
                 for(int i = 0; i < idx; i++)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ContactCard.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ContactCard.cs
@@ -179,7 +179,7 @@ namespace Tizen.NUI.Samples
 
                 // Fade out all the siblings
                 View parent = mContactCard.GetParent() as View;
-                for (uint i = 0; i < parent.GetChildCount(); ++i)
+                for (uint i = 0; i < parent.ChildCount; ++i)
                 {
                     View sibling = parent.GetChildAt(i);
                     if (sibling != mContactCard)
@@ -226,7 +226,7 @@ namespace Tizen.NUI.Samples
 
                 // Slowly fade in all the siblings
                 View parent = mContactCard.GetParent() as View;
-                for (uint i = 0; i < parent.GetChildCount(); ++i)
+                for (uint i = 0; i < parent.ChildCount; ++i)
                 {
                     View sibling = parent.GetChildAt(i);
                     if (sibling != mContactCard)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ContactCard.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ContactCard.cs
@@ -20,7 +20,6 @@ namespace Tizen.NUI.Samples
         private Animation mAnimation;
         private ContactCardLayoutInfo mContactCardLayoutInfo;
         private Vector2 foldedPosition;
-        private int mClippedImagePropertyIndex;
         private bool mFolded;
 
 
@@ -52,7 +51,6 @@ namespace Tizen.NUI.Samples
         {
             mContactCardLayoutInfo = contactCardLayoutInfo;
             foldedPosition = new Vector2(position.X, position.Y);
-            mClippedImagePropertyIndex = -1;
             mFolded = true;
 
             //NUIApplication.GetDefaultWindow().KeyEvent += OnKeyEvent;

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ContactCardLayouter.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ContactCardLayouter.cs
@@ -85,31 +85,27 @@ namespace Tizen.NUI.Samples
 
                 // Calculate the size of the folded card (use the minimum of width/height as size)
                 mContactCardLayoutInfo.foldedSize = (mContactCardLayoutInfo.unfoldedSize - (mContactCardLayoutInfo.padding * (MINIMUM_ITEMS_PER_ROW_OR_COLUMN - 1.0f))) / MINIMUM_ITEMS_PER_ROW_OR_COLUMN;
-                mContactCardLayoutInfo.foldedSize.Width = mContactCardLayoutInfo.foldedSize.Height = Math.Min(mContactCardLayoutInfo.foldedSize.Width, mContactCardLayoutInfo.foldedSize.Height);
+                float calculatedSize = Math.Min(mContactCardLayoutInfo.foldedSize.Width, mContactCardLayoutInfo.foldedSize.Height);
+                mContactCardLayoutInfo.foldedSize = new Vector2(calculatedSize, calculatedSize);
 
                 // Set the size and positions of the header
-                mContactCardLayoutInfo.headerSize.Width = mContactCardLayoutInfo.unfoldedSize.Width;
-                mContactCardLayoutInfo.headerSize.Height = mContactCardLayoutInfo.unfoldedSize.Height * HEADER_HEIGHT_TO_UNFOLDED_SIZE_RATIO;
+                mContactCardLayoutInfo.headerSize = new Vector2(mContactCardLayoutInfo.unfoldedSize.Width, mContactCardLayoutInfo.unfoldedSize.Height * HEADER_HEIGHT_TO_UNFOLDED_SIZE_RATIO);
                 mContactCardLayoutInfo.headerFoldedPosition = mContactCardLayoutInfo.headerSize * HEADER_FOLDED_POSITION_AS_RATIO_OF_SIZE;
                 mContactCardLayoutInfo.headerUnfoldedPosition = HEADER_UNFOLDED_POSITION;
 
                 // Set the image size and positions
                 mContactCardLayoutInfo.imageSize = mContactCardLayoutInfo.foldedSize * IMAGE_SIZE_AS_RATIO_TO_FOLDED_SIZE;
                 mContactCardLayoutInfo.imageFoldedPosition = mContactCardLayoutInfo.imageSize * IMAGE_FOLDED_POSITION_AS_RATIO_OF_SIZE;
-                mContactCardLayoutInfo.imageUnfoldedPosition.X = mContactCardLayoutInfo.padding.Width;
-                mContactCardLayoutInfo.imageUnfoldedPosition.Y = mContactCardLayoutInfo.headerSize.Height + mContactCardLayoutInfo.padding.Height;
+                mContactCardLayoutInfo.imageUnfoldedPosition = new Vector2(mContactCardLayoutInfo.padding.Width, mContactCardLayoutInfo.headerSize.Height + mContactCardLayoutInfo.padding.Height);
 
                 // Set the positions of the contact name
-                mContactCardLayoutInfo.textFoldedPosition.X = 0.0f;
-                mContactCardLayoutInfo.textFoldedPosition.Y = mContactCardLayoutInfo.imageFoldedPosition.X + mContactCardLayoutInfo.imageSize.Height * FOLDED_TEXT_POSITION_AS_RATIO_OF_IMAGE_SIZE;
-                mContactCardLayoutInfo.textUnfoldedPosition.X = mContactCardLayoutInfo.padding.Width;
-                mContactCardLayoutInfo.textUnfoldedPosition.Y = mContactCardLayoutInfo.imageUnfoldedPosition.Y + mContactCardLayoutInfo.imageSize.Height + mContactCardLayoutInfo.padding.Height;
+                mContactCardLayoutInfo.textFoldedPosition = new Vector2(0.0f, mContactCardLayoutInfo.imageFoldedPosition.X + mContactCardLayoutInfo.imageSize.Height * FOLDED_TEXT_POSITION_AS_RATIO_OF_IMAGE_SIZE);
+                mContactCardLayoutInfo.textUnfoldedPosition = new Vector2(mContactCardLayoutInfo.padding.Width, mContactCardLayoutInfo.imageUnfoldedPosition.Y + mContactCardLayoutInfo.imageSize.Height + mContactCardLayoutInfo.padding.Height);
 
                 // Figure out the positions of the contact cards
                 mItemsPerRow = (int)((mContactCardLayoutInfo.unfoldedSize.Width + mContactCardLayoutInfo.padding.Width) / (mContactCardLayoutInfo.foldedSize.Width + mContactCardLayoutInfo.padding.Width));
                 mLastPosition = new Vector2(mContactCardLayoutInfo.unfoldedPosition.X, mContactCardLayoutInfo.unfoldedPosition.Y);
-                mPositionIncrementer.X = mContactCardLayoutInfo.foldedSize.Width + mContactCardLayoutInfo.padding.Width;
-                mPositionIncrementer.Y = mContactCardLayoutInfo.foldedSize.Height + mContactCardLayoutInfo.padding.Height;
+                mPositionIncrementer = new Vector2(mContactCardLayoutInfo.foldedSize.Width + mContactCardLayoutInfo.padding.Width, mContactCardLayoutInfo.foldedSize.Height + mContactCardLayoutInfo.padding.Height);
 
                 mInitialized = true;
             }
@@ -124,17 +120,20 @@ namespace Tizen.NUI.Samples
 
             if(currentNumOfCards > 0)
             {
+                float positionX = mLastPosition.X;
+                float positionY = mLastPosition.Y;
                 if(currentNumOfCards % mItemsPerRow != 0)
                 {
-                    mLastPosition.X += mPositionIncrementer.X;
+                    positionX += mPositionIncrementer.X;
                 }
                 else
                 {
-                    mLastPosition.X = mContactCardLayoutInfo.unfoldedPosition.X;
-                    mLastPosition.Y += mPositionIncrementer.Y;
+                    positionX = mContactCardLayoutInfo.unfoldedPosition.X;
+                    positionY += mPositionIncrementer.Y;
                 }
+                mLastPosition = new Vector2(positionX, positionY);
             }
-
+            
             return mLastPosition;
         }
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliTableView.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliTableView.cs
@@ -736,12 +736,10 @@ namespace Tizen.NUI.Samples
         private RulerPtr mScrollRulerY;             //  ScrollView Y (vertical) ruler
         private View mPressedActor;             //  The currently pressed actor.
         private Timer mAnimationTimer;           //  Timer used to turn off animation after a specific time period
-        private TapGestureDetector mLogoTapDetector;          //  To detect taps on the logo
 
         // This struct encapsulates all data relevant to each of the elements used within the custom keyboard focus effect.
         private struct FocusEffect
         {
-            public ImageView actor;                   //  The parent keyboard focus highlight actor
             public Animation animation;               //  The animation for the parent keyboard focus highlight actor
         };
         FocusEffect[] mFocusEffect = new FocusEffect[FOCUS_ANIMATION_ACTOR_NUMBER];    //  The elements used to create the custom focus effect

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliTableView.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliTableView.cs
@@ -257,7 +257,7 @@ namespace Tizen.NUI.Samples
         {
             View background = new View();
             NUIApplication.GetDefaultWindow().Add(background);
-            background.SetStyleName(stylename);
+            background.StyleName = stylename;
             background.Name = "BACKGROUND";
             background.PositionUsesPivotPoint = true;
             background.PivotPoint = PivotPoint.Center;
@@ -271,7 +271,7 @@ namespace Tizen.NUI.Samples
         {
             ImageView focusableTile = new ImageView();
 
-            focusableTile.SetStyleName("DemoTile");
+            focusableTile.StyleName = "DemoTile";
             focusableTile.ResourceUrl = CommonResource.GetDaliResourcePath() + "DaliDemo/demo-tile-texture.9.png";
             focusableTile.PositionUsesPivotPoint = true;
             focusableTile.ParentOrigin = ParentOrigin.Center;
@@ -300,7 +300,7 @@ namespace Tizen.NUI.Samples
             label.PositionUsesPivotPoint = true;
             label.PivotPoint = PivotPoint.Center;
             label.ParentOrigin = ParentOrigin.Center;
-            label.SetStyleName("LauncherLabel");
+            label.StyleName = "LauncherLabel";
             label.MultiLine = true;
             label.Text = title;
             label.HorizontalAlignment = HorizontalAlignment.Center;

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FlexibleViewSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FlexibleViewSample.cs
@@ -181,7 +181,7 @@ namespace Tizen.NUI.Samples
             parent.Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Bottom,
+                VerticalAlignment = VerticalAlignment.Bottom,
                 CellPadding = new Size(50, 50)
             };
             root.Add(parent);
@@ -261,20 +261,19 @@ namespace Tizen.NUI.Samples
             flexibleView2.AttachScrollBar(scrollBar2);
 
             FocusManager.Instance.SetCurrentFocusView(flexibleView1);
-            FocusManager.Instance.PreFocusChange += onPreFocusChange;
+            FocusManager.Instance.FocusChanging += OnFocusChanging;
         }
 
-        private View onPreFocusChange(object sender, NUI.FocusManager.PreFocusChangeEventArgs e)
+        private void OnFocusChanging(object sender, NUI.FocusChangingEventArgs e)
         {
-            if (e.CurrentView != null && e.CurrentView.Name == "RecyclerView1" && e.Direction == View.FocusDirection.Right && e.ProposedView == null)
+            if (e.Current != null && e.Current.Name == "RecyclerView1" && e.Direction == View.FocusDirection.Right && e.Proposed == null)
             {
-                return flexibleView2;
+                e.Proposed = flexibleView2;
             }
-            if (e.CurrentView != null && e.CurrentView.Name == "RecyclerView2" && e.Direction == View.FocusDirection.Left && e.ProposedView == null)
+            if (e.Current != null && e.Current.Name == "RecyclerView2" && e.Direction == View.FocusDirection.Left && e.Proposed == null)
             {
-                return flexibleView1;
+                e.Proposed = flexibleView1;
             }
-            return e.CurrentView;
         }
 
         private void FlexibleView_FocusLost(object sender, EventArgs e)
@@ -352,7 +351,7 @@ namespace Tizen.NUI.Samples
 
         public void Deactivate()
         {
-            FocusManager.Instance.PreFocusChange -= onPreFocusChange;
+            FocusManager.Instance.FocusChanging -= OnFocusChanging;
             FocusManager.Instance.ClearFocus();
 
             flexibleView1.DetachScrollBar();

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
@@ -65,7 +65,6 @@ namespace Tizen.NUI.Samples
     private const int DEFAULT_SPACE = 9;
     private const int DEVIDE_BAR_SIZE = 4;
 
-    private TextLabel text;
     public class FrameUpdateCallback : FrameUpdateCallbackInterface
     {
       private int timeInterval;

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/GraphicsTypeTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/GraphicsTypeTest.cs
@@ -5,8 +5,6 @@ namespace Tizen.NUI.Samples
 {
     public class GraphicsTypeTest : IExample
     {
-        private int oldPageCount = 0;
-
         private Window window;
         private ScrollableBase rootView;
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/GridLayoutSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/GridLayoutSample.cs
@@ -100,7 +100,8 @@ namespace Tizen.NUI.Samples
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                 }
 
             };
@@ -132,7 +133,8 @@ namespace Tizen.NUI.Samples
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                 }
             };
             currentWindow.Add(bottomView_2);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ItemViewDemo/ItemViewSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ItemViewDemo/ItemViewSample.cs
@@ -448,7 +448,8 @@ namespace Tizen.NUI.Samples
             mContentView.Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Center
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             mRootView.Add(mContentView);
         }
@@ -465,7 +466,8 @@ namespace Tizen.NUI.Samples
             mToolBarLayer.Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Center
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             mRootView.Add(mToolBarLayer);
             mToolBarLayer.RaiseToTop();
@@ -576,7 +578,7 @@ namespace Tizen.NUI.Samples
             mDeleteButton.Clicked += (obj, e) =>
             {
                 ItemIdCollection removeList = new ItemIdCollection();
-                for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+                for (uint i = 0; i < mItemView.ChildCount; ++i)
                 {
                     View child = mItemView.GetChildAt(i);
                     if (child != null)
@@ -620,7 +622,7 @@ namespace Tizen.NUI.Samples
             {
                 ItemCollection insertList = new ItemCollection();
                 Random random = new Random();
-                for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+                for (uint i = 0; i < mItemView.ChildCount; ++i)
                 {
                     View child = mItemView.GetChildAt(i);
                     if (child != null)
@@ -663,7 +665,7 @@ namespace Tizen.NUI.Samples
             {
                 ItemCollection replaceList = new ItemCollection();
                 Random random = new Random();
-                for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+                for (uint i = 0; i < mItemView.ChildCount; ++i)
                 {
                     View child = mItemView.GetChildAt(i);
                     if (child != null)
@@ -752,7 +754,7 @@ namespace Tizen.NUI.Samples
             SetTitle("Edit: Remove");
             mTapDetector = new TapGestureDetector();
 
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 if (mItemView.GetChildAt(i) != null)
                 {
@@ -783,7 +785,7 @@ namespace Tizen.NUI.Samples
 
             mTapDetector = new TapGestureDetector();
 
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 View child = mItemView.GetChildAt(i);
                 if (child != null)
@@ -825,7 +827,7 @@ namespace Tizen.NUI.Samples
 
         void ExitRemoveManyMode()
         {
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 View child = mItemView.GetChildAt(i);
                 if (child != null)
@@ -853,7 +855,7 @@ namespace Tizen.NUI.Samples
             SetTitle("Edit: Insert");
             mTapDetector = new TapGestureDetector();
 
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 if (mItemView.GetChildAt(i) != null)
                 {
@@ -891,7 +893,7 @@ namespace Tizen.NUI.Samples
 
             mTapDetector = new TapGestureDetector();
 
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 View child = mItemView.GetChildAt(i);
                 if (child != null)
@@ -924,7 +926,7 @@ namespace Tizen.NUI.Samples
 
         void ExitInsertManyMode()
         {
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 View child = mItemView.GetChildAt(i);
                 if (child != null)
@@ -952,7 +954,7 @@ namespace Tizen.NUI.Samples
             SetTitle("Edit: Replace");
             mTapDetector = new TapGestureDetector();
 
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 if (mItemView.GetChildAt(i) != null)
                 {
@@ -981,7 +983,7 @@ namespace Tizen.NUI.Samples
 
             mTapDetector = new TapGestureDetector();
 
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 View child = mItemView.GetChildAt(i);
                 View box = child.FindChildByName("CheckBox");
@@ -1011,7 +1013,7 @@ namespace Tizen.NUI.Samples
         }
         void ExitReplaceManyMode()
         {
-            for (uint i = 0; i < mItemView.GetChildCount(); ++i)
+            for (uint i = 0; i < mItemView.ChildCount; ++i)
             {
                 View child = mItemView.GetChildAt(i);
                 View box = child.FindChildByName("CheckBox");

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LoadingSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LoadingSample.cs
@@ -36,7 +36,6 @@ namespace Tizen.NUI.Samples
                 GridOrientation = GridLayout.Orientation.Horizontal,
                 
             };
-            //parent.Layout.Measure(new MeasureSpecification(new LayoutLength(1000), MeasureSpecification.ModeType.Exactly), new MeasureSpecification(new LayoutLength(780), MeasureSpecification.ModeType.Exactly));
             root.Add(gridLayout);
 
             imageArray = new string[36];
@@ -76,7 +75,8 @@ namespace Tizen.NUI.Samples
             layout[1].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Center
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             loading[0] = new Loading();
             loading[0].Size = new Size(100, 100);
@@ -104,7 +104,8 @@ namespace Tizen.NUI.Samples
             layout[0].Layout = new LinearLayout()
             { 
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
                 CellPadding = new Size(10, 50)
             };
            
@@ -150,7 +151,8 @@ namespace Tizen.NUI.Samples
             layout[2].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Center
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             LoadingStyle style = new LoadingStyle
             {
@@ -167,7 +169,8 @@ namespace Tizen.NUI.Samples
             layout[3].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Center
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             button[2] = new Button();
             button[2].Size = new Size(400, 50);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PageTransitionSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PageTransitionSample.cs
@@ -66,7 +66,8 @@ namespace Tizen.NUI.Samples
                 ParentOrigin = ParentOrigin.BottomCenter,
                 Layout = new LinearLayout()
                 {
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
                     CellPadding = new Size(convertSize(60), convertSize(60)),
                 },

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PaginationSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PaginationSample.cs
@@ -24,7 +24,8 @@ namespace Tizen.NUI.Samples
             layout[0].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Vertical,
-                LinearAlignment = LinearLayout.Alignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
                 CellPadding = new Size(20, 50)
             };
             window.Add(layout[0]);
@@ -37,7 +38,8 @@ namespace Tizen.NUI.Samples
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                     CellPadding = new Size(20, 50)
                 }
             };
@@ -50,7 +52,8 @@ namespace Tizen.NUI.Samples
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                     CellPadding = new Size(20, 50)
                 }
             };

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PaletteSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PaletteSample.cs
@@ -81,7 +81,8 @@ namespace Tizen.NUI.Samples
                 Layout = new LinearLayout()
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                 }
 
             };

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ProgressSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ProgressSample.cs
@@ -23,7 +23,8 @@ namespace Tizen.NUI.Samples
             layout[0].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Vertical,
-                LinearAlignment = LinearLayout.Alignment.Center
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             window.Add(layout[0]);
 
@@ -35,7 +36,8 @@ namespace Tizen.NUI.Samples
             layout[1].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,
-                LinearAlignment = LinearLayout.Alignment.Center
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
             };
             layout[0].Add(layout[1]);
 
@@ -47,7 +49,7 @@ namespace Tizen.NUI.Samples
             layout[2].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Vertical,
-                LinearAlignment = LinearLayout.Alignment.CenterHorizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
                 CellPadding = new Size2D(50, 100)
             };
             layout[1].Add(layout[2]);
@@ -60,7 +62,7 @@ namespace Tizen.NUI.Samples
             layout[3].Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Vertical,
-                LinearAlignment = LinearLayout.Alignment.CenterHorizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
                 CellPadding = new Size2D(50, 100)
             };
             layout[1].Add(layout[3]);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PropertyNotificationTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PropertyNotificationTest.cs
@@ -7,7 +7,6 @@ namespace Tizen.NUI.Samples
     public class PropertyNotificationTest : IExample
     {
         Window win;
-        int cnt;
         TextLabel statusText;
         global::System.Random rand = new global::System.Random();
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RadioButtonSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RadioButtonSample.cs
@@ -49,7 +49,8 @@ namespace Tizen.NUI.Samples
                 {
                     LinearOrientation = LinearLayout.Orientation.Horizontal,
                     CellPadding = new Size(40, 40),
-                    LinearAlignment = LinearLayout.Alignment.Center,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
                 }
             };
             window.Add(root);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RiveAnimationFollowTouch.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RiveAnimationFollowTouch.cs
@@ -10,10 +10,7 @@ namespace Tizen.NUI.Samples
         private Layer defaultLayer;
 
         Tizen.NUI.Extension.RiveAnimationView rav;
-        Button playButton, stopButton;
-        Button bounceButton, brokeButton;
-        Button fillButton, strokeButton, opacityButton;
-        Button scaleButton, rotationButton, positionButton;
+        Button playButton;
         public void Activate()
         {
             window = NUIApplication.GetDefaultWindow();

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RiveAnimationUniverse.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RiveAnimationUniverse.cs
@@ -107,7 +107,8 @@ namespace Tizen.NUI.Samples
                     Layout = new LinearLayout()
                     {
                         LinearOrientation = LinearLayout.Orientation.Vertical,
-                        LinearAlignment = LinearLayout.Alignment.Center,
+                        HorizontalAlignment = HorizontalAlignment.Center,
+                        VerticalAlignment = VerticalAlignment.Center,
                         CellPadding = new Size(40, 0)
                     }
                 };

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollBarSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollBarSample.cs
@@ -41,7 +41,13 @@ namespace Tizen.NUI.Samples
         private void CreateNullStylePart()
         {
             null_style_parent = new View() { Size = new Size(960, 540) };
-            null_style_parent.Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Vertical, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(0, 50) };
+            null_style_parent.Layout = new LinearLayout() 
+            {
+                LinearOrientation = LinearLayout.Orientation.Vertical,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(0, 50)
+            };
             top_parent.Add(null_style_parent);
 
             // Add Textlabel of "Null style construction"
@@ -81,7 +87,13 @@ namespace Tizen.NUI.Samples
         private void CreateStylePart()
         {
             style_parent = new View() { Size = new Size(960, 540) };
-            style_parent.Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Vertical, LinearAlignment = LinearLayout.Alignment.CenterVertical, CellPadding = new Size2D(0, 50) };
+            style_parent.Layout = new LinearLayout() 
+            {
+                LinearOrientation = LinearLayout.Orientation.Vertical,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(0, 50)
+            };
             top_parent.Add(style_parent);
 
             // Add Textlabel of "Style construction"
@@ -125,7 +137,13 @@ namespace Tizen.NUI.Samples
         private void CreateBottomView()
         {
             bottom_parent = new View() { Size = new Size(1920, 540) };
-            bottom_parent.Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(50, 50) };
+            bottom_parent.Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(50, 50)
+            };
             root.Add(bottom_parent);
 
             // Create buttons

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SliderSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SliderSample.cs
@@ -137,7 +137,12 @@ namespace Tizen.NUI.Samples
 
             // Add Horizontal Slider
             hori_slider_parent = new View() { Size = new Size(960, 740) };
-            hori_slider_parent.Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Vertical, LinearAlignment = LinearLayout.Alignment.Bottom, CellPadding = new Size2D(0, 50) };
+            hori_slider_parent.Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Vertical,
+                VerticalAlignment = VerticalAlignment.Bottom,
+                CellPadding = new Size2D(0, 50)
+            };
             bottom_parent.Add(hori_slider_parent);
             hori_slider_parent.Add(slider_null_style[0]);
             hori_slider_parent.Add(slider_null_style[1]);
@@ -146,7 +151,13 @@ namespace Tizen.NUI.Samples
 
             // Add vertical Slider
             ver_slider_parent = new View() { Size = new Size(960, 740) };
-            ver_slider_parent.Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(100, 0) };
+            ver_slider_parent.Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(100, 0)
+            };
             bottom_parent.Add(ver_slider_parent);
             ver_slider_parent.Add(slider_null_style[2]);
             ver_slider_parent.Add(slider_null_style[3]);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SwitchSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/SwitchSample.cs
@@ -51,7 +51,12 @@ namespace Tizen.NUI.Samples
             // Init parent of TextView
             parentView[0] = new View();
             parentView[0].Size = new Size(1920, 200);
-            parentView[0].Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.CenterVertical, CellPadding = new Size2D(180, 0) };
+            parentView[0].Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(180, 0)
+            };
             root.Add(parentView[0]);
 
             for (int i = 0; i < 2; i++)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TabSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/TabSample.cs
@@ -52,7 +52,13 @@ namespace Tizen.NUI.Samples
             // Init parent of TextView
             parentView[0] = new View();
             parentView[0].Size = new Size(1920, 300);
-            parentView[0].Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(100, 0) };
+            parentView[0].Layout = new LinearLayout() 
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(100, 0)
+            };
             root.Add(parentView[0]);
 
             for (int i = 0; i < 2; i++)
@@ -79,7 +85,13 @@ namespace Tizen.NUI.Samples
             // Init parent of TabView
             parentView[1] = new View();
             parentView[1].Size = new Size(1920, 200);
-            parentView[1].Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(100, 0) };
+            parentView[1].Layout = new LinearLayout() 
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(100, 0)
+            };
             root.Add(parentView[1]);
 
             ///////////////////////////////////////////////Create by Property//////////////////////////////////////////////////////////
@@ -153,7 +165,13 @@ namespace Tizen.NUI.Samples
             // Init parent of ButtonView
             parentView[2] = new View();
             parentView[2].Size = new Size(1920, 200);
-            parentView[2].Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(100, 0) };
+            parentView[2].Layout = new LinearLayout() 
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(100, 0)
+            };
             root.Add(parentView[2]);
 
             // Create Buttons

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ToastSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ToastSample.cs
@@ -34,7 +34,13 @@ namespace Tizen.NUI.Samples
             // Init parent of TextView
             parentView[0] = new View();
             parentView[0].Size = new Size(1920, 200);
-            parentView[0].Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(300, 0) };
+            parentView[0].Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(300, 0)
+            };
             root.Add(parentView[0]);
 
             for (int i = 0; i < 2; i++)
@@ -63,7 +69,13 @@ namespace Tizen.NUI.Samples
             // Init parent of ToastView
             parentView[1] = new View();
             parentView[1].Size = new Size(1920, 500);
-            parentView[1].Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center, CellPadding = new Size2D(300, 0) };
+            parentView[1].Layout = new LinearLayout() 
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                CellPadding = new Size2D(300, 0)
+            };
             root.Add(parentView[1]);
 
             // Create Toasts
@@ -92,7 +104,12 @@ namespace Tizen.NUI.Samples
             // Init parent of LogPadView
             parentView[2] = new View();
             parentView[2].Size = new Size(1920, 380);
-            parentView[2].Layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Horizontal, LinearAlignment = LinearLayout.Alignment.Center};
+            parentView[2].Layout = new LinearLayout()
+            {
+                LinearOrientation = LinearLayout.Orientation.Horizontal,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            };
             root.Add(parentView[2]);
 
             // Create log pad

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ViewSizeWidthPropertySetTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ViewSizeWidthPropertySetTest.cs
@@ -74,19 +74,19 @@ namespace Tizen.NUI.Samples
                 }
                 else if (e.Key.KeyPressedName == "5")
                 {
-                    view1.MinimumSize.Width = 500;
+                    view1.MinimumSize = new Size2D(500, view1.MinimumSize.Height);
                 }
                 else if (e.Key.KeyPressedName == "6")
                 {
-                    view1.MinimumSize.Width = 100;
+                    view1.MinimumSize = new Size2D(100, view1.MinimumSize.Height);
                 }
                 else if (e.Key.KeyPressedName == "7")
                 {
-                    view1.MaximumSize.Width = 700;
+                    view1.MaximumSize = new Size2D(700, view1.MaximumSize.Height);
                 }
                 else if (e.Key.KeyPressedName == "8")
                 {
-                    view1.MaximumSize.Width = 70;
+                    view1.MaximumSize = new Size2D(70, view1.MaximumSize.Height);
                 }
                 else if (e.Key.KeyPressedName == "9")
                 {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowBorderTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowBorderTest.cs
@@ -95,7 +95,7 @@ namespace Tizen.NUI.Samples
                 HeightResizePolicy = ResizePolicyType.FillToParent,
                 Layout = new LinearLayout()
                 {
-                    LinearAlignment = LinearLayout.Alignment.Top,
+                    VerticalAlignment = VerticalAlignment.Top,
                     LinearOrientation = LinearLayout.Orientation.Vertical,
                     CellPadding = new Size(50, 50),
                 }


### PR DESCRIPTION
### Description of Change ###
 - Clean code according to NUI Coding style
 - Remove Unreachable code.
 - Replace `PreFocusChangeEventArgs` from `FocusChangingEventArgs`.
 - Use `HorizontalAlignment` or `VerticalAlignment` properties  instead of `LinearAlignment`.
 - Use new Vector2(...) constructor instead of using `X` or `Y` setter / `Width` or `Height` setter.
 - Remove not used variables : `axis`, `degree`, `mClippedImagePropertyIndex`, etc.
 - Use `StyleName` property instead of `SetStyleName(string)`.
 - Use `ChildCount` property instead of `GetChildCount()`.

### API Changes ###
- N/A
- 