### PR TITLE
[NUI] Fix ImageColor alpha not applied issue

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -67,6 +67,7 @@ namespace Tizen.NUI.BaseComponents
             ImageVisualProperty.WrapModeV,
             ImageVisualProperty.SynchronousLoading,
             Visual.Property.MixColor,
+            Visual.Property.Opacity,
             Visual.Property.PremultipliedAlpha,
             ImageVisualProperty.OrientationCorrection,
             ImageVisualProperty.FastTrackUploading,

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -589,6 +589,7 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
+                imageView.UpdateImage(Visual.Property.Opacity, new PropertyValue(((Color)newValue).A), false);
                 imageView.UpdateImage(Visual.Property.MixColor, new PropertyValue((Color)newValue));
             }
         },


### PR DESCRIPTION
Visual look at same value, Visual.MixColor's alpha and Visual.Opacity, we need to synchronize both values.

Since we don't open Visual.Opacity property for View side let we control this value inside of View.