### PR TITLE
[NUI] Add internal property to avoid binding canceling on property set

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.cs
@@ -68,14 +68,17 @@ namespace Tizen.NUI.Components
                         else if (collectionView.SelectionMode is ItemSelectionMode.Multiple)
                         {
                             var selectedList = collectionView.SelectedItems;
-                            bool contains = selectedList.Contains(context);
-                            if (newSelected && !contains)
+                            if (selectedList != null)
                             {
-                                selectedList.Add(context);
-                            }
-                            else if (!newSelected && contains)
-                            {
-                                selectedList.Remove(context);
+                                bool contains = selectedList.Contains(context);
+                                if (newSelected && !contains)
+                                {
+                                    selectedList.Add(context);
+                                }
+                                else if (!newSelected && contains)
+                                {
+                                    selectedList.Remove(context);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

assign a value directly into the property internally may have the potential issue of binding canceling.
 to prevent this, add internal property and use them insteadly.

see more detail about issue on below,
https://code.sec.samsung.net/confluence/display/GFX/NUI+Binding+Issue

This patch include below class property changes :

View.IsEnabled
Button.IsSelected
RecyclerViewItem.IsSelected

and all the usage of this properties.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
