### PR TITLE
[NUI] Add NUIApplicaion.GetScreenSize

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
@@ -98,6 +98,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_GetRenderThreadId")]
             public static extern int GetRenderThreadId(global::System.Runtime.InteropServices.HandleRef application);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetScreenSize")]
+            public static extern global::System.IntPtr GetScreenSize();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -472,6 +472,18 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets the screen size
+        /// </summary>
+        /// <returns>Screen size</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        static public Size GetScreenSize()
+        {
+            var ret = new Size(Interop.Application.GetScreenSize(), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
         /// Overrides this method if you want to handle behavior.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>


### PR DESCRIPTION
To provide the screen size, NUIApplication.GetScreenSize is added.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
