### PR TITLE
[NUI] Clear old resources cached marker data

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -133,9 +133,16 @@ namespace Tizen.NUI.BaseComponents
         {
             set
             {
+                // Reset cached infomations.
+                currentStates.contentInfo = null;
+                currentStates.mark1 = null;
+                currentStates.mark2 = null;
+                currentStates.framePlayRangeMin = -1;
+                currentStates.framePlayRangeMax = -1;
+                currentStates.totalFrame = -1;
+
                 string ret = (value == null ? "" : value);
                 currentStates.url = ret;
-                currentStates.totalFrame = -1; // Reset cached totalFrame value;
 
                 NUILog.Debug($"<[{GetId()}]SET url={currentStates.url}");
 
@@ -158,8 +165,6 @@ namespace Tizen.NUI.BaseComponents
 
                 // All states applied well.
                 currentStates.changed = false;
-
-                currentStates.contentInfo = null;
 
                 if (currentStates.scale != 1.0f)
                 {


### PR DESCRIPTION
After overhead reducetion patch #5280 merged, Some side effect occured.

Previously we always ask some properties to dali side visual. But now we return cached value in NUI.

Since URL property clear-up all properties, to fit previous logic, let we also clean-up cached properties. (Actually, mark only for this case)
