### PR TITLE
[MediaContent] Deprecate unused APIs

### DIFF
--- a/src/Tizen.Content.MediaContent/Interop/Interop.Face.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.Face.cs
@@ -20,53 +20,53 @@ using Tizen.Content.MediaContent;
 
 internal static partial class Interop
 {
-    internal static partial class Face
+    internal static partial class Face // Deprecated all
     {
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_create")]
-        internal static extern MediaContentError Create(string mediaId, out IntPtr face);
+        internal static extern MediaContentError Create(string mediaId, out IntPtr face); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_destroy")]
-        internal static extern MediaContentError Destroy(IntPtr face);
+        internal static extern MediaContentError Destroy(IntPtr face); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_clone")]
-        internal static extern MediaContentError Clone(out IntPtr dst, IntPtr src);
+        internal static extern MediaContentError Clone(out IntPtr dst, IntPtr src); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_get_face_id")]
-        internal static extern MediaContentError GetId(IntPtr face, out IntPtr faceId);
+        internal static extern MediaContentError GetId(IntPtr face, out IntPtr faceId); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_get_media_id")]
-        internal static extern MediaContentError GetMediaId(IntPtr face, out IntPtr mediaId);
+        internal static extern MediaContentError GetMediaId(IntPtr face, out IntPtr mediaId); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_get_face_rect")]
-        internal static extern MediaContentError GetFaceRect(IntPtr face,
+        internal static extern MediaContentError GetFaceRect(IntPtr face, // Deprecated
             out int x, out int y, out int w, out int h);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_get_orientation")]
-        internal static extern MediaContentError GetOrientation(IntPtr face, out Orientation orientation);
+        internal static extern MediaContentError GetOrientation(IntPtr face, out Orientation orientation); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_get_tag")]
-        internal static extern MediaContentError GetTag(IntPtr face, out IntPtr tag);
+        internal static extern MediaContentError GetTag(IntPtr face, out IntPtr tag); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_set_face_rect")]
-        internal static extern MediaContentError SetFaceRect(IntPtr face, int x, int y, int w, int h);
+        internal static extern MediaContentError SetFaceRect(IntPtr face, int x, int y, int w, int h); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_set_orientation")]
-        internal static extern MediaContentError SetOrientation(IntPtr face, Orientation orientation);
+        internal static extern MediaContentError SetOrientation(IntPtr face, Orientation orientation); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_set_tag")]
-        internal static extern MediaContentError SetTag(IntPtr face, string tag);
+        internal static extern MediaContentError SetTag(IntPtr face, string tag); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_insert_to_db")]
-        internal static extern MediaContentError Insert(IntPtr handle);
+        internal static extern MediaContentError Insert(IntPtr handle); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_update_to_db")]
-        internal static extern MediaContentError Update(IntPtr face);
+        internal static extern MediaContentError Update(IntPtr face); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_delete_from_db")]
-        internal static extern MediaContentError DeleteFromDb(string faceId);
+        internal static extern MediaContentError DeleteFromDb(string faceId); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_face_foreach_face_from_db")]
-        internal static extern MediaContentError ForeachFromDb(FilterHandle filter,
+        internal static extern MediaContentError ForeachFromDb(FilterHandle filter, // Deprecated
             Common.ItemCallback callback, IntPtr userData = default(IntPtr));
     }
 }

--- a/src/Tizen.Content.MediaContent/Interop/Interop.ImageInfo.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.ImageInfo.cs
@@ -32,16 +32,16 @@ internal static partial class Interop
         internal static extern MediaContentError GetDateTaken(IntPtr handle, out IntPtr dateTaken);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_exposure_time", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern MediaContentError GetExposureTime(IntPtr handle, out IntPtr exposureTime);
+        internal static extern MediaContentError GetExposureTime(IntPtr handle, out IntPtr exposureTime); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_fnumber", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern MediaContentError GetFNumber(IntPtr handle, out double fNumber);
+        internal static extern MediaContentError GetFNumber(IntPtr handle, out double fNumber); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_iso", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern MediaContentError GetISO(IntPtr handle, out int iso);
+        internal static extern MediaContentError GetISO(IntPtr handle, out int iso); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_model", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern MediaContentError GetModel(IntPtr handle, out IntPtr model);
+        internal static extern MediaContentError GetModel(IntPtr handle, out IntPtr model); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "image_meta_get_width", CallingConvention = CallingConvention.Cdecl)]
         internal static extern MediaContentError GetWidth(IntPtr handle, out int width);

--- a/src/Tizen.Content.MediaContent/Interop/Interop.MediaInfo.cs
+++ b/src/Tizen.Content.MediaContent/Interop/Interop.MediaInfo.cs
@@ -33,7 +33,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_insert_batch_to_db")]
         internal static extern MediaContentError BatchInsert(string[] filePathArray, int arrayLength,
-            InsertCompletedCallback callback, IntPtr userData = default(IntPtr));
+            InsertCompletedCallback callback, IntPtr userData = default);
 
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_destroy")]
@@ -44,28 +44,28 @@ internal static partial class Interop
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_foreach_media_from_db")]
         internal static extern MediaContentError ForeachMedia(FilterHandle filter, Common.ItemCallback callback,
-            IntPtr userData = default(IntPtr));
+            IntPtr userData = default);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_get_tag_count_from_db")]
         internal static extern MediaContentError GetTagCount(string mediaId, FilterHandle filter, out int tagCount);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_foreach_tag_from_db")]
         internal static extern MediaContentError ForeachTags(string mediaId, FilterHandle filter,
-            Common.ItemCallback callback, IntPtr userData = default(IntPtr));
+            Common.ItemCallback callback, IntPtr userData = default);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_get_bookmark_count_from_db")]
         internal static extern MediaContentError GetBookmarkCount(string mediaId, FilterHandle filter, out int bookmarkCount);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_foreach_bookmark_from_db")]
         internal static extern MediaContentError ForeachBookmarks(string mediaId, FilterHandle filter,
-            Common.ItemCallback callback, IntPtr userData = default(IntPtr));
+            Common.ItemCallback callback, IntPtr userData = default);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_get_face_count_from_db")]
-        internal static extern MediaContentError GetFaceCount(string mediaId, FilterHandle filter, out int bookmarkCount);
+        internal static extern MediaContentError GetFaceCount(string mediaId, FilterHandle filter, out int bookmarkCount); // Deprecated
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_foreach_face_from_db")]
-        internal static extern MediaContentError ForeachFaces(string mediaId, FilterHandle filter,
-            Common.ItemCallback callback, IntPtr userData = default(IntPtr));
+        internal static extern MediaContentError ForeachFaces(string mediaId, FilterHandle filter, // Deprecated
+            Common.ItemCallback callback, IntPtr userData = default);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_get_image")]
         internal static extern MediaContentError GetImage(MediaInfoHandle handle, out IntPtr imageHandle);
@@ -149,11 +149,11 @@ internal static partial class Interop
         internal static extern MediaContentError GenerateThumbnail(MediaInfoHandle handle);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_start_face_detection")]
-        internal static extern MediaContentError StartFaceDetection(MediaInfoHandle handle,
-            FaceDetectionCompletedCallback callback, IntPtr userData = default(IntPtr));
+        internal static extern MediaContentError StartFaceDetection(MediaInfoHandle handle, // Deprecated
+            FaceDetectionCompletedCallback callback, IntPtr userData = default);
 
         [DllImport(Libraries.MediaContent, EntryPoint = "media_info_cancel_face_detection")]
-        internal static extern MediaContentError CancelFaceDetection(MediaInfoHandle handle);
+        internal static extern MediaContentError CancelFaceDetection(MediaInfoHandle handle); // Deprecated
     }
 
     internal sealed class MediaInfoHandle : SafeHandle

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/Columns.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/Columns.cs
@@ -614,6 +614,7 @@ namespace Tizen.Content.MediaContent
     /// <seealso cref="MediaInfoCommand.CountFaceInfo(string, CountArguments)"/>
     /// <seealso cref="MediaInfoCommand.SelectFaceInfo(string, SelectArguments)"/>
     /// <since_tizen> 4 </since_tizen>
+    [Obsolete("Deprecated since API11; Will be removed in API13.")]
     public static class FaceInfoColumns
     {
         /// <summary>
@@ -625,6 +626,7 @@ namespace Tizen.Content.MediaContent
         /// </remarks>
         /// <seealso cref="FaceInfo.Tag"/>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public static string Tag => "MEDIA_FACE_TAG";
 
         /// <summary>
@@ -636,6 +638,7 @@ namespace Tizen.Content.MediaContent
         /// </remarks>
         /// <seealso cref="FaceInfo.Id"/>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public static string Id => "MEDIA_FACE_ID";
     }
 }

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/FaceInfo.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/FaceInfo.cs
@@ -22,6 +22,7 @@ namespace Tizen.Content.MediaContent
     /// Represents the face information for the media.
     /// </summary>
     /// <since_tizen> 4 </since_tizen>
+    [Obsolete("Deprecated since API11; Will be removed in API13.")]
     public class FaceInfo
     {
         internal FaceInfo(IntPtr handle)
@@ -51,6 +52,7 @@ namespace Tizen.Content.MediaContent
         /// The coordinates of the rectangle are orientation-applied values.
         /// </remarks>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public Rectangle Rect { get; }
 
         /// <summary>
@@ -58,6 +60,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The unique ID of face information.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public string Id { get; }
 
         /// <summary>
@@ -65,6 +68,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The media ID that the face information is added.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public string MediaInfoId { get; }
 
         /// <summary>
@@ -72,6 +76,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The tag of face information.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public string Tag { get; }
 
         /// <summary>
@@ -79,6 +84,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The orientation of face information.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public Orientation Orientation { get; }
 
         internal static FaceInfo FromHandle(IntPtr handle)
@@ -91,6 +97,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <returns>A string representation of the current face info.</returns>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public override string ToString() =>
             $"Id={Id}, MediaInfoId={MediaInfoId}, Rect=({Rect}), Tag={Tag}";
     }

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/FaceInfoCommand.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/FaceInfoCommand.cs
@@ -23,6 +23,7 @@ namespace Tizen.Content.MediaContent
     /// </summary>
     /// <seealso cref="Album"/>
     /// <since_tizen> 4 </since_tizen>
+    [Obsolete("Deprecated since API11; Will be removed in API13.")]
     public class FaceInfoCommand : MediaCommand
     {
         /// <summary>
@@ -32,6 +33,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ArgumentNullException"><paramref name="database"/> is null.</exception>
         /// <exception cref="ObjectDisposedException"><paramref name="database"/> has already been disposed.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public FaceInfoCommand(MediaDatabase database) : base(database)
         {
         }
@@ -49,6 +51,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ArgumentException"><paramref name="faceInfoId"/> is a zero-length string, contains only white space.</exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public bool Delete(string faceInfoId)
         {
             ValidateDatabase();
@@ -74,6 +77,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ObjectDisposedException">The <see cref="MediaDatabase"/> has already been disposed.</exception>
         /// <exception cref="MediaDatabaseException">An error occurred while executing the command.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public MediaDataReader<FaceInfo> Select()
         {
             return Select(null);
@@ -88,6 +92,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ObjectDisposedException">The <see cref="MediaDatabase"/> has already been disposed.</exception>
         /// <exception cref="MediaDatabaseException">An error occurred while executing the command.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public MediaDataReader<FaceInfo> Select(SelectArguments filter)
         {
             ValidateDatabase();
@@ -109,6 +114,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ArgumentException"><paramref name="faceInfoId"/> is a zero-length string, contains only white space.</exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public bool UpdateTag(string faceInfoId, string tag)
         {
             ValidateDatabase();
@@ -160,6 +166,7 @@ namespace Tizen.Content.MediaContent
         /// </exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public FaceInfo Insert(string mediaId, Rectangle area, Orientation orientation)
         {
             return Insert(mediaId, area, orientation, null);
@@ -185,6 +192,7 @@ namespace Tizen.Content.MediaContent
         /// </exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
         /// <since_tizen> 6 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public FaceInfo Insert(string mediaId, Rectangle area, Orientation orientation, string tag)
         {
             ValidateDatabase();

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/ImageInfo.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/ImageInfo.cs
@@ -88,6 +88,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The exposure time from EXIF.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public string ExposureTime { get; }
 
         /// <summary>
@@ -95,6 +96,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The FNumber from EXIF.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public double FNumber { get; }
 
         /// <summary>
@@ -102,6 +104,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The iso from EXIF.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public int Iso { get; }
 
         /// <summary>
@@ -109,6 +112,7 @@ namespace Tizen.Content.MediaContent
         /// </summary>
         /// <value>The model from EXIF.</value>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public string Model { get; }
     }
 }

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfoCommand.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfoCommand.cs
@@ -184,6 +184,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ArgumentNullException"><paramref name="mediaId"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="mediaId"/> is a zero-length string, contains only white space.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public MediaDataReader<FaceInfo> SelectFaceInfo(string mediaId, SelectArguments arguments)
         {
             ValidateDatabase();

--- a/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfoCommand.cs
+++ b/src/Tizen.Content.MediaContent/Tizen.Content.MediaContent/MediaInfoCommand.cs
@@ -145,6 +145,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ArgumentNullException"><paramref name="mediaId"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="mediaId"/> is a zero-length string, contains only white space.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public int CountFaceInfo(string mediaId, CountArguments arguments)
         {
             ValidateDatabase();
@@ -165,6 +166,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="ArgumentNullException"><paramref name="mediaId"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="mediaId"/> is a zero-length string, contains only white space.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public MediaDataReader<FaceInfo> SelectFaceInfo(string mediaId)
         {
             return SelectFaceInfo(mediaId, null);
@@ -1068,6 +1070,7 @@ namespace Tizen.Content.MediaContent
         /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
         /// <exception cref="UnauthorizedAccessException">The caller has no required privilege.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public Task<int> DetectFaceAsync(string mediaId)
         {
             return DetectFaceAsync(mediaId, CancellationToken.None);
@@ -1106,6 +1109,7 @@ namespace Tizen.Content.MediaContent
         /// </exception>
         /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
         /// <since_tizen> 4 </since_tizen>
+        [Obsolete("Deprecated since API11; Will be removed in API13.")]
         public Task<int> DetectFaceAsync(string mediaId, CancellationToken cancellationToken)
         {
             if (Features.IsSupported(Features.FaceRecognition) == false)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Deprecated unused APIs
- FaceInfo, FaceInfoCommand class
- Some properties of ImageInfo class
- Face APIs of MediaInfoCommand class

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - TCSACR-547

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
