### PR TITLE
[NUI][API10][AT-SPI] Add IAtspiTable and IAtspiTableCell interfaces

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -388,10 +388,146 @@ namespace Tizen.NUI
                 public delegate IntPtr AccessibilityGetValueText(IntPtr self);
                 [EditorBrowsable(EditorBrowsableState.Never)]
                 public AccessibilityGetValueText GetValueText; // 38
+
+                public delegate int AccessibilityGetRowCount(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetRowCount GetRowCount; // 39
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate int AccessibilityGetColumnCount(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetColumnCount GetColumnCount; // 40
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate int AccessibilityGetSelectedRowCount(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetSelectedRowCount GetSelectedRowCount; // 41
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate int AccessibilityGetSelectedColumnCount(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetSelectedColumnCount GetSelectedColumnCount; // 42
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetCaption(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetCaption GetCaption; // 43
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetSummary(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetSummary GetSummary; // 44
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetCell(IntPtr self, int row, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetCell GetCell; // 45
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate ulong AccessibilityGetChildIndex(IntPtr self, int row, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetChildIndex GetChildIndex; // 46
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetPositionByChildIndex(IntPtr self, ulong childIndex);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetPositionByChildIndex GetPositionByChildIndex; // 47
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetRowDescription(IntPtr self, int row);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetRowDescription GetRowDescription; // 48
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetColumnDescription(IntPtr self, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetColumnDescription GetColumnDescription; // 49
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetRowHeader(IntPtr self, int row);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetRowHeader GetRowHeader; // 50
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetColumnHeader(IntPtr self, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetColumnHeader GetColumnHeader; // 51
+
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate void AccessibilityGetSelectedRowsColumnsCallback(int index, IntPtr userData);
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate void AccessibilityGetSelectedRows(IntPtr self, AccessibilityGetSelectedRowsColumnsCallback callback, IntPtr userData);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetSelectedRows GetSelectedRows; // 52
+
+                // Reuses the callback type from GetSelectedRows
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate void AccessibilityGetSelectedColumns(IntPtr self, AccessibilityGetSelectedRowsColumnsCallback callback, IntPtr userData);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetSelectedColumns GetSelectedColumns; // 53
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityIsRowSelected(IntPtr self, int row);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityIsRowSelected IsRowSelected; // 54
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityIsColumnSelected(IntPtr self, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityIsColumnSelected IsColumnSelected; // 55
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityIsCellSelected(IntPtr self, int row, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityIsCellSelected IsCellSelected; // 56
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityAddRowSelection(IntPtr self, int row);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityAddRowSelection AddRowSelection; // 57
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityAddColumnSelection(IntPtr self, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityAddColumnSelection AddColumnSelection; // 58
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityRemoveRowSelection(IntPtr self, int row);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityRemoveRowSelection RemoveRowSelection; // 59
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate bool AccessibilityRemoveColumnSelection(IntPtr self, int column);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityRemoveColumnSelection RemoveColumnSelection; // 60
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetTable(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetTable GetTable; // 61
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate IntPtr AccessibilityGetCellPosition(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetCellPosition GetCellPosition; // 62
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate int AccessibilityGetCellRowSpan(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetCellRowSpan GetCellRowSpan; // 63
+
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public delegate int AccessibilityGetCellColumnSpan(IntPtr self);
+                [EditorBrowsable(EditorBrowsableState.Never)]
+                public AccessibilityGetCellColumnSpan GetCellColumnSpan; // 64
             }
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_DuplicateString")]
             public static extern IntPtr DaliAccessibilityDuplicateString(string arg);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_MakeIntPair")]
+            public static extern IntPtr DaliAccessibilityMakeIntPair(int first, int second);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetAccessibilityDelegate")]
             public static extern IntPtr DaliAccessibilitySetAccessibilityDelegate(IntPtr arg1_accessibilityDelegate, uint arg2_accessibilityDelegateSize);

--- a/src/Tizen.NUI/src/public/Accessibility/IAtspiTable.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/IAtspiTable.cs
@@ -1,0 +1,94 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Accessibility
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IAtspiTable
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetRowCount();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetColumnCount();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetSelectedRowCount();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetSelectedColumnCount();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        View AccessibilityGetCaption();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        View AccessibilityGetSummary();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IAtspiTableCell AccessibilityGetCell(int row, int column);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetChildIndex(int row, int column);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Tuple<int, int> AccessibilityGetPositionByChildIndex(int childIndex);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string AccessibilityGetRowDescription(int row);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        string AccessibilityGetColumnDescription(int column);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        View AccessibilityGetRowHeader(int row);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        View AccessibilityGetColumnHeader(int column);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<int> AccessibilityGetSelectedRows();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<int> AccessibilityGetSelectedColumns();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityIsRowSelected(int row);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityIsColumnSelected(int column);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityIsCellSelected(int row, int column);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityAddRowSelection(int row);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityAddColumnSelection(int column);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityRemoveRowSelection(int row);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AccessibilityRemoveColumnSelection(int column);
+    }
+}

--- a/src/Tizen.NUI/src/public/Accessibility/IAtspiTableCell.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/IAtspiTableCell.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Accessibility
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IAtspiTableCell
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IAtspiTable AccessibilityGetTable();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Tuple<int, int> AccessibilityGetCellPosition();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetCellRowSpan();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        int AccessibilityGetCellColumnSpan();
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEnum.cs
@@ -54,6 +54,16 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         Selection = 21,
+        /// <summary>
+        /// Accessibility interface which can represent a table
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Table = 23,
+        /// <summary>
+        /// Accessibility interface which can represent a table cell
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        TableCell = 24,
     }
 
     /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Note: This is an API10 backport of https://github.com/Samsung/TizenFX/pull/5305.

The purpose of these interfaces is to support Screen Reader operation with tables and grids (`Tizen.NUI.FLUX.Components.GridH` etc.), often in combination with `IAtspiSelection` (already present in TizenFX), for example reading the row and column number when navigating a grid of items, or selecting cells / rows / columns, as specified in the UX guide.

Dependencies (ABI change - need to be merged at the same time):
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/293419/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/293418/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
