### PR TITLE
[ThemeManager] Clear current theme cache when theme changed

### DIFF
--- a/src/Tizen.Applications.ThemeManager/Tizen.Applications.ThemeManager/ThemeLoader.cs
+++ b/src/Tizen.Applications.ThemeManager/Tizen.Applications.ThemeManager/ThemeLoader.cs
@@ -49,10 +49,19 @@ namespace Tizen.Applications.ThemeManager
             {
                 throw Interop.ThemeManager.ThemeManagerErrorFactory.GetException(err, "Failed to create themeloader");
             }
+
+            _callback = new Interop.ThemeManager.ThemeLoaderChangedCallback(OnThemeChanged);
+            err = Interop.ThemeManager.LoaderAddEvent(_loaderHandle, _callback, IntPtr.Zero, out _eventId);
+            if (err != Interop.ThemeManager.ErrorCode.None)
+            {
+                throw Interop.ThemeManager.ThemeManagerErrorFactory.GetException(err, "Failed to add event");
+            }
         }
 
         private int OnThemeChanged(IntPtr handle, IntPtr userData)
         {
+            _currentTheme = null;
+
             Interop.ThemeManager.ErrorCode err = Interop.ThemeManager.ThemeClone(handle, out IntPtr cloned);
             if (err != Interop.ThemeManager.ErrorCode.None)
                 return -1;
@@ -72,34 +81,12 @@ namespace Tizen.Applications.ThemeManager
         {
             add
             {
-                if (_changedEventHandler == null)
-                {
-                    if (_callback == null)
-                        _callback = new Interop.ThemeManager.ThemeLoaderChangedCallback(OnThemeChanged);
-                    Interop.ThemeManager.ErrorCode err = Interop.ThemeManager.LoaderAddEvent(_loaderHandle, _callback, IntPtr.Zero, out _eventId);
-
-                    if (err != Interop.ThemeManager.ErrorCode.None)
-                    {
-                        throw Interop.ThemeManager.ThemeManagerErrorFactory.GetException(err, "Failed to add event");
-                    }
-
-                }
                 _changedEventHandler += value;
 
             }
             remove
             {
                 _changedEventHandler -= value;
-                if (_changedEventHandler == null)
-                {
-                    Interop.ThemeManager.ErrorCode err = Interop.ThemeManager.LoaderRemoveEvent(_loaderHandle, _eventId);
-
-                    if (err != Interop.ThemeManager.ErrorCode.None)
-                    {
-                        throw Interop.ThemeManager.ThemeManagerErrorFactory.GetException(err, "Failed to remove event");
-                    }
-                    _callback = null;
-                }
             }
         }
 
@@ -217,6 +204,12 @@ namespace Tizen.Applications.ThemeManager
 
             if (_loaderHandle != IntPtr.Zero)
             {
+                Interop.ThemeManager.ErrorCode err = Interop.ThemeManager.LoaderRemoveEvent(_loaderHandle, _eventId);
+                if (err != Interop.ThemeManager.ErrorCode.None)
+                {
+                    Log.Error(LogTag, "Failed to remove event");
+                }
+
                 Interop.ThemeManager.LoaderDestroy(_loaderHandle);
                 _loaderHandle = IntPtr.Zero;
             }


### PR DESCRIPTION
### Description of Change ###
Clear current theme cache when theme changed


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
