### PR TITLE
[NUI] Register HitTest callback only if GrabTouchAfterLeave = true

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -209,9 +209,6 @@ namespace Tizen.NUI.BaseComponents
                 PositionUsesPivotPoint = false;
                 GrabTouchAfterLeave = defaultGrabTouchAfterLeave;
                 AllowOnlyOwnTouch = defaultAllowOnlyOwnTouch;
-
-                // TODO : Can we call this function only for required subclass?
-                RegisterHitTestCallback();
             }
 
             if (!shown)
@@ -3237,6 +3234,17 @@ namespace Tizen.NUI.BaseComponents
             set
             {
                 Object.InternalSetPropertyBool(SwigCPtr, View.Property.CaptureAllTouchAfterStart, value);
+
+                // Use custom HitTest callback only if GrabTouchAfterLeave is true.
+                if (value)
+                {
+                    RegisterHitTestCallback();
+                }
+                else
+                {
+                    UnregisterHitTestCallback();
+                }
+
                 NotifyPropertyChanged();
             }
         }


### PR DESCRIPTION
Since useless HitTest checkup function make performance down for standard cases, Let we make we use custom callback only if GrabTouchAfterLeave case.