### PR TITLE
[Tizen.Log] Replace dlog_print with dlog_print_dotnet

### DIFF
--- a/src/Tizen.Log/Interop/Interop.Dlog.cs
+++ b/src/Tizen.Log/Interop/Interop.Dlog.cs
@@ -50,10 +50,10 @@ internal static partial class Interop
             DLOG_PRIO_MAX,
         }
 
-        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
 
-        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "__dlog_print", CallingConvention = CallingConvention.Cdecl)]

--- a/src/Tizen/Interop/Interop.Dlog.cs
+++ b/src/Tizen/Interop/Interop.Dlog.cs
@@ -38,10 +38,10 @@ internal static partial class Interop
             DLOG_SILENT,
             DLOG_PRIO_MAX,
         }
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
+        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
 
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
+        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }

--- a/test/ElmSharp.Test/Log.cs
+++ b/test/ElmSharp.Test/Log.cs
@@ -54,7 +54,7 @@ namespace ElmSharp.Test
             Print(priority, tag, "%s: %s(%d) > %s", finfo.Name, func, line, message);
         }
 
-        [DllImportAttribute(Library, EntryPoint = "dlog_print")]
+        [DllImportAttribute(Library, EntryPoint = "dlog_print_dotnet")]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }

--- a/test/ElmSharp.Wearable.Test/TC/Log.cs
+++ b/test/ElmSharp.Wearable.Test/TC/Log.cs
@@ -54,7 +54,7 @@ namespace ElmSharp.Test
             Print(priority, tag, "%s: %s(%d) > %s", finfo.Name, func, line, message);
         }
 
-        [DllImportAttribute(Library, EntryPoint = "dlog_print")]
+        [DllImportAttribute(Library, EntryPoint = "dlog_print_dotnet")]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }


### PR DESCRIPTION
### Description of Change ###
Replace dlog_print with dlog_print_dotnet which is used for only csharp api.


### API Changes ###
 - ACR: No API changed