### PR TITLE
[NUI] Fix SVACE issue.

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTask.cs
@@ -15,7 +15,9 @@
  *
  */
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
@@ -48,7 +50,7 @@ namespace Tizen.NUI
                 return;
             }
 
-            foreach (var window in Application.GetWindowList())
+            foreach (var window in Application.GetWindowList() ?? Enumerable.Empty<Window>())
             {
                 window.GetRenderTaskList().RemoveTask(this);
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
[STATISTICAL] Value Application.GetWindowList(), which is result of method invocation with possible null return value, is dereferenced in foreach argument

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
