### PR TITLE
[NUI] Binds GetCurrentProperty to Animatable class

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Object.cs
+++ b/src/Tizen.NUI/src/internal/Common/Object.cs
@@ -37,6 +37,17 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
+        public static PropertyValue GetCurrentProperty(global::System.Runtime.InteropServices.HandleRef handle, int index)
+        {
+            if (handle.Handle == System.IntPtr.Zero)
+            {
+                throw new System.InvalidOperationException("Error! NUI's native dali object is already disposed. OR the native dali object handle of NUI becomes null!");
+            }
+
+            PropertyValue ret = new PropertyValue(Interop.Handle.GetCurrentProperty(handle, index), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
 
         public static void SetProperty(global::System.Runtime.InteropServices.HandleRef handle, int index, PropertyValue propertyValue)
         {

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Handle.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Handle.cs
@@ -68,6 +68,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetProperty")]
             public static extern global::System.IntPtr GetProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_GetCurrentProperty")]
+            public static extern global::System.IntPtr GetCurrentProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Handle_AddPropertyNotification__SWIG_0")]
             public static extern global::System.IntPtr AddPropertyNotification(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 

--- a/src/Tizen.NUI/src/public/Animation/Animatable.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animatable.cs
@@ -200,6 +200,18 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Retrieves the latest rendered frame value of the property.
+        /// </summary>
+        /// <param name="index">The index of the property.</param>
+        /// <returns>The property value.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PropertyValue GetCurrentProperty(int index)
+        {
+            PropertyValue ret = Tizen.NUI.Object.GetCurrentProperty(SwigCPtr, index);
+            return ret;
+        }
+
+        /// <summary>
         /// Adds a property notification to this object.
         /// </summary>
         /// <param name="property">The name of the property.</param>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
