### PR TITLE
[NUI] Fix NUI button not working when style disabled

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI.Components
         private EventHandler<StateChangedEventArgs> stateChangeHandler;
 
         private bool isPressed = false;
-        private bool styleApplied = false;
+        private bool styleApplying = false;
 
         /// <summary>
         /// Gets accessibility name.
@@ -193,7 +193,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void UpdateState()
         {
-            if (!styleApplied) return;
+            if (styleApplying) return;
 
             ControlState sourceState = ControlState;
             ControlState targetState;

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -1005,7 +1005,7 @@ namespace Tizen.NUI.Components
         {
             Debug.Assert(buttonIcon != null && buttonText != null);
 
-            styleApplied = false;
+            styleApplying = true;
 
             base.ApplyStyle(viewStyle);
 
@@ -1041,7 +1041,7 @@ namespace Tizen.NUI.Components
                 }
             }
 
-            styleApplied = true;
+            styleApplying = false;
             UpdateState();
         }
 


### PR DESCRIPTION
There was a flag that prevent state updating while applying style. But the flag seemed to have a bug : when style is disabled, the state updating is never going to be done.

This patch fixes the bug and changes the flag's name to be more contextual: styleApplied -> styleApplying.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
