### PR TITLE
[NUI] Add missing code

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Clipboard.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Clipboard.cs
@@ -25,6 +25,7 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr Get();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_SetData")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool SetData(global::System.Runtime.InteropServices.HandleRef clipboard, string mimeType, string data);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Clipboard_GetData")]


### PR DESCRIPTION
ref : 5ca58e74d71e2e91a9b0a8b549b3cffad232f6f9

Make sure that Interop return type is bool
Marshal's bool is mapped to 4byte in default.
So if native-code return boolean type, the datasize is mismatched and make problems

