### PR TITLE
[NUI] Do not connect default signals when View created

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/WindowViewAddedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Common/WindowViewAddedSignal.cs
@@ -1,0 +1,78 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal class WindowViewAddedSignal : Disposable
+    {
+
+        internal WindowViewAddedSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WindowViewAddedSignal.DeleteSignal(swigCPtr);
+        }
+
+        public bool Empty()
+        {
+            bool ret = Interop.WindowViewAddedSignal.Empty(SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public uint GetConnectionCount()
+        {
+            uint ret = Interop.WindowViewAddedSignal.GetConnectionCount(SwigCPtr);
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowViewAddedSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowViewAddedSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        public bool Emit()
+        {
+            bool ret = Interop.WindowViewAddedSignal.Emit(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        public WindowViewAddedSignal(Window window) : this(Interop.WindowViewAddedSignal.GetSignal(Window.getCPtr(window)), false)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowViewAddedSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowViewAddedSignal.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.Runtime.InteropServices;
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WindowViewAddedSignal
+        {
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_Signal")]
+            public static extern global::System.IntPtr GetSignal(HandleRef jarg1);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_Signal_Empty")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Empty(HandleRef jarg1);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_Signal_GetConnectionCount")]
+            public static extern uint GetConnectionCount(HandleRef jarg1);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_Signal_Connect")]
+            public static extern void Connect(HandleRef jarg1, HandleRef jarg2);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_Signal_Disconnect")]
+            public static extern void Disconnect(HandleRef jarg1, HandleRef jarg2);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_Signal_Emit")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Emit(HandleRef jarg1);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_Signal_new")]
+            public static extern global::System.IntPtr NewSignal();
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_View_Added_delete")]
+            public static extern void DeleteSignal(HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -163,23 +163,17 @@ namespace Tizen.NUI.BaseComponents
             if (HasBody())
             {
                 PositionUsesPivotPoint = false;
+                GrabTouchAfterLeave = defaultGrabTouchAfterLeave;
+                AllowOnlyOwnTouch = defaultAllowOnlyOwnTouch;
+
+                // TODO : Can we call this function only for required subclass?
+                RegisterHitTestCallback();
             }
-
-            onWindowSendEventCallback = SendViewAddedEventToWindow;
-            using ViewSignal signal = new ViewSignal(Interop.ActorSignal.ActorOnSceneSignal(SwigCPtr), false);
-            signal?.Connect(onWindowSendEventCallback);
-
-            hitTestResultDataCallback = OnHitTestResult;
-            using TouchDataSignal touchDataSignal = new TouchDataSignal(Interop.ActorSignal.ActorHitTestResultSignal(SwigCPtr), false);
-            touchDataSignal?.Connect(hitTestResultDataCallback);
 
             if (!shown)
             {
                 SetVisible(false);
             }
-
-            GrabTouchAfterLeave = defaultGrabTouchAfterLeave;
-            AllowOnlyOwnTouch = defaultAllowOnlyOwnTouch;
         }
 
         internal View(ViewImpl implementation, bool shown = true) : this(Interop.View.NewViewInternal(ViewImpl.getCPtr(implementation)), true)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -58,13 +58,6 @@ namespace Tizen.NUI.BaseComponents
         private ResourcesLoadedCallbackType ResourcesLoadedCallback;
         private EventHandler<BackgroundResourceLoadedEventArgs> backgroundResourceLoadedEventHandler;
         private _backgroundResourceLoadedCallbackType backgroundResourceLoadedCallback;
-        private OnWindowEventCallbackType onWindowSendEventCallback;
-        private void SendViewAddedEventToWindow(IntPtr data)
-        {
-            // Unused parameter
-            _ = data;
-            NUIApplication.GetDefaultWindow()?.SendViewAdded(this);
-        }
         private TouchDataCallbackType hitTestResultDataCallback;
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1541,14 +1541,6 @@ namespace Tizen.NUI.BaseComponents
                 backgroundResourceLoadedCallback = null;
             }
 
-            if (onWindowSendEventCallback != null)
-            {
-                NUILog.Debug($"[Dispose] onWindowSendEventCallback");
-
-                using ViewSignal signal = new ViewSignal(Interop.ActorSignal.ActorOnSceneSignal(GetBaseHandleCPtrHandleRef), false);
-                signal?.Disconnect(onWindowSendEventCallback);
-                onWindowSendEventCallback = null;
-            }
             NUILog.Debug($"[Dispose] DisConnectFromSignals END");
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -924,5 +924,41 @@ namespace Tizen.NUI.BaseComponents
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Register custom HitTest function for this view.
+        /// </summary>
+        /// <seealso cref="View.HitTest" />
+        /// <remarks>
+        /// This is a hidden API(inhouse API) only for internal purpose.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected void RegisterHitTestCallback()
+        {
+            if (hitTestResultDataCallback == null)
+            {
+                hitTestResultDataCallback = OnHitTestResult;
+                using TouchDataSignal touchDataSignal = new TouchDataSignal(Interop.ActorSignal.ActorHitTestResultSignal(SwigCPtr), false);
+                touchDataSignal?.Connect(hitTestResultDataCallback);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Unregister custom HitTest function.
+        /// </summary>
+        /// <remarks>
+        /// This is a hidden API(inhouse API) only for internal purpose.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected void UnregisterHitTestCallback()
+        {
+            if (hitTestResultDataCallback != null)
+            {
+                using TouchDataSignal touchDataSignal = new TouchDataSignal(Interop.ActorSignal.ActorHitTestResultSignal(SwigCPtr), false);
+                touchDataSignal?.Disconnect(hitTestResultDataCallback);
+                hitTestResultDataCallback = null;
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -663,6 +663,12 @@ namespace Tizen.NUI
             private bool isEnabledOverlay = false;
             private Extents prePadding = new Extents(0, 0, 0, 0);
 
+            internal BorderView() : base()
+            {
+                // BorderView will use custom HitTest function.
+                RegisterHitTestCallback();
+            }
+
             /// <summary>
             /// Set whether or not it is in overlay mode.
             /// The borderView's OverlayMode means that it is displayed at the top of the screen.

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/EventPropagationSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/EventPropagationSample.cs
@@ -11,6 +11,12 @@ namespace Tizen.NUI.Samples
 
     class MyView : View
     {
+        public MyView() : base()
+        {
+            // Notify that we will use custom HitTest function for this class.
+            RegisterHitTestCallback();
+        }
+
         protected override bool HitTest(Touch touch)
         {
             Tizen.Log.Error("NUI", $"override HitTest\n");

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/HitTestSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/HitTestSample.cs
@@ -53,6 +53,12 @@ namespace Tizen.NUI.Samples
 
     class MyView : View
     {
+        public MyView() : base()
+        {
+            // Notify that we will use custom HitTest function for this class.
+            RegisterHitTestCallback();
+        }
+
         protected override bool HitTest(Touch touch)
         {
             if(hitTest == true)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowEventsTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowEventsTest.cs
@@ -102,7 +102,7 @@ namespace Tizen.NUI.Samples
                 childViewWindow.KeyEvent += OnChildViewWindowKeyEvent;
                 childViewWindow.TransitionEffect += OnChildViewWindowTransitionEffect;
                 childViewWindow.KeyboardRepeatSettingsChanged += OnChildViewWindowKeyboardRepeatSettingsChanged;
-                childViewWindow.ViewAdded += OnChildViewWindowViewAdded;
+                //childViewWindow.ViewAdded += OnChildViewWindowViewAdded; // Block this signal for temprary
                 childViewWindow.AuxiliaryMessage += OnAuxiliaryMessageEvent;
             }
         }
@@ -120,7 +120,7 @@ namespace Tizen.NUI.Samples
                 childViewWindow.KeyEvent -= OnChildViewWindowKeyEvent;
                 childViewWindow.TransitionEffect -= OnChildViewWindowTransitionEffect;
                 childViewWindow.KeyboardRepeatSettingsChanged -= OnChildViewWindowKeyboardRepeatSettingsChanged;
-                childViewWindow.ViewAdded -= OnChildViewWindowViewAdded;
+                //childViewWindow.ViewAdded -= OnChildViewWindowViewAdded; // Block this signal for temprary
                 childViewWindow.AuxiliaryMessage -= OnAuxiliaryMessageEvent;
                 childViewWindow = null;
             }


### PR DESCRIPTION
Since Window.ViewAdded signal required to all common view's creation time,
It will reduce each view's creation time.
And more, ViewAdded signal only works for default windows previously.

Now we make the signal ownership from window.

And additionaly, register custom HitTest signal only if subclass required.

TODO : The role of signal conflict with View.AddedToWindow.
Can we just remove this ViewAdded signal?

TODO : Can we just skip default view constructor's signal connection?