### PR TITLE
[NUI] Change the call to GetRootLayer() so that the layer index can be updated.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1383,7 +1383,7 @@ namespace Tizen.NUI
 
             if (isBorderWindow)
             {
-                Interop.Actor.Add(GetBorderWindowRootLayer().SwigCPtr, layer.SwigCPtr);
+                Interop.Actor.Add(GetRootLayer().SwigCPtr, layer.SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) { throw NDalicPINVOKE.SWIGPendingException.Retrieve(); }
             }
             else


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
If the root layer index is not updated and another layer is added first, a problem occurs in calculating the layer index. Something like LowerBelow may not work.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
