### PR TITLE
[Applications.Common] Make it ineligible for garbage collection for delegate

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/Bundle.cs
@@ -98,6 +98,7 @@ namespace Tizen.Applications
             };
 
             Interop.Bundle.Foreach(_handle, iterator, IntPtr.Zero);
+            GC.KeepAlive(iterator);
             if ((BundleErrorFactory.BundleError)ErrorFacts.GetLastResult() == BundleErrorFactory.BundleError.InvalidParameter)
             {
                 throw new ArgumentException("Invalid parameter - cannot create bundle instance");


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This request is to prevent the delegate garbage collected. 
To make it ineligible for garbage collection, the patchset increments the reference of the iterator variable.

```
A callback was made on a garbage collected delegate of type 'Tizen.Applications.Common!Interop+Bundle+Ite
   at Interop+Service.Main(Int32, System.String[], ServiceAppLifecycleCallbacks ByRef, IntPtr)[0m @NEW_BLOCK
   at Tizen.Applications.CoreBackend.ServiceCoreBackend.Run(System.String[])[0m
   at Tizen.Applications.CoreApplication.Run(System.String[])[0m
   at Tizen.Applications.ServiceApplication.Run(System.String[])[0m
<<< onSigabrt >>>[0m
```
