### PR TITLE
[System.Feedback] Add privilege description to internal API for multi-theme

### DIFF
--- a/src/Tizen.System.Feedback/Feedback/Feedback.cs
+++ b/src/Tizen.System.Feedback/Feedback/Feedback.cs
@@ -424,12 +424,14 @@ namespace Tizen.System
         /// </summary>
         /// <remarks>
         /// Now this internal API works for FeedbackType.Sound only, FeedbackType.Vibration is not supported.
+        /// To set the index of theme for Sound type, the application should have http://tizen.org/privilege/systemsettings.admin privilege.
         /// </remarks>
         /// <since_tizen> 10 </since_tizen>
         /// <param name="type">The feedback type.</param>
         /// <param name="indexOfTheme">The index of theme will be set.</param>
         /// <exception cref="ArgumentException">Thrown when failed because of an invalid arguament.</exception>
         /// <exception cref="NotSupportedException">Thrown when failed becuase the device (haptic, sound) is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when failed because the access is not granted(No privilege)</exception>
         /// <exception cref="InvalidOperationException">Thrown when failed because of a system error.</exception>
         /// <example>
         /// <code>
@@ -454,6 +456,8 @@ namespace Tizen.System
                         throw new ArgumentException("Invalid Arguments");
                     case Interop.Feedback.FeedbackError.NotSupported:
                         throw new NotSupportedException("Device is not supported");
+                    case Interop.Feedback.FeedbackError.PermissionDenied:
+                        throw new UnauthorizedAccessException("Access is not granted");
                     case Interop.Feedback.FeedbackError.OperationFailed:
                     default:
                         throw new InvalidOperationException("Failed to set index of theme internal");


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

To call below feedback internal API, App should have accurate privilege.
Description and privilege type is added to below API.
 - public void SetThemeIndexInternal(FeedbackType type, uint indexOfTheme)

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
