### PR TITLE
[NUI] Add defence codes for specific events

### DIFF
--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManagerEvent.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManagerEvent.cs
@@ -1114,23 +1114,28 @@ namespace Tizen.NUI.Accessibility
         {
             add
             {
-                // Restricted to only one listener
                 if (_accessibilityManagerFocusedViewActivatedEventHandler == null)
                 {
-                    _accessibilityManagerFocusedViewActivatedEventCallbackDelegate = new FocusedViewActivatedEventCallbackDelegate(OnFocusedViewActivated);
-                    this.FocusedViewActivatedSignal().Connect(_accessibilityManagerFocusedViewActivatedEventCallbackDelegate);
+                    _accessibilityManagerFocusedViewActivatedEventCallbackDelegate = OnFocusedViewActivated;
+                    var signal = FocusedViewActivatedSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Connect(_accessibilityManagerFocusedViewActivatedEventCallbackDelegate);
+                    signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
-
                 _accessibilityManagerFocusedViewActivatedEventHandler += value;
             }
-
             remove
             {
                 _accessibilityManagerFocusedViewActivatedEventHandler -= value;
-
-                if (_accessibilityManagerFocusedViewActivatedEventHandler == null && FocusedViewActivatedSignal().Empty() == false)
+                if (_accessibilityManagerFocusedViewActivatedEventHandler == null && _accessibilityManagerFocusedViewActivatedEventCallbackDelegate != null)
                 {
-                    this.FocusedViewActivatedSignal().Disconnect(_accessibilityManagerFocusedViewActivatedEventCallbackDelegate);
+                    var signal = FocusedViewActivatedSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Disconnect(_accessibilityManagerFocusedViewActivatedEventCallbackDelegate);
+                    _accessibilityManagerFocusedViewActivatedEventCallbackDelegate = null;
+                    signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -184,23 +184,24 @@ namespace Tizen.NUI.BaseComponents
                 {
                     _keyCallback = OnKeyEvent;
                     var signal = KeyEventSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                     signal?.Connect(_keyCallback);
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 _keyEventHandler += value;
             }
             remove
             {
                 _keyEventHandler -= value;
-                if (_keyEventHandler == null)
+                if (_keyEventHandler == null && _keyCallback != null)
                 {
                     var signal = KeyEventSignal();
-                    if (signal?.Empty() == false)
-                    {
-                        signal?.Disconnect(_keyCallback);
-                        _keyCallback = null;
-                    }
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Disconnect(_keyCallback);
+                    _keyCallback = null;
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }
@@ -301,23 +302,24 @@ namespace Tizen.NUI.BaseComponents
                 {
                     _touchDataCallback = OnTouch;
                     var signal = TouchSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                     signal?.Connect(_touchDataCallback);
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 _touchDataEventHandler += value;
             }
             remove
             {
                 _touchDataEventHandler -= value;
-                if (_touchDataEventHandler == null)
+                if (_touchDataEventHandler == null && _touchDataCallback != null)
                 {
                     var signal = TouchSignal();
-                    if (signal?.Empty() == false)
-                    {
-                        signal?.Disconnect(_touchDataCallback);
-                        _touchDataCallback = null;
-                    }
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Disconnect(_touchDataCallback);
+                    _touchDataCallback = null;
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }
@@ -449,23 +451,24 @@ namespace Tizen.NUI.BaseComponents
                 {
                     _offWindowEventCallback = OffWindow;
                     var signal = OffWindowSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                     signal?.Connect(_offWindowEventCallback);
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 _offWindowEventHandler += value;
             }
             remove
             {
                 _offWindowEventHandler -= value;
-                if (_offWindowEventHandler == null)
+                if (_offWindowEventHandler == null && _offWindowEventCallback != null)
                 {
                     var signal = OffWindowSignal();
-                    if (signal?.Empty() == false)
-                    {
-                        signal?.Disconnect(_offWindowEventCallback);
-                        _offWindowEventCallback = null;
-                    }
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Disconnect(_offWindowEventCallback);
+                    _offWindowEventCallback = null;
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }
@@ -924,7 +927,7 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Error("implicit disposed(unreachable)! just return here!");
                 return true;
             }
-            
+
             if (touchData == global::System.IntPtr.Zero)
             {
                 NUILog.Error("touchData should not be null!");

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1131,7 +1131,7 @@ namespace Tizen.NUI.BaseComponents
             //Release your own unmanaged resources here.
             //You should not access any managed member here except static instance.
             //because the execution order of Finalizes is non-deterministic.
-            
+
             DisConnectFromSignals();
 
             foreach (View view in Children)
@@ -1194,9 +1194,11 @@ namespace Tizen.NUI.BaseComponents
             if (_offWindowEventCallback != null)
             {
                 ViewSignal signal = new ViewSignal(Interop.ActorSignal.Actor_OffSceneSignal(GetBaseHandleCPtrHandleRef), false);
+                if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                 signal?.Disconnect(_offWindowEventCallback);
                 signal?.Dispose();
                 _offWindowEventCallback = null;
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
             if (_onWindowEventCallback != null)
@@ -1239,9 +1241,11 @@ namespace Tizen.NUI.BaseComponents
             if (_touchDataCallback != null)
             {
                 TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.Actor_TouchSignal(GetBaseHandleCPtrHandleRef), false);
+                if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                 signal?.Disconnect(_touchDataCallback);
                 signal?.Dispose();
                 _touchDataCallback = null;
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
             if (_ResourcesLoadedCallback != null)
@@ -1255,9 +1259,11 @@ namespace Tizen.NUI.BaseComponents
             if (_keyCallback != null)
             {
                 ControlKeySignal signal = new ControlKeySignal(Interop.ViewSignal.View_KeyEventSignal(GetBaseHandleCPtrHandleRef), false);
+                if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                 signal?.Disconnect(_keyCallback);
                 signal?.Dispose();
                 _keyCallback = null;
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
             if (_keyInputFocusLostCallback != null)

--- a/src/Tizen.NUI/src/public/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/StyleManager.cs
@@ -62,17 +62,26 @@ namespace Tizen.NUI
             {
                 if (_styleManagerStyleChangedEventHandler == null)
                 {
-                    _styleManagerStyleChangedCallbackDelegate = (OnStyleChanged);
-                    StyleChangedSignal().Connect(_styleManagerStyleChangedCallbackDelegate);
+                    _styleManagerStyleChangedCallbackDelegate = OnStyleChanged;
+                    var signal = StyleChangedSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Connect(_styleManagerStyleChangedCallbackDelegate);
+                    signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 _styleManagerStyleChangedEventHandler += value;
             }
             remove
             {
                 _styleManagerStyleChangedEventHandler -= value;
-                if (_styleManagerStyleChangedEventHandler == null && StyleChangedSignal().Empty() == false)
+                if (_styleManagerStyleChangedEventHandler == null && _styleManagerStyleChangedCallbackDelegate != null)
                 {
-                    StyleChangedSignal().Disconnect(_styleManagerStyleChangedCallbackDelegate);
+                    var signal = StyleChangedSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Disconnect(_styleManagerStyleChangedCallbackDelegate);
+                    _styleManagerStyleChangedCallbackDelegate = null;
+                    signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/WindowEvent.cs
@@ -110,23 +110,24 @@ namespace Tizen.NUI
                 {
                     _rootLayerTouchDataCallback = OnWindowTouch;
                     var signal = TouchDataSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                     signal?.Connect(_rootLayerTouchDataCallback);
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 _rootLayerTouchDataEventHandler += value;
             }
             remove
             {
                 _rootLayerTouchDataEventHandler -= value;
-                if (_rootLayerTouchDataEventHandler == null)
+                if (_rootLayerTouchDataEventHandler == null && _rootLayerTouchDataCallback != null)
                 {
                     var signal = TouchDataSignal();
-                    if (signal?.Empty() == false)
-                    {
-                        signal?.Disconnect(_rootLayerTouchDataCallback);
-                        _rootLayerTouchDataCallback = null;
-                    }
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Disconnect(_rootLayerTouchDataCallback);
+                    _rootLayerTouchDataCallback = null;
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }
@@ -176,23 +177,24 @@ namespace Tizen.NUI
                 {
                     _stageKeyCallbackDelegate = OnStageKey;
                     var signal = KeyEventSignal();
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                     signal?.Connect(_stageKeyCallbackDelegate);
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
                 _stageKeyHandler += value;
             }
             remove
             {
                 _stageKeyHandler -= value;
-                if (_stageKeyHandler == null)
+                if (_stageKeyHandler == null && _stageKeyCallbackDelegate != null)
                 {
                     var signal = KeyEventSignal();
-                    if (signal?.Empty() == false)
-                    {
-                        signal?.Disconnect(_stageKeyCallbackDelegate);
-                        _stageKeyCallbackDelegate = null;
-                    }
+                    if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
+                    signal?.Disconnect(_stageKeyCallbackDelegate);
+                    _stageKeyCallbackDelegate = null;
                     signal?.Dispose();
+                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 }
             }
         }
@@ -577,9 +579,11 @@ namespace Tizen.NUI
             if (_rootLayerTouchDataCallback != null)
             {
                 TouchDataSignal signal = new TouchDataSignal(Interop.ActorSignal.Actor_TouchSignal(Layer.getCPtr(GetRootLayer())), false);
+                if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                 signal?.Disconnect(_rootLayerTouchDataCallback);
                 signal?.Dispose();
                 _rootLayerTouchDataCallback = null;
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
             if (_wheelEventCallback != null)
@@ -598,9 +602,11 @@ namespace Tizen.NUI
             if (_stageKeyCallbackDelegate != null)
             {
                 KeyEventSignal signal = new KeyEventSignal(Interop.Window.KeyEventSignal(GetBaseHandleCPtrHandleRef), false);
+                if (signal?.SwigCPtr.Handle == IntPtr.Zero) { signal = null; }
                 signal?.Disconnect(_stageKeyCallbackDelegate);
                 signal?.Dispose();
                 _stageKeyCallbackDelegate = null;
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
             if (_stageEventProcessingFinishedEventCallbackDelegate != null)


### PR DESCRIPTION
### Description of Change ###
- DA AllApps 일회성 문제 (https://code.sec.samsung.net/jira/browse/TDAF-1706) 수정을 위해 event 관련 방어코드를 추가하였습니다.
- 아래 event 들에 대해서 native handle 을 체크하는것과 event -= 가 먼저 불렸을 경우 Disconnect(null) 이 들어갈수 있는 경우를 막았습니다. 
(done) NUI.Timer.Tick
(done) NUI.StyleManager.StyleChanged
(done) View.TouchEvent
(done) View.KeyEvent
(done) View.RemovedFromWindow
(done) Window.TouchEvent
(done) Window.KeyEvent
(done) Animation.Finished
(done) AccessibilityManager.FocusedViewActivated
(done) PropertyNotification.Notified
(no native signal) ThemeManager.ThemeChanged 
(no native signal) ScrollableBase.Scrolling
(no native signal) ScrollableBase.ScrollOutOfBoundWithDisplacement
(no native signal) ScrollableBase.ScrollAnimationEnded
(no native signal) ScrollableBase.ScrollDragStarted
(no native signal) ScrollableBase.ScrollDragEnded
(no native signal) SelectButton.SelectedChanged
(no native signal) Switch.SelectedChanged
(no native signal) Popup.PopupButtonClickEvent
(no native signal) Navigation.ItemClickEvent
(no native signal) Button.Clicked
(no native signal) StyleManager.ThemeChangedEvent
(no native signal) BaseHandle.PropertySet

- PropertyNofification.cs 에는 #region 을 적용했고, ACR 걸리지 않는 private 에 naming 을 다시해서 가독성을 높혔습니다.

### API Changes ###
none