### PR TITLE
[NUI] Fix Button Theme not to set fixed size

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -435,11 +435,11 @@ namespace Tizen.NUI.Components
 
                     if (iconRelativeOrientation == IconOrientation.Left || iconRelativeOrientation == IconOrientation.Right)
                     {
-                        lengthWithoutText += (itemSpacing?.Width ?? 0) + iconMargin.Start + iconMargin.End + textMargin.Start + textMargin.End;
+                        lengthWithoutText += (itemSpacing?.Width ?? 0) + iconMargin.Start + iconMargin.End + textMargin.Start + textMargin.End + Padding.Start + Padding.End;
                     }
                     else
                     {
-                        lengthWithoutText += (itemSpacing?.Height ?? 0) + iconMargin.Top + iconMargin.Bottom + textMargin.Top + textMargin.Bottom;
+                        lengthWithoutText += (itemSpacing?.Height ?? 0) + iconMargin.Top + iconMargin.Bottom + textMargin.Top + textMargin.Bottom + Padding.Top + Padding.Bottom;
                     }
                 }
             }

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -39,7 +39,8 @@ namespace Tizen.NUI.Components
             // Button base style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.Button", new ButtonStyle()
             {
-                Size = new Size(252, 48),
+                MinimumSize = new Size(252, 48),
+                Padding = new Extents(32, 32, 8, 8),
                 ItemSpacing = new Size2D(8, 8),
                 CornerRadius = 12.0f,
                 ItemHorizontalAlignment = HorizontalAlignment.Center,
@@ -62,7 +63,8 @@ namespace Tizen.NUI.Components
             // Outlined Button style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.Button.Outlined", new ButtonStyle()
             {
-                Size = new Size(252, 48),
+                MinimumSize = new Size(252, 48),
+                Padding = new Extents(32, 32, 8, 8),
                 ItemSpacing = new Size2D(8, 8),
                 CornerRadius = 12.0f,
                 BorderlineWidth = 2.0f,
@@ -94,7 +96,6 @@ namespace Tizen.NUI.Components
             // TextOnly Button style
             theme.AddStyleWithoutClone("Tizen.NUI.Components.Button.TextOnly", new ButtonStyle()
             {
-                SizeHeight = 48,
                 MinimumSize = new Size(120, 48),
                 Padding = new Extents(32, 32, 8, 8),
                 ItemHorizontalAlignment = HorizontalAlignment.Center,


### PR DESCRIPTION
To increase Button width based on the Button's text, Button Theme sets MinimumSize instead of fixed Size.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
