### PR TITLE
[NUI] Add getter property about WindowPositionSizeWithBorder and Wind…

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -460,6 +460,44 @@ namespace Tizen.NUI
             return direction;
         }
 
+        /// <summary>
+        /// Gets position and size of the border window
+        /// </summary>
+        /// <returns>The total window size including the border area in the default window.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Rectangle WindowPositionSizeWithBorder
+        {
+            get
+            {
+                using var position = GetPosition();
+                using var size = GetWindowSizeWithBorder();
+                Rectangle ret = new Rectangle(position?.X ?? 0, position?.Y ?? 0, size?.Width ?? 0, size?.Height ?? 0);
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Gets size of the border window
+        /// </summary>
+        /// <returns>The total window size including the border area in the default window.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Size2D WindowSizeWithBorder
+        {
+            get
+            {
+                return GetWindowSizeWithBorder();
+            }
+        }
+
+        private Size2D GetWindowSizeWithBorder()
+        {
+            var val = new Uint16Pair(Interop.Window.GetSize(SwigCPtr), true);
+            Size2D size = new Size2D(val.GetWidth(), val.GetHeight());
+            val.Dispose();
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return size;
+        }
+
         private void DoOverlayMode(bool enable)
         {
             if (borderInterface.OverlayMode == true)


### PR DESCRIPTION
…owSizeWithBorder

In the case of a border window, the size including the border area is required.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
