### PR TITLE
[NUI] Search upper parents until registered object is found

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -274,7 +274,6 @@ namespace Tizen.NUI.BaseComponents
                 }
                 
                 BaseHandle baseHandle = Registry.GetManagedBaseHandleFromNativePtr(parent.Handle);
-                InternalParent = baseHandle;
 
                 return baseHandle as Container;
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -253,7 +253,35 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 4 </since_tizen>
         public override Container GetParent()
         {
-            return InternalParent as Container;
+            if (InternalParent == null && !(this is Window))
+            {
+                // Ask to dali, recersively.
+                
+                IntPtr cPtrParent = Interop.Actor.GetParent(SwigCPtr);
+                HandleRef parent = new global::System.Runtime.InteropServices.HandleRef(this, cPtrParent);
+                while (Interop.BaseHandle.HasBody(parent) && (Registry.GetManagedBaseHandleFromNativePtr(parent.Handle) == null))
+                {
+                    cPtrParent = Interop.Actor.GetParent(parent);
+
+                    Interop.BaseHandle.DeleteBaseHandle(parent);
+                    parent = new global::System.Runtime.InteropServices.HandleRef(this, cPtrParent);
+                }
+
+                if (!Interop.BaseHandle.HasBody(parent))
+                {
+                    Interop.BaseHandle.DeleteBaseHandle(parent);
+                    return null;
+                }
+                
+                BaseHandle baseHandle = Registry.GetManagedBaseHandleFromNativePtr(parent.Handle);
+                InternalParent = baseHandle;
+
+                return baseHandle as Container;
+            }
+            else
+            {
+                return InternalParent as Container;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
If a component's parent is not registered on NUI but still exists on DALi side, GetParent() on the object returns null.
This makes it impossible to reach to the component's NUI parent.

For example, when a child is Scene3D.Camera and its parent is SceneView, child.GetParent() always returns null(SceneView.mRootLayer not registered on NUI), thus SceneView is unreachable from Scene3D.Camera.

This patch implements recursive search on dali parents when NUI child's InternalParent is null.