### PR TITLE
[NUI] Add SystemFontSizeChanged.Finished event

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/WeakEventProxy.cs
+++ b/src/Tizen.NUI/src/internal/Common/WeakEventProxy.cs
@@ -101,15 +101,42 @@ namespace Tizen.NUI
 
     internal class SystemFontSizeChanged : WeakEventProxy<FontSizeChangedEventArgs>
     {
+        /// <summary>
+        /// An event invoked when system font size change is finished.
+        /// This can be used by applications to update layout after all font size changes are applied.
+        /// </summary>
+        public static event EventHandler<FontSizeChangedEventArgs> Finished
+        {
+            add
+            {
+                fontSizeChangeFinished += value;
+            }
+            remove
+            {
+                fontSizeChangeFinished -= value;
+            }
+        }
+
         protected override void ConnectToEvent(EventHandler<FontSizeChangedEventArgs> handler)
         {
             SystemSettings.FontSizeChanged += handler;
+            // To invoke Finished after all FontSizeChanged event handlers are invoked.
+            SystemSettings.FontSizeChanged -= FontSizeChangeFinished;
+            SystemSettings.FontSizeChanged += FontSizeChangeFinished;
         }
 
         protected override void DisconnectToEvent(EventHandler<FontSizeChangedEventArgs> handler)
         {
             SystemSettings.FontSizeChanged -= handler;
+            SystemSettings.FontSizeChanged -= FontSizeChangeFinished;
         }
+
+        private static void FontSizeChangeFinished(object sender, FontSizeChangedEventArgs args)
+        {
+            fontSizeChangeFinished?.Invoke(sender, args);
+        }
+
+        private static EventHandler<FontSizeChangedEventArgs> fontSizeChangeFinished;
     }
 
     internal class SystemLocaleLanguageChanged : WeakEventProxy<LocaleLanguageChangedEventArgs>


### PR DESCRIPTION
SystemFontSizeChanged is used to invoke system font size changed event
callback.

Some applications want to know the time right after all system font size
changed event callbacks are invoked.
e.g. Some application want to calculate layout when all text objects'
     font sizes are updated.

To support the above requirement, SystemFontSizeChanged.Finished event
is added.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
