### PR TITLE
[NUI] Add FontPreLoad API to FontClient

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FontClient.cs
@@ -25,6 +25,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_PreCache")]
             public static extern void PreCache(string[] fallbackFamilyArray, int fallbackFamilySize, string[] extraFamilyArray, int extraFamilySize, string localeFamily, bool useThread);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_FontPreLoad")]
+            public static extern void FontPreLoad(string[] fontPathArray, int fontPathSize, string[] memoryFontPathArray, int memoryFontPathSize, bool useThread);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FontClient_DEFAULT_POINT_SIZE_get")]
             public static extern uint DefaultPointSizeGet();
 

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// This is used to pre-cache fonts in order to improve the runtime performance of the application.
+        /// This is used to pre-cache FontConfig in order to improve the runtime performance of the application.
         /// </summary>
         /// <param name="fallbackFamilyList">A list of fallback font families to be pre-cached.</param>
         /// <param name="extraFamilyList">A list of additional font families to be pre-cached.</param>
@@ -81,6 +81,30 @@ namespace Tizen.NUI
             string[] extraFamilyArray = extraFamilySize > 0 ? extraFamilyList.ToArray() : null;
 
             Interop.FontClient.PreCache(fallbackFamilyArray, fallbackFamilySize, extraFamilyArray, extraFamilySize, localeFamily, useThread);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// This is used to pre-load FreeType font face in order to improve the runtime performance of the application.
+        /// <note>
+        /// The fonts in the fontPathList perform FT_New_Face during pre-loading, which can provide some performace benefits.<br />
+        /// The fonts in the memoryFontPathList read the font file and cache the buffer in memory during pre-load.<br />
+        /// This enables the use of FT_New_Memory_Face during runtime and provides a performance boost.<br />
+        /// It requires memory equivalent to the size of each font file.
+        /// </note>
+        /// </summary>
+        /// <param name="fontPathList">A list of font paths to be pre-loaded.</param>
+        /// <param name="memoryFontPathList">A list of memory font paths to be pre-loaded.</param>
+        /// <param name="useThread">if the font client should create thread and perform font pre-loading, false otherwise.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void FontPreLoad(List<string> fontPathList, List<string> memoryFontPathList, bool useThread)
+        {
+            int fontPathSize = fontPathList?.Count ?? 0;
+            int memoryFontPathSize = memoryFontPathList?.Count ?? 0;
+            string[] fontPathArray = fontPathSize > 0 ? fontPathList.ToArray() : null;
+            string[] memoryFontPathArray = memoryFontPathSize > 0 ? memoryFontPathList.ToArray() : null;
+
+            Interop.FontClient.FontPreLoad(fontPathArray, fontPathSize, memoryFontPathArray, memoryFontPathSize, useThread);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
This patch adds a new FontPreLoad API that preloads font faces.
this can prevents delays on main thread during the inital call of FT_New_Face.

using memoryFontPathList involves loading font buffers into memory. 
And using FT_New_Memory_Face at runtime, which uses more memory but can lead to greater performance improvements.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/292224/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/292534/