### PR TITLE
[NUI] Remove default parameter of Animation.Stop(EndActions)

### DIFF
--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -624,7 +624,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="action">The end action can be set.</param>
         /// <since_tizen> 3 </since_tizen>
-        public void Stop(EndActions action = EndActions.Cancel)
+        public void Stop(EndActions action)
         {
             SetEndAction(action);
             Interop.Animation.Stop(SwigCPtr);


### PR DESCRIPTION
Since we already have empty-parameter function named Stop(), Let we remove Stop(EndActions)'s default value so compiler don't feel confuse.
