### PR TITLE
[NUI] fix font size scale issue in fhub

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextUtils.cs
@@ -1139,7 +1139,9 @@ namespace Tizen.NUI.BaseComponents
         // The following values from 'system-settings/libutil/sstu.c'
         private const float FontSizeScaleSmall = 0.8f;
         private const float FontSizeScaleNormal = 1.0f;
-        private const float FontSizeScaleLarge = 1.5f;
+        // TODO: Profile Separation
+        private const float FontSizeScaleLarge = 1.0f;
+        //private const float FontSizeScaleLarge = 1.5f;
         private const float FontSizeScaleHuge = 1.9f;
         private const float FontSizeScaleGiant = 2.5f;
 #endif


### PR DESCRIPTION
Currently, it is impossible to differentiate between the mobile and common profiles.
Until profile differentiation becomes possible, set the default scale for each profile to 1.

* default font size scale of PROFILE_MOBILE = FontSizeScaleLarge
* default font size scale of PROFILE_COMMON = FontSizeScaleNormal
