### PR TITLE
[NUI.Gadget] Add NUIGadget class for inhouse developers

### DIFF
--- a/src/Tizen.NUI.Gadget/Interop/Interop.Libc.cs
+++ b/src/Tizen.NUI.Gadget/Interop/Interop.Libc.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Libc
+    {
+        [DllImport(Libraries.Libc, EntryPoint = "getenv")]
+        internal static extern IntPtr GetEnviornmentVariable(string name);
+    }
+}

--- a/src/Tizen.NUI.Gadget/Interop/Interop.Libraries.cs
+++ b/src/Tizen.NUI.Gadget/Interop/Interop.Libraries.cs
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal static partial class Interop
+{
+    internal static partial class Libraries
+    {
+        public const string PackageManager = "libcapi-appfw-package-manager.so.0";
+        public const string Libc = "libc.so.6";
+    }
+}

--- a/src/Tizen.NUI.Gadget/Interop/Interop.PkgMgrInfo.cs
+++ b/src/Tizen.NUI.Gadget/Interop/Interop.PkgMgrInfo.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class PackageManagerInfo
+    {
+        internal enum ErrorCode
+        {
+            None = 0,
+            Error = -1,
+            InvalidParameter = -2,
+            NoSuchPackage = -3,
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate int PackageInfoPackageMetadataListCallback(string key, string value, IntPtr userData);
+        // int (*pkgmgrinfo_pkg_metadata_list_cb)(const char *key, const char *value, void *user_data);
+
+        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_pkginfo")]
+        internal static extern ErrorCode PackageInfoGet(string packageId, out IntPtr handle);
+
+        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_destroy_pkginfo")]
+        internal static extern ErrorCode PackageInfoDestroy(IntPtr handle);
+
+        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_type")]
+        internal static extern ErrorCode PackageInfoGetResourceType(IntPtr handle, out IntPtr resourceType);
+
+        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_get_res_version")]
+        internal static extern ErrorCode PackageInfoGetResourceVersion(IntPtr handle, out IntPtr resourceVersion);
+
+        [DllImport(Libraries.PackageManager, EntryPoint = "pkgmgrinfo_pkginfo_foreach_metadata")]
+        internal static extern ErrorCode PackageInfoForeachMetadata(IntPtr handle, PackageInfoPackageMetadataListCallback callback, IntPtr userData);
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI.Gadget.csproj
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI.Gadget.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Tizen.Applications.Common\Tizen.Applications.Common.csproj" />
+    <ProjectReference Include="..\Tizen.Log\Tizen.Log.csproj" />
+    <ProjectReference Include="..\Tizen.NUI\Tizen.NUI.csproj" />
+    <ProjectReference Include="..\Tizen\Tizen.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Tizen.NUI.Gadget/Tizen.NUI.Gadget.sln
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI.Gadget.sln
@@ -1,0 +1,79 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI.Gadget", "Tizen.NUI.Gadget.csproj", "{2BD02936-BA0A-4738-BFCC-C939627FB414}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen", "..\Tizen\Tizen.csproj", "{2E04FB0F-03F4-40B0-BB25-5ADFB08C8DF3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Log", "..\Tizen.Log\Tizen.Log.csproj", "{8DA5B43B-63E9-460C-B64F-0B691539DC5D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Applications.Common", "..\Tizen.Applications.Common\Tizen.Applications.Common.csproj", "{2AEDCAA7-543F-48A1-BEA3-CF3E14F6EDC2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI", "..\Tizen.NUI\Tizen.NUI.csproj", "{E62C42D3-9CE0-4EE4-930B-59AD6B9E84BE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Applications.ComponentBased", "..\Tizen.Applications.ComponentBased\Tizen.Applications.ComponentBased.csproj", "{A9B4744E-EECC-44B6-8357-843DD20617EC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.System.Information", "..\Tizen.System.Information\Tizen.System.Information.csproj", "{AD4B56C0-01B2-4ED0-9DBD-6CF233D16FF4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Applications.ThemeManager", "..\Tizen.Applications.ThemeManager\Tizen.Applications.ThemeManager.csproj", "{F57F6911-C581-49CA-80A5-9B5DDDAE3D40}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.Tracer", "..\Tizen.Tracer\Tizen.Tracer.csproj", "{3B1A591D-0DBD-4456-9602-7039ED731C8C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.System.SystemSettings", "..\Tizen.System.SystemSettings\Tizen.System.SystemSettings.csproj", "{8D71B1B6-9901-436F-8914-9F812E1B10A7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2BD02936-BA0A-4738-BFCC-C939627FB414}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BD02936-BA0A-4738-BFCC-C939627FB414}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BD02936-BA0A-4738-BFCC-C939627FB414}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BD02936-BA0A-4738-BFCC-C939627FB414}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2E04FB0F-03F4-40B0-BB25-5ADFB08C8DF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E04FB0F-03F4-40B0-BB25-5ADFB08C8DF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E04FB0F-03F4-40B0-BB25-5ADFB08C8DF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E04FB0F-03F4-40B0-BB25-5ADFB08C8DF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DA5B43B-63E9-460C-B64F-0B691539DC5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DA5B43B-63E9-460C-B64F-0B691539DC5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DA5B43B-63E9-460C-B64F-0B691539DC5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DA5B43B-63E9-460C-B64F-0B691539DC5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AEDCAA7-543F-48A1-BEA3-CF3E14F6EDC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2AEDCAA7-543F-48A1-BEA3-CF3E14F6EDC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AEDCAA7-543F-48A1-BEA3-CF3E14F6EDC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2AEDCAA7-543F-48A1-BEA3-CF3E14F6EDC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E62C42D3-9CE0-4EE4-930B-59AD6B9E84BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E62C42D3-9CE0-4EE4-930B-59AD6B9E84BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E62C42D3-9CE0-4EE4-930B-59AD6B9E84BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E62C42D3-9CE0-4EE4-930B-59AD6B9E84BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9B4744E-EECC-44B6-8357-843DD20617EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9B4744E-EECC-44B6-8357-843DD20617EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9B4744E-EECC-44B6-8357-843DD20617EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9B4744E-EECC-44B6-8357-843DD20617EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD4B56C0-01B2-4ED0-9DBD-6CF233D16FF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD4B56C0-01B2-4ED0-9DBD-6CF233D16FF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD4B56C0-01B2-4ED0-9DBD-6CF233D16FF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD4B56C0-01B2-4ED0-9DBD-6CF233D16FF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F57F6911-C581-49CA-80A5-9B5DDDAE3D40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F57F6911-C581-49CA-80A5-9B5DDDAE3D40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F57F6911-C581-49CA-80A5-9B5DDDAE3D40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F57F6911-C581-49CA-80A5-9B5DDDAE3D40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B1A591D-0DBD-4456-9602-7039ED731C8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B1A591D-0DBD-4456-9602-7039ED731C8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B1A591D-0DBD-4456-9602-7039ED731C8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B1A591D-0DBD-4456-9602-7039ED731C8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D71B1B6-9901-436F-8914-9F812E1B10A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D71B1B6-9901-436F-8914-9F812E1B10A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D71B1B6-9901-436F-8914-9F812E1B10A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D71B1B6-9901-436F-8914-9F812E1B10A7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E9B5E719-0EB7-430C-97DC-3FE2E50EE668}
+	EndGlobalSection
+EndGlobal

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/Log.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/Log.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Copyright (c) 2022 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Runtime.CompilerServices;
+
+namespace Tizen.NUI
+{
+    internal class Log
+    {
+        private static string LogTag = "Tizen.NUI.Gadget";
+
+        public static void Error(string message, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
+        {
+            Tizen.Log.Error(LogTag, message, file, func, line);
+        }
+
+        public static void Warn(string message, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
+        {
+            Tizen.Log.Warn(LogTag, message, file, func, line);
+        }
+
+        public static void Info(string message, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
+        {
+            Tizen.Log.Info(LogTag, message, file, func, line);
+        }
+
+        public static void Debug(string message, [CallerFilePath] string file = "", [CallerMemberName] string func = "", [CallerLineNumber] int line = 0)
+        {
+            Tizen.Log.Debug(LogTag, message, file, func, line);
+        }
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
@@ -24,7 +24,7 @@ namespace Tizen.NUI
     /// <summary>
     /// This class represents a NUIGadget controlled lifecycles.
     /// </summary>
-    /// <since_tizen> 11 </since_tizen>
+    /// <since_tizen> 10 </since_tizen>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class NUIGadget
     {
@@ -32,7 +32,7 @@ namespace Tizen.NUI
         /// Initializes the gadget.
         /// </summary>
         /// /// <param name="type">The type of the NUIGadget.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public NUIGadget(NUIGadgetType type)
         {
             Type = type;
@@ -44,7 +44,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the class representing information of the current gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public NUIGadgetInfo NUIGadgetInfo
         {
             internal set;
@@ -54,7 +54,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the type.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public NUIGadgetType Type
         {
             internal set;
@@ -64,7 +64,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the class name.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public string ClassName
         {
             internal set;
@@ -74,7 +74,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the main view.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public View MainView
         {
             internal set;
@@ -84,7 +84,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the lifecycle state.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public NUIGadgetLifecycleState State
         {
             internal set;
@@ -163,7 +163,7 @@ namespace Tizen.NUI
         /// If 'base.OnCreate()' is not called, the event 'NUIGadgetLifecycleChanged' with  the 'NUIGadgetLifecycleState.Created' state will not be emitted.
         /// </summary>
         /// <returns>The main view object.</returns>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual Tizen.NUI.BaseComponents.View OnCreate()
         {
             State = NUIGadgetLifecycleState.Created;
@@ -175,7 +175,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the gadget receives the appcontrol message.
         /// </summary>
         /// <param name="e">The appcontrol received event argument.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnAppControlReceived(AppControlReceivedEventArgs e)
         {
         }
@@ -184,7 +184,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the gadget is destroyed.
         /// If 'base.OnDestroy()' is not called. the event 'NUIGadgetLifecycleChanged' with the 'NUIGadgetLifecycleState.Destroyed' state will not be emitted.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnDestroy()
         {
             State = NUIGadgetLifecycleState.Destroyed;
@@ -195,7 +195,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the gadget is paused.
         /// If 'base.OnPause()' is not called. the event 'NUIGadgetLifecycleChanged' with the 'NUIGadgetLifecycleState.Paused' state will not be emitted.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnPause()
         {
             State = NUIGadgetLifecycleState.Paused;
@@ -206,7 +206,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the gadget is resumed.
         /// If 'base.OnResume()' is not called. the event 'NUIGadgetLifecycleChanged' with the 'NUIGadgetLifecycleState.Resumed' state will not be emitted.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnResume()
         {
             State = NUIGadgetLifecycleState.Resumed;
@@ -217,7 +217,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the system language is changed.
         /// </summary>
         /// <param name="e">The locale changed event argument.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnLocaleChanged(LocaleChangedEventArgs e)
         {
         }
@@ -226,7 +226,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the system battery is low.
         /// </summary>
         /// <param name="e">The low batter event argument.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnLowBattery(LowBatteryEventArgs e)
         {
         }
@@ -235,7 +235,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the system memory is low.
         /// </summary>
         /// <param name="e">The low memory event argument.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnLowMemory(LowMemoryEventArgs e)
         {
         }
@@ -244,7 +244,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the region format is changed.
         /// </summary>
         /// <param name="e">The region format changed event argument.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnRegionFormatChanged(RegionFormatChangedEventArgs e)
         {
         }
@@ -253,7 +253,7 @@ namespace Tizen.NUI
         /// Overrides this method if want to handle behavior when the device orientation is changed.
         /// </summary>
         /// <param name="e">The device orientation changed event argument.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         protected virtual void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
         {
         }
@@ -261,7 +261,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Finishes the gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public void Finish()
         {
             Pause();

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
@@ -1,0 +1,271 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.Applications;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// This class represents a NUIGadget controlled lifecycles.
+    /// </summary>
+    /// <since_tizen> 11 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class NUIGadget
+    {
+        /// <summary>
+        /// Initializes the gadget.
+        /// </summary>
+        /// /// <param name="type">The type of the NUIGadget.</param>
+        /// <since_tizen> 11 </since_tizen>
+        public NUIGadget(NUIGadgetType type)
+        {
+            Type = type;
+            State = NUIGadgetLifecycleState.Initialized;
+        }
+
+        internal event EventHandler<NUIGadgetLifecycleChangedEventArgs> LifecycleChanged;
+
+        /// <summary>
+        /// Gets the class representing information of the current gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public NUIGadgetInfo NUIGadgetInfo
+        {
+            internal set;
+            get;
+        }
+
+        /// <summary>
+        /// Gets the type.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public NUIGadgetType Type
+        {
+            internal set;
+            get;
+        }
+
+        /// <summary>
+        /// Gets the class name.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public string ClassName
+        {
+            internal set;
+            get;
+        }
+
+        /// <summary>
+        /// Gets the main view.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public View MainView
+        {
+            internal set;
+            get;
+        }
+
+        /// <summary>
+        /// Gets the lifecycle state.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public NUIGadgetLifecycleState State
+        {
+            internal set;
+            get;
+        }
+
+        internal bool Create()
+        {
+            MainView = OnCreate();
+            if (MainView == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        internal void Resume()
+        {
+            if (State == NUIGadgetLifecycleState.Created || State == NUIGadgetLifecycleState.Paused)
+                OnResume();
+        }
+
+        internal void Pause()
+        {
+            if (State == NUIGadgetLifecycleState.Resumed)
+                OnPause();
+        }
+
+        internal void Destroy()
+        {
+            if (State == NUIGadgetLifecycleState.Created || State == NUIGadgetLifecycleState.Paused)
+                OnDestroy();
+        }
+
+        internal void HandleAppControlReceivedEvent(AppControlReceivedEventArgs args)
+        {
+            OnAppControlReceived(args);
+        }
+
+        internal void HandleEvents(NUIGadgetEventType eventType, EventArgs args)
+        {
+            switch (eventType)
+            {
+                case NUIGadgetEventType.LocaleChanged:
+                    OnLocaleChanged((LocaleChangedEventArgs)args);
+                    break;
+                case NUIGadgetEventType.LowMemory:
+                    OnLowMemory((LowMemoryEventArgs)args);
+                    break;
+                case NUIGadgetEventType.LowBattery:
+                    OnLowBattery((LowBatteryEventArgs)args);
+                    break;
+                case NUIGadgetEventType.RegionFormatChanged:
+                    OnRegionFormatChanged((RegionFormatChangedEventArgs)args);
+                    break;
+                case NUIGadgetEventType.DeviceORientationChanged:
+                    OnDeviceOrientationChanged((DeviceOrientationEventArgs)args);
+                    break;
+                default:
+                    Log.Warn("Unknown Event Type: " + eventType);
+                    break;
+            }
+        }
+
+        private void NotifyLifecycleChanged()
+        {
+            var args = new NUIGadgetLifecycleChangedEventArgs();
+            args.State = State;
+            args.Gadget = this;
+            LifecycleChanged?.Invoke(null, args);
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the gedget is started.
+        /// If 'base.OnCreate()' is not called, the event 'NUIGadgetLifecycleChanged' with  the 'NUIGadgetLifecycleState.Created' state will not be emitted.
+        /// </summary>
+        /// <returns>The main view object.</returns>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual Tizen.NUI.BaseComponents.View OnCreate()
+        {
+            State = NUIGadgetLifecycleState.Created;
+            NotifyLifecycleChanged();
+            return null;
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the gadget receives the appcontrol message.
+        /// </summary>
+        /// <param name="e">The appcontrol received event argument.</param>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnAppControlReceived(AppControlReceivedEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the gadget is destroyed.
+        /// If 'base.OnDestroy()' is not called. the event 'NUIGadgetLifecycleChanged' with the 'NUIGadgetLifecycleState.Destroyed' state will not be emitted.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnDestroy()
+        {
+            State = NUIGadgetLifecycleState.Destroyed;
+            NotifyLifecycleChanged();
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the gadget is paused.
+        /// If 'base.OnPause()' is not called. the event 'NUIGadgetLifecycleChanged' with the 'NUIGadgetLifecycleState.Paused' state will not be emitted.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnPause()
+        {
+            State = NUIGadgetLifecycleState.Paused;
+            NotifyLifecycleChanged();
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the gadget is resumed.
+        /// If 'base.OnResume()' is not called. the event 'NUIGadgetLifecycleChanged' with the 'NUIGadgetLifecycleState.Resumed' state will not be emitted.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnResume()
+        {
+            State = NUIGadgetLifecycleState.Resumed;
+            NotifyLifecycleChanged();
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the system language is changed.
+        /// </summary>
+        /// <param name="e">The locale changed event argument.</param>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnLocaleChanged(LocaleChangedEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the system battery is low.
+        /// </summary>
+        /// <param name="e">The low batter event argument.</param>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnLowBattery(LowBatteryEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the system memory is low.
+        /// </summary>
+        /// <param name="e">The low memory event argument.</param>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnLowMemory(LowMemoryEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the region format is changed.
+        /// </summary>
+        /// <param name="e">The region format changed event argument.</param>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnRegionFormatChanged(RegionFormatChangedEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Overrides this method if want to handle behavior when the device orientation is changed.
+        /// </summary>
+        /// <param name="e">The device orientation changed event argument.</param>
+        /// <since_tizen> 11 </since_tizen>
+        protected virtual void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
+        {
+        }
+
+        /// <summary>
+        /// Finishes the gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public void Finish()
+        {
+            Pause();
+            Destroy();
+        }
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetEventType.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetEventType.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Tizen.NUI
+{
+    internal enum NUIGadgetEventType
+    {
+        LocaleChanged = 0,
+
+        LowBattery = 1,
+
+        LowMemory = 2,
+
+        RegionFormatChanged = 3,
+
+        DeviceORientationChanged = 4,
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
@@ -1,0 +1,176 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using Tizen.Applications;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// This class provides properties to get information the gadget.
+    /// </summary>
+    /// <since_tizen> 11 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class NUIGadgetInfo
+    {
+        private const string MetadataUIGadgetDll = "http://tizen.org/metadata/ui-gadget/dll";
+        private string _resourcePath = string.Empty;
+
+        internal NUIGadgetInfo(string packageId)
+        {
+            PackageId = packageId;
+            Log.Warn("PackageId: " + PackageId);
+            AllowedPath = Application.Current.DirectoryInfo.Resource + "mount/allowed/";
+            Log.Warn("AllowedPath: " + AllowedPath);
+            GlobalPath = Application.Current.DirectoryInfo.Resource + "mount/global/";
+            Log.Warn("GlobalPath: " + GlobalPath);
+        }
+
+        private string AllowedPath { get; set; }
+
+        private string GlobalPath { get; set; }
+
+        /// <summary>
+        /// Gets the package ID of the gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public string PackageId { get; private set; }
+
+        /// <summary>
+        /// Gets the resource type of the gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public string ResourceType { get; private set; }
+
+        /// <summary>
+        /// Gets the resource version of the gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public string ResourceVersion { get; private set; }
+
+        /// <summary>
+        /// Gets the resource path of the gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public string ResourcePath
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(_resourcePath))
+                    return _resourcePath;
+
+                if (File.Exists(GlobalPath + ExecutableFile))
+                {
+                    _resourcePath = GlobalPath;
+                }
+                else if (File.Exists(AllowedPath + ExecutableFile))
+                {
+                    _resourcePath = AllowedPath;
+                }
+
+                return _resourcePath;
+            }
+        }
+
+        /// <summary>
+        /// Gets the executable file of the gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public string ExecutableFile { get; internal set; }
+
+        /// <summary>
+        /// Gets the metadata of the gadget.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public IDictionary<string, string> Metadata { get; private set; }
+
+        internal static NUIGadgetInfo CreateNUIGadgetInfo(string packageId)
+        {
+            Interop.PackageManagerInfo.ErrorCode errorCode = Interop.PackageManagerInfo.PackageInfoGet(packageId, out IntPtr handle);
+            if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+            {
+                Log.Error("Failed to get package info. error = " + errorCode);
+                return null;
+            }
+
+            NUIGadgetInfo info = new NUIGadgetInfo(packageId);
+
+            errorCode = Interop.PackageManagerInfo.PackageInfoGetResourceType(handle, out IntPtr resourceTypePtr);
+            if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+            {
+                Log.Error("Failed to get resource type. error = " + errorCode);
+            }
+            else
+            {
+                info.ResourceType = Marshal.PtrToStringAnsi(resourceTypePtr);
+            }
+
+            errorCode = Interop.PackageManagerInfo.PackageInfoGetResourceVersion(handle, out IntPtr resourceVersionPtr);
+            if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+            {
+                Log.Error("Failed to get resource version. error = " + errorCode);
+            }
+            else
+            {
+                info.ResourceVersion = Marshal.PtrToStringAnsi(resourceVersionPtr);
+            }
+
+            Dictionary<string, string> metadata = new Dictionary<string, string>();
+            int callback(string key, string value, IntPtr userData)
+            {
+                Log.Info("key: " + key + ", value: " + value);
+                if (key.Length != 0)
+                {
+                    if (!metadata.ContainsKey(key))
+                    {
+                        metadata.Add(key, value);
+                    }
+                }
+                return 0;
+            }
+
+            errorCode = Interop.PackageManagerInfo.PackageInfoForeachMetadata(handle, callback, IntPtr.Zero);
+            if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+            {
+                Log.Error("Failed to retrieve meatadata. error = " + errorCode);
+            }
+
+            info.Metadata = metadata;
+
+            if (info.Metadata.TryGetValue(MetadataUIGadgetDll, out string executableFile))
+            {
+                info.ExecutableFile = executableFile;
+                Log.Info("ExecutableFile: " + info.ExecutableFile);
+            }
+            else
+            {
+                Log.Error("Failed to find metadata. " + MetadataUIGadgetDll);
+            }
+
+            errorCode = Interop.PackageManagerInfo.PackageInfoDestroy(handle);
+            if (errorCode != Interop.PackageManagerInfo.ErrorCode.None)
+            {
+                Log.Warn("Failed to destroy package info. error = " + errorCode);
+            }
+
+            return info;
+        }
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
@@ -26,7 +26,7 @@ namespace Tizen.NUI
     /// <summary>
     /// This class provides properties to get information the gadget.
     /// </summary>
-    /// <since_tizen> 11 </since_tizen>
+    /// <since_tizen> 10 </since_tizen>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class NUIGadgetInfo
     {
@@ -50,25 +50,25 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the package ID of the gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public string PackageId { get; private set; }
 
         /// <summary>
         /// Gets the resource type of the gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public string ResourceType { get; private set; }
 
         /// <summary>
         /// Gets the resource version of the gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public string ResourceVersion { get; private set; }
 
         /// <summary>
         /// Gets the resource path of the gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public string ResourcePath
         {
             get
@@ -92,13 +92,13 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the executable file of the gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public string ExecutableFile { get; internal set; }
 
         /// <summary>
         /// Gets the metadata of the gadget.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public IDictionary<string, string> Metadata { get; private set; }
 
         internal static NUIGadgetInfo CreateNUIGadgetInfo(string packageId)

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleChangedEventArgs.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleChangedEventArgs.cs
@@ -22,20 +22,20 @@ namespace Tizen.NUI
     /// <summary>
     /// Arguments for the event raised when the NUIGadget lifecycle is changed.
     /// </summary>
-    /// <since_tizen> 11 </since_tizen>
+    /// <since_tizen> 10 </since_tizen>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class NUIGadgetLifecycleChangedEventArgs : EventArgs
     {
         /// <summary>
         /// The NUIGadget object.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public NUIGadget Gadget { get; internal set; }
 
         /// <summary>
         /// The state of the NUIGadget lifecycle.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public NUIGadgetLifecycleState State { get; internal set; }
     }
 }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleChangedEventArgs.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleChangedEventArgs.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Arguments for the event raised when the NUIGadget lifecycle is changed.
+    /// </summary>
+    /// <since_tizen> 11 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class NUIGadgetLifecycleChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The NUIGadget object.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public NUIGadget Gadget { get; internal set; }
+
+        /// <summary>
+        /// The state of the NUIGadget lifecycle.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public NUIGadgetLifecycleState State { get; internal set; }
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleState.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleState.cs
@@ -21,7 +21,7 @@ namespace Tizen.NUI
     /// <summary>
     /// Enumeration for the lifecycle state of the NUIGadget.
     /// </summary>
-    /// <since_tizen> 11 </since_tizen>
+    /// <since_tizen> 10 </since_tizen>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public  enum NUIGadgetLifecycleState
     {
@@ -29,35 +29,35 @@ namespace Tizen.NUI
         /// The initialized state.
         /// This state is set when the gadget is initialized. The constructor of the NUIGadget is called.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         Initialized = 0,
 
         /// <summary>
         /// The created state.
         /// This state is set when the gadget is created. The 'OnCreate()' method of the NUIGadget is called.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         Created = 1,
 
         /// <summary>
         /// The resumed state.
         /// This state is set when the gadget is resumed. The 'OnResume()' method of the NUIGadget is called.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         Resumed = 2,
 
         /// <summary>
         /// The paused state.
         /// This state is set when the gadget is paused. The 'OnPause()' method of the NUIGadget is called.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         Paused = 3,
 
         /// <summary>
         /// The destroyed state.
         /// This state is set when the gadget is destroyed. The 'OnDestroy()' method of the NUIGadget is called.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         Destroyed = 4,
     }
 }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleState.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleState.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Enumeration for the lifecycle state of the NUIGadget.
+    /// </summary>
+    /// <since_tizen> 11 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public  enum NUIGadgetLifecycleState
+    {
+        /// <summary>
+        /// The initialized state.
+        /// This state is set when the gadget is initialized. The constructor of the NUIGadget is called.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        Initialized = 0,
+
+        /// <summary>
+        /// The created state.
+        /// This state is set when the gadget is created. The 'OnCreate()' method of the NUIGadget is called.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        Created = 1,
+
+        /// <summary>
+        /// The resumed state.
+        /// This state is set when the gadget is resumed. The 'OnResume()' method of the NUIGadget is called.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        Resumed = 2,
+
+        /// <summary>
+        /// The paused state.
+        /// This state is set when the gadget is paused. The 'OnPause()' method of the NUIGadget is called.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        Paused = 3,
+
+        /// <summary>
+        /// The destroyed state.
+        /// This state is set when the gadget is destroyed. The 'OnDestroy()' method of the NUIGadget is called.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        Destroyed = 4,
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI
     /// <summary>
     /// This class has the methods and events of the NUIGadgetManager.
     /// </summary>
-    /// <since_tizen> 11 </since_tizen>
+    /// <since_tizen> 10 </since_tizen>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class NUIGadgetManager
     {
@@ -101,7 +101,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Occurs when the lifecycle of the NUIGadget is changed.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public static event EventHandler<NUIGadgetLifecycleChangedEventArgs> NUIGadgetLifecycleChanged;
 
         private static void OnNUIGadgetLifecycleChanged(object sender, NUIGadgetLifecycleChangedEventArgs args)
@@ -123,7 +123,7 @@ namespace Tizen.NUI
         /// <returns>The NUIGadget object.</returns>
         /// <exception cref="ArgumentException">Thrown when failed because of a invalid argument.</exception>
         /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public static NUIGadget Add(string resourceType, string className)
         {
             if (!_gadgetInfos.TryGetValue(resourceType, out NUIGadgetInfo info))
@@ -165,7 +165,7 @@ namespace Tizen.NUI
         /// Gets the information of the running NUIGadgets.
         /// </summary>
         /// <returns>The NUIGadget list.</returns>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public static IEnumerable<NUIGadget> GetGadgets()
         {
             return _gadgets;
@@ -175,7 +175,7 @@ namespace Tizen.NUI
         /// Removes the NUIGadget from a NUIGadgetManager.
         /// </summary>
         /// <param name="gadget">The NUIGadget object.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public static void Remove(NUIGadget gadget)
         {
             if (gadget == null || !_gadgets.Contains(gadget))
@@ -198,7 +198,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Removes all NUIGadget from a NUIGadgetManager.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public static void RemoveAll()
         {
             for (int i = _gadgets.Count - 1;  i >= 0; i--)
@@ -211,7 +211,7 @@ namespace Tizen.NUI
         /// Resumes the running NUIGadget.
         /// </summary>
         /// <param name="gadget">The NUIGadget object.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public static void Resume(NUIGadget gadget)
         {
             if (!_gadgets.Contains(gadget))
@@ -230,7 +230,7 @@ namespace Tizen.NUI
         /// Pauses the running NUIGadget.
         /// </summary>
         /// <param name="gadget">The NUIGadget object.</param>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         public static void Pause(NUIGadget gadget)
         {
             if (!_gadgets.Contains(gadget))
@@ -252,6 +252,7 @@ namespace Tizen.NUI
         /// <param name="appControl">The appcontrol object.</param>
         /// <exception cref="ArgumentException">Thrown when failed because of a invalid argument.</exception>
         /// <exception cref="ArgumentNullException">Thrown when failed because the argument is null.</exception>
+        /// <since_tizen> 10 </since_tizen>
         public static void SendAppControl(NUIGadget gadget, AppControl appControl)
         {
             if (gadget == null)

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -1,0 +1,303 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using Tizen.Applications;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Reflection;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// This class has the methods and events of the NUIGadgetManager.
+    /// </summary>
+    /// <since_tizen> 11 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class NUIGadgetManager
+    {
+        private static readonly Dictionary<string, NUIGadgetInfo> _gadgetInfos = new Dictionary<string, NUIGadgetInfo>();
+        private static readonly List<NUIGadget> _gadgets = new List<NUIGadget>();
+
+        static NUIGadgetManager()
+        {
+            IntPtr resPkgIds = Interop.Libc.GetEnviornmentVariable("RES_PKGIDS");
+            if (resPkgIds != IntPtr.Zero)
+            {
+                string packages = Marshal.PtrToStringAnsi(resPkgIds);
+                if (string.IsNullOrEmpty(packages))
+                {
+                    Log.Warn("There is no resource packages");
+                }
+                else
+                {
+                    foreach (string packageId in packages.Split(':').ToList())
+                    {
+                        NUIGadgetInfo info = NUIGadgetInfo.CreateNUIGadgetInfo(packageId);
+                        _gadgetInfos.Add(info.ResourceType, info);
+                    }
+                }
+            }
+            else
+            {
+                Log.Warn("Failed to get environment variable");
+            }
+
+            var context = (CoreApplication)CoreApplication.Current;
+            context.AppControlReceived += OnAppControlReceived;
+            context.LowMemory += OnLowMemory;
+            context.LowBattery += OnLowBattery;
+            context.LocaleChanged += OnLocaleChanged;
+            context.RegionFormatChanged += OnRegionFormatChanged;
+            context.DeviceOrientationChanged += OnDeviceOrientationChanged;
+        }
+
+        private static void OnAppControlReceived(object sender, AppControlReceivedEventArgs args)
+        {
+            HandleAppControl(args);
+        }
+
+        private static void OnLowMemory(object sender, LowMemoryEventArgs args)
+        {
+            HandleEvents(NUIGadgetEventType.LowMemory, args);
+        }
+
+        private static void OnLowBattery(object sender, LowBatteryEventArgs args)
+        {
+            HandleEvents(NUIGadgetEventType.LowBattery, args);
+        }
+
+        private static void OnLocaleChanged(object sender, LocaleChangedEventArgs args)
+        {
+            HandleEvents(NUIGadgetEventType.LocaleChanged, args);
+        }
+
+        private static void OnRegionFormatChanged(object sender, RegionFormatChangedEventArgs args)
+        {
+            HandleEvents(NUIGadgetEventType.RegionFormatChanged, args);
+        }
+
+        private static void OnDeviceOrientationChanged(object sender, DeviceOrientationEventArgs args)
+        {
+            HandleEvents(NUIGadgetEventType.DeviceORientationChanged, args);
+        }
+
+        /// <summary>
+        /// Occurs when the lifecycle of the NUIGadget is changed.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public static event EventHandler<NUIGadgetLifecycleChangedEventArgs> NUIGadgetLifecycleChanged;
+
+        private static void OnNUIGadgetLifecycleChanged(object sender, NUIGadgetLifecycleChangedEventArgs args)
+        {
+            NUIGadgetLifecycleChanged?.Invoke(sender, args);
+
+            if (args.State == NUIGadgetLifecycleState.Destroyed)
+            {
+                args.Gadget.LifecycleChanged -= OnNUIGadgetLifecycleChanged;
+                _gadgets.Remove(args.Gadget);
+            }
+        }
+
+        /// <summary>
+        /// Adds a NUIGadget to a NUIGadgetManager.
+        /// </summary>
+        /// <param name="resourceType">The resource type of the NUIGadget package.</param>
+        /// <param name="className">The class name of the NUIGadget.</param>
+        /// <returns>The NUIGadget object.</returns>
+        /// <exception cref="ArgumentException">Thrown when failed because of a invalid argument.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
+        /// <since_tizen> 11 </since_tizen>
+        public static NUIGadget Add(string resourceType, string className)
+        {
+            if (!_gadgetInfos.TryGetValue(resourceType, out NUIGadgetInfo info))
+            {
+                throw new ArgumentException("Failed to find NUIGadgetInfo. resource type: " + resourceType);
+            }
+
+            Assembly assembly = null;
+            try
+            {
+                Log.Warn("NUIGadgetAssembly.Load(): " + info.ResourcePath + info.ExecutableFile + " ++");
+                assembly = Assembly.Load(File.ReadAllBytes(info.ResourcePath + info.ExecutableFile));
+                Log.Warn("NUIGadgetAssembly.Load(): " + info.ResourcePath + info.ExecutableFile + " --");
+            }
+            catch (FileLoadException e)
+            {
+                throw new InvalidOperationException(e.Message);
+            }
+
+            NUIGadget gadget = assembly.CreateInstance(className) as NUIGadget;
+            if (gadget == null)
+            {
+                throw new InvalidOperationException("Failed to create instance. className: " + className);
+            }
+
+            gadget.NUIGadgetInfo = info;
+            gadget.ClassName = className;
+            gadget.LifecycleChanged += OnNUIGadgetLifecycleChanged;
+            if (!gadget.Create())
+            {
+                throw new InvalidOperationException("The View MUST be created");
+            }
+
+            _gadgets.Add(gadget);
+            return gadget;
+        }
+
+        /// <summary>
+        /// Gets the information of the running NUIGadgets.
+        /// </summary>
+        /// <returns>The NUIGadget list.</returns>
+        /// <since_tizen> 11 </since_tizen>
+        public static IEnumerable<NUIGadget> GetGadgets()
+        {
+            return _gadgets;
+        }
+
+        /// <summary>
+        /// Removes the NUIGadget from a NUIGadgetManager.
+        /// </summary>
+        /// <param name="gadget">The NUIGadget object.</param>
+        /// <since_tizen> 11 </since_tizen>
+        public static void Remove(NUIGadget gadget)
+        {
+            if (gadget == null || !_gadgets.Contains(gadget))
+            {
+                return;
+            }
+
+            if (gadget.State == NUIGadgetLifecycleState.Destroyed)
+            {
+                return;
+            }
+
+            _gadgets.Remove(gadget);
+            CoreApplication.Post(() => {
+                Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
+                gadget.Finish();
+            });
+        }
+
+        /// <summary>
+        /// Removes all NUIGadget from a NUIGadgetManager.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        public static void RemoveAll()
+        {
+            for (int i = _gadgets.Count - 1;  i >= 0; i--)
+            {
+                Remove(_gadgets[i]);
+            }
+        }
+
+        /// <summary>
+        /// Resumes the running NUIGadget.
+        /// </summary>
+        /// <param name="gadget">The NUIGadget object.</param>
+        /// <since_tizen> 11 </since_tizen>
+        public static void Resume(NUIGadget gadget)
+        {
+            if (!_gadgets.Contains(gadget))
+            {
+                return;
+            }
+
+            CoreApplication.Post(() =>
+            {
+                Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
+                gadget.Resume();
+            });
+        }
+
+        /// <summary>
+        /// Pauses the running NUIGadget.
+        /// </summary>
+        /// <param name="gadget">The NUIGadget object.</param>
+        /// <since_tizen> 11 </since_tizen>
+        public static void Pause(NUIGadget gadget)
+        {
+            if (!_gadgets.Contains(gadget))
+            {
+                return;
+            }
+
+            CoreApplication.Post(() =>
+            {
+                Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
+                gadget.Pause();
+            });
+        }
+
+        /// <summary>
+        /// Sends the appcontrol to the running NUIGadget.
+        /// </summary>
+        /// <param name="gadget">The NUIGadget object.</param>
+        /// <param name="appControl">The appcontrol object.</param>
+        /// <exception cref="ArgumentException">Thrown when failed because of a invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when failed because the argument is null.</exception>
+        public static void SendAppControl(NUIGadget gadget, AppControl appControl)
+        {
+            if (gadget == null)
+            {
+                throw new ArgumentNullException(nameof(gadget));
+            }
+
+            if (!_gadgets.Contains(gadget))
+            {
+                throw new ArgumentException("Invalid argument");
+            }
+
+            if (appControl == null)
+            {
+                throw new ArgumentNullException(nameof(appControl));
+            }
+
+            gadget.HandleAppControlReceivedEvent(new AppControlReceivedEventArgs(new ReceivedAppControl(appControl.SafeAppControlHandle)));
+        }
+
+        internal static bool HandleAppControl(AppControlReceivedEventArgs args)
+        {
+            if (!args.ReceivedAppControl.ExtraData.TryGet("__K_GADGET_RES_TYPE", out string resourceType) ||
+                !args.ReceivedAppControl.ExtraData.TryGet("__K_GADGET_CLASS_NAME", out string className))
+            {
+                return false;
+            }
+
+            foreach (NUIGadget gadget in _gadgets)
+            {
+                if (gadget.NUIGadgetInfo.ResourceType == resourceType && gadget.ClassName == className)
+                {
+                    gadget.HandleAppControlReceivedEvent(args);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        internal static void HandleEvents(NUIGadgetEventType eventType, EventArgs args)
+        {
+            foreach (NUIGadget gadget in _gadgets)
+            {
+                gadget.HandleEvents(eventType, args);
+            }
+        }
+    }
+}

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetType.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetType.cs
@@ -21,20 +21,20 @@ namespace Tizen.NUI
     /// <summary>
     /// Enumeration for the type of the NUIGadget.
     /// </summary>
-    /// <since_tizen> 11 </since_tizen>
+    /// <since_tizen> 10 </since_tizen>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum NUIGadgetType
     {
         /// <summary>
         /// The normal type.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         Normal = 0,
 
         /// <summary>
         /// The popup type.
         /// </summary>
-        /// <since_tizen> 11 </since_tizen>
+        /// <since_tizen> 10 </since_tizen>
         Popup = 1,
     }
 }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetType.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetType.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Enumeration for the type of the NUIGadget.
+    /// </summary>
+    /// <since_tizen> 11 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum NUIGadgetType
+    {
+        /// <summary>
+        /// The normal type.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        Normal = 0,
+
+        /// <summary>
+        /// The popup type.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        Popup = 1,
+    }
+}


### PR DESCRIPTION
The NUIGadget is the UI Gadget model for the NUIApplication. The NUIApplication is able to handle gadgets using the NUIGadgetManager.
The dll file of the gadget that is derived by the NUIGadget should be installed to 'res/allowed' or 'res/global' directory.
If the developer wants to allow it only to a specific application, the developer should install it in the 'res/allowed' directory.
And, the developer adds the allowed application information to the tizen-manifest.xml file.
This feature is for inhouse developers. The NUIGadget is available for platform level signed resource packages.