### PR TITLE
[NUI] Restore FeedHover due to api compatibility issue.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1168,13 +1168,7 @@ namespace Tizen.NUI
                 internalHoverTimer = new Timer(time);
                 internalHoverTimer.Tick += (s, e) =>
                 {
-                    using Touch touch = GetLastTouchEvent();
-                    if(touch != null && touch.GetPointCount() > 0)
-                    {
-                        using Vector2 screenPosition = touch.GetScreenPosition(0);
-                        using TouchPoint touchPoint = new TouchPoint(touch.GetDeviceId(0), TouchPoint.StateType.Motion, screenPosition.X, screenPosition.Y);
-                        FeedHover(touchPoint);
-                    }
+                    FeedHover();
                     internalHoverTimer?.Stop();
                     internalHoverTimer?.Dispose();
                     internalHoverTimer = null;
@@ -1212,10 +1206,20 @@ namespace Tizen.NUI
         /// <summary>
         /// Feeds a hover event into the window.
         /// </summary>
-        /// <param name="touchPoint">The touch point to feed hover event.</param>
+        /// <param name="touchPoint">The touch point to feed hover event. If null is entered, the feed hover event is generated with the last inputed touch point.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal void FeedHover(TouchPoint touchPoint)
+        internal void FeedHover(TouchPoint touchPoint = null)
         {
+            if (touchPoint == null)
+            {
+                using Touch touch = GetLastTouchEvent();
+                if (touch == null || touch.GetPointCount() < 1)
+                {
+                    return;
+                }
+                using Vector2 screenPosition = touch.GetScreenPosition(0);
+                touchPoint = new TouchPoint(touch.GetDeviceId(0), TouchPoint.StateType.Motion, screenPosition.X, screenPosition.Y);
+            }
             Interop.Window.FeedHoverEvent(SwigCPtr, TouchPoint.getCPtr(touchPoint));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
[NUI] Restore FeedHover due to api compatibility issue.
And the null check is done in FeedHover.

revert : https://github.com/Samsung/TizenFX/pull/5411

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
