### PR TITLE
[NUI] Fix Picker's HeightSpecification

### DIFF
--- a/src/Tizen.NUI.Components/Controls/DatePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/DatePicker.cs
@@ -287,8 +287,6 @@ namespace Tizen.NUI.Components
 
         private void Initialize()
         {
-            HeightSpecification = LayoutParamPolicies.MatchParent;
-
             Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,

--- a/src/Tizen.NUI.Components/Controls/Picker.cs
+++ b/src/Tizen.NUI.Components/Controls/Picker.cs
@@ -402,8 +402,6 @@ namespace Tizen.NUI.Components
 
         private void Initialize()
         {
-            HeightSpecification = LayoutParamPolicies.MatchParent;
-
             //Picker Using scroller internally. actually it is a kind of scroller which has infinity loop,
             //and item center align features.
             pickerScroller = new PickerScroller()

--- a/src/Tizen.NUI.Components/Controls/TimePicker.cs
+++ b/src/Tizen.NUI.Components/Controls/TimePicker.cs
@@ -393,8 +393,6 @@ namespace Tizen.NUI.Components
                          Justification = "The CellPadding will be dispose when the time picker disposed")]
         private void Initialize()
         {
-            HeightSpecification = LayoutParamPolicies.MatchParent;
-
             Layout = new LinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Horizontal,


### PR DESCRIPTION
Previously, HeightSpecifications of Picker, DatePicker, TimePicker are MatchParent.
So the Pickers' SizeHeights are calculated based on their parent's SizeHeight.
This causes the recursive size calculation problem if Picker's parent has WrapContent HeightSpecification. (e.g. Dialog)

Now, the Pickers' SizeHeights are set in DefaultThemeCommon as follows. Picker's SizeHeight is set in DefaultThemeCommon.
DatePicker's Pickers SizeHeights are set in DefaultThemeCommon. TimePicker's Pickers SizeHeights are set in DefaultThemeCommon.

Therefore, Picker does not need to have MatchParent HeightSpecification.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
