### PR TITLE
[Tdbc] Fix sqlite driver

### DIFF
--- a/src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/Connection.cs
+++ b/src/Tizen.Data.Tdbc.Driver.Sqlite/Tizen.Data.Tdbc.Driver.Sqlite/Connection.cs
@@ -89,14 +89,11 @@ namespace Tizen.Data.Tdbc.Driver.Sqlite
                     break;
             }
 
-            if (operationType == OperationType.Delete)
-                return;
-
             Sql sql = new Sql(string.Format("SELECT * from {0} WHERE rowid = {1}", table_name, rowid));
             using (IStatement stmt = CreateStatement())
             using (IResultSet resultSet = stmt.ExecuteQuery(sql))
             {
-                IRecord record = resultSet.FirstOrDefault();
+                IRecord record = resultSet?.FirstOrDefault();
                 lock (_lock)
                 {
                     RecordChangedEventArgs ev = new RecordChangedEventArgs(operationType, db_name, table_name, record);


### PR DESCRIPTION
When the operation type is delete, the empty record will be passed to callback.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
