### PR TITLE
[NUI] Change all CallingConvention to `Cdecl`

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -873,7 +873,7 @@ namespace Tizen.NUI.Components
 
         private Animation scrollAnimation;
         // Declare user alpha function delegate
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate float UserAlphaFunctionDelegate(float progress);
         private UserAlphaFunctionDelegate customScrollAlphaFunction;
         private float velocityOfLastPan = 0.0f;

--- a/src/Tizen.NUI/src/internal/Application/ComponentApplication.cs
+++ b/src/Tizen.NUI/src/internal/Application/ComponentApplication.cs
@@ -85,7 +85,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate IntPtr NUIComponentApplicationCreatenativeEventCallbackDelegate();
 
         public delegate IntPtr CreateNativeEventHandler();

--- a/src/Tizen.NUI/src/internal/Application/WatchApplication.cs
+++ b/src/Tizen.NUI/src/internal/Application/WatchApplication.cs
@@ -128,7 +128,7 @@ namespace Tizen.NUI
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TimeTickCallbackType(IntPtr application, IntPtr watchTime);
         private TimeTickCallbackType timeTickCallback;
         private DaliEventHandler<object, TimeTickEventArgs> timeTickEventHandler;
@@ -200,7 +200,7 @@ namespace Tizen.NUI
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AmbientTickCallbackType(IntPtr application, IntPtr watchTime);
         private AmbientTickCallbackType ambientTickCallback;
         private DaliEventHandler<object, AmbientTickEventArgs> ambientTickEventHandler;
@@ -272,7 +272,7 @@ namespace Tizen.NUI
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AmbientChangedCallbackType(IntPtr application, bool changed);
         private AmbientChangedCallbackType ambientChangedCallback;
         private DaliEventHandler<object, AmbientChangedEventArgs> ambientChangedEventHandler;

--- a/src/Tizen.NUI/src/internal/Common/DaliEventHandler.cs
+++ b/src/Tizen.NUI/src/internal/Common/DaliEventHandler.cs
@@ -22,7 +22,7 @@ using System.Runtime.InteropServices;
 namespace Tizen.NUI
 {
     /// <summary>
-    /// [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    /// [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -32,7 +32,7 @@ namespace Tizen.NUI
     public delegate R DaliEventHandlerWithReturnType<T, U, R>(T source, U e);
 
     /// <summary>
-    /// [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    /// [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -42,7 +42,7 @@ namespace Tizen.NUI
     internal delegate void EventCallbackDelegateType1(IntPtr arg1);
 
     /// <summary>
-    /// [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    /// [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     /// this should be removed with EventHandler from .NET
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
@@ -53,7 +53,7 @@ namespace Tizen.NUI
     public delegate void DaliEventHandler<T, U>(T source, U e);
 
     /// <summary>
-    /// [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    /// [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -63,9 +63,9 @@ namespace Tizen.NUI
     public delegate R EventHandlerWithReturnType<T, U, R>(T source, U e);
 
     /// <summary>
-    /// [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    /// [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     /// </summary>
-    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public delegate TReturn ReturnTypeEventHandler<TSource, TEvent, TReturn>(TSource source, TEvent e);
 }

--- a/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
+++ b/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
@@ -65,12 +65,12 @@ namespace Tizen.NUI
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ObjectCreatedEventCallbackDelegate(IntPtr baseHandle);
         private DaliEventHandler<object, ObjectCreatedEventArgs> objectRegistryObjectCreatedEventHandler;
         private ObjectCreatedEventCallbackDelegate objectRegistryObjectCreatedEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ObjectDestroyedEventCallbackDelegate(IntPtr fefObject);
         private DaliEventHandler<object, ObjectDestroyedEventArgs> objectRegistryObjectDestroyedEventHandler;
         private ObjectDestroyedEventCallbackDelegate objectRegistryObjectDestroyedEventCallbackDelegate;

--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -50,7 +50,7 @@ namespace Tizen.NUI
             Interop.ProcessorController.SetCallback(SwigCPtr, processorCallback);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ProcessorEventHandler();
 
         private ProcessorEventHandler processorCallback = null;

--- a/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
@@ -46,7 +46,7 @@ namespace Tizen.NUI
             finishedCallbackOfNative = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(transitionSetFinishedEventCallback);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TransitionSetFinishedEventCallbackType(IntPtr data);
 
         private event EventHandler transitionSetFinishedEventHandler;

--- a/src/Tizen.NUI/src/internal/Utility/Builder.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Builder.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI
         {
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void QuitEventCallbackDelegate();
         private DaliEventHandler<object, QuitEventArgs> builderQuitEventHandler;
         private QuitEventCallbackDelegate builderQuitEventCallbackDelegate;

--- a/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
@@ -82,7 +82,7 @@ namespace Tizen.NUI
             base.Dispose(type);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FinishedCallbackType(IntPtr application);
         private DaliEventHandler<object, EventArgs> finishedEventHandler;
         private FinishedCallbackType finishedCallback;

--- a/src/Tizen.NUI/src/internal/Utility/PageTurnView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/PageTurnView.cs
@@ -154,22 +154,22 @@ namespace Tizen.NUI
 
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void PagePanStartedCallbackDelegate(IntPtr page);
         private DaliEventHandler<object, PagePanStartedEventArgs> pageTurnViewPagePanStartedEventHandler;
         private PagePanStartedCallbackDelegate pageTurnViewPagePanStartedCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void PagePanFinishedCallbackDelegate(IntPtr page);
         private DaliEventHandler<object, PagePanFinishedEventArgs> pageTurnViewPagePanFinishedEventHandler;
         private PagePanFinishedCallbackDelegate pageTurnViewPagePanFinishedCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void PageTurnStartedCallbackDelegate(IntPtr page, uint pageIndex, bool isTurningForward);
         private DaliEventHandler<object, PageTurnStartedEventArgs> pageTurnViewPageTurnStartedEventHandler;
         private PageTurnStartedCallbackDelegate pageTurnViewPageTurnStartedCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void PageTurnFinishedCallbackDelegate(IntPtr page, uint pageIndex, bool isTurningForward);
         private DaliEventHandler<object, PageTurnFinishedEventArgs> pageTurnViewPageTurnFinishedEventHandler;
         private PageTurnFinishedCallbackDelegate pageTurnViewPageTurnFinishedCallbackDelegate;

--- a/src/Tizen.NUI/src/internal/WebView/WebContext.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebContext.cs
@@ -80,52 +80,52 @@ namespace Tizen.NUI
         /// <summary>
         /// The callback function that is invoked when security origin list is acquired.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void SecurityOriginListAcquiredCallback(IList<WebSecurityOrigin> list);
 
         /// <summary>
         /// The callback function that is invoked when storage usage is acquired.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void StorageUsageAcquiredCallback(ulong usage);
 
         /// <summary>
         /// The callback function that is invoked when password data list is acquired.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void PasswordDataListAcquiredCallback(IList<WebPasswordData> list);
 
         /// <summary>
         /// The callback function that is invoked when download is started.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void DownloadStartedCallback(string url);
 
         /// <summary>
         /// The callback function that is invoked when current mime type need be overridden.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate bool MimeOverriddenCallback(string url, string currentMime, out string newMime);
 
         /// <summary>
         /// The callback function that is invoked when http request need be intercepted.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void HttpRequestInterceptedCallback(WebHttpRequestInterceptor interceptor);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebContextSecurityOriginListAcquiredProxyCallback(IntPtr list);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebContextPasswordDataListAcquiredProxyCallback(IntPtr list);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebContextHttpRequestInterceptedProxyCallback(IntPtr interceptor);
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/WebView/WebCookieManager.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebCookieManager.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI
         {
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void CookieChangedCallback();
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -315,7 +315,7 @@ namespace Tizen.NUI.Accessibility
 
         #region Private
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SayFinishedEventCallbackType(int result);
 
         private static SayFinishedEventCallbackType callback = SayFinishedEventCallback;

--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManagerEvent.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManagerEvent.cs
@@ -23,150 +23,142 @@ namespace Tizen.NUI.Accessibility
 {
     public partial class AccessibilityManager
     {
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool StatusChangedEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerStatusChangedEventHandler;
         private StatusChangedEventCallbackDelegate accessibilityManagerStatusChangedEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionNextEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionNextEventHandler;
         private ActionNextEventCallbackDelegate accessibilityManagerActionNextEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionPreviousEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionPreviousEventHandler;
         private ActionPreviousEventCallbackDelegate accessibilityManagerActionPreviousEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionActivateEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionActivateEventHandler;
         private ActionActivateEventCallbackDelegate accessibilityManagerActionActivateEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionReadEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionReadEventHandler;
         private ActionReadEventCallbackDelegate accessibilityManagerActionReadEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionOverEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionOverEventHandler;
         private ActionOverEventCallbackDelegate accessibilityManagerActionOverEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionReadNextEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionReadNextEventHandler;
         private ActionReadNextEventCallbackDelegate accessibilityManagerActionReadNextEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionReadPreviousEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionReadPreviousEventHandler;
         private ActionReadPreviousEventCallbackDelegate accessibilityManagerActionReadPreviousEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionUpEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionUpEventHandler;
         private ActionUpEventCallbackDelegate accessibilityManagerActionUpEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionDownEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionDownEventHandler;
         private ActionDownEventCallbackDelegate accessibilityManagerActionDownEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionClearFocusEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionClearFocusEventHandler;
         private ActionClearFocusEventCallbackDelegate accessibilityManagerActionClearFocusEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionBackEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionBackEventHandler;
         private ActionBackEventCallbackDelegate accessibilityManagerActionBackEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionScrollUpEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionScrollUpEventHandler;
         private ActionScrollUpEventCallbackDelegate accessibilityManagerActionScrollUpEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionScrollDownEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionScrollDownEventHandler;
         private ActionScrollDownEventCallbackDelegate accessibilityManagerActionScrollDownEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionPageLeftEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionPageLeftEventHandler;
         private ActionPageLeftEventCallbackDelegate accessibilityManagerActionPageLeftEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionPageRightEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionPageRightEventHandler;
         private ActionPageRightEventCallbackDelegate accessibilityManagerActionPageRightEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionPageUpEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionPageUpEventHandler;
         private ActionPageUpEventCallbackDelegate accessibilityManagerActionPageUpEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionPageDownEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionPageDownEventHandler;
         private ActionPageDownEventCallbackDelegate accessibilityManagerActionPageDownEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionMoveToFirstEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionMoveToFirstEventHandler;
         private ActionMoveToFirstEventCallbackDelegate accessibilityManagerActionMoveToFirstEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionMoveToLastEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionMoveToLastEventHandler;
         private ActionMoveToLastEventCallbackDelegate accessibilityManagerActionMoveToLastEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionReadFromTopEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionReadFromTopEventHandler;
         private ActionReadFromTopEventCallbackDelegate accessibilityManagerActionReadFromTopEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionReadFromNextEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionReadFromNextEventHandler;
         private ActionReadFromNextEventCallbackDelegate accessibilityManagerActionReadFromNextEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionZoomEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionZoomEventHandler;
         private ActionZoomEventCallbackDelegate accessibilityManagerActionZoomEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionReadPauseResumeEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionReadPauseResumeEventHandler;
         private ActionReadPauseResumeEventCallbackDelegate accessibilityManagerActionReadPauseResumeEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool ActionStartStopEventCallbackDelegate(IntPtr accessibilityManager);
         private ReturnTypeEventHandler<object, EventArgs, bool> accessibilityManagerActionStartStopEventHandler;
         private ActionStartStopEventCallbackDelegate accessibilityManagerActionStartStopEventCallbackDelegate;
 
-        /*
-            // To be replaced by a new event that takes Touch
-            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-            private delegate bool ActionScrollEventCallbackDelegate(IntPtr accessibilityManager, IntPtr touchEvent);
-            private EventHandlerWithReturnType<object,ActionScrollEventArgs,bool> _accessibilityManagerActionScrollEventHandler;
-            private ActionScrollEventCallbackDelegate _accessibilityManagerActionScrollEventCallbackDelegate;
-        */
-
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusChangedEventCallbackDelegate(IntPtr view1, IntPtr view2);
         private EventHandler<FocusChangedEventArgs> accessibilityManagerFocusChangedEventHandler;
         private FocusChangedEventCallbackDelegate accessibilityManagerFocusChangedEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusedViewActivatedEventCallbackDelegate(IntPtr view);
         private EventHandler<FocusedViewActivatedEventArgs> accessibilityManagerFocusedViewActivatedEventHandler;
         private FocusedViewActivatedEventCallbackDelegate accessibilityManagerFocusedViewActivatedEventCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusOvershotEventCallbackDelegate(IntPtr currentFocusedView, AccessibilityManager.FocusOvershotDirection direction);
         private EventHandler<FocusOvershotEventArgs> accessibilityManagerFocusOvershotEventHandler;
         private FocusOvershotEventCallbackDelegate accessibilityManagerFocusOvershotEventCallbackDelegate;

--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -75,10 +75,10 @@ namespace Tizen.NUI
             finishedCallbackOfNative = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(animationFinishedEventCallback);
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnimationFinishedEventCallbackType(IntPtr data);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnimationProgressReachedEventCallbackType(IntPtr data);
 
         private event EventHandler animationFinishedEventHandler;

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -196,9 +196,9 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ResourceReadyEventCallbackType(IntPtr data);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void _resourceLoadedCallbackType(IntPtr view);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1175,7 +1175,7 @@ namespace Tizen.NUI.BaseComponents
             NUILog.Debug($"<[{GetId()}] onVisualEventSignal()! visualIndex={visualIndex}, signalId={signalId}>");
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void VisualEventSignalCallbackType(IntPtr targetView, int visualIndex, int signalId);
 
         private VisualEventSignalCallbackType visualEventSignalCallback;

--- a/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
@@ -219,13 +219,13 @@ namespace Tizen.NUI.BaseComponents
         {
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void StartedCallbackDelegate(IntPtr vector2);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void UpdatedCallbackDelegate(IntPtr vector2);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void CompletedCallbackDelegate(IntPtr vector2);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorEvent.cs
@@ -54,31 +54,31 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<InputFilteredEventArgs> textEditorInputFilteredEventHandler;
         private InputFilteredCallbackDelegate textEditorInputFilteredCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TextChangedCallbackDelegate(IntPtr textEditor);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ScrollStateChangedCallbackDelegate(IntPtr textEditor, ScrollState state);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void CursorPositionChangedCallbackDelegate(IntPtr textEditor, uint oldPosition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textEditor);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SelectionClearedCallbackDelegate(IntPtr textEditor);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SelectionStartedCallbackDelegate(IntPtr textEditor);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnchorClickedCallbackDelegate(IntPtr textEditor, IntPtr href, uint hrefLength);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SelectionChangedCallbackDelegate(IntPtr textEditor, uint oldStart, uint oldEnd);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void InputFilteredCallbackDelegate(IntPtr textEditor, InputFilterType type);
 
         private bool invokeTextChanged = true;

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldEvent.cs
@@ -47,28 +47,28 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler textFieldSelectionStartedEventHandler;
         private SelectionStartedCallbackDelegate textFieldSelectionStartedCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TextChangedCallbackDelegate(IntPtr textField);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void CursorPositionChangedCallbackDelegate(IntPtr textField, uint oldPosition);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void MaxLengthReachedCallbackDelegate(IntPtr textField);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnchorClickedCallbackDelegate(IntPtr textField, IntPtr href, uint hrefLength);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SelectionChangedCallbackDelegate(IntPtr textField, uint oldStart, uint oldEnd);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void InputFilteredCallbackDelegate(IntPtr textField, InputFilterType type);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SelectionClearedCallbackDelegate(IntPtr textField);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SelectionStartedCallbackDelegate(IntPtr textField);
 
         private bool invokeTextChanged = true;

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
@@ -35,10 +35,10 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler textLabelTextFitChangedEventHandler;
         private TextFitChangedCallbackDelegate textLabelTextFitChangedCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnchorClickedCallbackDelegate(IntPtr textLabel, IntPtr href, uint hrefLength);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TextFitChangedCallbackDelegate(IntPtr textLabel);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -199,7 +199,7 @@ namespace Tizen.NUI.BaseComponents
         {
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FinishedCallbackDelegate(IntPtr data);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -62,21 +62,21 @@ namespace Tizen.NUI.BaseComponents
         private _backgroundResourceLoadedCallbackType backgroundResourceLoadedCallback;
         private TouchDataCallbackType hitTestResultDataCallback;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OffWindowEventCallbackType(IntPtr control);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool WheelEventCallbackType(IntPtr view, IntPtr wheelEvent);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool KeyCallbackType(IntPtr control, IntPtr keyEvent);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool TouchDataCallbackType(IntPtr view, IntPtr touchData);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool HoverEventCallbackType(IntPtr view, IntPtr hoverEvent);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void VisibilityChangedEventCallbackType(IntPtr data, bool visibility, VisibilityChangeType type);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ResourcesLoadedCallbackType(IntPtr control);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void _backgroundResourceLoadedCallbackType(IntPtr view);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -84,11 +84,11 @@ namespace Tizen.NUI.BaseComponents
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void KeyInputFocusLostCallbackType(IntPtr control);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OnRelayoutEventCallbackType(IntPtr control);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OnWindowEventCallbackType(IntPtr control);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void LayoutDirectionChangedEventCallbackType(IntPtr data, ViewLayoutDirectionType type);
 
         // List of dispatch Event

--- a/src/Tizen.NUI/src/public/Clipboard/ClipboardEvent.cs
+++ b/src/Tizen.NUI/src/public/Clipboard/ClipboardEvent.cs
@@ -68,7 +68,7 @@ namespace Tizen.NUI
         private EventHandler<ClipboardEventArgs> clipboardDataReceivedEventHandler;
         private ClipboardDataReceivedCallback clipboardDataReceivedCallback;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ClipboardDataReceivedCallback(uint id, string mimeType, string data);
 
         private event EventHandler<ClipboardEventArgs> ClipboardDataReceived

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -31,7 +31,7 @@ namespace Tizen.NUI
         private int layoutCount = 0;
         private EventHandler<VisibilityChangedEventArgs> visibilityChangedEventHandler;
         private VisibilityChangedEventCallbackType visibilityChangedEventCallback;
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void VisibilityChangedEventCallbackType(IntPtr data, bool visibility, VisibilityChangeType type);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
@@ -54,7 +54,7 @@ namespace Tizen.NUI
         {
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void NotifyEventCallbackDelegate(IntPtr propertyNotification);
 
         ///<summary>

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -48,7 +48,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void StyleChangedCallbackDelegate(IntPtr styleManager, Tizen.NUI.StyleChangeType styleChange);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
+++ b/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
@@ -211,13 +211,13 @@ namespace Tizen.NUI
             propertyRangeManager = new PropertyRangeManager();
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate IntPtr CreateControlDelegate(IntPtr cPtrControlName);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate IntPtr GetPropertyDelegate(IntPtr controlPtr, IntPtr propertyName);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SetPropertyDelegate(IntPtr controlPtr, IntPtr propertyName, IntPtr propertyValue);
 
         /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
@@ -82,7 +82,7 @@ namespace Tizen.NUI
         }
 
         private DaliEventHandler<object, DetectedEventArgs> detectedEventHandler;
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void DetectedCallbackType(IntPtr actor, IntPtr longPressGesture);
         private DetectedCallbackType detectedCallback;
 

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -55,7 +55,7 @@ namespace Tizen.NUI
         }
 
         private DaliEventHandler<object, DetectedEventArgs> detectedEventHandler;
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void DetectedCallbackType(IntPtr actor, IntPtr panGesture);
         private DetectedCallbackType detectedCallback;
 

--- a/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
@@ -55,7 +55,7 @@ namespace Tizen.NUI
         }
 
         private DaliEventHandler<object, DetectedEventArgs> detectedEventHandler;
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void DetectedCallbackType(IntPtr actor, IntPtr pinchGesture);
         private DetectedCallbackType detectedCallback;
 

--- a/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
@@ -55,7 +55,7 @@ namespace Tizen.NUI
         }
 
         private DaliEventHandler<object, DetectedEventArgs> detectedEventHandler;
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void DetectedCallbackType(IntPtr actor, IntPtr rotationGesture);
         private DetectedCallbackType detectedCallback;
 

--- a/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
@@ -57,7 +57,7 @@ namespace Tizen.NUI
         }
 
         private DaliEventHandler<object, DetectedEventArgs> _detectedEventHandler;
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void DetectedCallbackType(IntPtr actor, IntPtr TapGesture);
         private DetectedCallbackType _detectedCallback;
 

--- a/src/Tizen.NUI/src/public/Input/AutofillContainer.cs
+++ b/src/Tizen.NUI/src/public/Input/AutofillContainer.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI
         private event EventHandler<AuthenticationEventArgs> authenticationEventHandler;
         private event EventHandler<ListEventArgs> listEventHandler;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AuthenticationEventCallbackType(IntPtr autofillContainer);
         private delegate void ListEventCallbackType(IntPtr control);
 

--- a/src/Tizen.NUI/src/public/Input/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/Input/FocusManager.cs
@@ -60,19 +60,19 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate IntPtr PreFocusChangeEventCallback(IntPtr current, IntPtr proposed, View.FocusDirection direction);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void FocusChangedEventCallback(IntPtr current, IntPtr next);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusGroupChangedEventCallback(IntPtr current, bool forwardDirection);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusedViewEnterKeyEventCallback(IntPtr view);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusedViewEnterKeyEventCallback2(IntPtr view);
 
         private View internalFocusIndicator = null;

--- a/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
@@ -50,7 +50,7 @@ namespace Tizen.NUI
         {
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ActivatedEventCallbackType(IntPtr data);
         private delegate IntPtr EventReceivedEventCallbackType(IntPtr inputMethodContext, IntPtr eventData);
         private delegate void StatusChangedEventCallbackType(bool statusChanged);

--- a/src/Tizen.NUI/src/public/Utility/CubeTransitionEffect.cs
+++ b/src/Tizen.NUI/src/public/Utility/CubeTransitionEffect.cs
@@ -33,7 +33,7 @@ namespace Tizen.NUI
         private EventHandler<TransitionCompletedEventArgs> transitionCompletedEventHandler;
         private TransitionCompletedCallbackDelegate _transitionCompletedCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TransitionCompletedCallbackDelegate(IntPtr cubeTransition, IntPtr cubeTexture);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Utility/ScrollViewEvent.cs
+++ b/src/Tizen.NUI/src/public/Utility/ScrollViewEvent.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
         private DaliEventHandler<object, SnapStartedEventArgs> scrollViewSnapStartedEventHandler;
         private SnapStartedCallbackDelegate scrollViewSnapStartedCallbackDelegate;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void SnapStartedCallbackDelegate(IntPtr data);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
+++ b/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
@@ -44,7 +44,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void StateChangedEventCallbackType(TTSState prevState, TTSState nextState);
         private event EventHandler<StateChangedEventArgs> stateChangedEventHandler;
 

--- a/src/Tizen.NUI/src/public/Utility/Timer.cs
+++ b/src/Tizen.NUI/src/public/Utility/Timer.cs
@@ -74,7 +74,7 @@ namespace Tizen.NUI
             Tizen.Log.Debug("NUI", $"(0x{SwigCPtr.Handle:X})Timer() destructor!, disposed={disposed}");
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool TickCallbackDelegate();
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -180,109 +180,109 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// The callback function that is invoked when the message is received from the script.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void JavaScriptMessageHandler(string message);
 
         /// <summary>
         /// The callback function that is invoked when the message is received from the script.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void JavaScriptAlertCallback(string message);
 
         /// <summary>
         /// The callback function that is invoked when the message is received from the script.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void JavaScriptConfirmCallback(string message);
 
         /// <summary>
         /// The callback function that is invoked when the message is received from the script.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void JavaScriptPromptCallback(string message1, string message2);
 
         /// <summary>
         /// The callback function that is invoked when screen shot is acquired asynchronously.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void ScreenshotAcquiredCallback(ImageView image);
 
         /// <summary>
         /// The callback function that is invoked when video playing is checked asynchronously.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void VideoPlayingCallback(bool isPlaying);
 
         /// <summary>
         /// The callback function that is invoked when geolocation permission is requested.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void GeolocationPermissionCallback(string host, string protocol);
 
         /// <summary>
         /// The callback function that is invoked when hit test is finished.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void HitTestFinishedCallback(WebHitTestResult test);
 
         /// <summary>
         /// The callback function that is invoked when the plain text of the current page is received.
         /// </summary>
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void PlainTextReceivedCallback(string plainText);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewPageLoadCallback(string pageUrl);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewPageLoadErrorCallback(IntPtr error);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewScrollEdgeReachedCallback(int edge);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewUrlChangedCallback(string pageUrl);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewFormRepostPolicyDecidedCallback(IntPtr maker);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewFrameRenderedCallback();
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewScreenshotAcquiredProxyCallback(IntPtr data);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewHitTestFinishedProxyCallback(IntPtr data);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewPolicyDecidedCallback(IntPtr maker);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewNewWindowCreatedCallback(out IntPtr outView);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewCertificateReceivedCallback(IntPtr certificate);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewHttpAuthRequestedCallback(IntPtr handler);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewConsoleMessageReceivedCallback(IntPtr message);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewContextMenuShownCallback(IntPtr menu);
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WebViewContextMenuHiddenCallback(IntPtr menu);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -184,17 +184,17 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WidgetAddedEventCallbackType(IntPtr data);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WidgetContentUpdatedEventCallbackType(IntPtr data);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WidgetDeletedEventCallbackType(IntPtr data);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WidgetCreationAbortedEventCallbackType(IntPtr data);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WidgetUpdatePeriodChangedEventCallbackType(IntPtr data);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WidgetFaultedEventCallbackType(IntPtr data);
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Window/GLWindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/GLWindowEvent.cs
@@ -29,11 +29,11 @@ namespace Tizen.NUI
         private EventCallbackDelegateType1 windowKeyCallbackDelegate;
         private WindowResizedEventCallbackType windowResizedEventCallback;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusChangedEventCallbackType(IntPtr window, bool focusGained);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool GLWindowTouchDataCallbackType(IntPtr touchData);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WindowResizedEventCallbackType(IntPtr windowSize);
 
         /// <summary>
@@ -393,7 +393,7 @@ namespace Tizen.NUI
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void GLVisibilityChangedEventCallbackType(IntPtr window, bool visibility);
         private GLVisibilityChangedEventCallbackType glVisibilityChangedEventCallback;
         private event EventHandler<VisibilityChangedEventArgs> visibilityChangedEventHandler;

--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -56,31 +56,31 @@ namespace Tizen.NUI
         private ResizeCompletedEventCallbackType resizeCompletedEventCallback;
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WindowFocusChangedEventCallbackType(IntPtr window, bool focusGained);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool RootLayerTouchDataCallbackType(IntPtr view, IntPtr touchData);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool WheelEventCallbackType(IntPtr view, IntPtr wheelEvent);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WindowResizeEventCallbackType(IntPtr window, IntPtr windowSize);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WindowFocusChangedEventCallbackType2(IntPtr window, bool focusGained);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TransitionEffectEventCallbackType(IntPtr window, int state, int type);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void MovedEventCallbackType(IntPtr window, IntPtr position);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OrientationChangedEventCallbackType(IntPtr window, int orientation);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void KeyboardRepeatSettingsChangedEventCallbackType();
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AuxiliaryMessageEventCallbackType(IntPtr kData, IntPtr vData, IntPtr optionsArray);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool InterceptKeyEventDelegateType(IntPtr arg1);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void WindowMouseInOutEventCallbackType(IntPtr window, IntPtr mouseEvent);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void MoveCompletedEventCallbackType(IntPtr window, IntPtr position);
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ResizeCompletedEventCallbackType(IntPtr window, IntPtr size);
 
 
@@ -1390,7 +1390,7 @@ namespace Tizen.NUI
 
         private EventHandler<WheelEventArgs> DetentEventHandler;
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void DetentEventCallbackType(IntPtr arg1);
 
         private DetentEventCallbackType DetentEventCallback;
@@ -1444,7 +1444,7 @@ namespace Tizen.NUI
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void VisibilityChangedEventCallbackType(IntPtr window, bool visibility);
         private VisibilityChangedEventCallbackType VisibilityChangedEventCallback;
         private event EventHandler<VisibilityChangedEventArgs> VisibilityChangedEventHandler;
@@ -1588,7 +1588,7 @@ namespace Tizen.NUI
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AccessibilityHighlightEventCallbackType(IntPtr window, bool highlight);
         private AccessibilityHighlightEventCallbackType AccessibilityHighlightEventCallback;
         private event EventHandler<AccessibilityHighlightEventArgs> AccessibilityHighlightEventHandler;


### PR DESCRIPTION
### Description of Change ###
- Change all the CallingConvention from `Stdcall` to `Cdecl`.
- `stdcall` is mainly used for Win32, and there's a default calling convention that `cdecl` should be used in native C/C++ programs.
   NUI is the C# GUI library, which is binding C++ library. So, it should use `cdecl` for the programs.
- In terms of security, the `cdecl` convention is "safer" because it is the caller that needs to deallocate the stack.


### API Changes ###
- N/A