### PR TITLE
[Connection] Fix race condition

### DIFF
--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -197,32 +197,38 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                if (_EthernetCableStateChanged == null)
+                lock(_EthernetCableStateChanged)
                 {
-                    try
+                    if (_EthernetCableStateChanged == null)
                     {
-                        EthernetCableStateChangedStart();
+                        try
+                        {
+                            EthernetCableStateChangedStart();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on adding EthernetCableStateChanged\n" + e.ToString());
+                            return;
+                        }
                     }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on adding EthernetCableStateChanged\n" + e.ToString());
-                        return;
-                    }
+                    _EthernetCableStateChanged += value;
                 }
-                _EthernetCableStateChanged += value;
             }
             remove
             {
-                _EthernetCableStateChanged -= value;
-                if (_EthernetCableStateChanged == null)
+                lock(_EthernetCableStateChanged)
                 {
-                    try
+                    _EthernetCableStateChanged -= value;
+                    if (_EthernetCableStateChanged == null)
                     {
-                        EthernetCableStateChangedStop();
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on removing EthernetCableStateChanged\n" + e.ToString());
+                        try
+                        {
+                            EthernetCableStateChangedStop();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on removing EthernetCableStateChanged\n" + e.ToString());
+                        }
                     }
                 }
             }
@@ -266,33 +272,39 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                if (_IPAddressChanged == null)
+                lock (_IPAddressChanged)
                 {
-                    try
+                    if (_IPAddressChanged == null)
                     {
-                        IPAddressChangedStart();
+                        try
+                        {
+                            IPAddressChangedStart();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on adding IPAddressChanged\n" + e.ToString());
+                            return;
+                        }
                     }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on adding IPAddressChanged\n" + e.ToString());
-                        return;
-                    }
+                    _IPAddressChanged += value;
                 }
-                _IPAddressChanged += value;
             }
 
             remove
             {
-                _IPAddressChanged -= value;
-                if (_IPAddressChanged == null)
+                lock (_IPAddressChanged)
                 {
-                    try
+                    _IPAddressChanged -= value;
+                    if (_IPAddressChanged == null)
                     {
-                        IPAddressChangedStop();
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on removing IPAddressChanged\n" + e.ToString());
+                        try
+                        {
+                            IPAddressChangedStop();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on removing IPAddressChanged\n" + e.ToString());
+                        }
                     }
                 }
             }
@@ -336,32 +348,38 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                if (_ProxyAddressChanged == null)
+                lock (_ProxyAddressChanged)
                 {
-                    try
+                    if (_ProxyAddressChanged == null)
                     {
-                        ProxyAddressChangedStart();
+                        try
+                        {
+                            ProxyAddressChangedStart();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on adding ProxyAddressChanged\n" + e.ToString());
+                            return;
+                        }
                     }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on adding ProxyAddressChanged\n" + e.ToString());
-                        return;
-                    }
+                    _ProxyAddressChanged += value;
                 }
-                _ProxyAddressChanged += value;
             }
             remove
             {
-                _ProxyAddressChanged -= value;
-                if (_ProxyAddressChanged == null)
+                lock (_ProxyAddressChanged)
                 {
-                    try
+                    _ProxyAddressChanged -= value;
+                    if (_ProxyAddressChanged == null)
                     {
-                        ProxyAddressChangedStop();
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on removing ProxyAddressChanged\n" + e.ToString());
+                        try
+                        {
+                            ProxyAddressChangedStop();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on removing ProxyAddressChanged\n" + e.ToString());
+                        }
                     }
                 }
             }

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -78,6 +78,12 @@ namespace Tizen.Network.Connection
         private EventHandler<EthernetCableStateEventArgs> _EthernetCableStateChanged = null;
         private EventHandler<AddressEventArgs> _ProxyAddressChanged = null;
 
+        private static readonly object _ConnectionTypeChangedLock = new object();
+        private static readonly object _IPAddressChangedLock = new object();
+        private static readonly object _EthernetCableStateChangedLock = new object();
+        private static readonly object _ProxyAddressChangedLock = new object();
+
+
         private Interop.Connection.ConnectionAddressChangedCallback _connectionAddressChangedCallback;
         private Interop.Connection.ConnectionTypeChangedCallback _connectionTypeChangedCallback;
         private Interop.Connection.ConnectionAddressChangedCallback _proxyAddressChangedCallback;
@@ -126,7 +132,7 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                lock (_ConnectionTypeChanged)
+                lock (_ConnectionTypeChangedLock)
                 {
                     if (_ConnectionTypeChanged == null)
                     {
@@ -145,7 +151,7 @@ namespace Tizen.Network.Connection
             }
             remove
             {
-                lock (_ConnectionTypeChanged)
+                lock (_ConnectionTypeChangedLock)
                 {
                     _ConnectionTypeChanged -= value;
                     if (_ConnectionTypeChanged == null)
@@ -197,7 +203,7 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                lock(_EthernetCableStateChanged)
+                lock(_EthernetCableStateChangedLock)
                 {
                     if (_EthernetCableStateChanged == null)
                     {
@@ -216,7 +222,7 @@ namespace Tizen.Network.Connection
             }
             remove
             {
-                lock(_EthernetCableStateChanged)
+                lock(_EthernetCableStateChangedLock)
                 {
                     _EthernetCableStateChanged -= value;
                     if (_EthernetCableStateChanged == null)
@@ -272,7 +278,7 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                lock (_IPAddressChanged)
+                lock (_IPAddressChangedLock)
                 {
                     if (_IPAddressChanged == null)
                     {
@@ -292,7 +298,7 @@ namespace Tizen.Network.Connection
 
             remove
             {
-                lock (_IPAddressChanged)
+                lock (_IPAddressChangedLock)
                 {
                     _IPAddressChanged -= value;
                     if (_IPAddressChanged == null)
@@ -348,7 +354,7 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                lock (_ProxyAddressChanged)
+                lock (_ProxyAddressChangedLock)
                 {
                     if (_ProxyAddressChanged == null)
                     {
@@ -367,7 +373,7 @@ namespace Tizen.Network.Connection
             }
             remove
             {
-                lock (_ProxyAddressChanged)
+                lock (_ProxyAddressChangedLock)
                 {
                     _ProxyAddressChanged -= value;
                     if (_ProxyAddressChanged == null)

--- a/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
+++ b/src/Tizen.Network.Connection/Tizen.Network.Connection/ConnectionInternalManager.cs
@@ -126,32 +126,38 @@ namespace Tizen.Network.Connection
         {
             add
             {
-                if (_ConnectionTypeChanged == null)
+                lock (_ConnectionTypeChanged)
                 {
-                    try
+                    if (_ConnectionTypeChanged == null)
                     {
-                        ConnectionTypeChangedStart();
+                        try
+                        {
+                            ConnectionTypeChangedStart();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on adding ConnectionTypeChanged\n" + e.ToString());
+                            return;
+                        }
                     }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on adding ConnectionTypeChanged\n" + e.ToString());
-                        return;
-                    }
+                    _ConnectionTypeChanged += value;
                 }
-                _ConnectionTypeChanged += value;
             }
             remove
             {
-                _ConnectionTypeChanged -= value;
-                if (_ConnectionTypeChanged == null)
+                lock (_ConnectionTypeChanged)
                 {
-                    try
+                    _ConnectionTypeChanged -= value;
+                    if (_ConnectionTypeChanged == null)
                     {
-                        ConnectionTypeChangedStop();
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(Globals.LogTag, "Exception on removing ConnectionTypeChanged\n" + e.ToString());
+                        try
+                        {
+                            ConnectionTypeChangedStop();
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(Globals.LogTag, "Exception on removing ConnectionTypeChanged\n" + e.ToString());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description of Change ###
A race condition occurred when two threads subscribed ConnectionManager.ConnectionTypeChanged.
Only the first event subscription register the C# side callback to the native capi.
So the subscription should be protected by lock.