### PR TITLE
[NUI] Fix some SVACE issues.

### DIFF
--- a/src/Tizen.NUI/src/internal/XamlBinding/ResourcesExtensions.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/ResourcesExtensions.cs
@@ -36,14 +36,14 @@ namespace Tizen.NUI.Binding
                         return null;
                     }
 
-                    if (ve.XamlResources != null)
+                    if (ve.XamlResources is var xres && xres != null)
                     {
-                        foreach (KeyValuePair<string, object> res in ve.XamlResources.MergedResources)
+                        foreach (KeyValuePair<string, object> res in xres.MergedResources)
                         {
                             // If a MergedDictionary value is overridden for a DynamicResource, 
                             // it comes out later in the enumeration of MergedResources
                             // TryGetValue ensures we pull the up-to-date value for the key
-                            if (!resources.ContainsKey(res.Key) && ve.XamlResources.TryGetValue(res.Key, out object value))
+                            if (!resources.ContainsKey(res.Key) && xres.TryGetValue(res.Key, out object value))
                                 resources.Add(res.Key, value);
                         }
                     }
@@ -72,7 +72,7 @@ namespace Tizen.NUI.Binding
             while (element != null)
             {
                 var ve = element as IResourcesProvider;
-                if (ve != null && ve.IsResourcesCreated && ve.XamlResources != null && ve.XamlResources.TryGetValue(key, out value))
+                if (ve != null && ve.IsResourcesCreated && ve.XamlResources is var xres && xres != null && xres.TryGetValue(key, out value))
                 {
                     return true;
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
[STATISTICAL] Value ve.XamlResources, which is result of method invocation with possible null return value, is dereferenced in member access expression ve.XamlResources.MergedResources.

[STATISTICAL] Value ve.XamlResources, which is result of method invocation with possible null return value, is dereferenced in method call ve.XamlResources.TryGetValue()

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
