### PR TITLE
[NUI][AT-SPI] Add IAtspiValue.AccessibilityGetValueText()

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Pagination.cs
+++ b/src/Tizen.NUI.Components/Controls/Pagination.cs
@@ -471,6 +471,15 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Formatted current value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string IAtspiValue.AccessibilityGetValueText()
+        {
+            return $"{SelectedIndex}";
+        }
+
+        /// <summary>
         /// Maximum value.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI.Components/Controls/Progress.cs
+++ b/src/Tizen.NUI.Components/Controls/Progress.cs
@@ -545,6 +545,15 @@ namespace Tizen.NUI.Components
             }
         }
 
+        /// <summary>
+        /// Formatted current value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string IAtspiValue.AccessibilityGetValueText()
+        {
+            return (this as IAtspiValue).AccessibilityGetCurrent().ToString();
+        }
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         bool IAtspiValue.AccessibilitySetCurrent(double value)
         {

--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -1609,6 +1609,15 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// Formatted current value.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string IAtspiValue.AccessibilityGetValueText()
+        {
+            return $"{CurrentValue}";
+        }
+
+        /// <summary>
         /// Gets maximum value for Accessibility.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -391,6 +391,11 @@ namespace Tizen.NUI
                 public delegate void AccessibilityGetAttributes(IntPtr self, AccessibilityGetAttributesCallback callback, IntPtr userData);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityGetAttributes GetAttributes; // 37
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetValueText(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetValueText GetValueText; // 38
             }
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_DuplicateString")]

--- a/src/Tizen.NUI/src/public/Accessibility/IAtspiValue.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/IAtspiValue.cs
@@ -26,8 +26,31 @@ namespace Tizen.NUI.Accessibility
         [EditorBrowsable(EditorBrowsableState.Never)]
         double AccessibilityGetMinimum();
 
+        /// <summary>
+        /// Gets the current numeric value.
+        /// </summary>
+        /// <remarks>
+        /// The application may set the "value_format" attribute to one of the
+        /// following values in order to customize what is read by the Screen Reader:
+        /// 1. "percent" (the default) - AccessibilityGetCurrent() normalized as
+        ///    a percentage of the range [AccessibilityGetMinimum(), AccessibilityGetMaximum()],
+        /// 2. "number" - AccessibilityGetCurrent() verbatim,
+        /// 3. "text" - AccessibilityGetValueText() is used instead of AccessibilityGetCurrent()
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         double AccessibilityGetCurrent();
+
+        /// <summary>
+        /// Gets the formatted current value.
+        /// </summary>
+        /// <remarks>
+        /// This does not have to be AccessibilityGetCurrent() formatted in any
+        /// particular way, i.e. it may be an arbitrary string, e.g. "small font size"
+        /// for the numeric value 10.0. The return value of this method is only
+        /// used if the "value_format" attribute is "text".
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string AccessibilityGetValueText();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         double AccessibilityGetMaximum();

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -59,7 +59,7 @@ namespace Tizen.NUI.BaseComponents
         /// Dictionary of accessibility attributes (key-value pairs of strings).
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected Dictionary<string, string> AccessibilityAttributes { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> AccessibilityAttributes { get; } = new Dictionary<string, string>();
 
         ///////////////////////////////////////////////////////////////////
         // ************************** Highlight ************************ //

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -420,6 +420,18 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
+        // AccessibilityValueTextRequested
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public class AccessibilityValueTextRequestedEventArgs : EventArgs
+        {
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public string Text { get; set; }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<AccessibilityValueTextRequestedEventArgs> AccessibilityValueTextRequested;
+
         ///////////////////////////////////////////////////////////////////
         // **************** AccessibilityActivatedSignal **************** //
         ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This API allows the application to provide the Screen Reader with a formatted string value rather than the default, floating-point one. This in turn, allows to customize in detail how e.g. slider values are read.

Direct dependencies (DALi and TizenFX ABI changes):
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/291324/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/291323/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/291322/

Indirect dependencies of the above (D-Bus GetReadingMaterial ABI change):
- https://review.tizen.org/gerrit/#/c/platform/upstream/at-spi2-core/+/291274/
- https://review.tizen.org/gerrit/#/c/platform/upstream/at-spi2-atk/+/291336/
- https://review.tizen.org/gerrit/#/c/platform/core/accessibility/screen-reader/+/291276/
- https://review.tizen.org/gerrit/#/c/platform/upstream/efl/+/291412/

### Usage guide

Component developers:
```c#
public class MyControl : CusomView, IAtspiValue
{
    protected override void OnInitialize()
    {
        base.OnInitialize();
        AccessibilityAttributes["value_format"] = "text";
    }

    string IAtspiValue.AccessibilityGetValueText()
    {
        return "textual description of the current value";
    }

    // ...
}
```

Application developers:
```c#
view.AccessibilityAttributes["value_format"] = "text";
view.AccessibilityValueTextRequested += (s, e) =>
{
    e.Text = "textual description of the current value";
};
```

`AccessibilityValueTextRequested` takes precedence over `AccessibilityGetValueText()`, which is the same behaviour as with `AccessibilityNameRequested` & `AccessibilityGetName()`, and `AccessibilityDescriptionRequested` & `AccessibilityGetDescription()`.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
