### PR TITLE
[NUI] Add constructors with string style to apply string style

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -65,6 +65,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of Dialog with style.
+        /// </summary>
+        /// <param name="style">Creates Dialog by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Dialog(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
         /// Creates a new instance of a Dialog with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created Dialog.</param>

--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -48,6 +48,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of ContentPage with style.
+        /// </summary>
+        /// <param name="style">Creates ContentPage by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ContentPage(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
         /// Creates a new instance of a ContentPage with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created ContentPage.</param>

--- a/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
@@ -57,6 +57,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of DialogPage with style.
+        /// </summary>
+        /// <param name="style">Creates DialogPage by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DialogPage(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
         /// Creates a new instance of a DialogPage with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created DialogPage.</param>

--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -188,6 +188,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of Navigator with style.
+        /// </summary>
+        /// <param name="style">Creates Navigator by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Navigator(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
         /// Creates a new instance of a Navigator with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created Navigator.</param>

--- a/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Page.cs
@@ -134,6 +134,15 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of Page with style.
+        /// </summary>
+        /// <param name="style">Creates Page by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Page(string style) : base(style)
+        {
+        }
+
+        /// <summary>
         /// Creates a new instance of a Page with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created Page.</param>

--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -980,6 +980,16 @@ namespace Tizen.NUI.Components
         /// <summary>
         /// Creates a new instance of a ScrollableBase with style.
         /// </summary>
+        /// <param name="style">Creates ScrollableBase by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ScrollableBase(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// Creates a new instance of a ScrollableBase with style.
+        /// </summary>
         /// <param name="style">A style applied to the newly created ScrollableBase.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ScrollableBase(ControlStyle style) : base(style)

--- a/src/Tizen.NUI.Components/Controls/TabBar.cs
+++ b/src/Tizen.NUI.Components/Controls/TabBar.cs
@@ -78,6 +78,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of TabBar with style.
+        /// </summary>
+        /// <param name="style">Creates TabBar by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabBar(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
         /// Creates a new instance of a TabBar with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created TabBar.</param>

--- a/src/Tizen.NUI.Components/Controls/TabContent.cs
+++ b/src/Tizen.NUI.Components/Controls/TabContent.cs
@@ -45,6 +45,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of TabContent with style.
+        /// </summary>
+        /// <param name="style">Creates TabContent by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabContent(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
         /// Creates a new instance of a TabContent with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created TabContent.</param>

--- a/src/Tizen.NUI.Components/Controls/TabView.cs
+++ b/src/Tizen.NUI.Components/Controls/TabView.cs
@@ -109,6 +109,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Creates a new instance of TabView.
+        /// </summary>
+        /// <param name="style">Creates TabView by special style defined in UX.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TabView(string style) : base(style)
+        {
+            Initialize();
+        }
+
+        /// <summary>
         /// Creates a new instance of a TabView with style.
         /// </summary>
         /// <param name="style">A style applied to the newly created TabView.</param>


### PR DESCRIPTION
To apply string style during constructing controls, constructors with string style are added.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
