### PR TITLE
[NUI] Fix issue of get ScrollableBase instance's Children

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -1115,6 +1115,16 @@ namespace Tizen.NUI.Components
         }
 
         /// <summary>
+        /// return the children of ContentContainer when user try to get the children of ScrollableBase.
+        /// </summary>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override List<View> GetChildren()
+        {
+            return ContentContainer.Children;
+        }
+
+        /// <summary>
         /// Scrolls to the item at the specified index.
         /// </summary>
         /// <param name="index">Index of item.</param>

--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -107,7 +107,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return childViews;
+                return GetChildren();
             }
         }
 
@@ -324,6 +324,16 @@ namespace Tizen.NUI
             }
             if (changedResources.Count != 0)
                 OnResourcesChanged(changedResources);
+        }
+
+        /// <summary>
+        /// Some type which inherit from Container overwrite the Add/Remove, so the getter of children should also be overwrite.
+        /// </summary>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual List<View> GetChildren()
+        {
+            return childViews;
         }
 
         /// <summary>


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
