### PR TITLE
[System.Feedback] [API10] Add internal APIs to support multi-theme sound conf…

### DIFF
--- a/src/Tizen.System.Feedback/Feedback/Feedback.cs
+++ b/src/Tizen.System.Feedback/Feedback/Feedback.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 
 namespace Tizen.System
@@ -325,6 +326,137 @@ namespace Tizen.System
                     case Interop.Feedback.FeedbackError.OperationFailed:
                     default:
                         throw new InvalidOperationException("Failed to stop pattern");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the count of theme can be used according to feedback type.
+        /// </summary>
+        /// <remarks>
+        /// Now this internal API works for FeedbackType.Sound only, FeedbackType.Vibration is not supported.
+        /// </remarks>
+        /// <since_tizen> 10 </since_tizen>
+        /// <param name="type">The feedback type.</param>
+        /// <returns>The counf of theme can be used according to feedback type.</returns>
+        /// <exception cref="Exception">Thrown when failed because the feedback is not initialized.</exception>
+        /// <exception cref="ArgumentException">Thrown when failed because of an invalid arguament.</exception>
+        /// <exception cref="NotSupportedException">Thrown when failed becuase the device (haptic, sound) is not supported.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of a system error.</exception>
+        /// <example>
+        /// <code>
+        /// Feedback feedback = new Feedback();
+        /// uint coundOfTheme = feedback.GetCountOfThemeInternal(FeedbackType.Sound);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint GetCountOfThemeInternal(FeedbackType type)
+        {
+            uint countOfTheme = 0;
+            Interop.Feedback.FeedbackError res;
+
+            res = (Interop.Feedback.FeedbackError)Interop.Feedback.GetCountOfThemeInternal((Interop.Feedback.FeedbackType)type, out countOfTheme);
+
+            if (res != Interop.Feedback.FeedbackError.None)
+            {
+                Log.Warn(LogTag, string.Format("Failed to get count of theme internal. err = {0}", res));
+                switch (res)
+                {
+                    case Interop.Feedback.FeedbackError.NotInitialized:
+                        throw new Exception("Not initialized");
+                    case Interop.Feedback.FeedbackError.InvalidParameter:
+                        throw new ArgumentException("Invalid Arguments");
+                    case Interop.Feedback.FeedbackError.NotSupported:
+                        throw new NotSupportedException("Device is not supported");
+                    case Interop.Feedback.FeedbackError.OperationFailed:
+                    default:
+                        throw new InvalidOperationException("Failed to get count of theme internal");
+                }
+            }
+            return countOfTheme;
+        }
+
+        /// <summary>
+        /// Gets the index of theme selected.
+        /// </summary>
+        /// <remarks>
+        /// Now this internal API works for FeedbackType.Sound only, FeedbackType.Vibration is not supported.
+        /// </remarks>
+        /// <since_tizen> 10 </since_tizen>
+        /// <param name="type">The feedback type.</param>
+        /// <returns>The index of theme selected as default theme according to feedback type.</returns>
+        /// <exception cref="ArgumentException">Thrown when failed because of an invalid arguament.</exception>
+        /// <exception cref="NotSupportedException">Thrown when failed becuase the device (haptic, sound) is not supported.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of a system error.</exception>
+        /// <example>
+        /// <code>
+        /// Feedback feedback = new Feedback();
+        /// uint indexOfTheme = feedback. GetThemeIndexInternal(FeedbackType.Sound);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint GetThemeIndexInternal(FeedbackType type)
+        {
+            uint countOfTheme = 0;
+            Interop.Feedback.FeedbackError res;
+
+            res = (Interop.Feedback.FeedbackError)Interop.Feedback.GetThemeIndexInternal((Interop.Feedback.FeedbackType)type, out countOfTheme);
+
+            if (res != Interop.Feedback.FeedbackError.None)
+            {
+                Log.Warn(LogTag, string.Format("Failed to get index of theme internal. err = {0}", res));
+                switch (res)
+                {
+                    case Interop.Feedback.FeedbackError.InvalidParameter:
+                        throw new ArgumentException("Invalid Arguments");
+                    case Interop.Feedback.FeedbackError.NotSupported:
+                        throw new NotSupportedException("Device is not supported");
+                    case Interop.Feedback.FeedbackError.OperationFailed:
+                    default:
+                        throw new InvalidOperationException("Failed to get index of theme internal");
+                }
+            }
+            return countOfTheme;
+        }
+
+        /// <summary>
+        /// Sets the index of theme according to feedback type.
+        /// </summary>
+        /// <remarks>
+        /// Now this internal API works for FeedbackType.Sound only, FeedbackType.Vibration is not supported.
+        /// </remarks>
+        /// <since_tizen> 10 </since_tizen>
+        /// <param name="type">The feedback type.</param>
+        /// <param name="indexOfTheme">The index of theme will be set.</param>
+        /// <exception cref="ArgumentException">Thrown when failed because of an invalid arguament.</exception>
+        /// <exception cref="NotSupportedException">Thrown when failed becuase the device (haptic, sound) is not supported.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of a system error.</exception>
+        /// <example>
+        /// <code>
+        /// Feedback feedback = new Feedback();
+        /// uint indexOfTheme = 0;
+        /// feedback.SetThemeIndexInternal(FeedbackType.Sound, indexOfTheme);
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetThemeIndexInternal(FeedbackType type, uint indexOfTheme)
+        {
+            Interop.Feedback.FeedbackError res;
+
+            res = (Interop.Feedback.FeedbackError)Interop.Feedback.SetThemeIndexInternal((Interop.Feedback.FeedbackType)type, indexOfTheme);
+
+            if (res != Interop.Feedback.FeedbackError.None)
+            {
+                Log.Warn(LogTag, string.Format("Failed to set index of theme internal. err = {0}", res));
+                switch (res)
+                {
+                    case Interop.Feedback.FeedbackError.InvalidParameter:
+                        throw new ArgumentException("Invalid Arguments");
+                    case Interop.Feedback.FeedbackError.NotSupported:
+                        throw new NotSupportedException("Device is not supported");
+                    case Interop.Feedback.FeedbackError.OperationFailed:
+                    default:
+                        throw new InvalidOperationException("Failed to set index of theme internal");
                 }
             }
         }

--- a/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
+++ b/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
@@ -55,5 +55,14 @@ internal static partial class Interop
 
         [DllImport(Libraries.Feedback, EntryPoint = "feedback_is_supported_pattern")]
         internal static extern int IsSupportedPattern(FeedbackType type, int pattern, out bool supported);
+
+        [DllImport(Libraries.Feedback, EntryPoint = "feedback_get_count_of_theme_internal")]
+        internal static extern int GetCountOfThemeInternal(FeedbackType type, out uint countOfTheme);
+
+        [DllImport(Libraries.Feedback, EntryPoint = "feedback_get_theme_index_internal")]
+        internal static extern int GetThemeIndexInternal(FeedbackType type, out uint indexOfTheme);
+
+        [DllImport(Libraries.Feedback, EntryPoint = "feedback_set_theme_index_internal")]
+        internal static extern int SetThemeIndexInternal(FeedbackType type, uint indexOfTheme);
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Allows selecting one of several theme files according to feedback type.
Now, this supports only feedback type Sound.

These are newly added to System.Feedback.

- public uint GetCountOfThemeInternal(FeedbackType type)
    -> It returns count of theme which is defined conf file according to feedback type.
        This indicates how many conf files are available.
- public uint GetThemeIndexInternal(FeedbackType type)
    -> It returns index of theme which is selected as default according to feedback type.
- public void SetThemeIndexInternal(FeedbackType type, uint indexOfTheme)
    -> It sets indexOfTheme to default conf index according to feedback type.
        By calling this, feedback will use the conf file with "indexOfTheme" index.

Added:
- public uint GetCountOfThemeInternal(FeedbackType type)
- public uint GetThemeIndexInternal(FeedbackType type)
- public void SetThemeIndexInternal(FeedbackType type, uint indexOfTheme)

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
