### PR TITLE
[NUI] Fix layer MoveAbove/MoveBelow API change window's List

### DIFF
--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -533,8 +533,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void MoveAbove(Layer target)
         {
-            Interop.Layer.MoveAbove(SwigCPtr, Layer.getCPtr(target));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            RaiseAbove(target);
         }
 
         /// <summary>
@@ -545,8 +544,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void MoveBelow(Layer target)
         {
-            Interop.Layer.MoveBelow(SwigCPtr, Layer.getCPtr(target));
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            LowerBelow(target);
         }
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.


### PR DESCRIPTION
Previous MoveAbove / MoveBelow API change only native side layer order.
It didn't apply to the window who hold this layer.
