### PR TITLE
[NUI] Cache url when we call SetImage + Make way to skip visual creation

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
@@ -404,12 +404,12 @@ namespace Tizen.NUI.BaseComponents
                     using PropertyValue arrayProperty = new PropertyValue(indexPropertyArray);
 
                     // Trigger the ImageView so that we have something update
-                    UpdateImage(ImageVisualProperty.URL, arrayProperty);
+                    UpdateImage(ImageVisualProperty.URL, arrayProperty, false);
                 }
             }
 
             using PropertyValue animatiedImage = new PropertyValue((int)Visual.Type.AnimatedImage);
-            UpdateImage(Visual.Property.Type, animatiedImage);
+            UpdateImage(Visual.Property.Type, animatiedImage, false);
 
             base.UpdateImage();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -120,6 +120,12 @@ namespace Tizen.NUI.BaseComponents
         public ImageView(string url) : this(Interop.ImageView.New(ConvertResourceUrl(ref url)), true)
         {
             _resourceUrl = url;
+
+            // Update cached property. Note that we should not re-create new visual.
+            using (PropertyValue urlValue = new PropertyValue(_resourceUrl))
+            {
+                UpdateImage(ImageVisualProperty.URL, urlValue, false);
+            }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
         }
@@ -134,6 +140,12 @@ namespace Tizen.NUI.BaseComponents
         public ImageView(string url, bool shown) : this(Interop.ImageView.New(ConvertResourceUrl(ref url)), true)
         {
             _resourceUrl = url;
+
+            // Update cached property. Note that we should not re-create new visual.
+            using (PropertyValue urlValue = new PropertyValue(_resourceUrl))
+            {
+                UpdateImage(ImageVisualProperty.URL, urlValue, false);
+            }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
         }
@@ -143,6 +155,20 @@ namespace Tizen.NUI.BaseComponents
             _resourceUrl = url;
             _desired_width = size?.GetWidth() ?? -1;
             _desired_height = size?.GetHeight() ?? -1;
+
+            // Update cached property. Note that we should not re-create new visual.
+            using (PropertyValue urlValue = new PropertyValue(_resourceUrl))
+            {
+                UpdateImage(ImageVisualProperty.URL, urlValue, false);
+            }
+            using (PropertyValue desiredWidthValue = new PropertyValue(_desired_width))
+            {
+                UpdateImage(ImageVisualProperty.DesiredWidth, desiredWidthValue, false);
+            }
+            using (PropertyValue desiredHeightValue = new PropertyValue(_desired_height))
+            {
+                UpdateImage(ImageVisualProperty.DesiredWidth, desiredHeightValue, false);
+            }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
             if (!shown)
@@ -327,7 +353,7 @@ namespace Tizen.NUI.BaseComponents
                     image?.Dispose();
 
                     // Update cached property map
-                    if(returnValue != null)
+                    if (returnValue != null)
                     {
                         MergeCachedImageVisualProperty(returnValue);
                     }
@@ -642,6 +668,12 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
             _resourceUrl = url;
+            // Update cached property. Note that we should not re-create new visual.
+            using (PropertyValue urlValue = new PropertyValue(_resourceUrl))
+            {
+                UpdateImage(ImageVisualProperty.URL, urlValue, false);
+            }
+            imagePropertyUpdatedFlag = false;
         }
 
         /// <summary>
@@ -747,9 +779,9 @@ namespace Tizen.NUI.BaseComponents
                 PropertyValue setValue = new PropertyValue(value ?? "");
                 UpdateImage(ImageVisualProperty.AlphaMaskURL, setValue);
                 // When we never set CropToMask property before, we should set default value as true.
-                using(PropertyValue cropToMask = GetCachedImageVisualProperty(ImageVisualProperty.CropToMask))
+                using (PropertyValue cropToMask = GetCachedImageVisualProperty(ImageVisualProperty.CropToMask))
                 {
-                    if(cropToMask == null)
+                    if (cropToMask == null)
                     {
                         using PropertyValue setCropValue = new PropertyValue(true);
                         UpdateImage(ImageVisualProperty.CropToMask, setCropValue);
@@ -936,7 +968,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 // Sync as current properties only if both _desired_width and _desired_height are setuped.
-                if(_desired_width != -1 && _desired_height != -1)
+                if (_desired_width != -1 && _desired_height != -1)
                 {
                     UpdateImage();
                 }
@@ -952,7 +984,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     _desired_width = value;
                     PropertyValue setValue = new PropertyValue(value);
-                    UpdateImage(ImageVisualProperty.DesiredWidth, setValue);
+                    UpdateImage(ImageVisualProperty.DesiredWidth, setValue, false);
                     setValue?.Dispose();
                 }
             }
@@ -983,7 +1015,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 // Sync as current properties only if both _desired_width and _desired_height are setuped.
-                if(_desired_width != -1 && _desired_height != -1)
+                if (_desired_width != -1 && _desired_height != -1)
                 {
                     UpdateImage();
                 }
@@ -999,7 +1031,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     _desired_height = value;
                     PropertyValue setValue = new PropertyValue(value);
-                    UpdateImage(ImageVisualProperty.DesiredHeight, setValue);
+                    UpdateImage(ImageVisualProperty.DesiredHeight, setValue, false);
                     setValue?.Dispose();
                 }
             }
@@ -1022,7 +1054,7 @@ namespace Tizen.NUI.BaseComponents
                 NotifyPropertyChanged();
             }
         }
-        
+
         private ReleasePolicyType InternalReleasePolicy
         {
             get
@@ -1228,6 +1260,21 @@ namespace Tizen.NUI.BaseComponents
             _resourceUrl = url;
             _desired_width = size?.GetWidth() ?? -1;
             _desired_height = size?.GetHeight() ?? -1;
+
+            // Update cached property. Note that we should not re-create new visual.
+            using (PropertyValue urlValue = new PropertyValue(_resourceUrl))
+            {
+                UpdateImage(ImageVisualProperty.URL, urlValue, false);
+            }
+            using (PropertyValue desiredWidthValue = new PropertyValue(_desired_width))
+            {
+                UpdateImage(ImageVisualProperty.DesiredWidth, desiredWidthValue, false);
+            }
+            using (PropertyValue desiredHeightValue = new PropertyValue(_desired_height))
+            {
+                UpdateImage(ImageVisualProperty.DesiredWidth, desiredHeightValue, false);
+            }
+            imagePropertyUpdatedFlag = false;
         }
 
         internal ViewResourceReadySignal ResourceReadySignal(View view)
@@ -1316,7 +1363,7 @@ namespace Tizen.NUI.BaseComponents
         // Callback for View ResourceReady signal
         private void OnResourceReady(IntPtr data)
         {
-            if(!CheckResourceReady())
+            if (!CheckResourceReady())
             {
                 return;
             }
@@ -1335,22 +1382,22 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetResourceUrl(string value)
         {
-            if(_resourceUrl != ConvertResourceUrl(ref value))
+            if (_resourceUrl != ConvertResourceUrl(ref value))
             {
                 _resourceUrl = value;
-                if(string.IsNullOrEmpty(_resourceUrl))
+                if (string.IsNullOrEmpty(_resourceUrl))
                 {
                     // Special case. If we set ResourceUrl as empty, Unregist visual.
                     RemoveImage();
                 }
                 else
                 {
-                    using(PropertyValue setValue = new PropertyValue(value))
+                    using (PropertyValue setValue = new PropertyValue(value))
                     {
                         UpdateImage(ImageVisualProperty.URL, setValue);
                     }
                     // Special case. If we set GeneratedUrl, Create ImageVisual synchronously.
-                    if(value.StartsWith("dali://") || value.StartsWith("enbuf://"))
+                    if (value.StartsWith("dali://") || value.StartsWith("enbuf://"))
                     {
                         UpdateImage();
                     }
@@ -1364,7 +1411,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 return;
             }
-            if(_border != value)
+            if (_border != value)
             {
                 _border = new Rectangle(value);
                 UpdateImage(NpatchImageVisualProperty.Border, new PropertyValue(_border));
@@ -1380,7 +1427,7 @@ namespace Tizen.NUI.BaseComponents
             // Unregist and detach process only if previous resourceUrl was not empty
             string currentResourceUrl = "";
             PropertyValue currentResourceUrlValue = GetCachedImageVisualProperty(ImageVisualProperty.URL);
-            if((currentResourceUrlValue?.Get(out currentResourceUrl) ?? false) && !string.IsNullOrEmpty(currentResourceUrl))
+            if ((currentResourceUrlValue?.Get(out currentResourceUrl) ?? false) && !string.IsNullOrEmpty(currentResourceUrl))
             {
                 PropertyValue emptyValue = new PropertyValue();
 
@@ -1389,7 +1436,7 @@ namespace Tizen.NUI.BaseComponents
 
                 // Image visual is not exist anymore. We should ignore lazy UpdateImage
                 imagePropertyUpdatedFlag = false;
-                if(imagePropertyUpdateProcessAttachedFlag)
+                if (imagePropertyUpdateProcessAttachedFlag)
                 {
                     ProcessorController.Instance.ProcessorOnceEvent -= UpdateImage;
                     imagePropertyUpdateProcessAttachedFlag = false;
@@ -1405,9 +1452,12 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Lazy call to UpdateImage.
         /// Collect Properties need to be update, and set properties that starts the Processing.
+        ///
+        /// If you want to update cachedImagePropertyMap, but don't want to request new visual creation, make requiredVisualCreation value as false.
+        /// (Example : if we change SynchronousLoading property from 'true' to 'false', or if we call this function during UpdateImage)
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual void UpdateImage(int key, PropertyValue value)
+        protected virtual void UpdateImage(int key, PropertyValue value, bool requiredVisualCreation = true)
         {
             // Update image property map value as inputed value.
             if (key != 0)
@@ -1432,8 +1482,8 @@ namespace Tizen.NUI.BaseComponents
                 imagePropertyUpdatedFlag = true;
                 cachedImagePropertyMap[key] = value;
 
-                // Lazy update only if _resourceUrl is not empty and ProcessAttachedFlag is false.
-                if (!string.IsNullOrEmpty(_resourceUrl) && !imagePropertyUpdateProcessAttachedFlag)
+                // Lazy update only if visual creation required, and _resourceUrl is not empty, and ProcessAttachedFlag is false.
+                if (requiredVisualCreation && !string.IsNullOrEmpty(_resourceUrl) && !imagePropertyUpdateProcessAttachedFlag)
                 {
                     imagePropertyUpdateProcessAttachedFlag = true;
                     ProcessorController.Instance.ProcessorOnceEvent += UpdateImage;
@@ -1464,11 +1514,11 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void UpdateImage()
         {
-            if(!imagePropertyUpdatedFlag) return;
+            if (!imagePropertyUpdatedFlag) return;
 
             imagePropertyUpdatedFlag = false;
 
-            if(cachedImagePropertyMap == null)
+            if (cachedImagePropertyMap == null)
             {
                 cachedImagePropertyMap = new PropertyMap();
             }
@@ -1476,10 +1526,10 @@ namespace Tizen.NUI.BaseComponents
             // Checkup the cached visual type is AnimatedImage.
             // It is trick to know that this code is running on AnimatedImageView.UpdateImage() / LottieAnimationView.UpdateImage() or not.
             int visualType = (int)Visual.Type.Invalid;
-            if(!((GetCachedImageVisualProperty(Visual.Property.Type)?.Get(out visualType) ?? false) && (visualType == (int)Visual.Type.AnimatedImage || visualType == (int)Visual.Type.AnimatedVectorImage)))
+            if (!((GetCachedImageVisualProperty(Visual.Property.Type)?.Get(out visualType) ?? false) && (visualType == (int)Visual.Type.AnimatedImage || visualType == (int)Visual.Type.AnimatedVectorImage)))
             {
                 // If ResourceUrl is not setuped, don't set property. fast return.
-                if(string.IsNullOrEmpty(_resourceUrl))
+                if (string.IsNullOrEmpty(_resourceUrl))
                 {
                     return;
                 }
@@ -1528,7 +1578,7 @@ namespace Tizen.NUI.BaseComponents
                 if (_resourceUrl != null)
                 {
                     Size2D imageSize = ImageLoader.GetOriginalImageSize(_resourceUrl, true);
-                    if( imageSize.Height > 0 && imageSize.Width > 0 && _desired_width > 0  && _desired_height > 0 )
+                    if (imageSize.Height > 0 && imageSize.Width > 0 && _desired_width > 0 && _desired_height > 0)
                     {
                         int adjustedDesiredWidth, adjustedDesiredHeight;
                         float aspectOfDesiredSize = (float)_desired_height / (float)_desired_width;
@@ -1571,17 +1621,17 @@ namespace Tizen.NUI.BaseComponents
         private void UpdateImageMap()
         {
             // Note : We can't use ImageView.Image property here. Because That property call UpdateImage internally.
-            using(PropertyMap imageMap = new PropertyMap())
+            using (PropertyMap imageMap = new PropertyMap())
             {
-                using(PropertyValue returnValue = Tizen.NUI.Object.GetProperty(SwigCPtr, ImageView.Property.IMAGE))
+                using (PropertyValue returnValue = Tizen.NUI.Object.GetProperty(SwigCPtr, ImageView.Property.IMAGE))
                 {
                     returnValue?.Get(imageMap);
                 }
-                if(cachedImagePropertyMap != null)
+                if (cachedImagePropertyMap != null)
                 {
                     imageMap?.Merge(cachedImagePropertyMap);
                 }
-                using(PropertyValue setValue = new PropertyValue(imageMap))
+                using (PropertyValue setValue = new PropertyValue(imageMap))
                 {
                     SetProperty(ImageView.Property.IMAGE, setValue);
                 }
@@ -1601,7 +1651,7 @@ namespace Tizen.NUI.BaseComponents
         protected virtual PropertyValue GetImageVisualProperty(int key)
         {
             PropertyValue ret = GetCachedImageVisualProperty(key);
-            if(ret == null)
+            if (ret == null)
             {
                 // If we cannot find result form cached map, Get value from native engine.
                 ret = Image?.Find(key);
@@ -1628,15 +1678,15 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void MergeCachedImageVisualProperty(PropertyMap map)
         {
-            if(map == null) return;
-            if(cachedImagePropertyMap == null)
+            if (map == null) return;
+            if (cachedImagePropertyMap == null)
             {
                 cachedImagePropertyMap = new PropertyMap();
             }
-            foreach(var key in cachedImagePropertyKeyList)
+            foreach (var key in cachedImagePropertyKeyList)
             {
                 PropertyValue value = map.Find(key);
-                if(value != null)
+                if (value != null)
                 {
                     // Update-or-Insert new value
                     cachedImagePropertyMap[key] = value;
@@ -1665,7 +1715,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void OnResourceLoaded(IntPtr view)
         {
-            if(!CheckResourceReady())
+            if (!CheckResourceReady())
             {
                 return;
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -256,7 +256,8 @@ namespace Tizen.NUI.BaseComponents
                         return;
                     }
                 }
-                imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue));
+                // Note : We need to create new visual if previous visual was async, and now we set value as sync.
+                imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue), (bool)newValue);
             }
         },
         defaultValueCreator: (bindable) =>
@@ -285,7 +286,8 @@ namespace Tizen.NUI.BaseComponents
                         return;
                     }
                 }
-                imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue));
+                // Note : We need to create new visual if previous visual was async, and now we set value as sync.
+                imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue), (bool)newValue);
             }
         },
         defaultValueCreator: (bindable) =>

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -750,10 +750,10 @@ namespace Tizen.NUI.BaseComponents
             // Update currentStates properties to cachedImagePropertyMap
             if(currentStates.changed)
             {
-                UpdateImage(ImageVisualProperty.LoopCount, new PropertyValue(currentStates.loopCount));
-                UpdateImage(ImageVisualProperty.StopBehavior, new PropertyValue((int)currentStates.stopEndAction));
-                UpdateImage(ImageVisualProperty.LoopingMode, new PropertyValue((int)currentStates.loopMode));
-                UpdateImage(ImageVisualProperty.RedrawInScalingDown, new PropertyValue(currentStates.redrawInScalingDown));
+                UpdateImage(ImageVisualProperty.LoopCount, new PropertyValue(currentStates.loopCount), false);
+                UpdateImage(ImageVisualProperty.StopBehavior, new PropertyValue((int)currentStates.stopEndAction), false);
+                UpdateImage(ImageVisualProperty.LoopingMode, new PropertyValue((int)currentStates.loopMode), false);
+                UpdateImage(ImageVisualProperty.RedrawInScalingDown, new PropertyValue(currentStates.redrawInScalingDown), false);
 
                 // Do not cache PlayRange and TotalFrameNumber into cachedImagePropertyMap.
                 // (To keep legacy implements behaviour)
@@ -761,7 +761,7 @@ namespace Tizen.NUI.BaseComponents
             }
 
             using PropertyValue animatiedImage = new PropertyValue((int)Visual.Type.AnimatedVectorImage);
-            UpdateImage(Visual.Property.Type, animatiedImage);
+            UpdateImage(Visual.Property.Type, animatiedImage, false);
 
             base.UpdateImage();
         }


### PR DESCRIPTION
Previously, we don't cache Url infomation at cached property map when we use SetImage API instead of ResourceUrl property.

Now, let we keep this cache information.

And also, add parameter that we dont want to create new visual when we change this property.