### PR TITLE
[NUI][API10] Fix a svace issue in CustomViewRegistry.cs.

### DIFF
--- a/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
+++ b/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
@@ -257,11 +257,17 @@ namespace Tizen.NUI
                 throw new ArgumentNullException(nameof(viewType));
             }
 
+            var viewTypeString = viewType.ToString();
+            if (null == viewTypeString)
+            {
+                throw new ArgumentNullException(viewTypeString);
+            }
+
             // add the mapping between the view name and it's create function
-            constructorMap.Add(viewType.ToString(), createFunction);
+            constructorMap.Add(viewTypeString, createFunction);
 
             // Call into DALi C++ to register the control with the type registry
-            TypeRegistration.RegisterControl(viewType.ToString(), createCallback);
+            TypeRegistration.RegisterControl(viewTypeString, createCallback);
 
             // Cycle through each property in the class
             foreach (System.Reflection.PropertyInfo propertyInfo in viewType.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Public))
@@ -283,14 +289,14 @@ namespace Tizen.NUI
                             ScriptableProperty scriptableProp = attr as ScriptableProperty;
 
                             // we get the start property index, based on the type and it's hierarchy, e.g. DateView (70,000)-> Spin (60,000) -> View (50,000)
-                            int propertyIndex = propertyRangeManager.GetPropertyIndex(viewType.ToString(), viewType, scriptableProp.type);
+                            int propertyIndex = propertyRangeManager.GetPropertyIndex(viewTypeString, viewType, scriptableProp.type);
 
                             // get the enum for the property type... E.g. registering a string property returns Tizen.NUI.PropertyType.String
                             Tizen.NUI.PropertyType propertyType = GetDaliPropertyType(propertyInfo.PropertyType.Name);
 
                             // Example   RegisterProperty("spin","maxValue", 50001, FLOAT, set, get );
                             // Native call to register the property
-                            TypeRegistration.RegisterProperty(viewType.ToString(), propertyInfo.Name, propertyIndex, propertyType, setPropertyCallback, getPropertyCallback);
+                            TypeRegistration.RegisterProperty(viewTypeString, propertyInfo.Name, propertyIndex, propertyType, setPropertyCallback, getPropertyCallback);
                         }
                     }
                     NUILog.Debug("property name = " + propertyInfo.Name);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
[STATISTICAL] Value viewType.ToString(), which is result of method invocation with possible null return value, is dereferenced in method call constructorMap.Add()。

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
