### PR TITLE
[NUI][AT-SPI] Set focus in OnAccessibilityActivated()

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -501,6 +501,11 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override bool OnAccessibilityActivated()
         {
+            if (!base.OnAccessibilityActivated())
+            {
+                return false;
+            }
+
             return OnKeyboardEnter();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -582,7 +582,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual bool OnAccessibilityActivated()
         {
-            return false;
+            return FocusManager.Instance.SetCurrentFocusView(this);
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This aligns the behaviour of `Components` (derived from `CustomView`), and other controls, with that of `BaseComponents` (and other controls with `ViewAccessibilityMode.Default`, backed by the C++ accessibility implementation), which set the keyboard focus on activation. Please note that in the latter case, the implementation of `View.OnAccessibilityActivated` is unused, and the unrelated method (albeit bearing the same name) `Control::OnAccessibilityActivated` is called:

```cpp
bool Control::OnAccessibilityActivated()
{
  if(Toolkit::KeyboardFocusManager::Get().SetCurrentFocusActor(Self()))
  {
    return OnKeyboardEnter();
  }
  return false;
}
```

So, in other words, this patch makes C# controls behave in a similar manner, i.e. set the keyboard focus on accessibility activation.




### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
