### PR TITLE
[NUI][API10] Fix a SVACE issue.

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -225,7 +225,7 @@ namespace Tizen.NUI
         // Parent not a View so assume it's a Layer which is the size of the window.
         private void MeasureAndLayout(View root, float parentWidth, float parentHeight)
         {
-            if (root.Layout != null)
+            if (root.Layout is var rootLayout && rootLayout != null)
             {
                 // Determine measure specification for root.
                 // The root layout policy could be an exact size, be match parent or wrap children.
@@ -237,7 +237,7 @@ namespace Tizen.NUI
                 var widthMode = GetMode(root.WidthSpecification);
                 var heightMode = GetMode(root.HeightSpecification);
 
-                if (root.Layout.NeedsLayout(widthSize, heightSize, widthMode, heightMode))
+                if (rootLayout.NeedsLayout(widthSize, heightSize, widthMode, heightMode))
                 {
                     var widthSpec = CreateMeasureSpecification(widthSize, widthMode);
                     var heightSpec = CreateMeasureSpecification(heightSize, heightMode);
@@ -251,8 +251,8 @@ namespace Tizen.NUI
                 // Start at root which was just measured.
                 PerformLayout(root, new LayoutLength(positionX),
                                      new LayoutLength(positionY),
-                                     new LayoutLength(positionX) + root.Layout.MeasuredWidth.Size,
-                                     new LayoutLength(positionY) + root.Layout.MeasuredHeight.Size);
+                                     new LayoutLength(positionX) + rootLayout.MeasuredWidth.Size,
+                                     new LayoutLength(positionY) + rootLayout.MeasuredHeight.Size);
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
WID:61196553 [STATISTICAL] Value root.Layout, which is result of method invocation with possible null return value, is dereferenced in member access expression root.Layout.MeasuredHeight

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
