### PR TITLE
[Tizen.Log] Remove Substring function

### DIFF
--- a/src/Tizen.Log/Interop/Interop.Dlog.cs
+++ b/src/Tizen.Log/Interop/Interop.Dlog.cs
@@ -51,16 +51,16 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
+        internal static unsafe extern int Print(LogPriority prio, byte* tag, string fmt, byte* msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
+        internal static unsafe extern int Print(LogPriority prio, byte* tag, string fmt, byte* file, byte* func, int line, byte* msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "__dlog_print", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int InternalPrint(LogID log_id, LogPriority prio, string tag, string fmt, string msg);
+        internal static unsafe extern int InternalPrint(LogID log_id, LogPriority prio, byte* tag, string fmt, byte* msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "__dlog_print", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int InternalPrint(LogID log_id, LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
+        internal static unsafe extern int InternalPrint(LogID log_id, LogPriority prio, byte* tag, string fmt, byte* file, byte* func, int line, byte* msg);
 
     }
 }

--- a/src/Tizen.Log/Tizen.Log.csproj
+++ b/src/Tizen.Log/Tizen.Log.csproj
@@ -8,4 +8,8 @@
     <TizenPreloadFile Include="Tizen.Log.preload" Sequence="30" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/Tizen.Log/Tizen/Log.cs
+++ b/src/Tizen.Log/Tizen/Log.cs
@@ -15,7 +15,9 @@
  */
 
 using System;
+using System.Text;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.ComponentModel;
 
 namespace Tizen
@@ -112,17 +114,52 @@ namespace Tizen
             Print(Interop.Dlog.LogPriority.DLOG_FATAL, tag, message, file, func, line);
         }
 
-        static void Print(Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
+        static unsafe void Print(Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
         {
-            if (String.IsNullOrEmpty(file))
+            int tagByteLength = Encoding.UTF8.GetMaxByteCount(tag.Length);
+            Span<byte> tagByte = tagByteLength < 1024 ? stackalloc byte[tagByteLength + 1] : new byte[tagByteLength + 1];
+
+            int messageByteLength = Encoding.UTF8.GetMaxByteCount(message.Length);
+            Span<byte> messageByte = messageByteLength < 1024 ? stackalloc byte[messageByteLength + 1] : new byte[messageByteLength + 1];
+
+            fixed (char* pTagChar = &MemoryMarshal.GetReference(tag.AsSpan()))
+            fixed (char* pMessageChar = &MemoryMarshal.GetReference(message.AsSpan()))
+            fixed (byte* pTagByte = &MemoryMarshal.GetReference(tagByte))
+            fixed (byte* pMessageByte = &MemoryMarshal.GetReference(messageByte))
             {
-                Interop.Dlog.Print(priority, tag, "%s", message);
-            }
-            else
-            {
-                int index = file.LastIndexOfAny(sep);
-                string filename = file.Substring(index + 1);
-                Interop.Dlog.Print(priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
+                int len = Encoding.UTF8.GetBytes(pTagChar, tag.Length, pTagByte, tagByteLength);
+                pTagByte[len] = 0;
+                len = Encoding.UTF8.GetBytes(pMessageChar, message.Length, pMessageByte, messageByteLength);
+                pMessageByte[len] = 0;
+
+                if (String.IsNullOrEmpty(file))
+                {
+                    Interop.Dlog.Print(priority, pTagByte, "%s", pMessageByte);
+                }
+                else
+                {
+                    int index = file.LastIndexOfAny(sep);
+                    string filename = file.Substring(index + 1);
+
+                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filename.Length);
+                    Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
+
+                    int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
+                    Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
+
+                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(filename.AsSpan()))
+                    fixed (char* pFuncChar = &MemoryMarshal.GetReference(func.AsSpan()))
+                    fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
+                    fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
+                    {
+                        len = Encoding.UTF8.GetBytes(pFilenameChar, filename.Length, pFilenameByte, filenameByteLength);
+                        pFilenameByte[len] = 0;
+                        len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
+                        pFuncByte[len] = 0;
+
+                        Interop.Dlog.Print(priority, pTagByte, "%s: %s(%d) > %s", pFilenameByte, pFuncByte, line, pMessageByte);
+                    }
+                }
             }
         }
     }
@@ -220,17 +257,52 @@ namespace Tizen
             Print(Interop.Dlog.LogID.LOG_ID_MAIN, Interop.Dlog.LogPriority.DLOG_FATAL, tag, message, file, func, line);
         }
 
-        static void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
+        static unsafe void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
         {
-            if (String.IsNullOrEmpty(file))
+            int tagByteLength = Encoding.UTF8.GetMaxByteCount(tag.Length);
+            Span<byte> tagByte = tagByteLength < 1024 ? stackalloc byte[tagByteLength + 1] : new byte[tagByteLength + 1];
+
+            int messageByteLength = Encoding.UTF8.GetMaxByteCount(message.Length);
+            Span<byte> messageByte = messageByteLength < 1024 ? stackalloc byte[messageByteLength + 1] : new byte[messageByteLength + 1];
+
+            fixed (char* pTagChar = &MemoryMarshal.GetReference(tag.AsSpan()))
+            fixed (char* pMessageChar = &MemoryMarshal.GetReference(message.AsSpan()))
+            fixed (byte* pTagByte = &MemoryMarshal.GetReference(tagByte))
+            fixed (byte* pMessageByte = &MemoryMarshal.GetReference(messageByte))
             {
-                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s", message);
-            }
-            else
-            {
-                int index = file.LastIndexOfAny(sep);
-                string filename = file.Substring(index + 1);
-                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
+                int len = Encoding.UTF8.GetBytes(pTagChar, tag.Length, pTagByte, tagByteLength);
+                pTagByte[len] = 0;
+                len = Encoding.UTF8.GetBytes(pMessageChar, message.Length, pMessageByte, messageByteLength);
+                pMessageByte[len] = 0;
+
+                if (String.IsNullOrEmpty(file))
+                {
+                    Interop.Dlog.InternalPrint(log_id, priority, pTagByte, "%s", pMessageByte);
+                }
+                else
+                {
+                    int index = file.LastIndexOfAny(sep);
+                    string filename = file.Substring(index + 1);
+
+                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filename.Length);
+                    Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
+
+                    int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
+                    Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
+
+                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(filename.AsSpan()))
+                    fixed (char* pFuncChar = &MemoryMarshal.GetReference(func.AsSpan()))
+                    fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
+                    fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
+                    {
+                        len = Encoding.UTF8.GetBytes(pFilenameChar, filename.Length, pFilenameByte, filenameByteLength);
+                        pFilenameByte[len] = 0;
+                        len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
+                        pFuncByte[len] = 0;
+
+                        Interop.Dlog.InternalPrint(log_id, priority, pTagByte, "%s: %s(%d) > %s", pFilenameByte, pFuncByte, line, pMessageByte);
+                    }
+                }
             }
         }
     }
@@ -328,18 +400,53 @@ namespace Tizen
             Print(Interop.Dlog.LogID.LOG_ID_MAIN, Interop.Dlog.LogPriority.DLOG_FATAL, tag, message, file, func, line);
         }
 
-        static void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
+        static unsafe void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
         {
 #if !DISABLE_SECURELOG
-            if (String.IsNullOrEmpty(file))
+            int tagByteLength = Encoding.UTF8.GetMaxByteCount(tag.Length);
+            Span<byte> tagByte = tagByteLength < 1024 ? stackalloc byte[tagByteLength + 1] : new byte[tagByteLength + 1];
+
+            int messageByteLength = Encoding.UTF8.GetMaxByteCount(message.Length);
+            Span<byte> messageByte = messageByteLength < 1024 ? stackalloc byte[messageByteLength + 1] : new byte[messageByteLength + 1];
+
+            fixed (char* pTagChar = &MemoryMarshal.GetReference(tag.AsSpan()))
+            fixed (char* pMessageChar = &MemoryMarshal.GetReference(message.AsSpan()))
+            fixed (byte* pTagByte = &MemoryMarshal.GetReference(tagByte))
+            fixed (byte* pMessageByte = &MemoryMarshal.GetReference(messageByte))
             {
-                Interop.Dlog.InternalPrint(log_id, priority, tag, "[SECURE_LOG] %s", message);
-            }
-            else
-            {
-                int index = file.LastIndexOfAny(sep);
-                string filename = file.Substring(index + 1);
-                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
+                int len = Encoding.UTF8.GetBytes(pTagChar, tag.Length, pTagByte, tagByteLength);
+                pTagByte[len] = 0;
+                len = Encoding.UTF8.GetBytes(pMessageChar, message.Length, pMessageByte, messageByteLength);
+                pMessageByte[len] = 0;
+
+                if (String.IsNullOrEmpty(file))
+                {
+                    Interop.Dlog.InternalPrint(log_id, priority, pTagByte, "%s", pMessageByte);
+                }
+                else
+                {
+                    int index = file.LastIndexOfAny(sep);
+                    string filename = file.Substring(index + 1);
+
+                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filename.Length);
+                    Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
+
+                    int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
+                    Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
+
+                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(filename.AsSpan()))
+                    fixed (char* pFuncChar = &MemoryMarshal.GetReference(func.AsSpan()))
+                    fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
+                    fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
+                    {
+                        len = Encoding.UTF8.GetBytes(pFilenameChar, filename.Length, pFilenameByte, filenameByteLength);
+                        pFilenameByte[len] = 0;
+                        len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
+                        pFuncByte[len] = 0;
+
+                        Interop.Dlog.InternalPrint(log_id, priority, pTagByte, "%s: %s(%d) > %s", pFilenameByte, pFuncByte, line, pMessageByte);
+                    }
+                }
             }
 #endif
         }

--- a/src/Tizen.Log/Tizen/Log.cs
+++ b/src/Tizen.Log/Tizen/Log.cs
@@ -138,21 +138,21 @@ namespace Tizen
                 }
                 else
                 {
-                    int index = file.LastIndexOfAny(sep);
-                    string filename = file.Substring(index + 1);
+                    int index = file.LastIndexOfAny(sep) + 1;
+                    int filenameLength = file.Length - index;
 
-                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filename.Length);
+                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filenameLength);
                     Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
 
                     int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
                     Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
 
-                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(filename.AsSpan()))
+                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(file.AsSpan(index)))
                     fixed (char* pFuncChar = &MemoryMarshal.GetReference(func.AsSpan()))
                     fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
                     fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
                     {
-                        len = Encoding.UTF8.GetBytes(pFilenameChar, filename.Length, pFilenameByte, filenameByteLength);
+                        len = Encoding.UTF8.GetBytes(pFilenameChar, filenameLength, pFilenameByte, filenameByteLength);
                         pFilenameByte[len] = 0;
                         len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
                         pFuncByte[len] = 0;
@@ -281,21 +281,21 @@ namespace Tizen
                 }
                 else
                 {
-                    int index = file.LastIndexOfAny(sep);
-                    string filename = file.Substring(index + 1);
+                    int index = file.LastIndexOfAny(sep) + 1;
+                    int filenameLength = file.Length - index;
 
-                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filename.Length);
+                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filenameLength);
                     Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
 
                     int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
                     Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
 
-                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(filename.AsSpan()))
+                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(file.AsSpan(index)))
                     fixed (char* pFuncChar = &MemoryMarshal.GetReference(func.AsSpan()))
                     fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
                     fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
                     {
-                        len = Encoding.UTF8.GetBytes(pFilenameChar, filename.Length, pFilenameByte, filenameByteLength);
+                        len = Encoding.UTF8.GetBytes(pFilenameChar, filenameLength, pFilenameByte, filenameByteLength);
                         pFilenameByte[len] = 0;
                         len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
                         pFuncByte[len] = 0;
@@ -425,21 +425,21 @@ namespace Tizen
                 }
                 else
                 {
-                    int index = file.LastIndexOfAny(sep);
-                    string filename = file.Substring(index + 1);
+                    int index = file.LastIndexOfAny(sep) + 1;
+                    int filenameLength = file.Length - index;
 
-                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filename.Length);
+                    int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filenameLength);
                     Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
 
                     int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
                     Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
 
-                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(filename.AsSpan()))
+                    fixed (char* pFilenameChar = &MemoryMarshal.GetReference(file.AsSpan(index)))
                     fixed (char* pFuncChar = &MemoryMarshal.GetReference(func.AsSpan()))
                     fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
                     fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
                     {
-                        len = Encoding.UTF8.GetBytes(pFilenameChar, filename.Length, pFilenameByte, filenameByteLength);
+                        len = Encoding.UTF8.GetBytes(pFilenameChar, filenameLength, pFilenameByte, filenameByteLength);
                         pFilenameByte[len] = 0;
                         len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
                         pFuncByte[len] = 0;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
To cut filename from whole filepath, Print function uses Substring function.
Also, filename string is newly created.
To avoid newly create memory which can be garbage collecting target,
Substring function is removed.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
