### PR TITLE
[Applications.Common / UI] Add new internal APIs

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.AppControl.cs
@@ -154,5 +154,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_auto_restart")]
         internal static extern ErrorCode SetAutoRestart(SafeAppControlHandle handle);
+
+        [DllImport(Libraries.AppControl, EntryPoint = "app_control_set_window_position")]
+        internal static extern ErrorCode SetWindowPosition(SafeAppControlHandle handle, int x, int y, int w, int h);
+
+        [DllImport(Libraries.AppControl, EntryPoint = "app_control_get_window_position")]
+        internal static extern ErrorCode GetWindowPosition(SafeAppControlHandle handle, out int x, out int y, out int w, out int h);
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -830,6 +830,63 @@ namespace Tizen.Applications
         }
 
         /// <summary>
+        /// Sets the window position.
+        /// </summary>
+        /// <param name="windowPosition">The window position object.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the invalid operation error occurs.</exception>
+        /// <since_tizen> 10 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetWindowPosition(WindowPosition windowPosition)
+        {
+            if (windowPosition == null)
+            {
+                throw new ArgumentNullException(nameof(windowPosition));
+            }
+
+            Interop.AppControl.ErrorCode err = Interop.AppControl.SetWindowPosition(this.SafeAppControlHandle, windowPosition.PositionX, windowPosition.PositionY, windowPosition.ScreenWidth, windowPosition.ScreenHeight);
+            if (err != Interop.AppControl.ErrorCode.None)
+            {
+                if (err == Interop.AppControl.ErrorCode.InvalidParameter)
+                {
+                    throw new ArgumentException("Invalid arguments");
+                }
+                else
+                {
+                    throw new InvalidOperationException("err = " + err);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the window position.
+        /// </summary>
+        /// <returns>The window position.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the invalid operation error occurs.</exception>
+        /// <since_tizen> 10 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WindowPosition GetWindowPosition()
+        {
+            Interop.AppControl.ErrorCode err = Interop.AppControl.GetWindowPosition(this.SafeAppControlHandle, out int x, out int y, out int w, out int h);
+            if (err != Interop.AppControl.ErrorCode.None)
+            {
+                if (err == Interop.AppControl.ErrorCode.InvalidParameter)
+                {
+                    throw new ArgumentException("Invalid arguments");
+                }
+                else
+                {
+                    throw new InvalidOperationException("err = " + err);
+                }
+            }
+
+            return new WindowPosition(x, y, w, h);
+        }
+
+        /// <summary>
         /// Class for extra data.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.Applications.Common/Tizen.Applications/WindowPosition.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/WindowPosition.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.Applications
+{
+    /// <summary>
+    /// Represents the window position of the application.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WindowPosition
+    {
+        /// <summary>
+        /// Initializes the instance of the WindowPosition class.
+        /// </summary>
+        /// <param name="x">The X position.</param>
+        /// <param name="y">The Y position.</param>
+        /// <param name="w">The width.</param>
+        /// <param name="h">The height.</param>
+        /// <since_tizen> 10 </since_tizen>
+        public WindowPosition(int x, int y, int w, int h)
+        {
+            PositionX = x;
+            PositionY = y;
+            ScreenWidth = w;
+            ScreenHeight = h;
+        }
+
+        /// <summary>
+        /// The X position.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public int PositionX
+        {
+            set;
+            get;
+        }
+        
+        /// <summary>
+        /// The Y position.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public int PositionY
+        {
+            set;
+            get;
+        }
+
+        /// <summary>
+        /// The width.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public int ScreenWidth
+        {
+            set;
+            get;
+        }
+
+        /// <summary>
+        /// The height.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public int ScreenHeight
+        {
+            set;
+            get;
+        }
+    }
+}

--- a/src/Tizen.Applications.UI/Interop/Interop.Application.cs
+++ b/src/Tizen.Applications.UI/Interop/Interop.Application.cs
@@ -53,6 +53,9 @@ internal static partial class Interop
         [DllImport(Libraries.Application, EntryPoint = "ui_app_remove_event_handler")]
         internal static extern ErrorCode RemoveEventHandler(IntPtr handle);
 
+        [DllImport(Libraries.Application, EntryPoint = "ui_app_get_window_position")]
+        internal static extern ErrorCode GetWindowPosition(out int x, out int y, out int w, out int h);
+
 
         [NativeStruct("ui_app_lifecycle_callback_s", Include="app.h", PkgConfig="capi-appfw-application")]
         [StructLayout(LayoutKind.Sequential)]

--- a/src/Tizen.Applications.UI/Tizen.Applications/CoreUIApplication.cs
+++ b/src/Tizen.Applications.UI/Tizen.Applications/CoreUIApplication.cs
@@ -15,8 +15,10 @@
  */
 
 using System;
+using System.ComponentModel;
 
 using Tizen.Applications.CoreBackend;
+using Tizen.Internals.Errors;
 
 namespace Tizen.Applications
 {
@@ -112,6 +114,24 @@ namespace Tizen.Applications
         protected virtual void OnPause()
         {
             Paused?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Gets the window position of the application.
+        /// </summary>
+        /// <returns>The window position.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when there is no window position.</exception>
+        /// <since_tizen> 10 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WindowPosition GetWindowPosition()
+        {
+            ErrorCode err = Interop.Application.GetWindowPosition(out int x, out int y, out int w, out int h);
+            if (err != ErrorCode.None)
+            {
+                throw new InvalidOperationException("Failed to get window position");
+            }
+
+            return new WindowPosition(x, y, w, h);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This request supports to set/get the window position.
The following APIs are added:
 - WindowPosition [class]
 - AppControl.SetWindowPosition() [method]
 - AppControl.GetWindowPosition() [method]
 - CoreUIApplication.GetWindowPosition() [method]

The caller application of the AppControl can set the window position to the AppControl instance.
When the target application is starting, the application can get the window position that is set by the caller using the method.