### PR TITLE
[DevicePolicyManager] Deprecate DevicePolicyManager APIs

### DIFF
--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/BluetoothPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/BluetoothPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The BluetoothPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the BluetoothPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class BluetoothPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string BluetoothPolicyName = "Bluetooth";
 
         /// <summary>
@@ -37,6 +39,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string BluetoothTetheringPolicyName = "BluetoothTethering";
 
         private readonly string _bluetoothPolicyName = "bluetooth";
@@ -57,6 +60,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of BluetoothPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~BluetoothPolicy()
         {
             this.Dispose(false);
@@ -67,6 +71,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the change is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsBluetoothAllowed
         {
             get
@@ -88,6 +93,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the change is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsBluetoothTetheringAllowed
         {
             get
@@ -107,6 +113,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -117,6 +124,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -159,6 +167,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when BluetoothPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> BluetoothPolicyChanged
         {
             add
@@ -217,6 +226,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when BluetoothPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> BluetoothTetheringPolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/BrowserPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/BrowserPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The BrowserPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the BrowserPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class BrowserPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string BrowserPolicyName = "Browser";
 
         private readonly string _browserPolicyName = "browser";
@@ -46,6 +48,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of BrowserPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~BrowserPolicy()
         {
             this.Dispose(false);
@@ -56,6 +59,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the use of web browser is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsBrowserAllowed
         {
             get
@@ -75,6 +79,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -85,6 +90,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -115,6 +121,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when BrowserPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> BrowserPolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/DevicePolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/DevicePolicy.cs
@@ -14,12 +14,15 @@
  *  limitations under the License
  */
 
+using System;
+
 namespace Tizen.Security.DevicePolicyManager
 {
     /// <summary>
     /// The abstract class for Policy instances.
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
+    [Obsolete("Deprecated since API level 11.")]
     public abstract class DevicePolicy
     {
         protected internal readonly DevicePolicyManager _dpm;

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/DevicePolicyManager.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/DevicePolicyManager.cs
@@ -24,6 +24,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// The DevicePolicyManager provides the methods to create handle for device policy.
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
+    [Obsolete("Deprecated since API level 11.")]
     public class DevicePolicyManager : IDisposable
     {
         private IntPtr _handle = IntPtr.Zero;
@@ -34,6 +35,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when connection refused or a memory error occurred.</exception>
+        [Obsolete("Deprecated since API level 11.")]
         public DevicePolicyManager()
         {
             _handle = Interop.DevicePolicyManager.CreateHandle();
@@ -51,6 +53,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <returns>An instance of policy.</returns>
         /// <since_tizen> 6 </since_tizen>
         /// <exception cref="InvalidOperationException">Thrown when failed to create instance of the policy.</exception>
+        [Obsolete("Deprecated since API level 11.")]
         public T GetPolicy<T>() where T : DevicePolicy
         {
             try
@@ -75,6 +78,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of DevicePolicyManager.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~DevicePolicyManager()
         {
             this.Dispose(false);
@@ -84,6 +88,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -111,6 +116,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/EmailPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/EmailPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The EmailPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the EmailPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class EmailPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string PopImapEmailPolicyName = "PopImapEmail";
 
         private readonly string _popImapPolicyName = "popimap_email";
@@ -46,6 +48,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of EmailPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~EmailPolicy()
         {
             this.Dispose(false);
@@ -56,6 +59,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the POP or IMAP email is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsPopImapAllowed
         {
             get
@@ -75,6 +79,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -85,6 +90,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -115,6 +121,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when EmailPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> PopImapPolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/LocationPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/LocationPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The LocationPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the LocationPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class LocationPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string LocationPolicyName = "Location";
 
         private readonly string _locationPolicyName = "location";
@@ -46,6 +48,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of LocationPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~LocationPolicy()
         {
             this.Dispose(false);
@@ -56,6 +59,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the location state change is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsLocationAllowed
         {
             get
@@ -75,6 +79,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -85,6 +90,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -115,6 +121,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when LocationPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> LocationPolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/MediaPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/MediaPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The MediaPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the MediaPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class MediaPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string CameraPolicyName = "Camera";
 
         /// <summary>
@@ -37,6 +39,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string MicrophonePolicyName = "Microphone";
 
         private readonly string _cameraPolicyName = "camera";
@@ -57,6 +60,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of MediaPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~MediaPolicy()
         {
             this.Dispose(false);
@@ -67,6 +71,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the use of camera is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsCameraAllowed
         {
             get
@@ -88,6 +93,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the use of microphone is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsMicrophoneAllowed
         {
             get
@@ -107,6 +113,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -117,6 +124,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -159,6 +167,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when MediaPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> CameraPolicyChanged
         {
             add
@@ -217,6 +226,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when MediaPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> MicrophonePolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/PasswordPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/PasswordPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The PasswordPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the PasswordPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class PasswordPolicy : DevicePolicy
     {
         internal PasswordPolicy(DevicePolicyManager dpm) : base(dpm)
@@ -36,6 +37,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <privilege>http://tizen.org/privilege/dpm.password</privilege>
         /// <privlevel>partner</privlevel>
+        [Obsolete("Deprecated since API level 11.")]
         public int DaysToExpiration
         {
             get
@@ -58,6 +60,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <privilege>http://tizen.org/privilege/dpm.password</privilege>
         /// <privlevel>partner</privlevel>
+        [Obsolete("Deprecated since API level 11.")]
         public int MinimumPreviousHistory
         {
             get
@@ -80,6 +83,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <privilege>http://tizen.org/privilege/dpm.password</privilege>
         /// <privlevel>partner</privlevel>
+        [Obsolete("Deprecated since API level 11.")]
         public int MaxInactivityTimeDeviceLock
         {
             get
@@ -103,6 +107,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <privilege>http://tizen.org/privilege/dpm.password</privilege>
         /// <privlevel>partner</privlevel>
+        [Obsolete("Deprecated since API level 11.")]
         public int MaximumFailedAttemptsForWipe
         {
             get
@@ -126,6 +131,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <privilege>http://tizen.org/privilege/dpm.password</privilege>
         /// <privlevel>partner</privlevel>
+        [Obsolete("Deprecated since API level 11.")]
         public int MinimumRequiredComplexChars
         {
             get
@@ -148,6 +154,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <privilege>http://tizen.org/privilege/dpm.password</privilege>
         /// <privlevel>partner</privlevel>
+        [Obsolete("Deprecated since API level 11.")]
         public int MinimumLength
         {
             get
@@ -172,6 +179,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <privilege>http://tizen.org/privilege/dpm.password</privilege>
         /// <privlevel>partner</privlevel>
+        [Obsolete("Deprecated since API level 11.")]
         public PasswordQuality Quality
         {
             get

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/PasswordQuality.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/PasswordQuality.cs
@@ -14,12 +14,15 @@
  *  limitations under the License
  */
 
+using System;
+
 namespace Tizen.Security.DevicePolicyManager
 {
     /// <summary>
     /// Enumeration for dpm password quality type
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
+    [Obsolete("Deprecated since API level 11.")]
     public enum PasswordQuality
     {
         /// <summary>

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/PolicyChangedEventArgs.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/PolicyChangedEventArgs.cs
@@ -22,6 +22,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// An extended EventArgs class contains the changed dpm policy state.
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
+    [Obsolete("Deprecated since API level 11.")]
     public class PolicyChangedEventArgs : EventArgs
     {
         internal PolicyChangedEventArgs(string name, string state)
@@ -34,11 +35,13 @@ namespace Tizen.Security.DevicePolicyManager
         /// Gets the name of the changed policy.
         /// </summary>
         /// <remarks>Each policy that can raise event has the name. The policy name value is in each policy class.</remarks>
+        [Obsolete("Deprecated since API level 11.")]
         public string PolicyName { get; }
 
         /// <summary>
         /// Gets the current state of the policy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsAllowed { get; }
     }
 }

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/StoragePolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/StoragePolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The StoragePolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the StoragePolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class StoragePolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string ExternalStoragePolicyName = "ExternalStorage";
 
         private readonly string _externalStoragePolicyName = "external_storage";
@@ -46,6 +48,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of StoragePolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~StoragePolicy()
         {
             this.Dispose(false);
@@ -56,6 +59,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the use of external storage is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsExternalStorageAllowed
         {
             get
@@ -75,6 +79,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -85,6 +90,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -115,6 +121,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when StoragePolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> ExternalStoragePolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/TelephonyPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/TelephonyPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The TelephonyPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the TelephonyPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class TelephonyPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string MessagingPolicyName = "Messaging";
 
         private readonly string _messagingPolicyName = "messaging";
@@ -46,6 +48,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of TelephonyPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~TelephonyPolicy()
         {
             this.Dispose(false);
@@ -59,6 +62,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <since_tizen> 6 </since_tizen>
         /// <exception cref="ArgumentException">Thrown when failed because of invalid parameter.</exception>
         /// <exception cref="TimeoutException">Thrown when failed because of timeout.</exception>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsMessagingAllowed(string simId)
         {
             int state;
@@ -74,6 +78,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -84,6 +89,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -114,6 +120,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when TelephonyPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> MessagingPolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/UsbPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/UsbPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The UsbPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the UsbPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class UsbPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string UsbTetheringPolicyName = "UsbTethering";
 
         private readonly string _usbTetheringPolicyName = "usb_tethering";
@@ -46,6 +48,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of UsbPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~UsbPolicy()
         {
             this.Dispose(false);
@@ -56,6 +59,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the change is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsUsbTetheringAllowed
         {
             get
@@ -75,6 +79,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -85,6 +90,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -115,6 +121,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when UsbPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> UsbTetheringPolicyChanged
         {
             add

--- a/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/WifiPolicy.cs
+++ b/src/Tizen.Security.DevicePolicyManager/Tizen.Security.DevicePolicyManager/WifiPolicy.cs
@@ -23,6 +23,7 @@ namespace Tizen.Security.DevicePolicyManager
     /// </summary>
     /// <since_tizen> 6 </since_tizen>
     /// <remarks>The WifiPolicy is created by <seealso cref="DevicePolicyManager.GetPolicy{T}"/>. and the DevicePolicyManager instance must exists when using the WifiPolicy.</remarks>
+    [Obsolete("Deprecated since API level 11.")]
     public class WifiPolicy : DevicePolicy, IDisposable
     {
         /// <summary>
@@ -30,6 +31,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string WifiPolicyName = "Wifi";
 
         /// <summary>
@@ -37,6 +39,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This is used in <see cref="PolicyChangedEventArgs.PolicyName"/>.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public static readonly string WifiHotspotPolicyName = "WifiHotspot";
 
         private readonly string _wifiPolicyName = "wifi";
@@ -58,6 +61,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// A Destructor of WifiPolicy.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         ~WifiPolicy()
         {
             this.Dispose(false);
@@ -68,6 +72,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the state change is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsWifiAllowed
         {
             get
@@ -89,6 +94,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <value>true if the state change is allowed, false otherwise. The default value is true.</value>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public bool IsWifiHotspotAllowed
         {
             get
@@ -108,6 +114,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// <summary>
         /// Releases any unmanaged resources used by this object.
         /// </summary>
+        [Obsolete("Deprecated since API level 11.")]
         public void Dispose()
         {
             this.Dispose(true);
@@ -118,6 +125,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>
+        [Obsolete("Deprecated since API level 11.")]
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -160,6 +168,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when WifiPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> WifiPolicyChanged
         {
             add
@@ -218,6 +227,7 @@ namespace Tizen.Security.DevicePolicyManager
         /// </summary>
         /// <remarks>This event will be removed automatically when WifiPolicy is destroyed.</remarks>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API level 11.")]
         public event EventHandler<PolicyChangedEventArgs> WifiHotspotPolicyChanged
         {
             add


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Deprecate DevicePolicyManager APIs

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: https://code.sec.samsung.net/jira/browse/TCSACR-539

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
