### PR TITLE
[NUI.Scene3D] Change the API name for BlendShape morphing

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
@@ -96,10 +96,10 @@ namespace Tizen.NUI.Scene3D
             public static extern global::System.IntPtr LoadBvhAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef model, string bvhBuffer, int bvhBufferLength, global::System.Runtime.InteropServices.HandleRef scale, bool translateRootFromModelNode);
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_LoadFacialAnimation_1")]
-            public static extern global::System.IntPtr LoadFacialAnimation(global::System.Runtime.InteropServices.HandleRef model, string facialFilename);
+            public static extern global::System.IntPtr LoadBlendShapeAnimation(global::System.Runtime.InteropServices.HandleRef model, string jsonFilename);
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_LoadFacialAnimation_2")]
-            public static extern global::System.IntPtr LoadFacialAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef model, string facialBuffer, int facialBufferLength);
+            public static extern global::System.IntPtr LoadBlendShapeAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef model, string jsonBuffer, int jsonBufferLength);
         }
     }
 }

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -416,9 +416,35 @@ namespace Tizen.NUI.Scene3D
         /// <returns>Animaion of facial</returns>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Do not use this LoadFacialAnimation. Use LoadBlendShapeAnimation instead.")]
         public Animation LoadFacialAnimation(string facialFilename)
         {
-            global::System.IntPtr cPtr = Interop.Model.LoadFacialAnimation(SwigCPtr, facialFilename);
+            return LoadBlendShapeAnimation(facialFilename);
+        }
+
+        /// <summary>
+        /// Load facial animation and assign to model.
+        /// </summary>
+        /// <param name="facialBuffer">Contents of json format file what we predefined.</param>
+        /// <returns>Animaion of facial</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Do not use this LoadFacialAnimation. Use LoadBlendShapeAnimation instead.")]
+        public Animation LoadFacialAnimationFromBuffer(string facialBuffer)
+        {
+            return LoadBlendShapeAnimationFromBuffer(facialBuffer);
+        }
+
+        /// <summary>
+        /// Load blendshape animation and assign to model from json file.
+        /// </summary>
+        /// <param name="jsonFilename">Name of json format file what we predefined.</param>
+        /// <returns>Animaion of facial</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Animation LoadBlendShapeAnimation(string jsonFilename)
+        {
+            global::System.IntPtr cPtr = Interop.Model.LoadBlendShapeAnimation(SwigCPtr, jsonFilename);
             Animation ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Animation;
             if (ret == null)
             {
@@ -437,15 +463,15 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
-        /// Load facial animation and assign to model.
+        /// Load morphing animation and assign to model from json string.
         /// </summary>
-        /// <param name="facialBuffer">Contents of json format file what we predefined.</param>
+        /// <param name="jsonBuffer">Contents of json format file what we predefined.</param>
         /// <returns>Animaion of facial</returns>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Animation LoadFacialAnimationFromBuffer(string facialBuffer)
+        public Animation LoadBlendShapeAnimationFromBuffer(string jsonBuffer)
         {
-            global::System.IntPtr cPtr = Interop.Model.LoadFacialAnimationFromBuffer(SwigCPtr, facialBuffer, facialBuffer.Length);
+            global::System.IntPtr cPtr = Interop.Model.LoadBlendShapeAnimationFromBuffer(SwigCPtr, jsonBuffer, jsonBuffer.Length);
             Animation ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Animation;
             if (ret == null)
             {


### PR DESCRIPTION
Since json file can change not only facial, The name of API is not good.

Instead, Let we change the name of facial API as 'BlendShapeAnimation'. Now user can notify that this API can control all kinds of blendshape.
