### PR TITLE
[NUI][API10] Change Scrollable constructor from public to internal.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
@@ -210,7 +210,7 @@ namespace Tizen.NUI.BaseComponents
         /// Create an instance of scrollable.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public Scrollable() : this(Interop.Scrollable.NewScrollable(), true)
+        internal Scrollable() : this(Interop.Scrollable.NewScrollable(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION
When Scrollable is created newly, it would crash.
In DALi, Scrollable could not be created directly.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
