### PR TITLE
[NUI] merge Window event changes of API10

### DIFF
--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI
         private KeyEventSignal interceptKeyEventSignal;
         private AuxiliaryMessageEventCallbackType auxiliaryMessageEventCallback;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WindowFocusChangedEventCallbackType(IntPtr window, bool focusGained);
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate bool RootLayerTouchDataCallbackType(IntPtr view, IntPtr touchData);
@@ -81,21 +81,19 @@ namespace Tizen.NUI
                 if (windowFocusChangedEventHandler == null)
                 {
                     windowFocusChangedEventCallback = OnWindowFocusedChanged;
-                    using WindowFocusSignalType windowFocusChangedSignal = WindowFocusChangedSignal();
-                    windowFocusChangedSignal?.Connect(windowFocusChangedEventCallback);
+                    using WindowFocusSignalType signal = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(SwigCPtr), false);
+                    signal?.Connect(windowFocusChangedEventCallback);
                 }
-
                 windowFocusChangedEventHandler += value;
             }
             remove
             {
                 windowFocusChangedEventHandler -= value;
-
-                using WindowFocusSignalType windowFocusChangedSignal = WindowFocusChangedSignal();
-                if (windowFocusChangedEventHandler == null && windowFocusChangedSignal?.Empty() == false && windowFocusChangedEventCallback != null)
+                if (windowFocusChangedEventHandler == null && windowFocusChangedEventCallback != null)
                 {
-                    windowFocusChangedSignal?.Disconnect(windowFocusChangedEventCallback);
-                    if(windowFocusChangedSignal?.Empty() == true)
+                    using WindowFocusSignalType signal = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(SwigCPtr), false);
+                    signal?.Disconnect(windowFocusChangedEventCallback);
+                    if (signal?.Empty() == true)
                     {
                         windowFocusChangedEventCallback = null;
                     }
@@ -117,19 +115,19 @@ namespace Tizen.NUI
                 if (rootLayerTouchDataEventHandler == null)
                 {
                     rootLayerTouchDataCallback = OnWindowTouch;
-                    using TouchDataSignal touchDataSignal = this.TouchDataSignal();
-                    touchDataSignal?.Connect(rootLayerTouchDataCallback);
+                    using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorTouchSignal(Layer.getCPtr(GetRootLayer())), false);
+                    signal?.Connect(rootLayerTouchDataCallback);
                 }
                 rootLayerTouchDataEventHandler += value;
             }
             remove
             {
                 rootLayerTouchDataEventHandler -= value;
-                using TouchDataSignal touchDataSignal = this.TouchDataSignal();
-                if (rootLayerTouchDataEventHandler == null && touchDataSignal?.Empty() == false && rootLayerTouchDataCallback != null)
+                if (rootLayerTouchDataEventHandler == null && rootLayerTouchDataCallback != null)
                 {
-                    touchDataSignal?.Disconnect(rootLayerTouchDataCallback);
-                    if(touchDataSignal?.Empty() == true)
+                    using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorTouchSignal(Layer.getCPtr(GetRootLayer())), false);
+                    signal?.Disconnect(rootLayerTouchDataCallback);
+                    if (signal?.Empty() == true)
                     {
                         rootLayerTouchDataCallback = null;
                     }
@@ -148,38 +146,38 @@ namespace Tizen.NUI
                 if (stageWheelHandler == null)
                 {
                     wheelEventCallback = OnStageWheel;
-                    using WheelSignal wheelSignal = WheelEventSignal();
-                    wheelSignal?.Connect(wheelEventCallback);
+                    using WheelSignal signal = new WheelSignal(Interop.ActorSignal.ActorWheelEventSignal(Layer.getCPtr(this.GetRootLayer())), false);
+                    signal?.Connect(wheelEventCallback);
                 }
                 stageWheelHandler += value;
 
                 if (DetentEventHandler == null)
                 {
                     DetentEventCallback = OnDetentEvent;
-                    using StageWheelSignal stageWheelSignal = StageWheelEventSignal();
-                    stageWheelSignal?.Connect(DetentEventCallback);
+                    using StageWheelSignal signal = new StageWheelSignal(Interop.StageSignal.WheelEventSignal(stageCPtr), false);
+                    signal?.Connect(DetentEventCallback);
                 }
                 DetentEventHandler += value;
             }
             remove
             {
                 stageWheelHandler -= value;
-                using WheelSignal wheelSignal = WheelEventSignal();
-                if (stageWheelHandler == null && wheelSignal?.Empty() == false)
+                if (stageWheelHandler == null && wheelEventCallback != null)
                 {
-                    wheelSignal?.Disconnect(wheelEventCallback);
-                    if(wheelSignal?.Empty() == true)
+                    using WheelSignal signal = new WheelSignal(Interop.ActorSignal.ActorWheelEventSignal(Layer.getCPtr(this.GetRootLayer())), false);
+                    signal?.Disconnect(wheelEventCallback);
+                    if (signal?.Empty() == true)
                     {
                         wheelEventCallback = null;
                     }
                 }
 
                 DetentEventHandler -= value;
-                using StageWheelSignal stageWheelSignal = StageWheelEventSignal();
-                if (DetentEventHandler == null && stageWheelSignal?.Empty() == false)
+                if (DetentEventHandler == null && DetentEventCallback != null)
                 {
-                    stageWheelSignal?.Disconnect(DetentEventCallback);
-                    if(stageWheelSignal?.Empty() == true)
+                    using StageWheelSignal signal = new StageWheelSignal(Interop.StageSignal.WheelEventSignal(stageCPtr), false);
+                    signal?.Disconnect(DetentEventCallback);
+                    if (signal?.Empty() == true)
                     {
                         DetentEventCallback = null;
                     }
@@ -198,19 +196,19 @@ namespace Tizen.NUI
                 if (stageKeyHandler == null)
                 {
                     stageKeyCallbackDelegate = OnStageKey;
-                    using KeyEventSignal keyEventSignal = KeyEventSignal();
-                    keyEventSignal?.Connect(stageKeyCallbackDelegate);
+                    using KeyEventSignal signal = new KeyEventSignal(Interop.Window.KeyEventSignal(SwigCPtr), false);
+                    signal?.Connect(stageKeyCallbackDelegate);
                 }
                 stageKeyHandler += value;
             }
             remove
             {
                 stageKeyHandler -= value;
-                using KeyEventSignal keyEventSignal = KeyEventSignal();
-                if (stageKeyHandler == null && keyEventSignal?.Empty() == false)
+                if (stageKeyHandler == null && stageKeyCallbackDelegate != null)
                 {
-                    keyEventSignal?.Disconnect(stageKeyCallbackDelegate);
-                    if(keyEventSignal?.Empty() == true)
+                    using KeyEventSignal signal = new KeyEventSignal(Interop.Window.KeyEventSignal(SwigCPtr), false);
+                    signal?.Disconnect(stageKeyCallbackDelegate);
+                    if (signal?.Empty() == true)
                     {
                         stageKeyCallbackDelegate = null;
                     }
@@ -230,25 +228,25 @@ namespace Tizen.NUI
                 if (stageInterceptKeyHandler == null)
                 {
                     stageInterceptKeyCallbackDelegate = OnStageInterceptKey;
-                    interceptKeyEventSignal = InterceptKeyEventSignal();
-                    interceptKeyEventSignal?.Connect(stageInterceptKeyCallbackDelegate);
+                    using KeyEventSignal signal = new KeyEventSignal(Interop.Window.InterceptKeyEventSignal(SwigCPtr), false);
+                    signal?.Connect(stageInterceptKeyCallbackDelegate);
                 }
                 stageInterceptKeyHandler += value;
             }
             remove
             {
                 stageInterceptKeyHandler -= value;
-                if (stageInterceptKeyHandler == null && interceptKeyEventSignal?.Empty() == false)
+                if (stageInterceptKeyHandler == null && stageInterceptKeyCallbackDelegate != null)
                 {
-                    interceptKeyEventSignal?.Disconnect(stageInterceptKeyCallbackDelegate);
-                    if (interceptKeyEventSignal?.Empty() == true)
+                    using KeyEventSignal signal = new KeyEventSignal(Interop.Window.InterceptKeyEventSignal(SwigCPtr), false);
+                    signal?.Disconnect(stageInterceptKeyCallbackDelegate);
+                    if (signal?.Empty() == true)
                     {
                         stageInterceptKeyCallbackDelegate = null;
                     }
                 }
             }
         }
-
 
         /// <summary>
         /// Emits the event when the window resized.
@@ -261,8 +259,8 @@ namespace Tizen.NUI
                 if (windowResizeEventHandler == null)
                 {
                     windowResizeEventCallback = OnResized;
-                    using ResizeSignal resizeSignal = ResizeSignal();
-                    resizeSignal?.Connect(windowResizeEventCallback);
+                    using ResizeSignal signal = new ResizeSignal(Interop.Window.ResizeSignal(SwigCPtr), false);
+                    signal?.Connect(windowResizeEventCallback);
                 }
 
                 windowResizeEventHandler += value;
@@ -270,12 +268,11 @@ namespace Tizen.NUI
             remove
             {
                 windowResizeEventHandler -= value;
-
-                using ResizeSignal resizeSignal = ResizeSignal();
-                if (windowResizeEventHandler == null && resizeSignal?.Empty() == false && windowResizeEventCallback != null)
+                if (windowResizeEventHandler == null && windowResizeEventCallback != null)
                 {
-                    resizeSignal?.Disconnect(windowResizeEventCallback);
-                    if(resizeSignal?.Empty() == true)
+                    using ResizeSignal signal = new ResizeSignal(Interop.Window.ResizeSignal(SwigCPtr), false);
+                    signal?.Disconnect(windowResizeEventCallback);
+                    if (signal?.Empty() == true)
                     {
                         windowResizeEventCallback = null;
                     }
@@ -301,21 +298,19 @@ namespace Tizen.NUI
                 if (windowFocusChangedEventHandler2 == null)
                 {
                     windowFocusChangedEventCallback2 = OnWindowFocusedChanged2;
-                    using WindowFocusSignalType windowFocusChangedSignal2 = WindowFocusChangedSignal();
-                    windowFocusChangedSignal2?.Connect(windowFocusChangedEventCallback2);
+                    using WindowFocusSignalType signal = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(SwigCPtr), false);
+                    signal?.Connect(windowFocusChangedEventCallback2);
                 }
-
                 windowFocusChangedEventHandler2 += value;
             }
             remove
             {
                 windowFocusChangedEventHandler2 -= value;
-
-                using WindowFocusSignalType windowFocusChangedSignal2 = WindowFocusChangedSignal();
-                if (windowFocusChangedEventHandler2 == null && windowFocusChangedSignal2?.Empty() == false && windowFocusChangedEventCallback2 != null)
+                if (windowFocusChangedEventHandler2 == null && windowFocusChangedEventCallback2 != null)
                 {
-                    windowFocusChangedSignal2?.Disconnect(windowFocusChangedEventCallback2);
-                    if(windowFocusChangedSignal2?.Empty() == true)
+                    using WindowFocusSignalType signal = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(SwigCPtr), false);
+                    signal?.Disconnect(windowFocusChangedEventCallback2);
+                    if (signal?.Empty() == true)
                     {
                         windowFocusChangedEventCallback2 = null;
                     }
@@ -334,17 +329,19 @@ namespace Tizen.NUI
                 if (transitionEffectHandler == null)
                 {
                     transitionEffectEventCallback = OnTransitionEffect;
-                    TransitionEffectEventSignal().Connect(transitionEffectEventCallback);
+                    using WindowTransitionEffectSignal signal = new WindowTransitionEffectSignal(Interop.WindowTransitionEffectSignal.GetSignal(SwigCPtr), false);
+                    signal?.Connect(transitionEffectEventCallback);
                 }
                 transitionEffectHandler += value;
             }
             remove
             {
                 transitionEffectHandler -= value;
-                if (transitionEffectHandler == null && TransitionEffectEventSignal().Empty() == false)
+                if (transitionEffectHandler == null && transitionEffectEventCallback != null)
                 {
-                    TransitionEffectEventSignal().Disconnect(transitionEffectEventCallback);
-                    if(TransitionEffectEventSignal().Empty() == true)
+                    using WindowTransitionEffectSignal signal = new WindowTransitionEffectSignal(Interop.WindowTransitionEffectSignal.GetSignal(SwigCPtr), false);
+                    signal?.Disconnect(transitionEffectEventCallback);
+                    if (signal?.Empty() == true)
                     {
                         transitionEffectEventCallback = null;
                     }
@@ -363,17 +360,19 @@ namespace Tizen.NUI
                 if (keyboardRepeatSettingsChangedHandler == null)
                 {
                     keyboardRepeatSettingsChangedEventCallback = OnKeyboardRepeatSettingsChanged;
-                    KeyboardRepeatSettingsChangedEventSignal().Connect(keyboardRepeatSettingsChangedEventCallback);
+                    using KeyboardRepeatSettingsChangedSignal signal = new KeyboardRepeatSettingsChangedSignal(Interop.KeyboardRepeatSettingsChangedSignal.GetSignal(SwigCPtr), false);
+                    signal?.Connect(keyboardRepeatSettingsChangedEventCallback);
                 }
                 keyboardRepeatSettingsChangedHandler += value;
             }
             remove
             {
                 keyboardRepeatSettingsChangedHandler -= value;
-                if (keyboardRepeatSettingsChangedHandler == null && KeyboardRepeatSettingsChangedEventSignal().Empty() == false)
+                if (keyboardRepeatSettingsChangedHandler == null && keyboardRepeatSettingsChangedEventCallback != null)
                 {
-                    KeyboardRepeatSettingsChangedEventSignal().Disconnect(keyboardRepeatSettingsChangedEventCallback);
-                    if(KeyboardRepeatSettingsChangedEventSignal().Empty() == true)
+                    using KeyboardRepeatSettingsChangedSignal signal = new KeyboardRepeatSettingsChangedSignal(Interop.KeyboardRepeatSettingsChangedSignal.GetSignal(SwigCPtr), false);
+                    signal?.Disconnect(keyboardRepeatSettingsChangedEventCallback);
+                    if (signal?.Empty() == true)
                     {
                         keyboardRepeatSettingsChangedEventCallback = null;
                     }
@@ -412,21 +411,19 @@ namespace Tizen.NUI
                 if (stageEventProcessingFinishedEventHandler == null)
                 {
                     stageEventProcessingFinishedEventCallbackDelegate = OnEventProcessingFinished;
-                    using VoidSignal eventProcessingFinishedSignal = EventProcessingFinishedSignal();
-                    eventProcessingFinishedSignal?.Connect(stageEventProcessingFinishedEventCallbackDelegate);
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.EventProcessingFinishedSignal(stageCPtr), false);
+                    signal?.Connect(stageEventProcessingFinishedEventCallbackDelegate);
                 }
                 stageEventProcessingFinishedEventHandler += value;
-
             }
             remove
             {
                 stageEventProcessingFinishedEventHandler -= value;
-
-                using VoidSignal eventProcessingFinishedSignal = EventProcessingFinishedSignal();
-                if (stageEventProcessingFinishedEventHandler == null && eventProcessingFinishedSignal?.Empty() == false)
+                if (stageEventProcessingFinishedEventHandler == null && stageEventProcessingFinishedEventCallbackDelegate != null)
                 {
-                    eventProcessingFinishedSignal?.Disconnect(stageEventProcessingFinishedEventCallbackDelegate);
-                    if(eventProcessingFinishedSignal?.Empty() == true)
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.EventProcessingFinishedSignal(stageCPtr), false);
+                    signal?.Disconnect(stageEventProcessingFinishedEventCallbackDelegate);
+                    if (signal?.Empty() == true)
                     {
                         stageEventProcessingFinishedEventCallbackDelegate = null;
                     }
@@ -441,20 +438,19 @@ namespace Tizen.NUI
                 if (stageContextLostEventHandler == null)
                 {
                     stageContextLostEventCallbackDelegate = OnContextLost;
-                    using VoidSignal contextLostSignal = ContextLostSignal();
-                    contextLostSignal?.Connect(stageContextLostEventCallbackDelegate);
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.ContextLostSignal(stageCPtr), false);
+                    signal?.Connect(stageContextLostEventCallbackDelegate);
                 }
                 stageContextLostEventHandler += value;
             }
             remove
             {
                 stageContextLostEventHandler -= value;
-
-                using VoidSignal contextLostSignal = ContextLostSignal();
-                if (stageContextLostEventHandler == null && contextLostSignal?.Empty() == false)
+                if (stageContextLostEventHandler == null && stageContextLostEventCallbackDelegate != null)
                 {
-                    contextLostSignal?.Disconnect(stageContextLostEventCallbackDelegate);
-                    if(contextLostSignal?.Empty() == true)
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.ContextLostSignal(stageCPtr), false);
+                    signal?.Disconnect(stageContextLostEventCallbackDelegate);
+                    if (signal?.Empty() == true)
                     {
                         stageContextLostEventCallbackDelegate = null;
                     }
@@ -469,20 +465,19 @@ namespace Tizen.NUI
                 if (stageContextRegainedEventHandler == null)
                 {
                     stageContextRegainedEventCallbackDelegate = OnContextRegained;
-                    using VoidSignal contextRegainedSignal = ContextRegainedSignal();
-                    contextRegainedSignal?.Connect(stageContextRegainedEventCallbackDelegate);
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.ContextRegainedSignal(stageCPtr), false);
+                    signal?.Connect(stageContextRegainedEventCallbackDelegate);
                 }
                 stageContextRegainedEventHandler += value;
             }
             remove
             {
                 stageContextRegainedEventHandler -= value;
-
-                using VoidSignal contextRegainedSignal = ContextRegainedSignal();
-                if (stageContextRegainedEventHandler == null && contextRegainedSignal?.Empty() == false)
+                if (stageContextRegainedEventHandler == null && stageContextRegainedEventCallbackDelegate != null)
                 {
-                    contextRegainedSignal?.Disconnect(stageContextRegainedEventCallbackDelegate);
-                    if(contextRegainedSignal?.Empty() == true)
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.ContextRegainedSignal(stageCPtr), false);
+                    signal?.Disconnect(stageContextRegainedEventCallbackDelegate);
+                    if (signal?.Empty() == true)
                     {
                         stageContextRegainedEventCallbackDelegate = null;
                     }
@@ -497,103 +492,24 @@ namespace Tizen.NUI
                 if (stageSceneCreatedEventHandler == null)
                 {
                     stageSceneCreatedEventCallbackDelegate = OnSceneCreated;
-                    using VoidSignal sceneCreatedSignal = SceneCreatedSignal();
-                    sceneCreatedSignal?.Connect(stageSceneCreatedEventCallbackDelegate);
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.SceneCreatedSignal(stageCPtr), false);
+                    signal?.Connect(stageSceneCreatedEventCallbackDelegate);
                 }
                 stageSceneCreatedEventHandler += value;
             }
             remove
             {
                 stageSceneCreatedEventHandler -= value;
-
-                using VoidSignal sceneCreatedSignal = SceneCreatedSignal();
-                if (stageSceneCreatedEventHandler == null && sceneCreatedSignal?.Empty() == false)
+                if (stageSceneCreatedEventHandler == null && stageSceneCreatedEventCallbackDelegate != null)
                 {
-                    sceneCreatedSignal?.Disconnect(stageSceneCreatedEventCallbackDelegate);
-                    if(sceneCreatedSignal?.Empty() == true)
+                    using VoidSignal signal = new VoidSignal(Interop.StageSignal.SceneCreatedSignal(stageCPtr), false);
+                    signal?.Disconnect(stageSceneCreatedEventCallbackDelegate);
+                    if (signal?.Empty() == true)
                     {
                         stageSceneCreatedEventCallbackDelegate = null;
                     }
                 }
             }
-        }
-
-        internal WindowFocusSignalType WindowFocusChangedSignal()
-        {
-            WindowFocusSignalType ret = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal WindowFocusSignalType FocusChangedSignal()
-        {
-            WindowFocusSignalType ret = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal KeyEventSignal KeyEventSignal()
-        {
-            KeyEventSignal ret = new KeyEventSignal(Interop.Window.KeyEventSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal KeyEventSignal InterceptKeyEventSignal()
-        {
-            KeyEventSignal ret = new KeyEventSignal(Interop.Window.InterceptKeyEventSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal VoidSignal EventProcessingFinishedSignal()
-        {
-            VoidSignal ret = new VoidSignal(Interop.StageSignal.EventProcessingFinishedSignal(stageCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal TouchSignal TouchSignal()
-        {
-            TouchSignal ret = new TouchSignal(Interop.Window.TouchSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal TouchDataSignal TouchDataSignal()
-        {
-            TouchDataSignal ret = new TouchDataSignal(Interop.ActorSignal.ActorTouchSignal(Layer.getCPtr(GetRootLayer())), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal VoidSignal ContextLostSignal()
-        {
-            VoidSignal ret = new VoidSignal(Interop.StageSignal.ContextLostSignal(stageCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal VoidSignal ContextRegainedSignal()
-        {
-            VoidSignal ret = new VoidSignal(Interop.StageSignal.ContextRegainedSignal(stageCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal VoidSignal SceneCreatedSignal()
-        {
-            VoidSignal ret = new VoidSignal(Interop.StageSignal.SceneCreatedSignal(stageCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        internal ResizeSignal ResizeSignal()
-        {
-            ResizeSignal ret = new ResizeSignal(Interop.Window.ResizeSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         internal System.IntPtr GetNativeWindowHandler()
@@ -609,178 +525,115 @@ namespace Tizen.NUI
         /// <since_tizen> 5 </since_tizen>
         internal void DisconnectNativeSignals()
         {
+            if (HasBody() == false)
+            {
+                NUILog.Debug($"[Dispose] DisConnectFromSignals() No native body! No need to Disconnect Signals!");
+                return;
+            }
+
             if (windowFocusChangedEventCallback != null)
             {
-                using WindowFocusSignalType windowFocusChangedSignal = WindowFocusChangedSignal();
-                if( windowFocusChangedSignal?.Empty() == false )
-                {
-                    windowFocusChangedSignal?.Disconnect(windowFocusChangedEventCallback);
-                    windowFocusChangedEventCallback = null;
-                }
+                using WindowFocusSignalType signal = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(windowFocusChangedEventCallback);
+                windowFocusChangedEventCallback = null;
             }
 
             if (rootLayerTouchDataCallback != null)
             {
-                using TouchDataSignal touchDataSignal = TouchDataSignal();
-                if( touchDataSignal?.Empty() == false )
-                {
-                    touchDataSignal?.Disconnect(rootLayerTouchDataCallback);
-                    rootLayerTouchDataCallback = null;
-                }
+                using TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.ActorTouchSignal(Layer.getCPtr(GetRootLayer())), false);
+                signal?.Disconnect(rootLayerTouchDataCallback);
+                rootLayerTouchDataCallback = null;
             }
-
             if (wheelEventCallback != null)
             {
-                using WheelSignal wheelSignal = WheelEventSignal();
-                if( wheelSignal?.Empty() == false )
-                {
-                    wheelSignal?.Disconnect(wheelEventCallback);
-                    wheelEventCallback = null;
-                }
+                using WheelSignal signal = new WheelSignal(Interop.ActorSignal.ActorWheelEventSignal(Layer.getCPtr(this.GetRootLayer())), false);
+                signal?.Disconnect(wheelEventCallback);
+                wheelEventCallback = null;
             }
 
             if (DetentEventCallback != null)
             {
-                using StageWheelSignal stageWheelSignal = StageWheelEventSignal();
-                if( stageWheelSignal?.Empty() == false )
-                {
-                    stageWheelSignal?.Disconnect(DetentEventCallback);
-                    DetentEventCallback = null;
-                }
+                using StageWheelSignal signal = new StageWheelSignal(Interop.StageSignal.WheelEventSignal(stageCPtr), false);
+                signal?.Disconnect(DetentEventCallback);
+                DetentEventCallback = null;
             }
 
             if (stageKeyCallbackDelegate != null)
             {
-                using KeyEventSignal keyEventSignal = KeyEventSignal();
-                if( keyEventSignal?.Empty() == false )
-                {
-                    keyEventSignal?.Disconnect(stageKeyCallbackDelegate);
-                    stageKeyCallbackDelegate = null;
-                }
+                using KeyEventSignal signal = new KeyEventSignal(Interop.Window.KeyEventSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(stageKeyCallbackDelegate);
+                stageKeyCallbackDelegate = null;
             }
 
             if (stageInterceptKeyCallbackDelegate != null)
             {
-                interceptKeyEventSignal?.Disconnect(stageInterceptKeyCallbackDelegate);
+                using KeyEventSignal signal = new KeyEventSignal(Interop.Window.InterceptKeyEventSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(stageInterceptKeyCallbackDelegate);
                 stageInterceptKeyCallbackDelegate = null;
             }
 
             if (stageEventProcessingFinishedEventCallbackDelegate != null)
             {
-                using VoidSignal eventProcessingFinishedSignal = EventProcessingFinishedSignal();
-                if( eventProcessingFinishedSignal?.Empty() == false )
-                {
-                    eventProcessingFinishedSignal?.Disconnect(stageEventProcessingFinishedEventCallbackDelegate);
-                    stageEventProcessingFinishedEventCallbackDelegate = null;
-                }
+                using VoidSignal signal = new VoidSignal(Interop.StageSignal.EventProcessingFinishedSignal(stageCPtr), false);
+                signal?.Disconnect(stageEventProcessingFinishedEventCallbackDelegate);
+                stageEventProcessingFinishedEventCallbackDelegate = null;
             }
 
             if (stageContextLostEventCallbackDelegate != null)
             {
-                using VoidSignal contextLostSignal = ContextLostSignal();
-                if( contextLostSignal?.Empty() == false )
-                {
-                    contextLostSignal?.Disconnect(stageContextLostEventCallbackDelegate);
-                    stageContextLostEventCallbackDelegate= null;
-                }
+                using VoidSignal signal = new VoidSignal(Interop.StageSignal.ContextLostSignal(stageCPtr), false);
+                signal?.Disconnect(stageContextLostEventCallbackDelegate);
+                stageContextLostEventCallbackDelegate = null;
             }
 
             if (stageContextRegainedEventCallbackDelegate != null)
             {
-                using VoidSignal contextRegainedSignal = ContextRegainedSignal();
-                if( contextRegainedSignal?.Empty() == false )
-                {
-                    contextRegainedSignal?.Disconnect(stageContextRegainedEventCallbackDelegate);
-                    stageContextRegainedEventCallbackDelegate = null;
-                }
+                using VoidSignal signal = new VoidSignal(Interop.StageSignal.ContextRegainedSignal(stageCPtr), false);
+                signal?.Disconnect(stageContextRegainedEventCallbackDelegate);
+                stageContextRegainedEventCallbackDelegate = null;
             }
 
             if (stageSceneCreatedEventCallbackDelegate != null)
             {
-                using VoidSignal sceneCreatedSignal = SceneCreatedSignal();
-                if( sceneCreatedSignal?.Empty() == false )
-                {
-                    sceneCreatedSignal?.Disconnect(stageSceneCreatedEventCallbackDelegate);
-                    stageSceneCreatedEventCallbackDelegate = null;
-                }
+                using VoidSignal signal = new VoidSignal(Interop.StageSignal.SceneCreatedSignal(stageCPtr), false);
+                signal?.Disconnect(stageSceneCreatedEventCallbackDelegate);
+                stageSceneCreatedEventCallbackDelegate = null;
             }
 
             if (windowResizeEventCallback != null)
             {
-                using ResizeSignal resizeSignal = ResizeSignal();
-                if( resizeSignal?.Empty() == false )
-                {
-                    resizeSignal?.Disconnect(windowResizeEventCallback);
-                    windowResizeEventCallback = null;
-                }
+                using ResizeSignal signal = new ResizeSignal(Interop.Window.ResizeSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(windowResizeEventCallback);
+                windowResizeEventCallback = null;
             }
 
             if (windowFocusChangedEventCallback2 != null)
             {
-                using WindowFocusSignalType windowFocusChangedSignal2 = WindowFocusChangedSignal();
-                if( windowFocusChangedSignal2?.Empty() == false )
-                {
-                    windowFocusChangedSignal2?.Disconnect(windowFocusChangedEventCallback2);
-                    windowFocusChangedEventCallback2 = null;
-                }
+                using WindowFocusSignalType signal = new WindowFocusSignalType(Interop.Window.FocusChangedSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(windowFocusChangedEventCallback2);
+                windowFocusChangedEventCallback2 = null;
             }
 
-            if (transitionEffectSignal != null)
+            if (transitionEffectEventCallback != null)
             {
-                TransitionEffectEventSignal().Disconnect(transitionEffectEventCallback);
+                using WindowTransitionEffectSignal signal = new WindowTransitionEffectSignal(Interop.WindowTransitionEffectSignal.GetSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(transitionEffectEventCallback);
                 transitionEffectEventCallback = null;
             }
 
-            if (keyboardRepeatSettingsChangedSignal != null)
+            if (keyboardRepeatSettingsChangedEventCallback != null)
             {
-                KeyboardRepeatSettingsChangedEventSignal().Disconnect(keyboardRepeatSettingsChangedEventCallback);
+                using KeyboardRepeatSettingsChangedSignal signal = new KeyboardRepeatSettingsChangedSignal(Interop.KeyboardRepeatSettingsChangedSignal.GetSignal(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(keyboardRepeatSettingsChangedEventCallback);
                 keyboardRepeatSettingsChangedEventCallback = null;
             }
 
             if (auxiliaryMessageEventCallback != null)
             {
-                using var signal = new WindowAuxiliaryMessageSignal(this);
-                signal.Disconnect(auxiliaryMessageEventCallback);
-                auxiliaryMessageEventHandler = null;
+                using WindowAuxiliaryMessageSignal signal = new WindowAuxiliaryMessageSignal(Interop.WindowAuxiliaryMessageSignalType.Get(GetBaseHandleCPtrHandleRef), false);
+                signal?.Disconnect(auxiliaryMessageEventCallback);
                 auxiliaryMessageEventCallback = null;
             }
-        }
-
-        private StageWheelSignal StageWheelEventSignal()
-        {
-            StageWheelSignal ret = new StageWheelSignal(Interop.StageSignal.WheelEventSignal(stageCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        private WheelSignal WheelEventSignal()
-        {
-            WheelSignal ret = new WheelSignal(Interop.ActorSignal.ActorWheelEventSignal(Layer.getCPtr(this.GetRootLayer())), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        private WindowTransitionEffectSignal TransitionEffectEventSignal()
-        {
-            if (transitionEffectSignal == null)
-            {
-                transitionEffectSignal = new WindowTransitionEffectSignal(this);
-                if (NDalicPINVOKE.SWIGPendingException.Pending)
-                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-            return transitionEffectSignal;
-        }
-
-        private KeyboardRepeatSettingsChangedSignal KeyboardRepeatSettingsChangedEventSignal()
-        {
-            if (keyboardRepeatSettingsChangedSignal == null)
-            {
-                keyboardRepeatSettingsChangedSignal = new KeyboardRepeatSettingsChangedSignal(this);
-                if (NDalicPINVOKE.SWIGPendingException.Pending)
-                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-            return keyboardRepeatSettingsChangedSignal;
         }
 
         private void OnWindowFocusedChanged(IntPtr window, bool focusGained)
@@ -1237,26 +1090,21 @@ namespace Tizen.NUI
                 if (VisibilityChangedEventHandler == null)
                 {
                     VisibilityChangedEventCallback = OnVisibilityChanged;
-                    VisibilityChangedEventSignal = new WindowVisibilityChangedEvent(this);
-                    VisibilityChangedEventSignal.Connect(VisibilityChangedEventCallback);
+                    using WindowVisibilityChangedEvent signal = new WindowVisibilityChangedEvent(Interop.WindowVisibilityChangedSignal.GetSignal(Window.getCPtr(this)), false);
+                    signal?.Connect(VisibilityChangedEventCallback);
                 }
                 VisibilityChangedEventHandler += value;
             }
             remove
             {
                 VisibilityChangedEventHandler -= value;
-                if (VisibilityChangedEventHandler == null)
+                if (VisibilityChangedEventHandler == null && VisibilityChangedEventCallback != null)
                 {
-                    if (VisibilityChangedEventSignal != null)
+                    using WindowVisibilityChangedEvent signal = new WindowVisibilityChangedEvent(Interop.WindowVisibilityChangedSignal.GetSignal(Window.getCPtr(this)), false);
+                    signal?.Disconnect(VisibilityChangedEventCallback);
+                    if (signal?.Empty() == true)
                     {
-                        if (VisibilityChangedEventSignal.Empty() == false)
-                        {
-                            VisibilityChangedEventSignal.Disconnect(VisibilityChangedEventCallback);
-                            if (VisibilityChangedEventSignal.Empty())
-                            {
-                                VisibilityChangedEventCallback = null;
-                            }
-                        }
+                        VisibilityChangedEventCallback = null;
                     }
                 }
             }
@@ -1277,7 +1125,7 @@ namespace Tizen.NUI
 
         private void OnAuxiliaryMessage(IntPtr kData, IntPtr vData, IntPtr optionsArray)
         {
-            if(kData == IntPtr.Zero || vData == IntPtr.Zero)
+            if (kData == IntPtr.Zero || vData == IntPtr.Zero)
             {
                 return;
             }
@@ -1298,7 +1146,7 @@ namespace Tizen.NUI
 
             AuxiliaryMessageEventArgs e = new AuxiliaryMessageEventArgs();
             e.Key = StringToVoidSignal.GetResult(kData);
-            e.Value = StringToVoidSignal.GetResult(vData);;
+            e.Value = StringToVoidSignal.GetResult(vData); ;
             e.Options = tmpList;
 
             auxiliaryMessageEventHandler?.Invoke(this, e);
@@ -1318,25 +1166,21 @@ namespace Tizen.NUI
                 if (auxiliaryMessageEventHandler == null)
                 {
                     auxiliaryMessageEventCallback = OnAuxiliaryMessage;
-                    using var signal = new WindowAuxiliaryMessageSignal(this);
-                    signal.Connect(auxiliaryMessageEventCallback);
+                    using WindowAuxiliaryMessageSignal signal = new WindowAuxiliaryMessageSignal(Interop.WindowAuxiliaryMessageSignalType.Get(SwigCPtr), false);
+                    signal?.Connect(auxiliaryMessageEventCallback);
                 }
                 auxiliaryMessageEventHandler += value;
             }
             remove
             {
                 auxiliaryMessageEventHandler -= value;
-                if (auxiliaryMessageEventHandler == null)
+                if (auxiliaryMessageEventHandler == null && auxiliaryMessageEventCallback != null)
                 {
-                    if (auxiliaryMessageEventCallback != null)
+                    using WindowAuxiliaryMessageSignal signal = new WindowAuxiliaryMessageSignal(Interop.WindowAuxiliaryMessageSignalType.Get(SwigCPtr), false);
+                    signal?.Disconnect(auxiliaryMessageEventCallback);
+                    if (signal?.Empty() == true)
                     {
-                        using var signal = new WindowAuxiliaryMessageSignal(this);
-                        signal.Disconnect(auxiliaryMessageEventCallback);
-
-                        if (signal.Empty())
-                        {
-                            auxiliaryMessageEventCallback = null;
-                        }
+                        auxiliaryMessageEventCallback = null;
                     }
                 }
             }


### PR DESCRIPTION
### Description of Change ###
[NUI] merge Window event changes of API10
- in API10 Window's event pattern had been changed and has been applied
- to resolve this exception in tizen_6.5(API9) =>
_E/DOTNET_LAUNCHER(11285): log.cc: stdErrRedirect(120) > Unhandled exception.
E/DOTNET_LAUNCHER(11285): log.cc: stdErrRedirect(120) >
E/DOTNET_LAUNCHER(11285): log.cc: stdErrRedirect(120) > System.ArgumentNullException: Value cannot be null. (Parameter 'd')
E/DOTNET_LAUNCHER(11285):    at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(Delegate d)
E/DOTNET_LAUNCHER(11285):    at System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate[TDelegate](TDelegate d)
E/DOTNET_LAUNCHER(11285):    at Tizen.NUI.KeyEventSignal.Disconnect(Delegate func) in /home/abuild/rpmbuild/BUILD/csapi-tizenfx-9.0.0.16852 nui22045/src/Tizen.NUI/src/internal/Common/KeyEventSignal.cs:line 56
E/DOTNET_LAUNCHER(11285):    at Tizen.NUI.Window.remove_KeyEvent(EventHandler`1 value) in /home/abuild/rpmbuild/BUILD/csapi-tizenfx-9.0.0.16852 nui22045/src/Tizen.NUI/src/public/Window/WindowEvent.cs:line 192_

### API Changes ###
none