### PR TITLE
[NUI] Add Dispose to LongPressGestureDetector and modify ReleaseSwigCPtr

### DIFF
--- a/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
@@ -195,14 +195,45 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// override it to clean-up your own resources.
+        /// </summary>
+        /// <param name="type"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                //Called by User
+                //Release your own managed resources here.
+                //You should release all of your own disposable objects here.
+            }
+
+            //Release your own unmanaged resources here.
+            //You should not access any managed member here except static instance.
+            //because the execution order of Finalizes is non-deterministic.
+
+            if (HasBody())
+            {
+                if (detectedCallback != null)
+                {
+                    using LongPressGestureDetectedSignal signal = new LongPressGestureDetectedSignal(Interop.LongPressGestureDetector.DetectedSignal(GetBaseHandleCPtrHandleRef), false);
+                    signal?.Disconnect(detectedCallback);
+                    detectedCallback = null;
+                }
+            }
+            base.Dispose(type);
+        }
+
         /// This will not be public opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            if (detectedEventHandler == null && DetectedSignal().Empty() == false)
-            {
-                DetectedSignal().Disconnect(detectedCallback);
-            }
             Interop.LongPressGestureDetector.DeleteLongPressGestureDetector(swigCPtr);
         }
 


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
[NUI] Add Dispose to LongPressGestureDetector and modify ReleaseSwigCPtr.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
