### PR TITLE
[Tizen.Content.Download] Update protection level for CacheManager class

### DIFF
--- a/src/Tizen.Content.Download/Tizen.Content.Download/CacheManager.cs
+++ b/src/Tizen.Content.Download/Tizen.Content.Download/CacheManager.cs
@@ -23,7 +23,7 @@ namespace Tizen.Content.Download
     /// The CacheManager class provides the functions to manage cache properties.
     /// </summary>
     /// <since_tizen> 11 </since_tizen>
-    static class CacheManager
+    public static class CacheManager
     {
 
         /// <summary>


### PR DESCRIPTION
Updates protection level to 'public' for CacheManager class. So that it can be used by applications.