### PR TITLE
[NUI] Make Tizen.NUI.Components not be preloaded in TV profile

### DIFF
--- a/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj
+++ b/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj
@@ -5,9 +5,13 @@
     <NoWarn>$(NoWarn);CS0618;CA1054;CA1056</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <TizenPreloadFile Include="Tizen.NUI.Components.preload" Sequence="31" />
-  </ItemGroup>
+  <Choose>
+    <When Condition="'$(BuildProfile)' != 'tv'">
+      <ItemGroup>
+        <TizenPreloadFile Include="Tizen.NUI.Components.preload" Sequence="31" />
+      </ItemGroup>
+    </When>
+  </Choose>
 
   <ItemGroup>
     <ProjectReference Include="..\Tizen.Log\Tizen.Log.csproj" />


### PR DESCRIPTION
### Description of Change ###
[NUI] Make Tizen.NUI.Components not be preloaded in TV profile


### API Changes ###
none