### PR TITLE
[NUI] Fix button bugs and improve switch.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.Internal.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI.Components
         private EventHandler<StateChangedEventArgs> stateChangeHandler;
 
         private bool isPressed = false;
-        internal int styleApplying = 0;
+        internal bool styleApplying = false;
 
         /// <summary>
         /// Gets accessibility name.
@@ -193,7 +193,7 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void UpdateState()
         {
-            if (styleApplying > 0) return;
+            if (styleApplying) return;
 
             ControlState sourceState = ControlState;
             ControlState targetState;
@@ -240,19 +240,26 @@ namespace Tizen.NUI.Components
 
             if (type == DisposeTypes.Explicit)
             {
-                Extension?.OnDispose(this);
+                if (Extension != null)
+                {
+                    Extension.OnDispose(this);
+                    Extension = null;
+                }
 
                 if (buttonIcon != null)
                 {
                     Utility.Dispose(buttonIcon);
+                    buttonIcon = null;
                 }
                 if (buttonText != null)
                 {
                     Utility.Dispose(buttonText);
+                    buttonText = null;
                 }
                 if (overlayImage != null)
                 {
                     Utility.Dispose(overlayImage);
+                    overlayImage = null;
                 }
             }
 
@@ -346,54 +353,45 @@ namespace Tizen.NUI.Components
             Size2D cellPadding = String.IsNullOrEmpty(buttonText.Text) ? new Size2D(0, 0) : itemSpacing;
 #pragma warning restore CA2000
 
+            var linearLayout = Layout as LinearLayout;
+            if (linearLayout == null) Layout = (linearLayout = new LinearLayout());
+
             if (IconRelativeOrientation == IconOrientation.Left)
             {
-                Layout = new LinearLayout()
-                {
-                    LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                linearLayout.LinearOrientation = LinearLayout.Orientation.Horizontal;
+                linearLayout.HorizontalAlignment = itemHorizontalAlignment;
+                linearLayout.VerticalAlignment = itemVerticalAlignment;
+                linearLayout.CellPadding = cellPadding;
 
                 Add(buttonIcon);
                 Add(buttonText);
             }
             else if (IconRelativeOrientation == IconOrientation.Right)
             {
-                Layout = new LinearLayout()
-                {
-                    LinearOrientation = LinearLayout.Orientation.Horizontal,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                linearLayout.LinearOrientation = LinearLayout.Orientation.Horizontal;
+                linearLayout.HorizontalAlignment = itemHorizontalAlignment;
+                linearLayout.VerticalAlignment = itemVerticalAlignment;
+                linearLayout.CellPadding = cellPadding;
 
                 Add(buttonText);
                 Add(buttonIcon);
             }
             else if (IconRelativeOrientation == IconOrientation.Top)
             {
-                Layout = new LinearLayout()
-                {
-                    LinearOrientation = LinearLayout.Orientation.Vertical,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                linearLayout.LinearOrientation = LinearLayout.Orientation.Vertical;
+                linearLayout.HorizontalAlignment = itemHorizontalAlignment;
+                linearLayout.VerticalAlignment = itemVerticalAlignment;
+                linearLayout.CellPadding = cellPadding;
 
                 Add(buttonIcon);
                 Add(buttonText);
             }
             else if (IconRelativeOrientation == IconOrientation.Bottom)
             {
-                Layout = new LinearLayout()
-                {
-                    LinearOrientation = LinearLayout.Orientation.Vertical,
-                    HorizontalAlignment = itemHorizontalAlignment,
-                    VerticalAlignment = itemVerticalAlignment,
-                    CellPadding = cellPadding
-                };
+                linearLayout.LinearOrientation = LinearLayout.Orientation.Vertical;
+                linearLayout.HorizontalAlignment = itemHorizontalAlignment;
+                linearLayout.VerticalAlignment = itemVerticalAlignment;
+                linearLayout.CellPadding = cellPadding;
 
                 Add(buttonText);
                 Add(buttonIcon);

--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -1005,20 +1005,18 @@ namespace Tizen.NUI.Components
         {
             Debug.Assert(buttonIcon != null && buttonText != null);
 
-            styleApplying++;
-
             base.ApplyStyle(viewStyle);
 
-            if (viewStyle is ButtonStyle buttonStyle)
+            if (!styleApplying && viewStyle is ButtonStyle buttonStyle)
             {
-                Extension = buttonStyle.CreateExtension();
+                styleApplying = true;
 
                 if (buttonStyle.Overlay != null)
                 {
                     OverlayImage?.ApplyStyle(buttonStyle.Overlay);
                 }
 
-                if (Extension != null)
+                if ((Extension = buttonStyle.CreateExtension()) != null)
                 {
                     buttonIcon.Unparent();
                     buttonIcon = Extension.OnCreateIcon(this, buttonIcon);
@@ -1039,9 +1037,8 @@ namespace Tizen.NUI.Components
                 {
                     buttonIcon.ApplyStyle(buttonStyle.Icon);
                 }
+                styleApplying = false;
             }
-
-            styleApplying--;
 
             UpdateState();
         }

--- a/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SlidingSwitchExtension.cs
@@ -82,27 +82,12 @@ namespace Tizen.NUI.Components.Extension
             }
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override ImageView OnCreateTrack(Switch switchButton, ImageView track)
+        public override void OnTrackOrThumbResized(Switch switchButton, ImageView track, ImageView thumb)
         {
-            base.OnCreateTrack(switchButton, track);
-            track.Relayout += (s, e) => {
-                if (slidingAnimation.State == Animation.States.Playing) return;
-                switchButton.Thumb.PositionX = switchButton.IsSelected ? switchButton.Track.Size.Width - switchButton.Thumb.Size.Width : 0;
-            };
-            return track;
-        }
-
-        /// <inheritdoc/>
-        public override ImageView OnCreateThumb(Switch switchButton, ImageView thumb)
-        {
-            base.OnCreateThumb(switchButton, thumb);
-            thumb.Relayout += (s, e) => {
-                if (slidingAnimation.State == Animation.States.Playing) return;
-                thumb.PositionX = switchButton.IsSelected ? switchButton.Track.Size.Width - thumb.Size.Width : 0;
-            };
-            return thumb;
+            var destX = switchButton.IsSelected ? switchButton.Track.Size.Width - thumb.Size.Width : 0;
+            if (destX != thumb.PositionX) thumb.PositionX = destX;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI.Components/Controls/Extension/SwitchExtension.cs
+++ b/src/Tizen.NUI.Components/Controls/Extension/SwitchExtension.cs
@@ -65,5 +65,11 @@ namespace Tizen.NUI.Components.Extension
         public virtual void OnSelectedChanged(Switch switchButton)
         {
         }
+
+        /// <summary> Called when the Switch's track or thumb resized. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual void OnTrackOrThumbResized(Switch switchButton, ImageView track, ImageView thumb)
+        {
+        }
     }
 }

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -115,20 +115,29 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override void ApplyStyle(ViewStyle viewStyle)
         {
-            styleApplying++;
+            styleApplying = true;
 
             base.ApplyStyle(viewStyle);
 
             if (viewStyle is SwitchStyle switchStyle)
             {
-                if (Extension is SwitchExtension extension)
+                if (Extension != null) Extension.OnDispose(this);
+
+                if ((Extension = switchStyle.CreateExtension()) != null && Extension is SwitchExtension extension)
                 {
                     Icon.Unparent();
                     thumb.Unparent();
+                    TextLabel.Unparent();
                     Icon = extension.OnCreateTrack(this, Icon);
                     thumb = extension.OnCreateThumb(this, thumb);
                     Icon.Add(thumb);
                     LayoutItems();
+
+                    Icon.Relayout -= OnTrackOrThumbRelayout;
+                    Icon.Relayout += OnTrackOrThumbRelayout;
+
+                    thumb.Relayout -= OnTrackOrThumbRelayout;
+                    thumb.Relayout += OnTrackOrThumbRelayout;
                 }
 
                 if (switchStyle.Track != null)
@@ -140,10 +149,24 @@ namespace Tizen.NUI.Components
                 {
                     Thumb.ApplyStyle(switchStyle.Thumb);
                 }
+
+                if (switchStyle.Text != null)
+                {
+                    TextLabel.ThemeChangeSensitive = false;
+                    TextLabel.ApplyStyle(switchStyle.Text);
+                }
             }
-            styleApplying--;
+            styleApplying = false;
 
             UpdateState();
+        }
+
+        private void OnTrackOrThumbRelayout(object sender, EventArgs args)
+        {
+            if (Extension is SwitchExtension switchExtension)
+            {
+                switchExtension.OnTrackOrThumbResized(this, Icon, thumb);
+            }
         }
 
         /// <summary>
@@ -292,7 +315,15 @@ namespace Tizen.NUI.Components
 
             if (type == DisposeTypes.Explicit)
             {
-                Utility.Dispose(thumb);
+                if (Icon != null)
+                {
+                    Icon.Relayout -= OnTrackOrThumbRelayout;
+                }
+                if (thumb != null)
+                {
+                    thumb.Relayout -= OnTrackOrThumbRelayout;
+                    Utility.Dispose(thumb);
+                }
             }
 
             base.Dispose(type);


### PR DESCRIPTION
* Button's IconOrientation bug In the previous code, when the IconOrientation property changed, the LayoutItems() was called and it created a new layout. But in case the button was inside another layout, the behaviour described above caused unexpect look. Therefore I fixed it by changing orientation related properties to the existing layout instead of creating a new layout.

* Improve switch and extension relationship The switch extension does not register any event handler to the switch components anymore.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
