### PR TITLE
[NUI.Gadget] Modify NUIGadgetResourceManager class

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetResourceManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetResourceManager.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.IO;
 using System.ComponentModel;
+using System.Resources;
 
 namespace Tizen.NUI
 {
@@ -88,50 +89,49 @@ namespace Tizen.NUI
                 cultureInfo = CultureInfo.CurrentUICulture;
             }
 
-            var resourceManager = GetResourceManager(cultureInfo.Name);
-            if (resourceManager == null)
+            string result = string.Empty;
+            try
             {
-                resourceManager = GetResourceManager("default");
+                var resourceManager = GetResourceManager(cultureInfo.Name);
                 if (resourceManager != null)
                 {
-#pragma warning disable CA1304
-                    return resourceManager.GetString(name);
-#pragma warning restore CA1304
+                    result = resourceManager.GetString(name, cultureInfo);
                 }
 
-                if (cultureInfo.Name != "en")
+                if (string.IsNullOrEmpty(result))
                 {
-                    resourceManager = GetResourceManager("en");
+                    resourceManager = GetResourceManager("default");
                     if (resourceManager != null)
                     {
 #pragma warning disable CA1304
-                        return resourceManager.GetString(name);
+                        result = resourceManager.GetString(name);
 #pragma warning restore CA1304
                     }
                 }
-
-                return string.Empty;
+            }
+            catch (InvalidOperationException e)
+            {
+                Log.Error("InvalidOperationException occurs. " + e.Message);
+            }
+            catch (MissingManifestResourceException e)
+            {
+                Log.Error("MissingManifestResourceException occurs. " + e.Message);
+            }
+            catch (MissingSatelliteAssemblyException e)
+            {
+                Log.Error("MissingSateliteAssemblyException occurs. " + e.Message);
             }
 
-            return resourceManager.GetString(name, cultureInfo);
+            return result;
         }
 
-        private global::System.Resources.ResourceManager GetResourceManager(string locale)
+        private global::System.Resources.ResourceManager GetResourceManager(string path, string baseName)
         {
-            global::System.Resources.ResourceManager resourceManager;
-            if (_resourceMap.TryGetValue(locale, out resourceManager))
-            {
-                return resourceManager;
-            }
+            global::System.Resources.ResourceManager resourceManager = null;
 
-            string path = string.Empty;
-            if (locale == "default")
+            if (string.IsNullOrEmpty(path))
             {
-                path = _resourcePath + _resourceDll;
-            }
-            else
-            {
-                path = _resourcePath + locale + "/" + _resourceDll;
+                return null;
             }
 
             if (!File.Exists(path))
@@ -146,20 +146,11 @@ namespace Tizen.NUI
                 Assembly assembly = Assembly.Load(File.ReadAllBytes(path));
                 if (assembly != null)
                 {
-                    string baseName = _resourceClassName;
-                    if (locale != "default")
-                    {
-                        baseName += "." + locale;
-                    }
-
                     resourceManager = new global::System.Resources.ResourceManager(baseName, assembly);
                     if (resourceManager == null)
                     {
                         Log.Error("Failed to create ResourceManager");
-                    }
-                    else
-                    {
-                        _resourceMap.Add(locale, resourceManager);
+                        return null;
                     }
                 }
             }
@@ -176,6 +167,37 @@ namespace Tizen.NUI
                 Log.Error("Exception occurs. " + e.Message);
             }
 #pragma warning restore CA1031
+
+            return resourceManager;
+        }
+
+
+        private global::System.Resources.ResourceManager GetResourceManager(string locale)
+        {
+            global::System.Resources.ResourceManager resourceManager;
+
+            if (_resourceMap.TryGetValue(locale, out resourceManager))
+            {
+                return resourceManager;
+            }
+
+            string baseName = _resourceClassName;
+            string path;
+            if (locale == "default")
+            {
+                path = _resourcePath + _resourceDll;
+            }
+            else
+            {
+                path = _resourcePath + locale + "/" + _resourceDll;
+                baseName += "." + locale;
+            }
+
+            resourceManager = GetResourceManager(path, baseName);
+            if (resourceManager != null)
+            {
+                _resourceMap.Add(locale, resourceManager);
+            }
 
             return resourceManager;
         }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetResourceManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetResourceManager.cs
@@ -91,6 +91,14 @@ namespace Tizen.NUI
             var resourceManager = GetResourceManager(cultureInfo.Name);
             if (resourceManager == null)
             {
+                resourceManager = GetResourceManager("default");
+                if (resourceManager != null)
+                {
+#pragma warning disable CA1304
+                    return resourceManager.GetString(name);
+#pragma warning restore CA1304
+                }
+
                 if (cultureInfo.Name != "en")
                 {
                     resourceManager = GetResourceManager("en");
@@ -116,7 +124,16 @@ namespace Tizen.NUI
                 return resourceManager;
             }
 
-            string path = _resourcePath + locale + "/" + _resourceDll;
+            string path = string.Empty;
+            if (locale == "default")
+            {
+                path = _resourcePath + _resourceDll;
+            }
+            else
+            {
+                path = _resourcePath + locale + "/" + _resourceDll;
+            }
+
             if (!File.Exists(path))
             {
                 Log.Warn(path + " does not exist");
@@ -129,7 +146,12 @@ namespace Tizen.NUI
                 Assembly assembly = Assembly.Load(File.ReadAllBytes(path));
                 if (assembly != null)
                 {
-                    string baseName = _resourceClassName + "." + locale;
+                    string baseName = _resourceClassName;
+                    if (locale != "default")
+                    {
+                        baseName += "." + locale;
+                    }
+
                     resourceManager = new global::System.Resources.ResourceManager(baseName, assembly);
                     if (resourceManager == null)
                     {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
When getting the resource manager using the current culture info is failed, the NUIGadgetResourceManager tries to get the resource manager using the "default" string. It means using "/res/allowed/<resource>.dll" file.
If getting string is failed, the resource manager should try to get string from the default satelite assembly.


