### PR TITLE
[NUI] Fix SVACE issue.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -308,7 +308,7 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
 
                 // Sync as current properties
-                view?.UpdateBackgroundExtraData();
+                view.UpdateBackgroundExtraData();
 
                 PropertyMap tmp = new PropertyMap();
                 var propertyValue = Object.GetProperty(view.SwigCPtr, Property.BACKGROUND);
@@ -1889,7 +1889,7 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             // Sync as current properties
-            view?.UpdateBackgroundExtraData();
+            view.UpdateBackgroundExtraData();
 
             PropertyMap map = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SHADOW).Get(map);
@@ -1923,7 +1923,7 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             // Sync as current properties
-            view?.UpdateBackgroundExtraData();
+            view.UpdateBackgroundExtraData();
 
             PropertyMap map = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.SHADOW).Get(map);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
WID:57779827 Value view, which can have null value due to comparison with null, is dereferenced in member access expression view.SwigCPtr

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
