### PR TITLE
[NUI] Fix issue when LottieAnimationView use DesiredSize

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -59,6 +59,8 @@ namespace Tizen.NUI.BaseComponents
             currentStates.totalFrame = -1;
             currentStates.scale = scale;
             currentStates.redrawInScalingDown = true;
+            currentStates.desiredWidth = 0;
+            currentStates.desiredHeight = 0;
 
             // Set changed flag as true when initalized state.
             // After some properties change, LottieAnimationView.UpdateImage will apply these inital values.
@@ -173,6 +175,18 @@ namespace Tizen.NUI.BaseComponents
                     .Add(ImageVisualProperty.StopBehavior, stopAction)
                     .Add(ImageVisualProperty.LoopingMode, loopMode)
                     .Add(ImageVisualProperty.RedrawInScalingDown, redrawInScalingDown);
+
+                if (currentStates.desiredWidth > 0)
+                {
+                    using PropertyValue desiredWidth = new PropertyValue((int)currentStates.desiredWidth);
+                    map.Add(ImageVisualProperty.DesiredWidth, desiredWidth);
+                }
+                if (currentStates.desiredHeight > 0)
+                {
+                    using PropertyValue desiredHeight = new PropertyValue((int)currentStates.desiredHeight);
+                    map.Add(ImageVisualProperty.DesiredHeight, desiredHeight);
+                }
+
                 Image = map;
 
                 // All states applied well.
@@ -190,6 +204,40 @@ namespace Tizen.NUI.BaseComponents
                 NUILog.Debug($"<[{GetId()}] GET");
                 NUILog.Debug($"gotten url={ret} >");
                 return ret;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the desired image width for LottieAnimationView<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new int DesiredWidth
+        {
+            get
+            {
+                return currentStates.desiredWidth;
+            }
+            set
+            {
+                currentStates.desiredWidth = value;
+                base.DesiredWidth = currentStates.desiredWidth;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the desired image height for LottieAnimationView<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new int DesiredHeight
+        {
+            get
+            {
+                return currentStates.desiredHeight;
+            }
+            set
+            {
+                currentStates.desiredHeight = value;
+                base.DesiredHeight = currentStates.desiredHeight;
             }
         }
 
@@ -1089,6 +1137,7 @@ namespace Tizen.NUI.BaseComponents
             internal List<Tuple<string, int, int>> contentInfo;
             internal string mark1, mark2;
             internal bool redrawInScalingDown;
+            internal int desiredWidth, desiredHeight;
             internal bool changed;
         };
         private states currentStates;


### PR DESCRIPTION
Since #5350 patch will reset previous whole informations when we use ResourceUrl.

So, If user set ResourceUrl set DesiredSize, the desired size informatins disapeared.