### PR TITLE
[NUI.Scene3D][API10] Use Model defined camera

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
@@ -67,6 +67,16 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_GetAnimation_2")]
             public static extern global::System.IntPtr GetAnimation(global::System.Runtime.InteropServices.HandleRef model, string name);
 
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_GetCameraCount")]
+            public static extern uint GetCameraCount(global::System.Runtime.InteropServices.HandleRef model);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_GenerateCamera")]
+            public static extern global::System.IntPtr GenerateCamera(global::System.Runtime.InteropServices.HandleRef model, uint index);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_ApplyCamera")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool ApplyCamera(global::System.Runtime.InteropServices.HandleRef model, uint index, global::System.Runtime.InteropServices.HandleRef camera);
+
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_LoadBvhAnimation_1")]
             public static extern global::System.IntPtr LoadBvhAnimation(global::System.Runtime.InteropServices.HandleRef model, string bvhFilename, global::System.Runtime.InteropServices.HandleRef scale);
         }

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -227,6 +227,63 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// Gets number of camera parameters that has been loaded from model file.
+        /// </summary>
+        /// <remarks>
+        /// This method should be called after Model load has been finished.
+        /// </remarks>
+        /// <returns>The number of loaded camera parameters.</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint GetCameraCount()
+        {
+            uint ret = Interop.Model.GetCameraCount(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Generate Camera using camera parameters at the index.
+        /// If camera parameter is valid, create new Camera.
+        /// Else, return empty Handle.
+        /// </summary>
+        /// <remarks>
+        /// This method should be called after Model load has been finished.
+        /// </remarks>
+        /// <returns>Generated Camera by the index, or empty Handle if generation failed.</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Camera GenerateCamera(uint index)
+        {
+            global::System.IntPtr cPtr = Interop.Model.GenerateCamera(SwigCPtr, index);
+            Camera ret = new Camera(cPtr, true); // Always create new camera.
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Apply camera parameters at the index to inputed Camera.
+        /// If camera parameter is valid and camera is not empty, apply parameters.
+        /// It will change camera's transform and near / far / fov or orthographic size / aspect ratio (if defined)
+        /// </summary>
+        /// <remarks>
+        /// This method should be called after Model load has been finished.
+        /// </remarks>
+        /// <returns>True if Apply successed. False otherwise.</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ApplyCamera(uint index, Camera camera)
+        {
+            bool ret = false;
+            if(camera?.HasBody() == true)
+            {
+                ret = Interop.Model.ApplyCamera(SwigCPtr, index, Camera.getCPtr(camera));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            return ret;
+        }
+
+        /// <summary>
         /// Load bvh animation and assign to model.
         /// Scale is additional scale factor of bvh animation. It is possible that
         /// Model's scale may not matched with bvh animation scale.


### PR DESCRIPTION
Make API that we can use gltf model file defined camera.

Since Tizen.NUI.Scene3D.Camera is one of View & This camera should be children of SceneView to render the scene, Camera cannot be owned by Model itself.

So, we support only for 'Generate' or 'Apply' camera parameters loaded from gltf model.