### PR TITLE
[NUI] Deprecated Animation.Stop(EndActions)

### DIFF
--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -702,12 +702,16 @@ namespace Tizen.NUI
         /// <summary>
         /// Stops the animation. It will change this animation's EndAction property.
         /// </summary>
-        /// <remark>
-        /// Change the value from EndActions.Discard, or to EndActions.Discard during animation is playing / paused will not works well.<br />
-        /// If you want to stop by EndActions.Discard, EndAction property also should be EndActions.Discard before Play API called.
-        /// </remark>
+        /// <remarks>
+        /// Change the value from EndActions.Discard, or to EndActions.Discard during animation is playing / paused will not works well.<br/>
+        /// If you want to stop by EndActions.Discard, EndAction property also should be EndActions.Discard before Play API called. <br/>
+        /// <br/>
+        /// This method is deprecated since API11 because EndActions property concept is not matched with Stop(). <br/>
+        /// Use <see cref="EndAction"/> property instead.
+        /// </remarks>
         /// <param name="action">The end action can be set.</param>
         /// <since_tizen> 3 </since_tizen>
+        [Obsolete("Deprecated in API11, will be removed in API13. Use EndAction property instead.")]
         public void Stop(EndActions action)
         {
             SetEndAction(action);


### PR DESCRIPTION
That API change the 'EndAction' property.
And also, EndAction input parameter will not works well if

 - It's value is EndActions.Discard
 - Already finished animation

So, we'd better guide to app developer to use EndAction property instead of Stop(EndActions) API.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: ACR-540 https://code.sec.samsung.net/jira/browse/TCSACR-540

Deprecated:
 - void Stop(EndActions action);