### PR TITLE
[NUI] Disable ThemeManager preload

### DIFF
--- a/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
+++ b/src/Tizen.NUI.Components/Theme/DefaultTheme.cs
@@ -25,13 +25,6 @@ namespace Tizen.NUI.Components
 
         public static void Preload()
         {
-            if (ThemeManager.InitialThemeDisabled) return;
-
-            ThemeManager.AddPackageTheme(Instance);
-
-            if (string.IsNullOrEmpty(ExternalThemeManager.CurrentThemeId)) return;
-
-            ThemeManager.LoadPlatformTheme(ExternalThemeManager.CurrentThemeId);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -626,7 +626,6 @@ namespace Tizen.NUI
         static public void Preload()
         {
             Interop.Application.PreInitialize();
-            ThemeManager.Preload();
             IsPreload = true;
         }
 

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -454,15 +454,6 @@ namespace Tizen.NUI
             UpdateThemeForInitialize();
         }
 
-        internal static void Preload()
-        {
-            if (InitialThemeDisabled) return;
-
-            if (string.IsNullOrEmpty(ExternalThemeManager.CurrentThemeId)) return;
-
-            LoadPlatformTheme(ExternalThemeManager.CurrentThemeId);
-        }
-
         // TODO Please make it private after removing Tizen.NUI.Components.StyleManager.
         internal static void UpdateThemeForUpdate()
         {


### PR DESCRIPTION
### Description of Change ###
Because of the dbus issue from tizen theme manager, this patch removed NUI ThemeManager from the preload.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
