### PR TITLE
[NUI] Fast track uploading image

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -349,6 +349,24 @@ namespace Tizen.NUI.BaseComponents
         });
 
         /// <summary>
+        /// FastTrackUploadingProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty FastTrackUploadingProperty = BindableProperty.Create(nameof(FastTrackUploading), typeof(bool), typeof(ImageView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
+            if (newValue != null)
+            {
+                instance.InternalFastTrackUploading = (bool)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
+            return instance.InternalFastTrackUploading;
+        });
+
+        /// <summary>
         /// ImageMapProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -537,7 +555,7 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (Tizen.NUI.BaseComponents.ImageView)bindable;
             if (newValue != null)
             {
-                Object.InternalSetPropertyString(imageView.SwigCPtr, ImageView.Property.PlaceHolderUrl, (string)newValue );
+                Object.InternalSetPropertyString(imageView.SwigCPtr, ImageView.Property.PlaceHolderUrl, (string)newValue);
             }
         },
         defaultValueCreator: (bindable) =>

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -969,6 +969,14 @@ namespace Tizen.NUI
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly int MaskingMode = NDalic.ImageVisualOrientationCorrection + 12;
+
+        /// <summary>
+        /// @brief Whether to uploading texture before ResourceReady signal emit or after texture load completed time.
+        /// @details Name "fastTrackUploading", type Property::BOOLEAN.
+        /// @note It is used in the ImageVisual. The default is false.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly int FastTrackUploading = NDalic.ImageVisualOrientationCorrection + 13;
     }
 
     /// <summary>


### PR DESCRIPTION
Add new feature about flag that ImageView's image uploading faster.

Previously, NUI has some operations to support some kind of visual transition, or calculate natural size for relayout, or etc.

This patch make a way to user that we need to upload image as soon as possible, don't care about other platform supported features.

relative dali patches :

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/295645
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/294405
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/295658