### PR TITLE
[NUI] Fix some svace issues.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/FlexibleView/LinearLayoutManager.cs
+++ b/src/Tizen.NUI.Components/Controls/FlexibleView/LinearLayoutManager.cs
@@ -425,6 +425,8 @@ namespace Tizen.NUI.Components
                             return position + 1;
                         }
                         break;
+                    default:
+                        break;
                 }
             }
             else
@@ -442,6 +444,8 @@ namespace Tizen.NUI.Components
                         {
                             return position + 1;
                         }
+                        break;
+                    default:
                         break;
                 }
             }

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/GridLayouter.cs
@@ -1295,6 +1295,8 @@ namespace Tizen.NUI.Components
                         targetSibling = IsHorizontal ? targetSibling : currentFocusedView.SiblingOrder + 1;
                         break;
                     }
+                default:
+                    break;
             }
 
             if (targetSibling > -1 && targetSibling < Container.Children.Count)

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Layouter/LinearLayouter.cs
@@ -1498,6 +1498,8 @@ namespace Tizen.NUI.Components
                         targetSibling = IsHorizontal? targetSibling : currentFocusedView.SiblingOrder + 1;
                         break;
                     }
+                default:
+                    break;
             }
 
             if (targetSibling > -1 && targetSibling < Container.Children.Count)

--- a/src/Tizen.NUI.Wearable/src/public/RecyclerView/GridRecycleLayoutManager.cs
+++ b/src/Tizen.NUI.Wearable/src/public/RecyclerView/GridRecycleLayoutManager.cs
@@ -289,6 +289,8 @@ namespace Tizen.NUI.Wearable
                         targetSibling = isHorizontal ? currentFocusedView.SiblingOrder + Columns : currentFocusedView.SiblingOrder + 1;
                         break;
                     }
+                default:
+                    break;
             }
 
             if (targetSibling > -1 && targetSibling < Container.Children.Count)

--- a/src/Tizen.NUI.Wearable/src/public/RecyclerView/LinearRecycleLayoutManager.cs
+++ b/src/Tizen.NUI.Wearable/src/public/RecyclerView/LinearRecycleLayoutManager.cs
@@ -216,6 +216,8 @@ namespace Tizen.NUI.Wearable
                         targetSibling = isHorizontal ? targetSibling : currentFocusedView.SiblingOrder + 1;
                         break;
                     }
+                default:
+                    break;
             }
 
             if (targetSibling > -1 && targetSibling < Container.Children.Count)

--- a/src/Tizen.NUI.Wearable/src/public/RecyclerView/RecyclerView.cs
+++ b/src/Tizen.NUI.Wearable/src/public/RecyclerView/RecyclerView.cs
@@ -355,6 +355,8 @@ namespace Tizen.NUI.Wearable
                             nextFocusedView = DownFocusableView;
                             break;
                         }
+                    default:
+                        break;
                 }
 
                 if (nextFocusedView)

--- a/src/Tizen.NUI/src/internal/XamlBinding/BindingExpression.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/BindingExpression.cs
@@ -99,16 +99,19 @@ namespace Tizen.NUI.Binding
             object sourceObject;
             if (_weakSource != null && _weakSource.TryGetTarget(out sourceObject))
             {
-                for (var i = 0; i < _parts.Count - 1; i++)
+                if (_parts.Count > 1)
                 {
-                    BindingExpressionPart part = _parts[i];
-
-                    if (!part.IsSelf)
+                    for (var i = 0; i < _parts.Count - 1; i++)
                     {
-                        part.TryGetValue(sourceObject, out sourceObject);
-                    }
+                        BindingExpressionPart part = _parts[i];
 
-                    part.Unsubscribe();
+                        if (!part.IsSelf)
+                        {
+                            part.TryGetValue(sourceObject, out sourceObject);
+                        }
+
+                        part.Unsubscribe();
+                    }
                 }
             }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -182,7 +182,7 @@ namespace Tizen.NUI.BaseComponents
         {
             unsafe
             {
-                if (textures != null)
+                if (textures != null && textures.Count > 0)
                 {
                     IntPtr unmanagedPointer = Marshal.AllocHGlobal(sizeof(IntPtr) * textures.Count);
                     IntPtr[] texturesArray = new IntPtr[textures.Count];

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -250,6 +250,8 @@ namespace Tizen.NUI
                             childLayout.ConditionForAnimation = TransitionCondition.LayoutChanged;
                             break;
                         }
+                    default:
+                        break;
                 }
             }
 

--- a/src/Tizen.NUI/src/public/Rendering/VertexBuffer.cs
+++ b/src/Tizen.NUI/src/public/Rendering/VertexBuffer.cs
@@ -49,12 +49,12 @@ namespace Tizen.NUI
         /// This function expects an array of structures with the same format that was given in the construction.
         /// </summary>
         /// <param name="vertices">The vertex data that will be copied to the buffer.</param>
-        /// <exception cref="ArgumentNullException"> Thrown when vertices is null. </exception>
+        /// <exception cref="ArgumentNullException"> Thrown when vertices is null or length of the vertices is 0. </exception>
         /// <since_tizen> 8 </since_tizen>
 
         public void SetData<VertexType>(VertexType[] vertices) where VertexType : struct
         {
-            if (null == vertices)
+            if (null == vertices || vertices.Length == 0)
             {
                 throw new ArgumentNullException(nameof(vertices));
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
WID:56638093 An overflow in the arithmetic expression sizeof(IntPtr) * textures.Count which is used in Marshal.AllocHGlobal(sizeof(IntPtr) * textures.Count) may occur. Please use checked arithmetic to throw IntegerOverflowException in case of overflow instead of possible memory damage

WID:56646651 The iteration number in loop with condition i < _parts.Count - 1 is off by one

WID:56638091 An overflow in the arithmetic expression structSize * vertices.Length which is used in Marshal.AllocHGlobal(structSize * vertices.Length) may occur. Please use checked arithmetic to throw IntegerOverflowException in case of overflow instead of possible memory damage

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
