### PR TITLE
[NUI] Add ModelRoot Property in Model class

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -150,26 +150,39 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
-        /// Adds modelNode to this Model.
+        /// Retrieves root ModelNode of this Model.
         /// </summary>
-        /// <param name="modelRoot">Root of a ModelNode tree</param>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void AddModelNode(ModelNode modelRoot)
+        public ModelNode ModelRoot
         {
-            Interop.Model.AddModelNode(SwigCPtr, ModelNode.getCPtr(modelRoot));
+            get
+            {
+                return GetModelRoot();
+            }
+        }
+
+        /// <summary>
+        /// Adds modelNode to this Model.
+        /// </summary>
+        /// <param name="modelNode">Root of a ModelNode tree</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddModelNode(ModelNode modelNode)
+        {
+            Interop.Model.AddModelNode(SwigCPtr, ModelNode.getCPtr(modelNode));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>
         /// Removes modelNode from this Model.
         /// </summary>
-        /// <param name="modelRoot">Root of a ModelNode tree to be removed</param>
+        /// <param name="modelNode">Root of a ModelNode tree to be removed</param>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void RemoveModelNode(ModelNode modelRoot)
+        public void RemoveModelNode(ModelNode modelNode)
         {
-            Interop.Model.RemoveModelNode(SwigCPtr, ModelNode.getCPtr(modelRoot));
+            Interop.Model.RemoveModelNode(SwigCPtr, ModelNode.getCPtr(modelNode));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
### Description of Change ###

 - Add ModelRoot Property to retrieve root ModelNode of the Model object.
 - Change parameter name of AddModelNode and RemoveModelNode to modelNode

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
