### PR TITLE
[NUI] Introduce WindowData

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -1576,6 +1576,19 @@ namespace Tizen.NUI
             return instance;
         }
 
+        public static Application NewApplication(string[] args, string stylesheet, bool useUIThread, WindowData windowData)
+        {
+            if (instance != null)
+            {
+                return instance;
+            }
+            Application ret = New(args, stylesheet, useUIThread, windowData);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            instance = ret;
+            return instance;
+        }
+
         /// <summary>
         /// Ensures that the function passed in is called from the main loop when it is idle.
         /// </summary>
@@ -1705,6 +1718,30 @@ namespace Tizen.NUI
                 argvStr = string.Join(" ", args);
 
                 ret = new Application(Interop.Application.New(argc, stylesheet, (int)windowMode, Rectangle.getCPtr(positionSize), useUIThread), true);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            catch (Exception exception)
+            {
+                Tizen.Log.Fatal("NUI", "[Error] got exception during Application New(), this should not occur, message : " + exception.Message);
+                Tizen.Log.Fatal("NUI", "[Error] error line number : " + new StackTrace(exception, true).GetFrame(0).GetFileLineNumber());
+                Tizen.Log.Fatal("NUI", "[Error] Stack Trace : " + exception.StackTrace);
+                throw;
+            }
+
+            return ret;
+        }
+
+        public static Application New(string[] args, string stylesheet, bool useUIThread, WindowData windowData)
+        {
+            Application ret = null;
+            int argc = 0;
+            string argvStr = "";
+            try
+            {
+                argc = args.Length;
+                argvStr = string.Join(" ", args);
+
+                ret = new Application(Interop.Application.New(argc, argvStr, stylesheet, useUIThread, WindowData.getCPtr(windowData)), true);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
             catch (Exception exception)

--- a/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
@@ -34,6 +34,7 @@ namespace Tizen.NUI
         private Rectangle windowRectangle = null;
         private WindowType defaultWindowType = WindowType.Normal;
         private ICoreTask coreTask;
+        private WindowData windowData = null;
 
         /// <summary>
         /// The Dictionary to contain each type of event callback.
@@ -88,6 +89,13 @@ namespace Tizen.NUI
             this.stylesheet = stylesheet;
             this.windowMode = windowMode;
             this.defaultWindowType = type;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public NUICoreBackend(WindowData windowData)
+        {
+            //NOTE: windowMode, defaultWindowType, windowRectangle are not used.
+            this.windowData = windowData;
         }
 
         /// <summary>
@@ -171,7 +179,12 @@ namespace Tizen.NUI
                 args[0] = this.GetType().Assembly.FullName.Replace(" ", "");
             }
 
-            if (defaultWindowType != WindowType.Normal)
+            if (windowData != null)
+            {
+                bool enableUIThread = coreTask != null;
+                application = Application.NewApplication(args, stylesheet, enableUIThread, windowData);
+            }
+            else if (defaultWindowType != WindowType.Normal)
             {
                 application = Application.NewApplication(stylesheet, windowMode, defaultWindowType);
             }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
@@ -95,6 +95,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New__SWIG_6")]
             public static extern global::System.IntPtr New(int jarg1, string jarg3, int jarg4, global::System.Runtime.InteropServices.HandleRef jarg5, bool jarg7);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_New_WithWindowData")]
+            public static extern global::System.IntPtr New(int argc, string argv, string styleSheet, bool uiThread, global::System.Runtime.InteropServices.HandleRef windowData);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetScreenSize")]
             public static extern global::System.IntPtr GetScreenSize();
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowData.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.Runtime.InteropServices;
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WindowData
+        {
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowData")]
+            public static extern global::System.IntPtr New();
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowData")]
+            public static extern void DeleteWindowData(HandleRef nuiWindowData);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetPositionSize")]
+            public static extern void SetPositionSize(HandleRef nuiWindowData, HandleRef nuiPositionSize);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetPositionSize")]
+            public static extern global::System.IntPtr GetPositionSize(HandleRef nuiWindowData);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetWindowType")]
+            public static extern void SetWindowType(HandleRef nuiWindowData, int nuiWindowType);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetWindowType")]
+            public static extern int GetWindowType(HandleRef nuiWindowData);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetTransparency")]
+            public static extern void SetTransparency(HandleRef nuiWindowData, bool nuiTransparency);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetTransparency")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool GetTransparency(HandleRef nuiWindowData);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -264,6 +264,22 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// The constructor with a ThemeOptions, WindowData
+        /// </summary>
+        /// <param name="option">The theme option.</param>
+        /// <param name="windowData">The default window data</param>
+        [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public NUIApplication(ThemeOptions option, WindowData windowData) : base(new NUICoreBackend(windowData))
+        {
+            if (windowData.BorderInterface != null)
+            {
+                EnableBorder(windowData.BorderInterface);
+            }
+            ApplyThemeOption(option);
+        }
+
+        /// <summary>
         /// Occurs whenever the application is resumed.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>

--- a/src/Tizen.NUI/src/public/Application/WindowData.cs
+++ b/src/Tizen.NUI/src/public/Application/WindowData.cs
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.NUI.Binding;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// This class represents the default window data for an Application object.
+    /// It contains information about the default window.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class WindowData : Disposable
+    {
+        private IBorderInterface borderInterface = null;
+
+        public WindowData() : this(Interop.WindowData.New(), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal WindowData(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the position and size of the default window.
+        /// The default size of the position and size is X=0, Y=0, WIDTH=0, HEIGHT=0.
+        /// </summary>
+        /// <value>The position and size of the default window.</value>
+        public Rectangle PositionSize
+        {
+            set
+            {
+                Interop.WindowData.SetPositionSize(SwigCPtr, Rectangle.getCPtr(value));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            get
+            {
+                Rectangle ret = Rectangle.GetRectangleFromPtr(Interop.WindowData.GetPositionSize(SwigCPtr));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the mode of the default window.
+        /// The default mode is WindowMode.Transparent.
+        /// </summary>
+        /// <value>The mode of the default window.</value>
+        public NUIApplication.WindowMode WindowMode
+        {
+            set
+            {
+                Interop.WindowData.SetTransparency(SwigCPtr, NUIApplication.WindowMode.Transparent == value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            get
+            {
+                bool transparent = Interop.WindowData.GetTransparency(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
+                return transparent ? NUIApplication.WindowMode.Transparent : NUIApplication.WindowMode.Opaque;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the type of the default window.
+        /// The default type is WindowType.Normal.
+        /// </summary>
+        /// <value>The type of the default window.</value>
+        public WindowType WindowType
+        {
+            set
+            {
+                Interop.WindowData.SetWindowType(SwigCPtr, (int)value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            get
+            {
+                WindowType ret = (WindowType)Interop.WindowData.GetWindowType(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
+                return ret;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the border interface of the default window.
+        /// The default value is null.
+        /// </summary>
+        /// <value>The border interface of the default window.</value>
+        public IBorderInterface BorderInterface
+        {
+            set
+            {
+                borderInterface = value;
+            }
+            get
+            {
+                return borderInterface;
+            }
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WindowData.DeleteWindowData(swigCPtr);
+        }
+    }
+}


### PR DESCRIPTION
The NUIApplication class had to add new constructors whenever the Window class added a new constructor. Because the class has a default window. To simplify this process, WindowData is introduced which contains all the data of the default window.

refer to : 
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/290155
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/290165

The above patches were merged.