### PR TITLE
[NUI] Add GenerateUrl API to FrameBuffer

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
@@ -72,5 +72,16 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
+
+        /// <summary>
+        /// Generate URI from current buffer.
+        /// </summary>
+        /// <param name="pixelFormat">The pixel format for this frame buffer</param>
+        /// <param name="width">The width for this frame buffer</param>
+        /// <param name="height">The height for this frame buffer</param>
+        public ImageUrl GenerateUrl(PixelFormat pixelFormat, int width, int height)
+        {
+            return new ImageUrl(Interop.FrameBuffer.GenerateUrl(this.SwigCPtr.Handle, (int)pixelFormat, width, height), true);
+        }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameBuffer.cs
@@ -56,6 +56,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameBuffer_GenerateUrl")]
+            public static extern global::System.IntPtr GenerateUrl(global::System.IntPtr frameBuffer, int pixelFormat, int width, int height);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
