### PR TITLE
[NUI] Add Window validation check

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -1845,6 +1845,12 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static List<Window> GetWindowList()
         {
+            if (Interop.Stage.IsInstalled() == false)
+            {
+                NUILog.ErrorBacktrace($"[ERROR] dali adaptor and dali window is not ready. just return NULL here");
+                return null;
+            }
+
             uint ListSize = Interop.Application.GetWindowsListSize();
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 

--- a/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
+++ b/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
@@ -238,6 +238,22 @@ namespace Tizen.NUI
         {
             Tizen.Log.Error("NUI", $"{msg} (at line {lineNum} of {caller} in {file})\n");
         }
+
+        public static void ErrorBacktrace(string msg,
+            [CallerLineNumber] int lineNum = 0,
+            [CallerMemberName] string caller = null,
+            [CallerFilePath] string file = null
+        )
+        {
+            Tizen.Log.Error("NUI", $"[ERR]{msg} (at line {lineNum} of {caller} in {file})\n");
+            Tizen.Log.Error("NUI", $"[ERR] Back Trace =>");
+            global::System.Diagnostics.StackTrace st = new global::System.Diagnostics.StackTrace(true);
+            for (int i = 0; i < st.FrameCount; i++)
+            {
+                global::System.Diagnostics.StackFrame sf = st.GetFrame(i);
+                Tizen.Log.Error("NUI", " Method " + sf.GetMethod());
+            }
+        }
     }
 
 }


### PR DESCRIPTION
### Description of Change ###
[NUI] Add Window validation check
- before the dali adaptor and window are not ready, the `Interop.Application.GetWindowsListSize()` gives native crash (dali assert)

- error msg =>
2112.329 D/DOTNET_LAUNCHER(P 9983, T11096): log.h: ~FunctionEntryExitTracker(91) > [90m-DotNETLog:log.cc(80) void writeStringTofile(char*)[0m
2112.329 E/DOTNET_LAUNCHER(P 9983, T11096): log.cc: stdErrRedirect(127) > [31mException: [0m
2112.329 E/DOTNET_LAUNCHER(P 9983, T11096): log.cc: stdErrRedirect(127) > [31mIsAvailable() && "Adaptor not instantiated"[0m
2112.329 E/DOTNET_LAUNCHER(P 9983, T11096): log.cc: stdErrRedirect(127) > [31m thrown[0m

- add validation checking in `GetWindowList()`


### API Changes ###
none