### PR TITLE
[NUI] Disable compiler warnings complaining about theme off in TV profile

### DIFF
--- a/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-
+#pragma warning disable CS0162 // Unreachable code detected: Some lines can be unreachable in TV profile
 namespace Tizen.NUI.Components
 {
     internal partial class DefaultThemeCreator
@@ -35,4 +35,4 @@ namespace Tizen.NUI.Components
         }
     }
 }
-
+#pragma warning restore CS0162

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -21,6 +21,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Tizen.NUI.BaseComponents;
 
+#pragma warning disable CS0162 // Unreachable code detected: Some lines can be unreachable in TV profile
 namespace Tizen.NUI
 {
     /// <summary>
@@ -534,3 +535,4 @@ namespace Tizen.NUI
         }
     }
 }
+#pragma warning restore CS0162 // Unreachable code detected


### PR DESCRIPTION
There are some code that are unreachable according to device profile.
It's a configuration on compilation which needs a change in the constant to support different devices.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
