### PR TITLE
[NUI.XamlBuild] Support XamlC for Theme

### DIFF
--- a/src/Tizen.NUI.XamlBuild/src/internal/Xaml/ApplyPropertiesVisitor.cs
+++ b/src/Tizen.NUI.XamlBuild/src/internal/Xaml/ApplyPropertiesVisitor.cs
@@ -137,6 +137,17 @@ namespace Tizen.NUI.Xaml
                 if (xpe == null && TryAddToResourceDictionary(source as ResourceDictionary, value, xKey, node, out xpe))
                     return;
 
+                // Dictionary with string key
+                if (xpe == null && xKey != null)
+                {
+                    var indexer = GetIndexer(source, typeof(string), value.GetType());
+                    if (indexer != null)
+                    {
+                        indexer.SetValue(source, value, new[] { xKey });
+                        return;
+                    }
+                }
+
                 // Collection element, implicit content, or implicit collection element.
                 if (xpe == null && typeof(IEnumerable).IsAssignableFrom(Context.Types[parentElement]) && Context.Types[parentElement].GetRuntimeMethods().Any(mi => mi.Name == "Add" && mi.GetParameters().Length == 1)) {
                     var addMethod =
@@ -724,6 +735,8 @@ namespace Tizen.NUI.Xaml
             SetPropertyValue(source, new XmlName("", runTimeName.Name), value, Context.RootElement, node, Context, node);
             return true;
         }
+
+        private PropertyInfo GetIndexer(object source, Type keyType, Type valueType) => source.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).FirstOrDefault(p => p.Name == "Item" && p.PropertyType.IsAssignableFrom(valueType) && p.GetIndexParameters().Length != 0 && p.GetIndexParameters()[0].ParameterType == keyType);
     }
 }
  

--- a/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NodeILExtensions.cs
+++ b/src/Tizen.NUI.XamlBuild/src/public/XamlBuild/NodeILExtensions.cs
@@ -26,6 +26,7 @@ using Tizen.NUI.Binding;
 using Tizen.NUI.EXaml;
 using Tizen.NUI.EXaml.Build.Tasks;
 using Tizen.NUI.Xaml;
+using Mono.Cecil.Rocks;
 
 using static Mono.Cecil.Cil.Instruction;
 using static Mono.Cecil.Cil.OpCodes;
@@ -589,6 +590,10 @@ namespace Tizen.NUI.Xaml.Build.Tasks
                         {
                             yield return ins;
                         }
+
+                        var realType = targetType.MakeGenericInstanceType(new TypeReference[] { typeReference });
+                        var realMethod = method.MakeGeneric(realType, new TypeReference[] { typeReference });
+                        yield return Create(Call, module.ImportReference(realMethod));
                     }
                 }
 

--- a/src/Tizen.NUI/src/public/Theme/Theme.cs
+++ b/src/Tizen.NUI/src/public/Theme/Theme.cs
@@ -300,6 +300,12 @@ namespace Tizen.NUI
             map[styleName] = value?.Clone();
         }
 
+        /// <summary>
+        /// For internal use
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Add(string key, ViewStyle style) => this[key] = style;
+
         /// <inheritdoc/>
         /// <since_tizen> 9 </since_tizen>
         public object Clone()


### PR DESCRIPTION
To support building Xaml for themes at application compile time, it is needed to add some code to Tizen.NUI.XamlBuild:
* When setting a property, it treats a Theme as a dictionary object.
* When converting a string value to a type that has an implicit operator, it calls an implicit operator explicitly to prevent TypeConversionException at runtime.

Signed-off-by: Jiyun Yang <ji.yang@samsung.com>

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
