### PR TITLE
[NUI] Add DispatchHoverEvents and DispatchPrentHoverEvents

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -81,6 +81,8 @@ namespace Tizen.NUI.BaseComponents
         private int configGestureCount = 0;
         private bool dispatchTouchEvents = true;
         private bool dispatchParentTouchEvents = true;
+        private bool dispatchHoverEvents = true;
+        private bool dispatchParentHoverEvents = true;
         private bool dispatchGestureEvents = true;
         private bool dispatchParentGestureEvents = true;
         private string internalName = string.Empty;
@@ -3541,6 +3543,80 @@ namespace Tizen.NUI.BaseComponents
         }
 
         private bool OnDispatchParentTouchEvent(object source, View.TouchEventArgs e)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Gets or sets the status of whether hover events can be dispatched.
+        /// If a View's DispatchHoverEvents is set to false, then it's can not will receive hover event and parents will not receive a hover event signal either.
+        /// This works without adding a HoverEvent callback in the View.
+        /// <note>
+        /// If the <see cref="Tizen.NUI.BaseComponents.View.Sensitive"/> is a property that determines whether or not to be hittable, then this property prevents the propagation of the hit hover event.
+        /// </note>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DispatchHoverEvents
+        {
+            get
+            {
+                return dispatchHoverEvents;
+            }
+            set
+            {
+                if (dispatchHoverEvents != value)
+                {
+                    dispatchHoverEvents = value;
+                    if (dispatchHoverEvents == false)
+                    {
+                        HoverEvent += OnDispatchHoverEvent;
+                    }
+                    else
+                    {
+                        HoverEvent -= OnDispatchHoverEvent;
+                    }
+                }
+            }
+        }
+
+        private bool OnDispatchHoverEvent(object source, View.HoverEventArgs e)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Gets or sets the status of whether hover events can be dispatched to the parent.
+        /// If a View's DispatchParentHoverEvents is set to false, then parents will not receive a hover event signal either.
+        /// This works without adding a HoverEvent callback in the View.
+        /// <note>
+        /// If the <see cref="Tizen.NUI.BaseComponents.View.Sensitive"/> is a property that determines whether or not to be hittable, then this property prevents the propagation of the hit hover event.
+        /// </note>
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DispatchParentHoverEvents
+        {
+            get
+            {
+                return dispatchParentHoverEvents;
+            }
+            set
+            {
+                if (dispatchParentHoverEvents != value)
+                {
+                    dispatchParentHoverEvents = value;
+                    if (dispatchParentHoverEvents == false)
+                    {
+                        HoverEvent += OnDispatchParentHoverEvent;
+                    }
+                    else
+                    {
+                        HoverEvent -= OnDispatchParentHoverEvent;
+                    }
+                }
+            }
+        }
+
+        private bool OnDispatchParentHoverEvent(object source, View.HoverEventArgs e)
         {
             return true;
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -835,15 +835,30 @@ namespace Tizen.NUI.BaseComponents
                 return true;
             }
 
+            if (DispatchHoverEvents == false)
+            {
+                NUILog.Debug("If DispatchHoverEvents is false, it can not dispatch.");
+                return true;
+            }
+
             HoverEventArgs e = new HoverEventArgs();
 
             e.Hover = Tizen.NUI.Hover.GetHoverFromPtr(hoverEvent);
 
+            bool consumed = false;
+
             if (hoverEventHandler != null)
             {
-                return hoverEventHandler(this, e);
+                consumed = hoverEventHandler(this, e);
             }
-            return false;
+
+            if (DispatchParentHoverEvents == false && consumed == false)
+            {
+                NUILog.Debug("If DispatchParentHoverEvents is false, it can not dispatch to parent.");
+                return true;
+            }
+
+            return consumed;
         }
 
         // Callback for View Wheel signal


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
If DispatchHoverEvents sets false, view will not receive any HoverEvent including own. 
If DispatchPrentHoverEvents sets false, the parent view does not receive HoverEvent.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
