### PR TITLE
[Applications.Common] Fix getting default locale

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
@@ -26,6 +26,9 @@ internal static partial class Interop
         [DllImport(Libraries.Libc, EntryPoint = "free", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Free(IntPtr ptr);
 
+        [DllImport(Libraries.Libc, EntryPoint = "getenv")]
+        internal static extern IntPtr GetEnvironmentVariable(string name);
+
         [NativeStruct("struct timespec", Include = "time.h")]
         [StructLayout(LayoutKind.Sequential)]
         internal struct TimeStamp

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -595,12 +595,7 @@ namespace Tizen.Applications
 
         internal static string GetDefaultLocale()
         {
-            IntPtr stringPtr = IntPtr.Zero;
-            if (Interop.BaseUtilsi18n.GetDefault(out stringPtr) != 0)
-            {
-                return string.Empty;
-            }
-
+            IntPtr stringPtr = Interop.Libc.GetEnvironmentVariable("LANG");
             if (stringPtr == IntPtr.Zero)
             {
                 return string.Empty;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Unfortunately, the dotnet loader process uses the icu library before calling the OnCreate() method of the CoreApplication class.
It makes a problem about CultureInfo setting if the language is changed before executing an application.
This request uses the environment variable instead of the base util library.

Signed-off-by: Hwankyu Jhun <h.jhun@samsung.com>