### PR TITLE
[NUI] Add InterceptWheelEvent

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
@@ -52,6 +52,12 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_WheelEventSignal_Disconnect")]
             public static extern void WheelEventDisconnect(HandleRef actor, HandleRef handler);
 
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptWheelSignal_Connect")]
+            public static extern void InterceptWheelConnect(HandleRef actor, HandleRef handler);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InterceptWheelSignal_Disconnect")]
+            public static extern void InterceptWheelDisconnect(HandleRef actor, HandleRef handler);
+
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_OnSceneSignal_Connect")]
             public static extern void OnSceneConnect(HandleRef actor, HandleRef handler);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -545,9 +545,9 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalTargetSize = new Vector3(0, 0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveTargetSize(SwigCPtr, internalTargetSize.SwigCPtr);
-            
+
             if (NDalicPINVOKE.SWIGPendingException.Pending)
             {
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -562,7 +562,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalCurrentSize = new Size2D(0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveCurrentPropertyVector2ActualVector3(SwigCPtr, Property.SIZE, internalCurrentSize.SwigCPtr);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -627,7 +627,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalCurrentPosition = new Position(0, 0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, Property.POSITION, internalCurrentPosition.SwigCPtr);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -643,7 +643,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalCurrentWorldPosition = new Vector3(0, 0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.WorldPosition, internalCurrentWorldPosition.SwigCPtr);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -772,7 +772,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalCurrentScale = new Vector3(0, 0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.SCALE, internalCurrentScale.SwigCPtr);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -789,7 +789,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalCurrentWorldScale = new Vector3(0, 0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveCurrentPropertyVector3(SwigCPtr, View.Property.WorldScale, internalCurrentWorldScale.SwigCPtr);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -866,7 +866,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalCurrentColor = new Vector4(0, 0, 0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveCurrentPropertyVector4(SwigCPtr, Interop.ActorProperty.ColorGet(), internalCurrentColor.SwigCPtr);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -890,7 +890,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 internalCurrentWorldColor = new Vector4(0, 0, 0, 0);
             }
-            
+
             Interop.ActorInternal.RetrieveCurrentPropertyVector4(SwigCPtr, Property.WorldColor, internalCurrentWorldColor.SwigCPtr);
 
             if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -1446,6 +1446,15 @@ namespace Tizen.NUI.BaseComponents
                 Interop.ActorSignal.OnSceneDisconnect(GetBaseHandleCPtrHandleRef, onWindowEventCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExistsDebug();
                 onWindowEventCallback = null;
+            }
+
+            if (interceptWheelCallback != null)
+            {
+                NUILog.Debug($"[Dispose] interceptWheelCallback");
+
+                Interop.ActorSignal.InterceptWheelDisconnect(GetBaseHandleCPtrHandleRef, interceptWheelCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                interceptWheelCallback = null;
             }
 
             if (wheelEventCallback != null)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ScrollableFocus/ScrollableFocusSample.cs
@@ -9,20 +9,17 @@ namespace Tizen.NUI.Samples
     public class ScrollableFocusSample : IExample
     {
         public View root;
-        public class CustomScrollableBase : ScrollableBase
-        {
-            public override bool OnWheel(Wheel wheel)
-            {
-                base.OnWheel(wheel);
-                Window window = NUIApplication.GetDefaultWindow();
-                window.LazyFeedHover();
-                return true;
-            }
-        }
 
         public void Activate()
         {
             Window window = NUIApplication.GetDefaultWindow();
+
+            // Use LazyFeedHover if you want to trigger the HoverEvent again when a Wheel event is received.
+            window.InterceptWheelEvent += (s, e) =>
+            {
+                window.LazyFeedHover();
+                return false;
+            };
 
             root = new View();
             root.Layout = new AbsoluteLayout();
@@ -48,7 +45,7 @@ namespace Tizen.NUI.Samples
             };
             root.Add(topbtn);
 
-            var scrollview = new CustomScrollableBase
+            var scrollview = new ScrollableBase
             {
                 ScrollingDirection = ScrollableBase.Direction.Vertical,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
@@ -72,7 +69,7 @@ namespace Tizen.NUI.Samples
             };
             root.Add(middle);
 
-            var myscrollview = new CustomScrollableBase
+            var myscrollview = new ScrollableBase
             {
                 ScrollingDirection = ScrollableBase.Direction.Vertical,
                 WidthSpecification = LayoutParamPolicies.MatchParent,


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The Wheel event calls the WheelEvent callback by going back from the last child actor to the parent via hitTest. InterceptWheelEvent checks the wheel event in the parent first. Returning false from interceptWheelEvent allows child actors to receive WheelEvents. If it returns true, the actor will receive a WheelEvent.

for example
```c++
   View parent = new View();
   View child = new View();
   parent.Add(child);
   child.WheelEvent += childFunctor;
   parent.WheelEvent += parentFunctor;
```

The callbacks are called in the order childFunctor -> parentFunctor.

If you connect InterceptWheelEvent to parentActor.
```c++
   parent.InterceptWheelEvent += interceptFunctor;
```

When interceptFunctor returns false, it is called in the same order childFunctor -> parentFunctor. If intereptFunctor returns true, it means that the WheelEvent was intercepted. So the child actor will not be able to receive wheel events. Only the parentFunctor is called.

refer :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/295232/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/295233/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->


<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
