### PR TITLE
[NUI] Add DispatchParentTouchEvent

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -80,6 +80,7 @@ namespace Tizen.NUI.BaseComponents
         private RotationGestureDetector rotationGestureDetector = null;
         private int configGestureCount = 0;
         private bool dispatchTouchEvents = true;
+        private bool dispatchParentTouchEvents = true;
         private bool dispatchGestureEvents = true;
         private bool dispatchParentGestureEvents = true;
         private string internalName = string.Empty;
@@ -3503,6 +3504,43 @@ namespace Tizen.NUI.BaseComponents
         }
 
         private bool OnDispatchTouchEvent(object source, View.TouchEventArgs e)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Gets or sets the status of whether touch events can be dispatched to the parent.
+        /// If a View's DispatchParentTouchEvents is set to false, then parents will not receive a touch event signal either.
+        /// This works without adding a TouchEvent callback in the View.
+        /// <note>
+        /// If the <see cref="Tizen.NUI.BaseComponents.View.Sensitive"/> is a property that determines whether or not to be hittable, then this property prevents the propagation of the hit touch event.
+        /// </note>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DispatchParentTouchEvents
+        {
+            get
+            {
+                return dispatchParentTouchEvents;
+            }
+            set
+            {
+                if (dispatchParentTouchEvents != value)
+                {
+                    dispatchParentTouchEvents = value;
+                    if (dispatchParentTouchEvents == false)
+                    {
+                        TouchEvent += OnDispatchParentTouchEvent;
+                    }
+                    else
+                    {
+                        TouchEvent -= OnDispatchParentTouchEvent;
+                    }
+                }
+            }
+        }
+
+        private bool OnDispatchParentTouchEvent(object source, View.TouchEventArgs e)
         {
             return true;
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -741,7 +741,7 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Error("touchData should not be null!");
                 return true;
             }
-            
+
             TouchEventArgs e = new TouchEventArgs();
             e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);
             return HitTest(e.Touch);
@@ -805,6 +805,12 @@ namespace Tizen.NUI.BaseComponents
             if (enableControlState && !consumed)
             {
                 consumed = HandleControlStateOnTouch(e.Touch);
+            }
+
+            if (DispatchParentTouchEvents == false)
+            {
+                NUILog.Debug("If DispatchParentTouchEvents is false, it can not dispatch to parent.");
+                return true;
             }
 
             return consumed;


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
If a View's DispatchParentTouchEvents is set to false, then parents will not receive a touch event signal either.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
