### PR TITLE
[NUI] Add Font PreCache API to FontClient

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
@@ -22,6 +22,9 @@ namespace Tizen.NUI
         internal static partial class FontClient
         {
             //for FontClient
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_PreCache")]
+            public static extern void PreCache(string[] fallbackFamilyArray, int fallbackFamilySize, string[] extraFamilyArray, int extraFamilySize, string localeFamily, bool useThread);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_DEFAULT_POINT_SIZE_get")]
             public static extern uint DefaultPointSizeGet();
 

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -66,6 +66,25 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// This is used to pre-cache fonts in order to improve the runtime performance of the application.
+        /// </summary>
+        /// <param name="fallbackFamilyList">A list of fallback font families to be pre-cached.</param>
+        /// <param name="extraFamilyList">A list of additional font families to be pre-cached.</param>
+        /// <param name="localeFamily">A locale font family to be pre-cached.</param>
+        /// <param name="useThread">True if the font client should create thread and perform pre-caching, false otherwise.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void PreCache(List<string> fallbackFamilyList, List<string> extraFamilyList, string localeFamily, bool useThread)
+        {
+            int fallbackFamilySize = fallbackFamilyList?.Count ?? 0;
+            int extraFamilySize = extraFamilyList?.Count ?? 0;
+            string[] fallbackFamilyArray = fallbackFamilySize > 0 ? fallbackFamilyList.ToArray() : null;
+            string[] extraFamilyArray = extraFamilySize > 0 ? extraFamilyList.ToArray() : null;
+
+            Interop.FontClient.PreCache(fallbackFamilyArray, fallbackFamilySize, extraFamilyArray, extraFamilySize, localeFamily, useThread);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Called when the user changes the system defaults.
         /// </summary>
         /// <since_tizen> 5 </since_tizen>


### PR DESCRIPTION
This patch adds a new PreCache API to enable pre-caching of fonts and improve the runtime performance of the application.

Pre-caching default fonts and fallback lists can enhance the responsiveness performance by minimizing the calls to FcFontSort and FcFontMatch, during the early stages of boot-up.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/290395/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/290460/