### PR TITLE
[NUI] Fix Menu not to show Content if there is no menu item

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -165,13 +165,22 @@ namespace Tizen.NUI.Components
 
             set
             {
+                if (Content == null)
+                {
+                    Content = CreateDefaultContent();
+                    if (styleApplied && (menuStyle != null))
+                    {
+                        Content.ApplyStyle(menuStyle.Content);
+                    }
+                }
+
                 if (menuItems != null)
                 {
                     foreach (var oldItem in menuItems)
                     {
-                        if (content.Children?.Contains(oldItem) == true)
+                        if (Content.Children?.Contains(oldItem) == true)
                         {
-                            content.Remove(oldItem);
+                            Content.Remove(oldItem);
                         }
                     }
                 }
@@ -180,12 +189,18 @@ namespace Tizen.NUI.Components
 
                 if (menuItems == null)
                 {
+                    Content.SetVisible(false);
                     return;
+                }
+
+                if (Content.Visibility == false)
+                {
+                    Content.SetVisible(true);
                 }
 
                 foreach (var item in menuItems)
                 {
-                    content.Add(item);
+                    Content.Add(item);
                     menuItemGroup.Add(item);
                 }
             }
@@ -482,12 +497,6 @@ namespace Tizen.NUI.Components
             // if Anchor has Layout, then Menu is displayed at an incorrect position.
             ExcludeLayouting = true;
 
-            Content = CreateDefaultContent();
-            if (styleApplied && (menuStyle != null))
-            {
-                Content.ApplyStyle(menuStyle.Content);
-            }
-
             Scrim = CreateDefaultScrim();
 
             menuItemGroup = new MenuItemGroup();
@@ -559,12 +568,7 @@ namespace Tizen.NUI.Components
         // If there is not enought space, then menu's size can be also resized.
         private void CalculateMenuPosition()
         {
-            if ((Anchor == null) || (Content == null))
-            {
-                return;
-            }
-
-            if (Items == null)
+            if (Anchor == null)
             {
                 return;
             }


### PR DESCRIPTION
Menu.Content is a container of menu items.

Previously, Menu.Content was displayed even if there is no menu item. Now, Menu.Content is displayed only if menu item exists.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
