### PR TITLE
[NUI] Reuse internally created Key/Touch for Window.GetLastEvent API

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -314,6 +314,12 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetLastTouchEvent")]
             public static extern global::System.IntPtr GetLastTouchEvent(global::System.Runtime.InteropServices.HandleRef window);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastKeyEvent")]
+            public static extern void InternalRetrievingLastKeyEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef key);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastTouchEvent")]
+            public static extern void InternalRetrievingLastTouchEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef touch);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetNeedsRotationCompletedAcknowledgement")]
             public static extern void SetNeedsRotationCompletedAcknowledgement(global::System.Runtime.InteropServices.HandleRef window, bool needAcknowledgement);
 

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -41,6 +41,8 @@ namespace Tizen.NUI
         private string windowTitle;
         private List<Layer> childLayers = new List<Layer>();
         private LayoutController localController;
+        private Key internalLastKeyEvent;
+        private Touch internalLastTouchEvent;
 
         static internal bool IsSupportedMultiWindow()
         {
@@ -1849,9 +1851,13 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Key GetLastKeyEvent()
         {
-            Key ret = new Key(Interop.Window.GetLastKeyEvent(SwigCPtr), false);
+            if(internalLastKeyEvent == null)
+            {
+                internalLastKeyEvent = new Key();
+            }
+            Interop.Window.InternalRetrievingLastKeyEvent(SwigCPtr, internalLastKeyEvent.SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            return internalLastKeyEvent;
         }
 
         /// <summary>
@@ -1861,9 +1867,13 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Touch GetLastTouchEvent()
         {
-            Touch ret = new Touch(Interop.Window.GetLastTouchEvent(SwigCPtr), false);
+            if(internalLastTouchEvent == null)
+            {
+                internalLastTouchEvent = new Touch();
+            }
+            Interop.Window.InternalRetrievingLastTouchEvent(SwigCPtr, internalLastTouchEvent.SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
+            return internalLastTouchEvent;
         }
 
         /// <summary>
@@ -1947,6 +1957,11 @@ namespace Tizen.NUI
                 childLayers.Clear();
 
                 localController?.Dispose();
+
+                internalLastKeyEvent?.Dispose();
+                internalLastKeyEvent = null;
+                internalLastTouchEvent?.Dispose();
+                internalLastTouchEvent = null;
             }
 
 


### PR DESCRIPTION
To reduce the GC call for each Event getter, let we create Key/Touch only one time for each window, and reuse it.
