### PR TITLE
[NUI][API10] Fix some SVACE issue

### DIFF
--- a/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
@@ -281,25 +281,34 @@ namespace Tizen.NUI
         {
             if (IsNativeHandleInvalid())
             {
-                var process = global::System.Diagnostics.Process.GetCurrentProcess()?.Id ?? -1;
-                var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
-                var me = this.GetType().FullName;
                 if (this.Disposed)
                 {
                     if (propertyNotificationNotifyEventHandler != null)
                     {
+                        var process = global::System.Diagnostics.Process.GetCurrentProcess();
+                        var processId = process.Id;
+                        var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+                        var me = this.GetType().FullName;
+
                         Tizen.Log.Error("NUI", $"Error! NUI's native dali object is already disposed. " +
                             $"OR the native dali object handle of NUI becomes null! \n" +
-                            $" process:{process} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                            $" process:{processId} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                        process.Dispose();
                     }
                 }
                 else
                 {
                     if (this.IsDisposeQueued)
                     {
+                        var process = global::System.Diagnostics.Process.GetCurrentProcess();
+                        var processId = process.Id;
+                        var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+                        var me = this.GetType().FullName;
+
                         //in this case, this object is ready to be disposed waiting on DisposeQueue, so event callback should not be invoked!
                         Tizen.Log.Error("NUI", "in this case, the View object is ready to be disposed waiting on DisposeQueue, so event callback should not be invoked! just return here! \n" +
-                            $"process:{process} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                            $"process:{processId} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                        process.Dispose();
                         return;
                     }
                 }

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -589,25 +589,34 @@ namespace Tizen.NUI
         {
             if (IsNativeHandleInvalid())
             {
-                var process = global::System.Diagnostics.Process.GetCurrentProcess()?.Id ?? -1;
-                var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
-                var me = this.GetType().FullName;
                 if (this.Disposed)
                 {
                     if (detectedEventHandler != null)
                     {
+                        var process = global::System.Diagnostics.Process.GetCurrentProcess();
+                        var processId = process.Id;
+                        var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+                        var me = this.GetType().FullName;
+
                         Tizen.Log.Error("NUI", $"Error! NUI's native dali object is already disposed. " +
                             $"OR the native dali object handle of NUI becomes null! \n" +
-                            $" process:{process} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                            $" process:{processId} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                        process.Dispose();
                     }
                 }
                 else
                 {
                     if (this.IsDisposeQueued)
                     {
+                        var process = global::System.Diagnostics.Process.GetCurrentProcess();
+                        var processId = process.Id;
+                        var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+                        var me = this.GetType().FullName;
+
                         //in this case, this object is ready to be disposed waiting on DisposeQueue, so event callback should not be invoked!
                         Tizen.Log.Error("NUI", "in this case, the View object is ready to be disposed waiting on DisposeQueue, so event callback should not be invoked! just return here! \n" +
-                            $"process:{process} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                            $"process:{processId} thread:{thread}, isDisposed:{this.Disposed}, isDisposeQueued:{this.IsDisposeQueued}, me:{me}\n");
+                        process.Dispose();
                         return;
                     }
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
SVACE issue：
WID:33777276 global::System.Diagnostics.Process.GetCurrentProcess() becomes out of scope and is not disposed

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
