### PR TITLE
[NUI] Add SetTapRecognizerTime

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.GestureOptions.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GestureOptions.cs
@@ -92,6 +92,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapMaximumAllowedTime")]
             public static extern void SetDoubleTapTimeout(uint ms);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GestureOptions_SetTapRecognizerTime")]
+            public static extern void SetTapRecognizerTime(uint ms);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Events/GestureOptions.cs
+++ b/src/Tizen.NUI/src/public/Events/GestureOptions.cs
@@ -328,7 +328,8 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Sets the duration in milliseconds between the first tap's up event and the second tap's down event to be recognized as a duoble-tap gesture.
+        /// Sets the duration in milliseconds the duration time for recognizing multi-tap gesture.
+        /// If there are two taps within this time, it is a double tap.
         /// </summary>
         /// <remarks>This is a global configuration option. Affects all gestures.</remarks>
         /// <param name="ms">The time value in milliseconds</param>
@@ -336,6 +337,20 @@ namespace Tizen.NUI
         public void SetDoubleTapTimeout(uint ms)
         {
             Interop.GestureOptions.SetDoubleTapTimeout(ms);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Sets the recognizer time required to be recognized as a tap gesture,
+        /// This time is from touch down to touch up to recognize the tap gesture.
+        /// If the time between touch down and touch up is longer than recognizer time, it is not recognized as a tap gesture.
+        /// </summary>
+        /// <remarks>This is a global configuration option. Affects all gestures.</remarks>
+        /// <param name="ms">The time value in milliseconds</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetTapRecognizerTime(uint ms)
+        {
+            Interop.GestureOptions.SetTapRecognizerTime(ms);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
This is the time from touch down to touch up to recognize a tap gesture.

If set to 300ms, a touch up after a touch down must occur within 300ms to be recognized as a tap gesture.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
