### PR TITLE
[NUI][AT-SPI] Override ContentPage.AccessibilityGetName()

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/ContentPage.cs
@@ -104,6 +104,13 @@ namespace Tizen.NUI.Components
             AccessibilityRole = Role.PageTab;
         }
 
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override string AccessibilityGetName()
+        {
+            return AppBar?.Title;
+        }
+
         /// <summary>
         /// AppBar of ContentPage.
         /// AppBar is added as a child of ContentPage automatically.


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

ContentPage often serves as a default label in scenarios where Navigator is used, so Screen Reader will ask ContentPage about the accessibility name (text to read) when a Navigator page is pushed. Therefore, it makes sense to try to provide the text from ContentPage.AppBar.Title (if it exists). The application developer can always customize this by setting the AccessibilityName property or adding an AccessibilityRelation.LabelledBy.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
