### PR TITLE
[NUI] Binding PointerConstraintsEvent

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.PointerConstraints.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PointerConstraints.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class PointerConstraints
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_PointerConstraintsEvent__SWIG_0")]
+            public static extern global::System.IntPtr NewPointerConstraints(int x, int y, bool locked, bool confined);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PointerConstraintsEvent")]
+            public static extern void DeletePointerConstraints(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_x_get")]
+            public static extern int XGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_y_get")]
+            public static extern int YGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_locked_get")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool LockedGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PointerConstraintsEvent_confined_get")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool ConfinedGet(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowPointerConstraintsSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowPointerConstraintsSignal.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class WindowPointerConstraintsSignal
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal")]
+            public static extern global::System.IntPtr GetSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Empty")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool Empty(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_GetConnectionCount")]
+            public static extern uint GetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Connect")]
+            public static extern void Connect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Disconnect")]
+            public static extern void Disconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowPointerConstraintsEventSignal_Emit")]
+            public static extern void Emit(global::System.Runtime.InteropServices.HandleRef signalType, global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef mouseEvent);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WindowPointerConstraintsEventSignal")]
+            public static extern global::System.IntPtr NewWindowPointerConstraintsSignal();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_WindowPointerConstraintsEventSignal")]
+            public static extern void DeleteWindowPointerConstraintsSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Window/WindowPointerConstraintsSignal.cs
+++ b/src/Tizen.NUI/src/internal/Window/WindowPointerConstraintsSignal.cs
@@ -1,0 +1,102 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    internal class WindowPointerConstraintsSignal : Disposable
+    {
+        internal WindowPointerConstraintsSignal(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.WindowPointerConstraintsSignal.DeleteWindowPointerConstraintsSignal(swigCPtr);
+        }
+
+        /// <summary>
+        /// Queries whether there are any connected slots.
+        /// </summary>
+        /// <returns>True if there are any slots connected to the signal</returns>
+        public bool Empty()
+        {
+            bool ret = Interop.WindowPointerConstraintsSignal.Empty(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Queries the number of slots.
+        /// </summary>
+        /// <returns>The number of slots connected to this signal</returns>
+        public uint GetConnectionCount()
+        {
+            uint ret = Interop.WindowPointerConstraintsSignal.GetConnectionCount(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Connects a function.
+        /// </summary>
+        /// <param name="func">The function to connect</param>
+        public void Connect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowPointerConstraintsSignal.Connect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Disconnects a function.
+        /// </summary>
+        /// <param name="func">The function to disconnect</param>
+        public void Disconnect(System.Delegate func)
+        {
+            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(func);
+            {
+                Interop.WindowPointerConstraintsSignal.Disconnect(SwigCPtr, new System.Runtime.InteropServices.HandleRef(this, ip));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Emits the signal.
+        /// </summary>
+        /// <param name="window">The first value to pass to callbacks</param>
+        /// <param name="pointerConstraints">The second value to pass to callbacks</param>
+        public void Emit(Window window, PointerConstraints pointerConstraints)
+        {
+            Interop.WindowPointerConstraintsSignal.Emit(SwigCPtr, Window.getCPtr(window), PointerConstraints.getCPtr(pointerConstraints));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        public WindowPointerConstraintsSignal(Window window) : this(Interop.WindowPointerConstraintsSignal.GetSignal(Window.getCPtr(window)), false)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Window/PointerConstraints.cs
+++ b/src/Tizen.NUI/src/public/Window/PointerConstraints.cs
@@ -1,0 +1,135 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// PointerConstraints is used when pointer is locked/unlocked
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class PointerConstraints : Disposable
+    {
+
+        /// <summary>
+        /// The default constructor.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PointerConstraints() : this(Interop.PointerConstraints.NewPointerConstraints(0, 0, false, false), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        /// <param name="x">The x coordinate relative to window where event happened.</param>
+        /// <param name="y">The y coordinate relative to window where event happened.</param>
+        /// <param name="locked">The status whether pointer is locked/unlocked.</param>
+        /// <param name="confined">The status whether pointer is confined/unconfined.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PointerConstraints(int x, int y, bool locked, bool confined): this(Interop.PointerConstraints.NewPointerConstraints(x, y, locked, confined), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal PointerConstraints(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        {
+        }
+
+        /// <summary>
+        /// Gets the x, y position,
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Position2D Position
+        {
+            get
+            {
+                return position;
+            }
+        }
+
+        /// <summary>
+        /// Gets the status whether pointer is locked/unlocked.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Locked
+        {
+            get
+            {
+                return locked;
+            }
+        }
+
+        /// <summary>
+        /// Gets the status whether pointer is confined/unconfined.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Confined
+        {
+            get
+            {
+                return confined;
+            }
+        }
+
+        private Position2D position
+        {
+            get
+            {
+                Position2D ret = new Position2D(Interop.PointerConstraints.XGet(SwigCPtr), Interop.PointerConstraints.YGet(SwigCPtr));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private bool locked
+        {
+            get
+            {
+                bool ret = Interop.PointerConstraints.LockedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        private bool confined
+        {
+            get
+            {
+                bool ret = Interop.PointerConstraints.ConfinedGet(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+        }
+
+        internal static PointerConstraints GetPointerConstraintsFromPtr(global::System.IntPtr cPtr)
+        {
+            PointerConstraints ret = new PointerConstraints(cPtr, false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.PointerConstraints.DeletePointerConstraints(swigCPtr);
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
[NUI] Binding PointerConstraintsEvent
```c++
window.PointerConstraintsEvent += OnPointerConstraints;

private void OnPointerConstraints(object sender, PointerConstraintsEventArgs e)
{
  //e.PointerConstraints.Position.X
  //e.PointerConstraints.Position.Y
  //e.PointerConstraints.Locked
  //e.PointerConstraints.Confined
}
```
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/298394/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/298506/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
