### PR TITLE
[NUI] Add DeviceInfo Event

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.DeviceInfo.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DeviceInfo.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class DeviceInfo
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_DeviceInfoEvent__SWIG_0")]
+            public static extern global::System.IntPtr NewDeviceInfo(int type, string name, string identifier, string seatName);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_DeviceInfoEvent")]
+            public static extern void DeleteDeviceInfo(global::System.Runtime.InteropServices.HandleRef deviceInfo);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceInfoEvent_type_get")]
+            public static extern int TypeGet(global::System.Runtime.InteropServices.HandleRef deviceInfo);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceInfoEvent_name_get")]
+            public static extern string NameGet(global::System.Runtime.InteropServices.HandleRef deviceInfo);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceInfoEvent_identifier_get")]
+            public static extern string IdentifierGet(global::System.Runtime.InteropServices.HandleRef deviceInfo);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceInfoEvent_seatname_get")]
+            public static extern string SeatNameGet(global::System.Runtime.InteropServices.HandleRef deviceInfo);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceInfoEvent_GetDeviceClass")]
+            public static extern int DeviceClassGet(global::System.Runtime.InteropServices.HandleRef deviceInfo);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DeviceInfoEvent_GetDeviceSubClass")]
+            public static extern int DeviceSubClassGet(global::System.Runtime.InteropServices.HandleRef deviceInfo);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowDeviceInfoEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowDeviceInfoEventSignal.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WindowDeviceInfoEventSignal
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDeviceInfoEventSignal")]
+            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDeviceInfoEventSignal_Empty")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef signalType);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDeviceInfoEventSignal_GetConnectionCount")]
+            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef signalType);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDeviceInfoEventSignal_Connect")]
+            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDeviceInfoEventSignal_Disconnect")]
+            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowDeviceInfoEventSignal_Emit")]
+            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef deviceInfoEvent);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowDeviceInfoEventSignal")]
+            public static extern global::System.IntPtr NewWindowDeviceInfoEventSignal();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowDeviceInfoEventSignal")]
+            public static extern void DeleteWindowDeviceInfoEventSignal(global::System.Runtime.InteropServices.HandleRef signalType);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Window/WindowDeviceInfoEventSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowDeviceInfoEventSignal.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    internal class WindowDeviceInfoEventSignal : Disposable
+    {
+        internal WindowDeviceInfoEventSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WindowDeviceInfoEventSignal.DeleteWindowDeviceInfoEventSignal(swigCPtr);
+        }
+
+        /// <summary>
+        /// Queries whether there are any connected slots.
+        /// </summary>
+        /// <returns>True if there are any slots connected to the signal</returns>
+        public bool Empty()
+        {
+            bool ret = Interop.WindowDeviceInfoEventSignal.Empty(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Queries the number of slots.
+        /// </summary>
+        /// <returns>The number of slots connected to this signal</returns>
+        public uint GetConnectionCount()
+        {
+            uint ret = Interop.WindowDeviceInfoEventSignal.GetConnectionCount(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Connects a function.
+        /// </summary>
+        /// <param name="func">The function to connect</param>
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowDeviceInfoEventSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Disconnects a function.
+        /// </summary>
+        /// <param name="func">The function to disconnect</param>
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowDeviceInfoEventSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Emits the signal.
+        /// </summary>
+        /// <param name="window">The first value to pass to callbacks</param>
+        /// <param name="deviceInfo">The second value to pass to callbacks</param>
+        public void Emit(Window window, DeviceInfo deviceInfo)
+        {
+            Interop.WindowDeviceInfoEventSignal.Emit(SwigCPtr, Window.getCPtr(window), DeviceInfo.getCPtr(deviceInfo));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        public WindowDeviceInfoEventSignal(Window window) : this(Interop.WindowDeviceInfoEventSignal.GetSignal(Window.getCPtr(window)), false)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Window/DeviceInfo.cs
+++ b/src/Tizen.NUI/src/public/Window/DeviceInfo.cs
@@ -1,0 +1,226 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// DeviceInfo is used when a device such as a mouse or keyboard is connected or disconnected.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class DeviceInfo : Disposable
+    {
+
+        /// <summary>
+        /// The default constructor.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceInfo() : this(Interop.DeviceInfo.NewDeviceInfo((int)DeviceInfo.StateType.None, "", "", ""), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        /// <param name="state">The state of the event.</param>
+        /// <param name="name">The device name</param>
+        /// <param name="identifier">The identifier.</param>
+        /// <param name="seatname">The seat name.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceInfo(DeviceInfo.StateType state, string name, string identifier, string seatname) : this(Interop.DeviceInfo.NewDeviceInfo((int)state, name, identifier, seatname), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal DeviceInfo(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// The state of the device info event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum StateType
+        {
+            /// <summary>
+            /// Default value
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            None,
+
+            /// <summary>
+            /// device added
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Added,
+
+            /// <summary>
+            /// device removed
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Removed
+        }
+
+        /// <summary>
+        /// The state of the device info event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceInfo.StateType State
+        {
+            get
+            {
+                return state;
+            }
+        }
+
+        /// <summary>
+        /// The device name
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Name
+        {
+            get
+            {
+                return name;
+            }
+        }
+
+        /// <summary>
+        /// The identifier
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Identifier
+        {
+            get
+            {
+                return identifier;
+            }
+        }
+
+        /// <summary>
+        /// The seat name
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string SeatName
+        {
+            get
+            {
+                return seatName;
+            }
+        }
+
+        /// <summary>
+        /// Get the device class the device info event originated from.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceClassType DeviceClass
+        {
+            get
+            {
+                return deviceClass;
+            }
+        }
+
+        /// <summary>
+        /// Get the device subclass the device info event originated from.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public DeviceSubClassType DeviceSubClass
+        {
+            get
+            {
+                return deviceSubClass;
+            }
+        }
+
+        private DeviceInfo.StateType state
+        {
+            get
+            {
+                DeviceInfo.StateType ret = (DeviceInfo.StateType)Interop.DeviceInfo.TypeGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private string name
+        {
+            get
+            {
+                string ret = Interop.DeviceInfo.NameGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private string identifier
+        {
+            get
+            {
+                string ret = Interop.DeviceInfo.IdentifierGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private string seatName
+        {
+            get
+            {
+                string ret = Interop.DeviceInfo.SeatNameGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private DeviceClassType deviceClass
+        {
+            get
+            {
+                int ret = Interop.DeviceInfo.DeviceClassGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return (DeviceClassType)ret;
+            }
+        }
+
+        private DeviceSubClassType deviceSubClass
+        {
+            get
+            {
+                int ret = Interop.DeviceInfo.DeviceSubClassGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return (DeviceSubClassType)ret;
+            }
+        }
+
+        internal static DeviceInfo GetDeviceInfoFromPtr(global::System.IntPtr cPtr)
+        {
+            DeviceInfo ret = new DeviceInfo(cPtr, false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.DeviceInfo.DeleteDeviceInfo(swigCPtr);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
[NUI] Add DeviceInfo Event
```c++
Window window = NUIApplication.GetDefaultWindow();
window.DeviceInfoEvent += (s, e) =>
{
  Tizen.Log.Error("NUI", $"device info type : {e.DeviceInfo.State}, [{e.DeviceInfo.Name}], [{e.DeviceInfo.Identifier}], [{e.DeviceInfo.SeatName}]\n");
  if (e.DeviceInfo.State == DeviceInfo.StateType.Added)
  {
    // device added
  }
  else if (e.DeviceInfo.State == DeviceInfo.StateType.Removed)
  {
    // device removed
  }
};
```

refer :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/294039/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/294385/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
