### PR TITLE
[NUI] Registry is not required at GetTouchFromPtr()

### DIFF
--- a/src/Tizen.NUI/src/public/Events/Touch.cs
+++ b/src/Tizen.NUI/src/public/Events/Touch.cs
@@ -239,12 +239,7 @@ namespace Tizen.NUI
 
         internal static Touch GetTouchFromPtr(global::System.IntPtr cPtr)
         {
-            Touch ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Touch;
-            if (ret == null)
-            {
-                ret = new Touch(cPtr, false);
-            }
-
+            Touch ret = new Touch(cPtr, false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
Registry is not required at GetTouchFromPtr()
In the case of an object created from DALi, it is created with new BaseHandle(intPtr, false).

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
