### PR TITLE
[NUI] Binding GetDeviceClass and GetDeviceSubclass of touch event

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Touch.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Touch.cs
@@ -66,6 +66,12 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetAngle")]
             public static extern global::System.IntPtr GetAngle(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceClass")]
+            public static extern int GetDeviceClass(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_GetDeviceSubclass")]
+            public static extern int GetDeviceSubClass(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Touch_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
 

--- a/src/Tizen.NUI/src/public/Events/Touch.cs
+++ b/src/Tizen.NUI/src/public/Events/Touch.cs
@@ -212,6 +212,31 @@ namespace Tizen.NUI
             return (MouseButton)ret;
         }
 
+        /// <summary>
+        /// Gets the device class type from which the mouse/touch event is originated.
+        /// </summary>
+        /// <param name="point">The index of a touch point.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceClassType GetDeviceClass(uint point)
+        {
+            int ret = Interop.Touch.GetDeviceClass(SwigCPtr, point);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return (DeviceClassType)ret;
+        }
+
+        /// <summary>
+        /// Gets the subclass type of the device from which the mouse/touch event is originated.
+        /// </summary>
+        /// <param name="point">The index of a touch point.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceSubClassType GetDeviceSubClass(uint point)
+        {
+            int ret = Interop.Touch.GetDeviceSubClass(SwigCPtr, point);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return (DeviceSubClassType)ret;
+        }
+
+
         internal static Touch GetTouchFromPtr(global::System.IntPtr cPtr)
         {
             Touch ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Touch;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Binding GetDeviceClass and GetDeviceSubClass
```c++
view.TouchEvent += (s, e) =>
{
   if (DeviceClassType.Mouse == e.Touch.GetDeviceClass(0))
   {
   }
   else if (DeviceClassType.Touch == e.Touch.GetDeviceClass(0))
   {
   }
  return false;
}
```
refer :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/292340/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
