### PR TITLE
Add DestroySignal Function

### DIFF
--- a/src/Tizen.Log/Interop/Interop.Dlog.cs
+++ b/src/Tizen.Log/Interop/Interop.Dlog.cs
@@ -50,10 +50,10 @@ internal static partial class Interop
             DLOG_PRIO_MAX,
         }
 
-        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
 
-        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "__dlog_print", CallingConvention = CallingConvention.Cdecl)]

--- a/src/Tizen.Log/Interop/Interop.Dlog.cs
+++ b/src/Tizen.Log/Interop/Interop.Dlog.cs
@@ -51,16 +51,16 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
-        internal static unsafe extern int Print(LogPriority prio, byte* tag, byte* fmt, byte* msg);
+        internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
-        internal static unsafe extern int Print(LogPriority prio, byte* tag, byte* fmt, byte* file, byte* func, int line, byte* msg);
+        internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "__dlog_print", CallingConvention = CallingConvention.Cdecl)]
-        internal static unsafe extern int InternalPrint(LogID log_id, LogPriority prio, byte* tag, byte* fmt, byte* msg);
+        internal static extern int InternalPrint(LogID log_id, LogPriority prio, string tag, string fmt, string msg);
 
         [DllImport(Libraries.Dlog, EntryPoint = "__dlog_print", CallingConvention = CallingConvention.Cdecl)]
-        internal static unsafe extern int InternalPrint(LogID log_id, LogPriority prio, byte* tag, byte* fmt, byte* file, byte* func, int line, byte* msg);
+        internal static extern int InternalPrint(LogID log_id, LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
 
     }
 }

--- a/src/Tizen.Log/Tizen.Log.csproj
+++ b/src/Tizen.Log/Tizen.Log.csproj
@@ -8,8 +8,4 @@
     <TizenPreloadFile Include="Tizen.Log.preload" Sequence="30" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-  </ItemGroup>
-
 </Project>

--- a/src/Tizen.Log/Tizen.Log.csproj
+++ b/src/Tizen.Log/Tizen.Log.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
 </Project>

--- a/src/Tizen.Log/Tizen/Log.cs
+++ b/src/Tizen.Log/Tizen/Log.cs
@@ -15,130 +15,11 @@
  */
 
 using System;
-using System.Text;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.ComponentModel;
 
 namespace Tizen
 {
-    internal static class LogPrinter
-    {
-        private static char[] sep = { '\\', '/' };
-        private static byte[] fmt1 = Encoding.UTF8.GetBytes("%s");
-        private static byte[] fmt2 = Encoding.UTF8.GetBytes("%s: %s(%d) > %s");
-
-        private static unsafe void _Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
-        {
-            int tagByteLength = Encoding.UTF8.GetMaxByteCount(tag.Length);
-            Span<byte> tagByte = tagByteLength < 1024 ? stackalloc byte[tagByteLength + 1] : new byte[tagByteLength + 1];
-
-            int messageByteLength = Encoding.UTF8.GetMaxByteCount(message.Length);
-            Span<byte> messageByte = messageByteLength < 1024 ? stackalloc byte[messageByteLength + 1] : new byte[messageByteLength + 1];
-
-            fixed (char* pTagChar = tag)
-            fixed (char* pMessageChar = message)
-            fixed (byte* pTagByte = &MemoryMarshal.GetReference(tagByte))
-            fixed (byte* pMessageByte = &MemoryMarshal.GetReference(messageByte))
-            fixed (byte* pFmt1Byte = fmt1)
-            fixed (byte* pFmt2Byte = fmt2)
-            {
-                int len = Encoding.UTF8.GetBytes(pTagChar, tag.Length, pTagByte, tagByteLength);
-                pTagByte[len] = 0;
-                len = Encoding.UTF8.GetBytes(pMessageChar, message.Length, pMessageByte, messageByteLength);
-                pMessageByte[len] = 0;
-
-                if (String.IsNullOrEmpty(file))
-                {
-                    if (log_id == Interop.Dlog.LogID.LOG_ID_INVALID)
-                        Interop.Dlog.Print(priority, pTagByte, pFmt1Byte, pMessageByte);
-                    else
-                        Interop.Dlog.InternalPrint(log_id, priority, pTagByte, pFmt1Byte, pMessageByte);
-                    return;
-                }
-
-                int index = file.LastIndexOfAny(sep) + 1;
-                int filenameLength = file.Length - index;
-
-                int filenameByteLength = Encoding.UTF8.GetMaxByteCount(filenameLength);
-                Span<byte> filenameByte = filenameByteLength < 1024 ? stackalloc byte[filenameByteLength + 1] : new byte[filenameByteLength + 1];
-
-                int funcByteLength = Encoding.UTF8.GetMaxByteCount(func.Length);
-                Span<byte> funcByte = funcByteLength < 1024 ? stackalloc byte[funcByteLength + 1] : new byte[funcByteLength + 1];
-
-                fixed (char* pFilenameChar = file)
-                fixed (char* pFuncChar = func)
-                fixed (byte* pFilenameByte = &MemoryMarshal.GetReference(filenameByte))
-                fixed (byte* pFuncByte = &MemoryMarshal.GetReference(funcByte))
-                {
-                    len = Encoding.UTF8.GetBytes(pFilenameChar + index, filenameLength, pFilenameByte, filenameByteLength);
-                    pFilenameByte[len] = 0;
-                    len = Encoding.UTF8.GetBytes(pFuncChar, func.Length, pFuncByte, funcByteLength);
-                    pFuncByte[len] = 0;
-
-                    if (log_id == Interop.Dlog.LogID.LOG_ID_INVALID)
-                        Interop.Dlog.Print(priority, pTagByte, pFmt2Byte, pFilenameByte, pFuncByte, line, pMessageByte);
-                    else
-                        Interop.Dlog.InternalPrint(log_id, priority, pTagByte, pFmt2Byte, pFilenameByte, pFuncByte, line, pMessageByte);
-                }
-            }
-        }
-
-        private static unsafe void _PrintFallback(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
-        {
-            fixed (byte* pTagByte = Encoding.UTF8.GetBytes(tag))
-            fixed (byte* pMessageByte = Encoding.UTF8.GetBytes(message))
-            fixed (byte* pFmt1Byte = fmt1)
-            fixed (byte* pFmt2Byte = fmt2)
-            {
-                if (String.IsNullOrEmpty(file))
-                {
-                    if (log_id == Interop.Dlog.LogID.LOG_ID_INVALID)
-                        Interop.Dlog.Print(priority, pTagByte, pFmt1Byte, pMessageByte);
-                    else
-                        Interop.Dlog.InternalPrint(log_id, priority, pTagByte, pFmt1Byte, pMessageByte);
-                    return;
-                }
-
-                int index = file.LastIndexOfAny(sep);
-                string filename = file.Substring(index + 1);
-
-                fixed (byte* pFilenameByte = Encoding.UTF8.GetBytes(filename))
-                fixed (byte* pFuncByte = Encoding.UTF8.GetBytes(func))
-                {
-                    if (log_id == Interop.Dlog.LogID.LOG_ID_INVALID)
-                        Interop.Dlog.Print(priority, pTagByte, pFmt2Byte, pFilenameByte, pFuncByte, line, pMessageByte);
-                    else
-                        Interop.Dlog.InternalPrint(log_id, priority, pTagByte, pFmt2Byte, pFilenameByte, pFuncByte, line, pMessageByte);
-                }
-            }
-        }
-
-        public static unsafe void Print(Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
-        {
-            try
-            {
-                _Print(Interop.Dlog.LogID.LOG_ID_INVALID, priority, tag, message, file, func, line);
-            }
-            catch (StackOverflowException)
-            {
-                _PrintFallback(Interop.Dlog.LogID.LOG_ID_INVALID, priority, tag, message, file, func, line);
-            }
-        }
-
-        public static unsafe void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
-        {
-            try
-            {
-                _Print(log_id, priority, tag, message, file, func, line);
-            }
-            catch (StackOverflowException)
-            {
-                _PrintFallback(log_id, priority, tag, message, file, func, line);
-            }
-        }
-    }
-
     /// <summary>
     /// Provides methods to print log messages to the Tizen logging system.
     /// Depending on products, some priorities (e.g., Vervose and Debug) can be disabled by default to prevent too many logs.
@@ -231,9 +112,18 @@ namespace Tizen
             Print(Interop.Dlog.LogPriority.DLOG_FATAL, tag, message, file, func, line);
         }
 
-        static unsafe void Print(Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
+        static void Print(Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
         {
-            LogPrinter.Print(priority, tag, message, file, func, line);
+            if (String.IsNullOrEmpty(file))
+            {
+                Interop.Dlog.Print(priority, tag, "%s", message);
+            }
+            else
+            {
+                int index = file.LastIndexOfAny(sep);
+                string filename = file.Substring(index + 1);
+                Interop.Dlog.Print(priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
+            }
         }
     }
 
@@ -330,9 +220,18 @@ namespace Tizen
             Print(Interop.Dlog.LogID.LOG_ID_MAIN, Interop.Dlog.LogPriority.DLOG_FATAL, tag, message, file, func, line);
         }
 
-        static unsafe void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
+        static void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
         {
-            LogPrinter.Print(log_id, priority, tag, message, file, func, line);
+            if (String.IsNullOrEmpty(file))
+            {
+                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s", message);
+            }
+            else
+            {
+                int index = file.LastIndexOfAny(sep);
+                string filename = file.Substring(index + 1);
+                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
+            }
         }
     }
 
@@ -429,10 +328,19 @@ namespace Tizen
             Print(Interop.Dlog.LogID.LOG_ID_MAIN, Interop.Dlog.LogPriority.DLOG_FATAL, tag, message, file, func, line);
         }
 
-        static unsafe void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
+        static void Print(Interop.Dlog.LogID log_id, Interop.Dlog.LogPriority priority, string tag, string message, string file, string func, int line)
         {
 #if !DISABLE_SECURELOG
-            LogPrinter.Print(log_id, priority, tag, message, file, func, line);
+            if (String.IsNullOrEmpty(file))
+            {
+                Interop.Dlog.InternalPrint(log_id, priority, tag, "[SECURE_LOG] %s", message);
+            }
+            else
+            {
+                int index = file.LastIndexOfAny(sep);
+                string filename = file.Substring(index + 1);
+                Interop.Dlog.InternalPrint(log_id, priority, tag, "%s: %s(%d) > %s", filename, func, line, message);
+            }
 #endif
         }
     }

--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -401,6 +401,26 @@ namespace Tizen.NUI
             DestroySignal(taskDeviceOrientationChangedSignal, applicationTaskDeviceOrientationChangedEventCallback);
             DestroySignal(taskAppControlSignal, applicationTaskAppControlEventCallbackDelegate);
 
+            initSignal = null;
+            terminateSignal = null;
+            pauseSignal = null;
+            resumeSignal = null;
+            resetSignal = null;
+            languageChangedSignal = null;
+            regionChangedSignal = null;
+            batteryLowSignal = null;
+            memoryLowSignal = null;
+            deviceOrientationChangedSignal = null;
+            appControlSignal = null;
+            taskInitSignal = null;
+            taskTerminateSignal = null;
+            taskLanguageChangedSignal = null;
+            taskRegionChangedSignal = null;
+            taskBatteryLowSignal = null;
+            taskMemoryLowSignal = null;
+            taskDeviceOrientationChangedSignal = null;
+            taskAppControlSignal = null;
+            
             window?.Dispose();
             window = null;
 
@@ -556,6 +576,7 @@ namespace Tizen.NUI
                 if (applicationInitEventHandler != null)
                 {
                     DestroySignal(initSignal, applicationInitEventCallbackDelegate);
+                    initSignal = null;
                 }
 
                 applicationInitEventHandler -= value;
@@ -667,6 +688,7 @@ namespace Tizen.NUI
                 if (applicationPauseEventHandler != null)
                 {
                     DestroySignal(pauseSignal, applicationPauseEventCallbackDelegate);
+                    pauseSignal = null;
                 }
 
                 applicationPauseEventHandler -= value;
@@ -706,6 +728,7 @@ namespace Tizen.NUI
                 if (applicationResumeEventHandler != null)
                 {
                     DestroySignal(resumeSignal, applicationResumeEventCallbackDelegate);
+                    resumeSignal = null;
                 }
 
                 applicationResumeEventHandler -= value;
@@ -745,6 +768,7 @@ namespace Tizen.NUI
                 if (applicationResetEventHandler != null)
                 {
                     DestroySignal(resetSignal, applicationResetEventCallbackDelegate);
+                    resetSignal = null;
                 }
 
                 applicationResetEventHandler -= value;
@@ -784,6 +808,7 @@ namespace Tizen.NUI
                 if (applicationLanguageChangedEventHandler != null)
                 {
                     DestroySignal(languageChangedSignal, applicationLanguageChangedEventCallbackDelegate);
+                    languageChangedSignal = null;
                 }
 
                 applicationLanguageChangedEventHandler -= value;
@@ -823,6 +848,7 @@ namespace Tizen.NUI
                 if (applicationRegionChangedEventHandler != null)
                 {
                     DestroySignal(regionChangedSignal, applicationRegionChangedEventCallbackDelegate);
+                    regionChangedSignal = null;
                 }
 
                 applicationRegionChangedEventHandler -= value;
@@ -862,6 +888,7 @@ namespace Tizen.NUI
                 if (applicationBatteryLowEventHandler != null)
                 {
                     DestroySignal(batteryLowSignal, applicationBatteryLowEventCallbackDelegate);
+                    batteryLowSignal = null;
                 }
 
                 applicationBatteryLowEventHandler -= value;
@@ -900,6 +927,7 @@ namespace Tizen.NUI
                 if (applicationMemoryLowEventHandler != null)
                 {
                     DestroySignal(memoryLowSignal, applicationMemoryLowEventCallbackDelegate);
+                    batteryLowSignal = null;
                 }
 
                 applicationMemoryLowEventHandler -= value;
@@ -938,6 +966,7 @@ namespace Tizen.NUI
                 if (applicationDeviceOrientationChangedEventHandler != null)
                 {
                     DestroySignal(deviceOrientationChangedSignal, applicationDeviceOrientationChangedEventCallback);
+                    deviceOrientationChangedSignal = null;
                 }
 
                 applicationDeviceOrientationChangedEventHandler -= value;
@@ -975,6 +1004,7 @@ namespace Tizen.NUI
                 if (applicationAppControlEventHandler != null)
                 {
                     DestroySignal(appControlSignal, applicationAppControlEventCallbackDelegate);
+                    appControlSignal = null;
                 }
 
                 applicationAppControlEventHandler -= value;
@@ -1017,6 +1047,7 @@ namespace Tizen.NUI
                 if (applicationTaskInitEventHandler != null)
                 {
                     DestroySignal(taskInitSignal, applicationTaskInitEventCallbackDelegate);
+                    taskInitSignal = null;
                 }
 
                 applicationTaskInitEventHandler -= value;
@@ -1058,6 +1089,7 @@ namespace Tizen.NUI
                 if (applicationTaskTerminateEventHandler != null)
                 {
                     DestroySignal(taskTerminateSignal, applicationTaskTerminateEventCallbackDelegate);
+                    taskTerminateSignal = null;
                 }
 
                 applicationTaskTerminateEventHandler -= value;
@@ -1098,6 +1130,7 @@ namespace Tizen.NUI
                 if (applicationTaskLanguageChangedEventHandler != null)
                 {
                     DestroySignal(taskLanguageChangedSignal, applicationTaskLanguageChangedEventCallbackDelegate);
+                    taskLanguageChangedSignal = null;
                 }
 
                 applicationTaskLanguageChangedEventHandler -= value;
@@ -1138,6 +1171,7 @@ namespace Tizen.NUI
                 if (applicationTaskRegionChangedEventHandler != null)
                 {
                     DestroySignal(taskRegionChangedSignal, applicationTaskRegionChangedEventCallbackDelegate);
+                    taskRegionChangedSignal = null;
                 }
 
                 applicationTaskRegionChangedEventHandler -= value;
@@ -1178,6 +1212,7 @@ namespace Tizen.NUI
                 if (applicationTaskBatteryLowEventHandler != null)
                 {
                     DestroySignal(taskBatteryLowSignal, applicationTaskBatteryLowEventCallbackDelegate);
+                    taskBatteryLowSignal = null;
                 }
 
                 applicationTaskBatteryLowEventHandler -= value;
@@ -1217,6 +1252,7 @@ namespace Tizen.NUI
                 if (applicationTaskMemoryLowEventHandler != null)
                 {
                     DestroySignal(taskMemoryLowSignal, applicationTaskMemoryLowEventCallbackDelegate);
+                    taskMemoryLowSignal = null;
                 }
 
                 applicationTaskMemoryLowEventHandler -= value;
@@ -1255,6 +1291,7 @@ namespace Tizen.NUI
                 if (applicationTaskDeviceOrientationChangedEventHandler != null)
                 {
                     DestroySignal(taskDeviceOrientationChangedSignal, applicationTaskDeviceOrientationChangedEventCallback);
+                    taskDeviceOrientationChangedSignal = null;
                 }
 
                 applicationTaskDeviceOrientationChangedEventHandler -= value;
@@ -1293,6 +1330,7 @@ namespace Tizen.NUI
                 if (applicationTaskAppControlEventHandler != null)
                 {
                     DestroySignal(taskAppControlSignal, applicationTaskAppControlEventCallbackDelegate);
+                    taskAppControlSignal = null;
                 }
 
                 applicationTaskAppControlEventHandler -= value;
@@ -1815,7 +1853,6 @@ namespace Tizen.NUI
             {
                 signal?.Disconnect(callbackDelegate);
                 signal?.Dispose();
-                signal = null;
             }
         }
     }

--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -379,145 +379,34 @@ namespace Tizen.NUI
             //Release your own unmanaged resources here.
             //You should not access any managed member here except static instance.
             //because the execution order of Finalizes is non-deterministic.
-            if (applicationInitEventCallbackDelegate != null)
-            {
-                initSignal?.Disconnect(applicationInitEventCallbackDelegate);
-                initSignal?.Dispose();
-                initSignal = null;
-            }
+            DestroySignal(initSignal, applicationInitEventCallbackDelegate);
+            DestroySignal(terminateSignal, applicationTerminateEventCallbackDelegate);
+            DestroySignal(pauseSignal, applicationPauseEventCallbackDelegate);
+            DestroySignal(resumeSignal, applicationResumeEventCallbackDelegate);
+            DestroySignal(resetSignal, applicationResetEventCallbackDelegate);
+            DestroySignal(languageChangedSignal, applicationLanguageChangedEventCallbackDelegate);
+            DestroySignal(regionChangedSignal, applicationRegionChangedEventCallbackDelegate);
 
-            if (applicationTerminateEventCallbackDelegate != null)
-            {
-                terminateSignal?.Disconnect(applicationTerminateEventCallbackDelegate);
-                terminateSignal?.Dispose();
-                terminateSignal = null;
-            }
+            DestroySignal(batteryLowSignal, applicationBatteryLowEventCallbackDelegate);
+            DestroySignal(memoryLowSignal, applicationMemoryLowEventCallbackDelegate);
+            DestroySignal(deviceOrientationChangedSignal, applicationDeviceOrientationChangedEventCallback);
+            DestroySignal(appControlSignal, applicationAppControlEventCallbackDelegate);
+            DestroySignal(taskInitSignal, applicationTaskInitEventCallbackDelegate);
+            DestroySignal(taskTerminateSignal, applicationTaskTerminateEventCallbackDelegate);
+            DestroySignal(taskLanguageChangedSignal, applicationTaskLanguageChangedEventCallbackDelegate);
+            DestroySignal(taskRegionChangedSignal, applicationTaskRegionChangedEventCallbackDelegate);
+            DestroySignal(taskBatteryLowSignal, applicationTaskBatteryLowEventCallbackDelegate);
 
-            if (applicationPauseEventCallbackDelegate != null)
-            {
-                pauseSignal?.Disconnect(applicationPauseEventCallbackDelegate);
-                pauseSignal?.Dispose();
-                pauseSignal = null;
-            }
-
-            if (applicationResumeEventCallbackDelegate != null)
-            {
-                resumeSignal?.Disconnect(applicationResumeEventCallbackDelegate);
-                resumeSignal?.Dispose();
-                resumeSignal = null;
-            }
-
-            if (applicationResetEventCallbackDelegate != null)
-            {
-                resetSignal?.Disconnect(applicationResetEventCallbackDelegate);
-                resetSignal?.Dispose();
-                resetSignal = null;
-            }
-
-            if (applicationLanguageChangedEventCallbackDelegate != null)
-            {
-                languageChangedSignal?.Disconnect(applicationLanguageChangedEventCallbackDelegate);
-                languageChangedSignal?.Dispose();
-                languageChangedSignal = null;
-            }
-
-            if (applicationRegionChangedEventCallbackDelegate != null)
-            {
-                regionChangedSignal?.Disconnect(applicationRegionChangedEventCallbackDelegate);
-                regionChangedSignal?.Dispose();
-                regionChangedSignal = null;
-            }
-
-            if (applicationBatteryLowEventCallbackDelegate != null)
-            {
-                batteryLowSignal?.Disconnect(applicationBatteryLowEventCallbackDelegate);
-                batteryLowSignal?.Dispose();
-                batteryLowSignal = null;
-            }
-
-            if (applicationMemoryLowEventCallbackDelegate != null)
-            {
-                memoryLowSignal?.Disconnect(applicationMemoryLowEventCallbackDelegate);
-                memoryLowSignal?.Dispose();
-                memoryLowSignal = null;
-            }
-
-            if (applicationDeviceOrientationChangedEventCallback != null)
-            {
-                deviceOrientationChangedSignal?.Disconnect(applicationDeviceOrientationChangedEventCallback);
-                deviceOrientationChangedSignal?.Dispose();
-                deviceOrientationChangedSignal = null;
-            }
-
-            if (applicationAppControlEventCallbackDelegate != null)
-            {
-                appControlSignal?.Disconnect(applicationAppControlEventCallbackDelegate);
-                appControlSignal?.Dispose();
-                appControlSignal = null;
-            }
-
-            //Task
-            if (applicationTaskInitEventCallbackDelegate != null)
-            {
-                taskInitSignal?.Disconnect(applicationTaskInitEventCallbackDelegate);
-                taskInitSignal?.Dispose();
-                taskInitSignal = null;
-            }
-
-            if (applicationTaskTerminateEventCallbackDelegate != null)
-            {
-                taskTerminateSignal?.Disconnect(applicationTaskTerminateEventCallbackDelegate);
-                taskTerminateSignal?.Dispose();
-                taskTerminateSignal = null;
-            }
-
-            if (applicationTaskLanguageChangedEventCallbackDelegate != null)
-            {
-                taskLanguageChangedSignal?.Disconnect(applicationTaskLanguageChangedEventCallbackDelegate);
-                taskLanguageChangedSignal?.Dispose();
-                taskLanguageChangedSignal = null;
-            }
-
-            if (applicationTaskRegionChangedEventCallbackDelegate != null)
-            {
-                taskRegionChangedSignal?.Disconnect(applicationTaskRegionChangedEventCallbackDelegate);
-                taskRegionChangedSignal?.Dispose();
-                taskRegionChangedSignal = null;
-            }
-
-            if (applicationTaskBatteryLowEventCallbackDelegate != null)
-            {
-                taskBatteryLowSignal?.Disconnect(applicationTaskBatteryLowEventCallbackDelegate);
-                taskBatteryLowSignal?.Dispose();
-                taskBatteryLowSignal = null;
-            }
-
-            if (applicationTaskMemoryLowEventCallbackDelegate != null)
-            {
-                taskMemoryLowSignal?.Disconnect(applicationTaskMemoryLowEventCallbackDelegate);
-                taskMemoryLowSignal?.Dispose();
-                taskMemoryLowSignal = null;
-            }
-
-            if (applicationTaskDeviceOrientationChangedEventCallback != null)
-            {
-                taskDeviceOrientationChangedSignal?.Disconnect(applicationTaskDeviceOrientationChangedEventCallback);
-                taskDeviceOrientationChangedSignal?.Dispose();
-                taskDeviceOrientationChangedSignal = null;
-            }
-
-            if (applicationTaskAppControlEventCallbackDelegate != null)
-            {
-                taskAppControlSignal?.Disconnect(applicationTaskAppControlEventCallbackDelegate);
-                taskAppControlSignal?.Dispose();
-                taskAppControlSignal = null;
-            }
+            DestroySignal(taskMemoryLowSignal, applicationTaskMemoryLowEventCallbackDelegate);
+            DestroySignal(taskDeviceOrientationChangedSignal, applicationTaskDeviceOrientationChangedEventCallback);
+            DestroySignal(taskAppControlSignal, applicationTaskAppControlEventCallbackDelegate);
 
             window?.Dispose();
             window = null;
 
             base.Dispose(type);
         }
+
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Application.DeleteApplication(swigCPtr);
@@ -666,9 +555,7 @@ namespace Tizen.NUI
             {
                 if (applicationInitEventHandler != null)
                 {
-                    initSignal?.Disconnect(applicationInitEventCallbackDelegate);
-                    initSignal?.Dispose();
-                    initSignal = null;
+                    DestroySignal(initSignal, applicationInitEventCallbackDelegate);
                 }
 
                 applicationInitEventHandler -= value;
@@ -734,9 +621,7 @@ namespace Tizen.NUI
             {
                 if (applicationTerminateEventHandler != null)
                 {
-                    terminateSignal?.Disconnect(applicationTerminateEventCallbackDelegate);
-                    terminateSignal?.Dispose();
-                    terminateSignal = null;
+                    DestroySignal(terminateSignal, applicationTerminateEventCallbackDelegate);
                 }
 
                 applicationTerminateEventHandler -= value;
@@ -781,9 +666,7 @@ namespace Tizen.NUI
             {
                 if (applicationPauseEventHandler != null)
                 {
-                    pauseSignal?.Disconnect(applicationPauseEventCallbackDelegate);
-                    pauseSignal?.Dispose();
-                    pauseSignal = null;
+                    DestroySignal(pauseSignal, applicationPauseEventCallbackDelegate);
                 }
 
                 applicationPauseEventHandler -= value;
@@ -822,9 +705,7 @@ namespace Tizen.NUI
             {
                 if (applicationResumeEventHandler != null)
                 {
-                    resumeSignal?.Disconnect(applicationResumeEventCallbackDelegate);
-                    resumeSignal?.Dispose();
-                    resumeSignal = null;
+                    DestroySignal(resumeSignal, applicationResumeEventCallbackDelegate);
                 }
 
                 applicationResumeEventHandler -= value;
@@ -863,9 +744,7 @@ namespace Tizen.NUI
             {
                 if (applicationResetEventHandler != null)
                 {
-                    resetSignal?.Disconnect(applicationResetEventCallbackDelegate);
-                    resetSignal?.Dispose();
-                    resetSignal = null;
+                    DestroySignal(resetSignal, applicationResetEventCallbackDelegate);
                 }
 
                 applicationResetEventHandler -= value;
@@ -904,9 +783,7 @@ namespace Tizen.NUI
             {
                 if (applicationLanguageChangedEventHandler != null)
                 {
-                    languageChangedSignal?.Disconnect(applicationLanguageChangedEventCallbackDelegate);
-                    languageChangedSignal?.Dispose();
-                    languageChangedSignal = null;
+                    DestroySignal(languageChangedSignal, applicationLanguageChangedEventCallbackDelegate);
                 }
 
                 applicationLanguageChangedEventHandler -= value;
@@ -945,9 +822,7 @@ namespace Tizen.NUI
             {
                 if (applicationRegionChangedEventHandler != null)
                 {
-                    regionChangedSignal?.Disconnect(applicationRegionChangedEventCallbackDelegate);
-                    regionChangedSignal?.Dispose();
-                    regionChangedSignal = null;
+                    DestroySignal(regionChangedSignal, applicationRegionChangedEventCallbackDelegate);
                 }
 
                 applicationRegionChangedEventHandler -= value;
@@ -986,9 +861,7 @@ namespace Tizen.NUI
             {
                 if (applicationBatteryLowEventHandler != null)
                 {
-                    batteryLowSignal?.Disconnect(applicationBatteryLowEventCallbackDelegate);
-                    batteryLowSignal?.Dispose();
-                    batteryLowSignal = null;
+                    DestroySignal(batteryLowSignal, applicationBatteryLowEventCallbackDelegate);
                 }
 
                 applicationBatteryLowEventHandler -= value;
@@ -1026,9 +899,7 @@ namespace Tizen.NUI
             {
                 if (applicationMemoryLowEventHandler != null)
                 {
-                    memoryLowSignal?.Disconnect(applicationMemoryLowEventCallbackDelegate);
-                    memoryLowSignal?.Dispose();
-                    memoryLowSignal = null;
+                    DestroySignal(memoryLowSignal, applicationMemoryLowEventCallbackDelegate);
                 }
 
                 applicationMemoryLowEventHandler -= value;
@@ -1066,9 +937,7 @@ namespace Tizen.NUI
             {
                 if (applicationDeviceOrientationChangedEventHandler != null)
                 {
-                    deviceOrientationChangedSignal?.Disconnect(applicationDeviceOrientationChangedEventCallback);
-                    deviceOrientationChangedSignal?.Dispose();
-                    deviceOrientationChangedSignal = null;
+                    DestroySignal(deviceOrientationChangedSignal, applicationDeviceOrientationChangedEventCallback);
                 }
 
                 applicationDeviceOrientationChangedEventHandler -= value;
@@ -1105,9 +974,7 @@ namespace Tizen.NUI
             {
                 if (applicationAppControlEventHandler != null)
                 {
-                    appControlSignal?.Disconnect(applicationAppControlEventCallbackDelegate);
-                    appControlSignal?.Dispose();
-                    appControlSignal = null;
+                    DestroySignal(appControlSignal, applicationAppControlEventCallbackDelegate);
                 }
 
                 applicationAppControlEventHandler -= value;
@@ -1149,9 +1016,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskInitEventHandler != null)
                 {
-                    taskInitSignal?.Disconnect(applicationTaskInitEventCallbackDelegate);
-                    taskInitSignal?.Dispose();
-                    taskInitSignal = null;
+                    DestroySignal(taskInitSignal, applicationTaskInitEventCallbackDelegate);
                 }
 
                 applicationTaskInitEventHandler -= value;
@@ -1192,9 +1057,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskTerminateEventHandler != null)
                 {
-                    taskTerminateSignal?.Disconnect(applicationTaskTerminateEventCallbackDelegate);
-                    taskTerminateSignal?.Dispose();
-                    taskTerminateSignal = null;
+                    DestroySignal(taskTerminateSignal, applicationTaskTerminateEventCallbackDelegate);
                 }
 
                 applicationTaskTerminateEventHandler -= value;
@@ -1234,9 +1097,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskLanguageChangedEventHandler != null)
                 {
-                    taskLanguageChangedSignal?.Disconnect(applicationTaskLanguageChangedEventCallbackDelegate);
-                    taskLanguageChangedSignal?.Dispose();
-                    taskLanguageChangedSignal = null;
+                    DestroySignal(taskLanguageChangedSignal, applicationTaskLanguageChangedEventCallbackDelegate);
                 }
 
                 applicationTaskLanguageChangedEventHandler -= value;
@@ -1276,9 +1137,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskRegionChangedEventHandler != null)
                 {
-                    taskRegionChangedSignal?.Disconnect(applicationTaskRegionChangedEventCallbackDelegate);
-                    taskRegionChangedSignal?.Dispose();
-                    taskRegionChangedSignal = null;
+                    DestroySignal(taskRegionChangedSignal, applicationTaskRegionChangedEventCallbackDelegate);
                 }
 
                 applicationTaskRegionChangedEventHandler -= value;
@@ -1318,9 +1177,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskBatteryLowEventHandler != null)
                 {
-                    taskBatteryLowSignal?.Disconnect(applicationTaskBatteryLowEventCallbackDelegate);
-                    taskBatteryLowSignal?.Dispose();
-                    taskBatteryLowSignal = null;
+                    DestroySignal(taskBatteryLowSignal, applicationTaskBatteryLowEventCallbackDelegate);
                 }
 
                 applicationTaskBatteryLowEventHandler -= value;
@@ -1359,9 +1216,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskMemoryLowEventHandler != null)
                 {
-                    taskMemoryLowSignal?.Disconnect(applicationTaskMemoryLowEventCallbackDelegate);
-                    taskMemoryLowSignal?.Dispose();
-                    taskMemoryLowSignal = null;
+                    DestroySignal(taskMemoryLowSignal, applicationTaskMemoryLowEventCallbackDelegate);
                 }
 
                 applicationTaskMemoryLowEventHandler -= value;
@@ -1399,9 +1254,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskDeviceOrientationChangedEventHandler != null)
                 {
-                    taskDeviceOrientationChangedSignal?.Disconnect(applicationTaskDeviceOrientationChangedEventCallback);
-                    taskDeviceOrientationChangedSignal?.Dispose();
-                    taskDeviceOrientationChangedSignal = null;
+                    DestroySignal(taskDeviceOrientationChangedSignal, applicationTaskDeviceOrientationChangedEventCallback);
                 }
 
                 applicationTaskDeviceOrientationChangedEventHandler -= value;
@@ -1439,9 +1292,7 @@ namespace Tizen.NUI
             {
                 if (applicationTaskAppControlEventHandler != null)
                 {
-                    taskAppControlSignal?.Disconnect(applicationTaskAppControlEventCallbackDelegate);
-                    taskAppControlSignal?.Dispose();
-                    taskAppControlSignal = null;
+                    DestroySignal(taskAppControlSignal, applicationTaskAppControlEventCallbackDelegate);
                 }
 
                 applicationTaskAppControlEventHandler -= value;
@@ -1956,6 +1807,16 @@ namespace Tizen.NUI
             DeviceOrientationChangedSignalType ret = new DeviceOrientationChangedSignalType(NDalicPINVOKE.ApplicationTaskDeviceOrientationChangedSignal(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        private void DestroySignal(Signal signal, Delegate callbackDelegate)
+        {
+            if (callbackDelegate != null)
+            {
+                signal?.Disconnect(callbackDelegate);
+                signal?.Dispose();
+                signal = null;
+            }
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Application/ApplicationControlSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/ApplicationControlSignal.cs
@@ -17,7 +17,7 @@
 
 namespace Tizen.NUI
 {
-    internal class ApplicationControlSignal : Disposable
+    internal class ApplicationControlSignal : Disposable, Signal
     {
         internal ApplicationControlSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {

--- a/src/Tizen.NUI/src/internal/Application/ApplicationSignal.cs
+++ b/src/Tizen.NUI/src/internal/Application/ApplicationSignal.cs
@@ -17,9 +17,8 @@
 
 namespace Tizen.NUI
 {
-    internal class ApplicationSignal : Disposable
+    internal class ApplicationSignal : Disposable, Signal
     {
-
         internal ApplicationSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/internal/Common/DeviceOrientationChangedSignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/DeviceOrientationChangedSignalType.cs
@@ -17,7 +17,7 @@
 
 namespace Tizen.NUI
 {
-    internal class DeviceOrientationChangedSignalType : Disposable
+    internal class DeviceOrientationChangedSignalType : Disposable, Signal
     {
         internal DeviceOrientationChangedSignalType(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {

--- a/src/Tizen.NUI/src/internal/Common/LowBatterySignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/LowBatterySignalType.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     /// <summary>
     /// LowBatterySignalType.
     /// </summary>
-    internal class LowBatterySignalType : Disposable
+    internal class LowBatterySignalType : Disposable, Signal
     {
         internal LowBatterySignalType(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {

--- a/src/Tizen.NUI/src/internal/Common/LowMemorySignalType.cs
+++ b/src/Tizen.NUI/src/internal/Common/LowMemorySignalType.cs
@@ -17,7 +17,7 @@
 
 namespace Tizen.NUI
 {
-    internal class LowMemorySignalType : Disposable
+    internal class LowMemorySignalType : Disposable, Signal
     {
         internal LowMemorySignalType(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {

--- a/src/Tizen.NUI/src/internal/Common/Signal.cs
+++ b/src/Tizen.NUI/src/internal/Common/Signal.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal interface Signal
+    {
+        public bool Empty();
+
+        public uint GetConnectionCount();
+
+        public void Connect(System.Delegate func);
+
+        public void Disconnect(System.Delegate func);
+        
+        public void Dispose();
+    }
+}

--- a/src/Tizen/Interop/Interop.Dlog.cs
+++ b/src/Tizen/Interop/Interop.Dlog.cs
@@ -38,10 +38,10 @@ internal static partial class Interop
             DLOG_SILENT,
             DLOG_PRIO_MAX,
         }
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string msg);
 
-        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print_dotnet", CallingConvention = CallingConvention.Cdecl)]
+        [DllImportAttribute(Libraries.Dlog, EntryPoint = "dlog_print", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }

--- a/test/ElmSharp.Test/Log.cs
+++ b/test/ElmSharp.Test/Log.cs
@@ -54,7 +54,7 @@ namespace ElmSharp.Test
             Print(priority, tag, "%s: %s(%d) > %s", finfo.Name, func, line, message);
         }
 
-        [DllImportAttribute(Library, EntryPoint = "dlog_print_dotnet")]
+        [DllImportAttribute(Library, EntryPoint = "dlog_print")]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }

--- a/test/ElmSharp.Wearable.Test/TC/Log.cs
+++ b/test/ElmSharp.Wearable.Test/TC/Log.cs
@@ -54,7 +54,7 @@ namespace ElmSharp.Test
             Print(priority, tag, "%s: %s(%d) > %s", finfo.Name, func, line, message);
         }
 
-        [DllImportAttribute(Library, EntryPoint = "dlog_print_dotnet")]
+        [DllImportAttribute(Library, EntryPoint = "dlog_print")]
         internal static extern int Print(LogPriority prio, string tag, string fmt, string file, string func, int line, string msg);
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
- DestroySignal을 넣어서 EventCallback종료시 호출
- Signal Interface를 추가해서 시그널이 상속받도록 변경



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
