### PR TITLE
[MediaVision] Remove deprecated API - InferenceTargetType

### DIFF
--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceModelConfiguration.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceModelConfiguration.cs
@@ -361,31 +361,6 @@ namespace Tizen.Multimedia.Vision
         }
 
         /// <summary>
-        /// Gets or sets the inference model's target.
-        /// </summary>
-        /// <remarks>
-        /// The default target is <see cref="InferenceTargetType.CPU"/>.<br/>
-        /// If target doesn't support <see cref="InferenceTargetType.GPU"/> and <see cref="InferenceTargetType.Custom"/>,
-        /// <see cref="InferenceTargetType.CPU"/> will be used internally, despite the user's choice.
-        /// </remarks>
-        /// <exception cref="ArgumentException"><paramref name="value"/> is not valid.</exception>
-        /// <since_tizen> 6 </since_tizen>
-        [Obsolete("Deprecated since API8. Will be removed in API10. Please use Device instead.")]
-        public InferenceTargetType Target
-        {
-            get
-            {
-                return (InferenceTargetType)GetInt(_keyTargetType);
-            }
-            set
-            {
-                ValidationUtil.ValidateEnum(typeof(InferenceTargetType), value, nameof(Target));
-
-                Set(_keyTargetType, (int)value);
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the processor type for inference models.
         /// </summary>
         /// <remarks>

--- a/src/Tizen.Multimedia.Vision/MediaVision/InferenceType.cs
+++ b/src/Tizen.Multimedia.Vision/MediaVision/InferenceType.cs
@@ -74,29 +74,6 @@ namespace Tizen.Multimedia.Vision
     }
 
     /// <summary>
-    /// Specifies the type of target. It's used for running inference backend.
-    /// </summary>
-    /// <since_tizen> 6 </since_tizen>
-    [Obsolete("Deprecated since API8; Will be removed in API10. Please use InferenceTargetDevice instead.")]
-    public enum InferenceTargetType
-    {
-        /// <summary>
-        /// CPU target
-        /// </summary>
-        CPU,
-
-        /// <summary>
-        /// GPU target
-        /// </summary>
-        GPU,
-
-        /// <summary>
-        /// Custom target
-        /// </summary>
-        Custom
-    }
-
-    /// <summary>
     /// Specifies the target device which is used for running <see cref="InferenceModelConfiguration.Backend"/>.
     /// </summary>
     /// <since_tizen> 8 </since_tizen>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Remove deprecated API
 - InferenceTargetType enum
 - Target property

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - TCSACR-

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
