### PR TITLE
[NUI] Fix Slider thumb position by adding SliderStyle.ThumbMaximumSize

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.Internal.cs
@@ -71,6 +71,11 @@ namespace Tizen.NUI.Components
 
         // To store the thumb size of normal state
         private Size thumbSize = null;
+        // To store the maximum size of the thumb
+        // This is used to calculate the track length and thumb position.
+        // The track length is calculated by subtracting the maximum size of the thumb from the slider size.
+        // The thumb position is calculated by using the track length.
+        private Size thumbMaximumSize = null;
         // To store the thumb image url of normal state
         private string thumbImageUrl = null;
         // To store the thumb color of normal state
@@ -619,11 +624,11 @@ namespace Tizen.NUI.Components
             {
                 if (direction == DirectionType.Horizontal)
                 {
-                    bgTrackLowIndicatorOffset = (int)(thumbImage.Size.Width * 0.5f);
+                    bgTrackLowIndicatorOffset = (int)((thumbSize != null ? thumbSize.Width : (thumbMaximumSize != null ? thumbMaximumSize.Width : 0)) * 0.5f);
                 }
                 else if (direction == DirectionType.Vertical)
                 {
-                    bgTrackLowIndicatorOffset = (int)(thumbImage.Size.Height * 0.5f);
+                    bgTrackLowIndicatorOffset = (int)((thumbSize != null ? thumbSize.Height : (thumbMaximumSize != null ? thumbMaximumSize.Height : 0)) * 0.5f);
                 }
             }
             else if (type == IndicatorType.Image || type == IndicatorType.Text)
@@ -654,11 +659,11 @@ namespace Tizen.NUI.Components
             {
                 if (direction == DirectionType.Horizontal)
                 {
-                    bgTrackHighIndicatorOffset = (int)(thumbImage.Size.Width * 0.5f);
+                     bgTrackHighIndicatorOffset = (int)((thumbSize != null ? thumbSize.Width : (thumbMaximumSize != null ? thumbMaximumSize.Width : 0)) * 0.5f);
                 }
                 else if (direction == DirectionType.Vertical)
                 {
-                    bgTrackHighIndicatorOffset = (int)(thumbImage.Size.Height * 0.5f);
+                    bgTrackHighIndicatorOffset = (int)((thumbSize != null ? thumbSize.Height : (thumbMaximumSize != null ? thumbMaximumSize.Height : 0)) * 0.5f);
                 }
             }
             else if (type == IndicatorType.Image || type == IndicatorType.Text)

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1587,6 +1587,11 @@ namespace Tizen.NUI.Components
                 CreateWarningSlidedTrack().ApplyStyle(sliderStyle.WarningProgress);
             }
 
+            if (null != sliderStyle?.ThumbMaximumSize)
+            {
+                thumbMaximumSize = new Size(sliderStyle.ThumbMaximumSize);
+            }
+
             EnableControlStatePropagation = true;
         }
 
@@ -1709,6 +1714,12 @@ namespace Tizen.NUI.Components
                 {
                     editModeIndicator.Dispose();
                     editModeIndicator = null;
+                }
+
+                if (thumbMaximumSize != null)
+                {
+                    thumbMaximumSize.Dispose();
+                    thumbMaximumSize = null;
                 }
             }
 

--- a/src/Tizen.NUI.Components/Style/SliderStyle.cs
+++ b/src/Tizen.NUI.Components/Style/SliderStyle.cs
@@ -227,6 +227,15 @@ namespace Tizen.NUI.Components
             set => SetValue(TrackPaddingProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the maximum size of the thumb.
+        /// This is used to calculate the track length and thumb position.
+        /// The track length is calculated by subtracting the maximum size of the thumb from the slider size.
+        /// The thumb position is calculated by using the track length.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Size ThumbMaximumSize { get; set; } = new Size();
+
         /// <inheritdoc/>
         /// <since_tizen> 8 </since_tizen>
         public override void CopyFrom(BindableObject bindableObject)
@@ -246,6 +255,7 @@ namespace Tizen.NUI.Components
                 HighIndicator.CopyFrom(sliderStyle.HighIndicator);
                 ValueIndicatorText.CopyFrom(sliderStyle.ValueIndicatorText);
                 ValueIndicatorImage.CopyFrom(sliderStyle.ValueIndicatorImage);
+                ThumbMaximumSize = new Size(sliderStyle.ThumbMaximumSize);
             }
         }
 

--- a/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultThemeCommon.cs
@@ -241,6 +241,9 @@ namespace Tizen.NUI.Components
             {
                 Size = new Size(850, 50),
                 TrackThickness = 8,
+                // The maximum size of the Thumb.
+                // e.g. The size of IoT_slider_handler_pressed.png
+                ThumbMaximumSize = new Size(40, 40),
                 Track = new ImageViewStyle()
                 {
                     Size = new Size(800, 8),


### PR DESCRIPTION
Slider thumb position is calculated by using the track length. The track length was calculated by subtracting the thumb image size from the slider size.
Thumb image size changes by its control state.
e.g. normal size is (26, 26) and pressed size is (40, 40). So the right end position of the thumb changes by its control state.

To resolve the above, the thumb position is calculated by using the maximum size of the thumb image all the time.
e.g. pressed size (40, 40) is used for the thumb position calculation.

To use the maximum size of the thumb image, ThumbMaximumSize is added to SliderStyle.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
