### PR TITLE
[NUI][AT-SPI] Add ViewAccessibilityMode

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
@@ -26,6 +26,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_New")]
             public static extern global::System.IntPtr New();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_NewCustom")]
+            public static extern global::System.IntPtr NewCustom();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_View__SWIG_0")]
             public static extern global::System.IntPtr NewView();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -116,10 +116,54 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Accessibility mode for controlling View's Accessible implementation.
+        /// It is only relevant when deriving custom controls from View directly,
+        /// as classes derived from CustomView (or any of its subclasses) get the
+        /// Custom mode by default.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum ViewAccessibilityMode
+        {
+            /// <summary>
+            /// Default accessibility implementation. Overriding View.Accessibility...()
+            /// virtual methods will have no effect.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Default,
+            /// <summary>
+            /// Custom accessibility implementation. Overriding View.Accessibility...()
+            /// will be necessary to provide accessibility support for the View.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Custom,
+        }
+
+        private static IntPtr NewWithAccessibilityMode(ViewAccessibilityMode accessibilityMode)
+        {
+            switch (accessibilityMode)
+            {
+                case ViewAccessibilityMode.Custom:
+                {
+                    return Interop.View.NewCustom();
+                }
+                case ViewAccessibilityMode.Default:
+                default:
+                {
+                    return Interop.View.New();
+                }
+            }
+        }
+
+        /// <summary>
         /// Creates a new instance of a view.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public View() : this(Interop.View.New(), true)
+        public View() : this(ViewAccessibilityMode.Default)
+        {
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public View(ViewAccessibilityMode accessibilityMode) : this(NewWithAccessibilityMode(accessibilityMode), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

The accessibility mode helps select the right Accessible implementation for a given view. It does not affect controls derived from `CustomView` (or any of its subclasses), e.g. `Tizen.NUI.Components`, which already behave in the custom mode. The default mode is kept for `Tizen.NUI.BaseComponents`. However, this patch add a possibility of opting into the custom mode for controls derived directly from `View` (e.g. `FluxView`), and by doing so, to be able to implement accessibility support for them in the C# language.

(Note: This is a backport of https://github.com/Samsung/TizenFX/pull/5109)

Dependencies:
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/290143/ (merged)

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
