### PR TITLE
[NUI] Make subclass of ImageView can use ResourceUrl normally.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
@@ -388,6 +388,13 @@ namespace Tizen.NUI.BaseComponents
         {
             if (!imagePropertyUpdatedFlag) return;
 
+            // Assume that we are using standard Image at first.
+            // (Since we might cache Visual.Property.Type as Visual.Type.AnimatedImage even we don't use URLs.)
+            using (PropertyValue imageType = new PropertyValue((int)Visual.Type.Image))
+            {
+                UpdateImage(Visual.Property.Type, imageType, false);
+            }
+
             if (resourceURLs != null && resourceURLs.Count != 0)
             {
                 using (PropertyArray indexPropertyArray = new PropertyArray())
@@ -406,10 +413,11 @@ namespace Tizen.NUI.BaseComponents
                     // Trigger the ImageView so that we have something update
                     UpdateImage(ImageVisualProperty.URL, arrayProperty, false);
                 }
-            }
 
-            using PropertyValue animatiedImage = new PropertyValue((int)Visual.Type.AnimatedImage);
-            UpdateImage(Visual.Property.Type, animatiedImage, false);
+                // Trick that we are using resourceURLs without ResourceUrl API.
+                using PropertyValue animatiedImage = new PropertyValue((int)Visual.Type.AnimatedImage);
+                UpdateImage(Visual.Property.Type, animatiedImage, false);
+            }
 
             base.UpdateImage();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1525,9 +1525,9 @@ namespace Tizen.NUI.BaseComponents
             }
 
             // Checkup the cached visual type is AnimatedImage.
-            // It is trick to know that this code is running on AnimatedImageView.UpdateImage() / LottieAnimationView.UpdateImage() or not.
+            // It is trick to know that this code is running on AnimatedImageView.UpdateImage() with resourceURLs or not.
             int visualType = (int)Visual.Type.Invalid;
-            if (!((GetCachedImageVisualProperty(Visual.Property.Type)?.Get(out visualType) ?? false) && (visualType == (int)Visual.Type.AnimatedImage || visualType == (int)Visual.Type.AnimatedVectorImage)))
+            if (!((GetCachedImageVisualProperty(Visual.Property.Type)?.Get(out visualType) ?? false) && (visualType == (int)Visual.Type.AnimatedImage)))
             {
                 // If ResourceUrl is not setuped, don't set property. fast return.
                 if (string.IsNullOrEmpty(_resourceUrl))
@@ -1691,6 +1691,11 @@ namespace Tizen.NUI.BaseComponents
                 {
                     // Update-or-Insert new value
                     cachedImagePropertyMap[key] = value;
+                    if (key == ImageVisualProperty.URL)
+                    {
+                        // Special case. If key is Url, update _resourceUrl here.
+                        value.Get(out _resourceUrl);
+                    }
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -700,9 +700,6 @@ namespace Tizen.NUI.BaseComponents
                 currentStates.changed = false;
             }
 
-            using PropertyValue animatiedImage = new PropertyValue((int)Visual.Type.AnimatedVectorImage);
-            UpdateImage(Visual.Property.Type, animatiedImage, false);
-
             base.UpdateImage();
         }
 


### PR DESCRIPTION
If we skip to set ImageVisualType, or set ImageVisualType as Image, we will try to find best visual by it's file format codes. But previously, we fix the type of visual.
So, instead of some special case like URLs, just make we use Image type.

And also, make _resourceUrl latest value if we success to get url from visual.
Now we can store _resourceUrl even we update the `Image` property.