### PR TITLE
[NUI][API10] Fix ImageUrl.Dispose issue

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1297,6 +1297,11 @@ namespace Tizen.NUI.BaseComponents
                     {
                         UpdateImage(ImageVisualProperty.URL, setValue);
                     }
+                    // Special case. If we set GeneratedUrl, Create ImageVisual synchronously.
+                    if(value.StartsWith("dali://") || value.StartsWith("enbuf://"))
+                    {
+                        UpdateImage();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Since we update ImageView lazy, ImageUrl's lifecycle might not matched what user think.

```
ImageUrl imageUrl = ~~~.GenerateUrl();
ImageView imageView = new ImageView(imageUrl.ToString());
imageUrl.Dispose(); ///< We should allow this situation.
```

To make scene, We allow to call UpdateImage(); synchoronously if we use GeneratedUrl().

Signed-off-by: Eunki Hong <eunkiki.hong@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
