### PR TITLE
[NUI] Fix to use SizeHeight instead of Size with width 0

### DIFF
--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -161,7 +161,7 @@ namespace Tizen.NUI.Components
                 },
                 Buttons = new ButtonStyle()
                 {
-                    Size = new Size(0, 80),
+                    SizeHeight = 80,
                     CornerRadius = 0,
                     BackgroundColor = new Selector<Color>()
                     {
@@ -603,7 +603,7 @@ namespace Tizen.NUI.Components
                     PixelSize = 24,
                     VerticalAlignment = VerticalAlignment.Center,
                     HorizontalAlignment = HorizontalAlignment.Center,
-                    Size = new Size(0, 44),
+                    SizeHeight = 44,
                     TextColor = new Selector<Color>()
                     {
                         Normal = new Color(0.035f, 0.055f, 0.123f, 1.0f),
@@ -737,7 +737,7 @@ namespace Tizen.NUI.Components
                         PixelSize = 24,
                         VerticalAlignment = VerticalAlignment.Center,
                         HorizontalAlignment = HorizontalAlignment.Center,
-                        Size = new Size(0, 44),
+                        SizeHeight = 44,
                         TextColor = new Selector<Color>()
                         {
                             Normal = new Color(0.035f, 0.055f, 0.123f, 1.0f),
@@ -762,7 +762,7 @@ namespace Tizen.NUI.Components
                         PixelSize = 24,
                         VerticalAlignment = VerticalAlignment.Center,
                         HorizontalAlignment = HorizontalAlignment.Center,
-                        Size = new Size(0, 44),
+                        SizeHeight = 44,
                         TextColor = new Selector<Color>()
                         {
                             Normal = new Color(0.035f, 0.055f, 0.123f, 1.0f),


### PR DESCRIPTION
Previously, although users sets size with width 0, the width is updated by dali's size calculation (e.g. text calculation) instead of width 0 set by user.

The following patch fixed the above bug.
8033b0ed4a31ebcd9449c2e0c98074247502c9be

By applying the above patch, some size assignment in theme should be fixed to set size height instead of size with width 0.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
