### PR TITLE
[NUI] Get Lottie ActionId of SetDynamicProperty

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LottieAnimationView.cs
@@ -31,6 +31,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_JUMP_TO_get")]
             public static extern int AnimatedVectorImageVisualActionJumpToGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_AnimatedVectorImageVisual_Actions_SET_DYNAMIC_PROPERTY_get")]
+            public static extern int AnimatedVectorImageVisualActionSetDynamicProperty();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -453,7 +453,7 @@ namespace Tizen.NUI.BaseComponents
 
         // This is used for internal purpose. hidden API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected int SetDynamicProperty => ActionJumpTo + 1;
+        protected int ActionSetDynamicProperty { get; set; } = Interop.LottieAnimationView.AnimatedVectorImageVisualActionSetDynamicProperty();
         #endregion Property
 
 
@@ -662,7 +662,7 @@ namespace Tizen.NUI.BaseComponents
             weakReferencesOfLottie?.Add(dynamicPropertyCallbackId, new WeakReference<LottieAnimationView>(this));
             InternalSavedDynamicPropertyCallbacks?.Add(dynamicPropertyCallbackId, info.Callback);
 
-            Interop.View.DoActionExtension(SwigCPtr, ImageView.Property.IMAGE, SetDynamicProperty, dynamicPropertyCallbackId, info.KeyPath, (int)info.Property, Marshal.GetFunctionPointerForDelegate<System.Delegate>(rootCallback));
+            Interop.View.DoActionExtension(SwigCPtr, ImageView.Property.IMAGE, ActionSetDynamicProperty, dynamicPropertyCallbackId, info.KeyPath, (int)info.Property, Marshal.GetFunctionPointerForDelegate<System.Delegate>(rootCallback));
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION
Since we change the value of SetDynamicProperty value in dali side, we need to get correct value from dali.

relative dali patches : 
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/296210