### PR TITLE
[NUI][API10] Fix SVACE issues.

### DIFF
--- a/src/Tizen.NUI/src/internal/XamlBinding/TizenPlatformServices.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/TizenPlatformServices.cs
@@ -77,7 +77,10 @@ namespace Tizen.NUI.Binding
         {
             using (var client = new HttpClient())
             using (HttpResponseMessage response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false))
-                return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                if (response.Content is var content && content != null)
+                    return await content.ReadAsStreamAsync().ConfigureAwait(false);
+                else
+                    return null;
         }
 
         public Assembly[] GetAssemblies()

--- a/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
+++ b/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
@@ -180,7 +180,7 @@ namespace Tizen.NUI.EXaml
             object temp = null;
             GlobalDataList eXamlData = null;
             LoadEXaml.Load(temp, eXamlStr, out eXamlData);
-            return eXamlData.Root;
+            return eXamlData?.Root;
         }
 
         /// Internal used, will never be opened.


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
WID:41130995 Value eXamlData, which has null value, is dereferenced in member access expression eXamlData.Root

WID:42318188 [STATISTICAL] Value response.Content, which is result of method invocation with possible null return value, is dereferenced in method call response.Content.ReadAsStreamAsync()

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
