### PR TITLE
[NUI] Switch camera includes current camera's Unparent()

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -354,6 +354,7 @@ namespace Tizen.NUI.Scene3D
             {
                 return;
             }
+            this.GetSelectedCamera()?.Unparent();
             Interop.SceneView.SelectCamera(SwigCPtr, index);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -369,6 +370,7 @@ namespace Tizen.NUI.Scene3D
             {
                 return;
             }
+            this.GetSelectedCamera()?.Unparent();
             Interop.SceneView.SelectCamera(SwigCPtr, name);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION
Synchronizing DALi and NUI cameras' parent.

DALi's SelectCamera() includes unparenting current camera component, and NUI's SelectCamera() simply calls the function.
However, since they manage different objects on each side, NUI's camera is still attached to its parent.

This can be a problem in a situation such as:

// dummy is a View
dummy.Add(defaultCamera);
sceneView.Add(dummy);

sceneView.SelectCamera(1u);

sceneView.SelectCamera(0u);
dummy.Add(defaultCamera);

In NUI side, default camera was never detached from dummy but DALi's SceneView now has both dummy and default camera as its children. (The last line is ignored on NUI side.)