### PR TITLE
[NUI][AT-SPI] Add AccessibilityDynamicAttributes

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -61,6 +61,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Dictionary<string, string> AccessibilityAttributes { get; } = new Dictionary<string, string>();
 
+        /// <summary>
+        /// Dictionary of dynamically-evaluated accessibility attributes (key-value pairs of strings).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Dictionary<string, Func<string>> AccessibilityDynamicAttributes { get; } = new Dictionary<string, Func<string>>();
+
         ///////////////////////////////////////////////////////////////////
         // ************************** Highlight ************************ //
         ///////////////////////////////////////////////////////////////////

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
@@ -126,6 +126,11 @@ namespace Tizen.NUI.BaseComponents
             {
                 callback(attribute.Key, attribute.Value, userData);
             }
+
+            foreach (var attribute in view.AccessibilityDynamicAttributes)
+            {
+                callback(attribute.Key, attribute.Value.Invoke(), userData);
+            }
         }
 
         private static IntPtr AccessibilityGetDescriptionWrapper(IntPtr self)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Note: This is a backport of https://github.com/Samsung/TizenFX/pull/5287.

Currently, the public API only allows static attribute values, for example:

```c#
// Initial value:
view.AccessibilityAttributes["current_page"] = CurrentPage;

// Need to update in some other place in code when CurrentPage changes:
view.AccessibilityAttributes["current_page"] = CurrentPage;
```

However, the attributes are actually already evaluated dynamically on demand in the helper method `AccessibilityGetAttributes` called by the AT-SPI bridge. Therefore, it makes sense to allow associating a key with a functor as well as a string value, for example:

```c#
// Always up-to-date thanks to dynamic evaluation:
view.AccessibilityDynamicAttributes["current_page"] = () => CurrentPage;
```

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
