### PR TITLE
[NUI] Fix not to propagate gesture from scrim

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Menu.cs
+++ b/src/Tizen.NUI.Components/Controls/Menu.cs
@@ -529,6 +529,7 @@ namespace Tizen.NUI.Components
                 ExcludeLayouting = true,
                 BackgroundColor = Color.Transparent,
                 Size = new Size(NUIApplication.GetDefaultWindow().Size),
+                DispatchParentGestureEvents = false,
             };
 
             scrim.TouchEvent += (object source, TouchEventArgs e) =>

--- a/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/DialogPage.cs
@@ -325,6 +325,7 @@ namespace Tizen.NUI.Components
                 }
                 return true;
             };
+            scrim.DispatchParentGestureEvents = false;
 
             return scrim;
         }


### PR DESCRIPTION
Scrim should block all touch and gesture events.
Therefore, gesture is also not propagated from scrim.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
