### PR TITLE
[NUI][API10] Fix SVACE issue.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -277,14 +277,14 @@ namespace Tizen.NUI
                 if (hasBottomView) borderHeight += bottomView.SizeHeight;
 
                 // Sets the minimum / maximum size to be resized by RequestResizeToServer.
-                if (borderInterface.MinSize != null)
+                if (borderInterface.MinSize is var minSize && minSize != null)
                 {
-                    using Size2D mimimumSize = new Size2D(borderInterface.MinSize.Width + (int)borderInterface.BorderLineThickness * 2, borderInterface.MinSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
+                    using Size2D mimimumSize = new Size2D(minSize.Width + (int)borderInterface.BorderLineThickness * 2, minSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMimimumSize(mimimumSize);
                 }
-                if (borderInterface.MaxSize != null)
+                if (borderInterface.MaxSize is var maxSize && maxSize != null)
                 {
-                    using Size2D maximumSize = new Size2D(borderInterface.MaxSize.Width + (int)borderInterface.BorderLineThickness * 2, borderInterface.MaxSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
+                    using Size2D maximumSize = new Size2D(maxSize.Width + (int)borderInterface.BorderLineThickness * 2, maxSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMaximumSize(maximumSize);
                 }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
SVACE issue:
WID:38318506 [STATISTICAL] Value borderInterface.MinSize, which is result of method invocation with possible null return value, is dereferenced in member access expression borderInterface.MinSize.Width.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
