### PR TITLE
[VoiceControl] remove unsupported error type

### DIFF
--- a/src/Tizen.Uix.VoiceControl/Tizen.Uix.VoiceControl/VoiceControlClient.cs
+++ b/src/Tizen.Uix.VoiceControl/Tizen.Uix.VoiceControl/VoiceControlClient.cs
@@ -337,7 +337,6 @@ namespace Tizen.Uix.VoiceControl
         /// </remarks>
         /// <param name="name">Invocation name to be invoked by an application.</param>
         /// <exception cref="InvalidOperationException">This exception can be due to an invalid state.</exception>
-        /// <exception cref="ArgumentException">This exception can be due to an invalid parameter.</exception>
         /// <exception cref="NotSupportedException">This exception can be due to not supported.</exception>
         /// <exception cref="UnauthorizedAccessException">This exception can be due to permission denied.</exception>
         /// <pre>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Remove unsupported error type according to the description of native CAPI. 

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: NON-ACR

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
