### PR TITLE
[NUI] Fix the SVACE issue.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Popup.cs
+++ b/src/Tizen.NUI.Components/Controls/Popup.cs
@@ -844,7 +844,7 @@ namespace Tizen.NUI.Components
 
         private void PopupStylePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName.Equals("LayoutDirection"))
+            if (e.PropertyName is var propName && propName != null && propName.Equals("LayoutDirection"))
             {
                 btGroup.UpdateButton(buttonStyle);
             }

--- a/src/Tizen.NUI.Wearable/src/public/Title.cs
+++ b/src/Tizen.NUI.Wearable/src/public/Title.cs
@@ -247,7 +247,7 @@ namespace Tizen.NUI.Components
 
         private void TitlePropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (isFadeOutColorSet == false  && e.PropertyName.Equals("BackgroundColor") )
+            if (isFadeOutColorSet == false  && e.PropertyName is var propName && propName != null && propName.Equals("BackgroundColor") )
             {
                 fadeOutColor = this.BackgroundColor;
                 UpdateImage();


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
fix the issue : Value e.PropertyName, which is result of method invocation with possible null return value, is dereferenced in method call e.PropertyName.Equals()

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
