### PR TITLE
[NUI] Add SystemFontSizeChangedManager class

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/SystemFontSizeChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemFontSizeChangedManager.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+extern alias TizenSystemSettings;
+using TizenSystemSettings.Tizen.System;
+
+using System;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// A static class which adds user handler to the SystemSettings.FontSizeChanged event.
+    /// This class also adds user handler to the last of the SystemSettings.FontSizeChanged event.
+    /// </summary>
+    internal static class SystemFontSizeChangedManager
+    {
+        static SystemFontSizeChangedManager()
+        {
+            SystemSettings.FontSizeChanged += SystemFontSizeChanged;
+        }
+
+        /// <summary>
+        /// The handler invoked last after all handlers added to the SystemSettings.FontSizeChanged event are invoked.
+        /// </summary>
+        public static event EventHandler<FontSizeChangedEventArgs> Finished;
+
+        /// <summary>
+        /// Adds the given handler to the SystemSettings.FontSizeChanged event.
+        /// </summary>
+        /// <param name="handler">A handler to be added to the event</param>
+        public static void Add(EventHandler<FontSizeChangedEventArgs> handler)
+        {
+            proxy.Add(handler);
+        }
+
+        /// <summary>
+        /// Removes the given handler from the SystemSettings.FontSizeChanged event.
+        /// </summary>
+        /// <param name="handler">A handler to be added to the event</param>
+        public static void Remove(EventHandler<FontSizeChangedEventArgs> handler)
+        {
+            proxy.Remove(handler);
+        }
+
+        private static void SystemFontSizeChanged(object sender, FontSizeChangedEventArgs args)
+        {
+            proxy.Invoke(sender, args);
+            Finished?.Invoke(sender, args);
+        }
+
+        private static WeakEvent<EventHandler<FontSizeChangedEventArgs>> proxy = new WeakEvent<EventHandler<FontSizeChangedEventArgs>>();
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -35,7 +35,6 @@ namespace Tizen.NUI.BaseComponents
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextEditor";
         static private string defaultFontFamily = "TizenSans";
         private static SystemFontTypeChanged systemFontTypeChanged = new SystemFontTypeChanged();
-        private static SystemFontSizeChanged systemFontSizeChanged = new SystemFontSizeChanged();
         private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
         private string textEditorTextSid = null;
         private string textEditorPlaceHolderTextSid = null;
@@ -2614,7 +2613,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 try
                 {
-                    systemFontSizeChanged.Add(SystemSettingsFontSizeChanged);
+                    SystemFontSizeChangedManager.Add(SystemSettingsFontSizeChanged);
                     hasSystemFontSizeChanged = true;
                 }
                 catch (Exception e)
@@ -2631,7 +2630,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 try
                 {
-                    systemFontSizeChanged.Remove(SystemSettingsFontSizeChanged);
+                    SystemFontSizeChangedManager.Remove(SystemSettingsFontSizeChanged);
                     hasSystemFontSizeChanged = false;
                 }
                 catch (Exception e)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -34,7 +34,6 @@ namespace Tizen.NUI.BaseComponents
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextField";
         static private string defaultFontFamily = "TizenSans";
         private static SystemFontTypeChanged systemFontTypeChanged = new SystemFontTypeChanged();
-        private static SystemFontSizeChanged systemFontSizeChanged = new SystemFontSizeChanged();
         private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
         private string textFieldTextSid = null;
         private string textFieldPlaceHolderTextSid = null;
@@ -2624,7 +2623,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 try
                 {
-                    systemFontSizeChanged.Add(SystemSettingsFontSizeChanged);
+                    SystemFontSizeChangedManager.Add(SystemSettingsFontSizeChanged);
                     hasSystemFontSizeChanged = true;
                 }
                 catch (Exception e)
@@ -2641,7 +2640,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 try
                 {
-                    systemFontSizeChanged.Remove(SystemSettingsFontSizeChanged);
+                    SystemFontSizeChangedManager.Remove(SystemSettingsFontSizeChanged);
                     hasSystemFontSizeChanged = false;
                 }
                 catch (Exception e)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -82,7 +82,6 @@ namespace Tizen.NUI.BaseComponents
         static TextLabel() { }
 
         private static SystemFontTypeChanged systemFontTypeChanged = new SystemFontTypeChanged();
-        private static SystemFontSizeChanged systemFontSizeChanged = new SystemFontSizeChanged();
         private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextLabel";
         static private string defaultFontFamily = "BreezeSans";
@@ -1636,7 +1635,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 try
                 {
-                    systemFontSizeChanged.Add(SystemSettingsFontSizeChanged);
+                    SystemFontSizeChangedManager.Add(SystemSettingsFontSizeChanged);
                     hasSystemFontSizeChanged = true;
                 }
                 catch (Exception e)
@@ -1653,7 +1652,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 try
                 {
-                    systemFontSizeChanged.Remove(SystemSettingsFontSizeChanged);
+                    SystemFontSizeChangedManager.Remove(SystemSettingsFontSizeChanged);
                     hasSystemFontSizeChanged = false;
                 }
                 catch (Exception e)


### PR DESCRIPTION
SystemFontSizeChangedManager is a static class which adds user handlers
to the SystemSettings.FontSizeChanged event.

It is similar to SystemFontSizeChanged class but it is a static class
and it also provides Finished event handler invoked last after all
handlers added to the SystemSettings.FontSizeChanged event are invoked.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
