### PR TITLE
[NUI.Gadget] Add Assembly property to NUIGadgetInfo

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Tizen.Applications;
 
@@ -106,6 +107,8 @@ namespace Tizen.NUI
         internal string ResourceFile { get; set; }
 
         internal string ResourceClassName { get; set; }
+
+        internal Assembly Assembly { get; set; }
 
         internal static NUIGadgetInfo CreateNUIGadgetInfo(string packageId)
         {

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -139,19 +139,21 @@ namespace Tizen.NUI
                 throw new ArgumentException("Failed to find NUIGadgetInfo. resource type: " + resourceType);
             }
 
-            Assembly assembly = null;
             try
             {
-                Log.Warn("NUIGadgetAssembly.Load(): " + info.ResourcePath + info.ExecutableFile + " ++");
-                assembly = Assembly.Load(File.ReadAllBytes(info.ResourcePath + info.ExecutableFile));
-                Log.Warn("NUIGadgetAssembly.Load(): " + info.ResourcePath + info.ExecutableFile + " --");
+                if (info.Assembly == null)
+                {
+                    Log.Warn("NUIGadgetAssembly.Load(): " + info.ResourcePath + info.ExecutableFile + " ++");
+                    info.Assembly = Assembly.Load(File.ReadAllBytes(info.ResourcePath + info.ExecutableFile));
+                    Log.Warn("NUIGadgetAssembly.Load(): " + info.ResourcePath + info.ExecutableFile + " --");
+                }
             }
             catch (FileLoadException e)
             {
                 throw new InvalidOperationException(e.Message);
             }
 
-            NUIGadget gadget = assembly.CreateInstance(className, true) as NUIGadget;
+            NUIGadget gadget = info.Assembly.CreateInstance(className, true) as NUIGadget;
             if (gadget == null)
             {
                 throw new InvalidOperationException("Failed to create instance. className: " + className);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
To improve instance creation speed, this patch adds the Assembly property to the NUIGadgetInfo.
If the NUIGadgetInfo has the property that is not null, NUIGadgetManager uses it.

