### PR TITLE
[NUI] Fix Switch thumb positioning

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI.Components
         private EventHandler<StateChangedEventArgs> stateChangeHandler;
 
         private bool isPressed = false;
-        private bool styleApplying = false;
+        internal int styleApplying = 0;
 
         /// <summary>
         /// Gets accessibility name.
@@ -193,7 +193,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void UpdateState()
         {
-            if (styleApplying) return;
+            if (styleApplying > 0) return;
 
             ControlState sourceState = ControlState;
             ControlState targetState;

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -1005,7 +1005,7 @@ namespace Tizen.NUI.Components
         {
             Debug.Assert(buttonIcon != null && buttonText != null);
 
-            styleApplying = true;
+            styleApplying++;
 
             base.ApplyStyle(viewStyle);
 
@@ -1041,7 +1041,8 @@ namespace Tizen.NUI.Components
                 }
             }
 
-            styleApplying = false;
+            styleApplying--;
+
             UpdateState();
         }
 

--- a/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
@@ -82,6 +82,26 @@ namespace Tizen.NUI.Components.Extension
             }
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override ImageView OnCreateTrack(Switch switchButton, ImageView track)
+        {
+            base.OnCreateTrack(switchButton, track);
+            track.Relayout += (s, e) => {
+                switchButton.Thumb.PositionX = switchButton.IsSelected ? switchButton.Track.Size.Width - switchButton.Thumb.Size.Width : 0;
+            };
+            return track;
+        }
+
+        /// <inheritdoc/>
+        public override ImageView OnCreateThumb(Switch switchButton, ImageView thumb)
+        {
+            base.OnCreateThumb(switchButton, thumb);
+            thumb.Relayout += (s, e) => {
+                thumb.PositionX = switchButton.IsSelected ? switchButton.Track.Size.Width - thumb.Size.Width : 0;
+            };
+            return thumb;
+        }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void Dispose(bool disposing)

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -115,6 +115,10 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void ApplyStyle(ViewStyle viewStyle)
         {
+            styleApplying++;
+
+            base.ApplyStyle(viewStyle);
+
             if (viewStyle is SwitchStyle switchStyle)
             {
                 if (Extension is SwitchExtension extension)
@@ -137,8 +141,9 @@ namespace Tizen.NUI.Components
                     Thumb.ApplyStyle(switchStyle.Thumb);
                 }
             }
+            styleApplying--;
 
-            base.ApplyStyle(viewStyle);
+            UpdateState();
         }
 
         /// <summary>


### PR DESCRIPTION
When the size of thumb or track changes, the it should update the position of the thumb properly.

And to prevent unnecessary switch state updating while applying style, upgrade styleApplying flag to int type.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
