### PR TITLE
[NUI][API10] Reduce get/set overhead for some LottieAnimationView properties

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
@@ -403,10 +403,6 @@ namespace Tizen.NUI.BaseComponents
                     break;
             }
 
-            //temporal fix
-            Extents tmp = base.Margin;
-            base.Margin = tmp;
-
             base.Play();
             AnimationState = AnimationStates.Playing;
 


### PR DESCRIPTION
Let's beleve the cached properties what LottieAnimationVIew already cached.

Since ImageView.Image is heavy operation, we should call this thing less times.