### PR TITLE
[NUI] Add new constructor to Rotation by using Quaternion vector4

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Rotation.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Rotation.cs
@@ -33,6 +33,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_3")]
             public static extern global::System.IntPtr NewRotation3(global::System.Runtime.InteropServices.HandleRef pitch, global::System.Runtime.InteropServices.HandleRef yaw, global::System.Runtime.InteropServices.HandleRef roll);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Rotation_4")]
+            public static extern global::System.IntPtr NewRotation4(global::System.Runtime.InteropServices.HandleRef vector4);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Rotation")]
             public static extern void DeleteRotation(global::System.Runtime.InteropServices.HandleRef rotation);
 

--- a/src/Tizen.NUI/src/public/Common/Rotation.cs
+++ b/src/Tizen.NUI/src/public/Common/Rotation.cs
@@ -75,6 +75,16 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// The constructor of Rotation from Quaternion Vector4.
+        /// </summary>
+        /// <param name="vector">Quaternion vector for Rotation.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Rotation(Vector4 vector) : this(Interop.Rotation.NewRotation4(Vector4.getCPtr(vector)), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// (0.0f,0.0f,0.0f,1.0f).
         /// </summary>
         /// <since_tizen> 3 </since_tizen>


### PR DESCRIPTION
This patch is to add new constructor of Rotation that using Quaternion Vector4 as an input parameter.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/293354/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
