### PR TITLE
[NUI] Fix empty item case crash. wrong bracket conditions.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -239,9 +239,9 @@ namespace Tizen.NUI.Components
             }
 
             while (!failed &&
-                    Source.IsHeader(firstIndex) ||
+                   (Source.IsHeader(firstIndex) ||
                     Source.IsGroupHeader(firstIndex) ||
-                    Source.IsGroupFooter(firstIndex))
+                    Source.IsGroupFooter(firstIndex)))
             {
                 if (Source.IsFooter(firstIndex)
                     || ((Source.Count - 1) <= firstIndex))

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -227,9 +227,9 @@ namespace Tizen.NUI.Components
             }
 
             while (!failed &&
-                    Source.IsHeader(firstIndex) ||
+                   (Source.IsHeader(firstIndex) ||
                     Source.IsGroupHeader(firstIndex) ||
-                    Source.IsGroupFooter(firstIndex))
+                    Source.IsGroupFooter(firstIndex)))
             {
                 if (Source.IsFooter(firstIndex)
                     || ((Source.Count - 1) <= firstIndex))


### PR DESCRIPTION
when failed flag is true,
other condition should be ingored.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
