### PR TITLE
[NUI] Add WindowMouseInOutEvent (#5242)

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.MouseInOut.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.MouseInOut.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class MouseInOut
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_MouseInOutEvent__SWIG_0")]
+            public static extern global::System.IntPtr NewMouseInOut(int jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, uint jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_MouseInOutEvent")]
+            public static extern void DeleteMouseInOut(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_type_get")]
+            public static extern int TypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_modifiers_get")]
+            public static extern uint ModifiersGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_point_get")]
+            public static extern global::System.IntPtr PointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_timeStamp_get")]
+            public static extern uint TimeStampGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_GetDeviceClass")]
+            public static extern int DeviceClassGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_MouseInOutEvent_GetDeviceSubClass")]
+            public static extern int DeviceSubClassGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseInOutEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowMouseInOutEventSignal.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WindowMouseInOutEventSignal
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal")]
+            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Empty")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_GetConnectionCount")]
+            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Connect")]
+            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Disconnect")]
+            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowMouseInOutEventSignal_Emit")]
+            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowMouseInOutEventSignal")]
+            public static extern global::System.IntPtr NewWindowMouseInOutEventSignal();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowMouseInOutEventSignal")]
+            public static extern void DeleteWindowMouseInOutEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Window/WindowMouseInOutEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowMouseInOutEventSignal.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    internal class WindowMouseInOutEventSignal : Disposable
+    {
+        internal WindowMouseInOutEventSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WindowMouseInOutEventSignal.DeleteWindowMouseInOutEventSignal(swigCPtr);
+        }
+
+        /// <summary>
+        /// Queries whether there are any connected slots.
+        /// </summary>
+        /// <returns>True if there are any slots connected to the signal</returns>
+        public bool Empty()
+        {
+            bool ret = Interop.WindowMouseInOutEventSignal.Empty(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Queries the number of slots.
+        /// </summary>
+        /// <returns>The number of slots connected to this signal</returns>
+        public uint GetConnectionCount()
+        {
+            uint ret = Interop.WindowMouseInOutEventSignal.GetConnectionCount(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Connects a function.
+        /// </summary>
+        /// <param name="func">The function to connect</param>
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowMouseInOutEventSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Disconnects a function.
+        /// </summary>
+        /// <param name="func">The function to disconnect</param>
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowMouseInOutEventSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Emits the signal.
+        /// </summary>
+        /// <param name="window">The first value to pass to callbacks</param>
+        /// <param name="mouseInOut">The second value to pass to callbacks</param>
+        public void Emit(Window window, MouseInOut mouseInOut)
+        {
+            Interop.WindowMouseInOutEventSignal.Emit(SwigCPtr, Window.getCPtr(window), MouseInOut.getCPtr(mouseInOut));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        public WindowMouseInOutEventSignal(Window window) : this(Interop.WindowMouseInOutEventSignal.GetSignal(Window.getCPtr(window)), false)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Window/MouseInOut.cs
+++ b/src/Tizen.NUI/src/public/Window/MouseInOut.cs
@@ -1,0 +1,227 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// MouseInOut is used when the mouse enters or exits a window.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class MouseInOut : Disposable
+    {
+
+        /// <summary>
+        /// The default constructor.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public MouseInOut() : this(Interop.MouseInOut.NewMouseInOut((int)MouseInOut.StateType.None, 0, Vector2.getCPtr(new Vector2(0, 0)), 0), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        /// <param name="state">The state of the event.</param>
+        /// <param name="modifiers">Modifier keys pressed during the event (such as Shift, Alt, and Ctrl).</param>
+        /// <param name="point">The coordinates of the cursor relative to the top-left of the screen.</param>
+        /// <param name="timeStamp">The time the event is being started.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public MouseInOut(MouseInOut.StateType state, uint modifiers, Vector2 point, uint timeStamp) : this(Interop.MouseInOut.NewMouseInOut((int)state, modifiers, Vector2.getCPtr(point), timeStamp), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal MouseInOut(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The state of the mouse event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum StateType
+        {
+            /// <summary>
+            /// Default value
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            None,
+
+            /// <summary>
+            /// Mouse entered
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            In,
+
+            /// <summary>
+            /// Mouse exited
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Out
+        }
+
+        /// <summary>
+        /// The state of the mouse event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public MouseInOut.StateType State
+        {
+            get
+            {
+                return state;
+            }
+        }
+
+        /// <summary>
+        /// Modifier keys pressed during the event (such as Shift, Alt, and Ctrl).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint Modifiers
+        {
+            get
+            {
+                return modifiers;
+            }
+        }
+
+        /// <summary>
+        /// The coordinates of the cursor relative to the top-left of the screen.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Vector2 Point
+        {
+            get
+            {
+                return point;
+            }
+        }
+
+        /// <summary>
+        /// The time the mouse evnet is being started
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint TimeStamp
+        {
+            get
+            {
+                return timeStamp;
+            }
+        }
+
+        /// <summary>
+        /// Get the device class the mouse event originated from.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceClassType DeviceClass
+        {
+            get
+            {
+                return deviceClass;
+            }
+        }
+
+        /// <summary>
+        /// Get the device subclass the mouse event originated from.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceSubClassType DeviceSubClass
+        {
+            get
+            {
+                return deviceSubClass;
+            }
+        }
+
+        private MouseInOut.StateType state
+        {
+            get
+            {
+                MouseInOut.StateType ret = (MouseInOut.StateType)Interop.MouseInOut.TypeGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private uint modifiers
+        {
+            get
+            {
+                uint ret = Interop.MouseInOut.ModifiersGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private Vector2 point
+        {
+            get
+            {
+                global::System.IntPtr cPtr = Interop.MouseInOut.PointGet(SwigCPtr);
+                Vector2 ret = (cPtr == global::System.IntPtr.Zero) ? null : new Vector2(cPtr, false);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private uint timeStamp
+        {
+            get
+            {
+                uint ret = Interop.MouseInOut.TimeStampGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private DeviceClassType deviceClass
+        {
+            get
+            {
+                int ret = Interop.MouseInOut.DeviceClassGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return (DeviceClassType)ret;
+            }
+        }
+
+        private DeviceSubClassType deviceSubClass
+        {
+            get
+            {
+                int ret = Interop.MouseInOut.DeviceSubClassGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return (DeviceSubClassType)ret;
+            }
+        }
+
+        internal static MouseInOut GetMouseInOutFromPtr(global::System.IntPtr cPtr)
+        {
+            MouseInOut ret = new MouseInOut(cPtr, false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.MouseInOut.DeleteMouseInOut(swigCPtr);
+        }
+    }
+}


### PR DESCRIPTION
You can receive events when the mouse cursor appears or disappears from a window.
If MouseInOut.StateType.In, the mouse cursor entered the window.
If MouseInOut.StateType.Out, the mouse cursor exited the window.

```c++
window.MouseInOutEvent += (s, e) =>
{
 Tizen.Log.Info("NUI", $"State {e.MouseInOut.State}");
}
```

refer :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/292294/ 
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/292295/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
