### PR TITLE
[NUI] Binding GetLastHoverEvent

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -344,11 +344,17 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetLastTouchEvent")]
             public static extern global::System.IntPtr GetLastTouchEvent(global::System.Runtime.InteropServices.HandleRef window);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetLastHoverEvent")]
+            public static extern global::System.IntPtr GetLastHoverEvent(global::System.Runtime.InteropServices.HandleRef window);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastKeyEvent")]
             public static extern void InternalRetrievingLastKeyEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef key);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastTouchEvent")]
             public static extern void InternalRetrievingLastTouchEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef touch);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastHoverEvent")]
+            public static extern void InternalRetrievingLastHoverEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef hover);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetNeedsRotationCompletedAcknowledgement")]
             public static extern void SetNeedsRotationCompletedAcknowledgement(global::System.Runtime.InteropServices.HandleRef window, bool needAcknowledgement);

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -43,6 +43,7 @@ namespace Tizen.NUI
         private LayoutController localController;
         private Key internalLastKeyEvent;
         private Touch internalLastTouchEvent;
+        private Hover internalLastHoverEvent;
         private Timer internalHoverTimer;
 
         static internal bool IsSupportedMultiWindow()
@@ -1268,13 +1269,13 @@ namespace Tizen.NUI
         {
             if (touchPoint == null)
             {
-                using Touch touch = GetLastTouchEvent();
-                if (touch == null || touch.GetPointCount() < 1)
+                using Hover hover = GetLastHoverEvent();
+                if (hover == null || hover.GetPointCount() < 1)
                 {
                     return;
                 }
-                using Vector2 screenPosition = touch.GetScreenPosition(0);
-                touchPoint = new TouchPoint(touch.GetDeviceId(0), TouchPoint.StateType.Motion, screenPosition.X, screenPosition.Y);
+                using Vector2 screenPosition = hover.GetScreenPosition(0);
+                touchPoint = new TouchPoint(hover.GetDeviceId(0), TouchPoint.StateType.Motion, screenPosition.X, screenPosition.Y);
             }
             Interop.Window.FeedHoverEvent(SwigCPtr, TouchPoint.getCPtr(touchPoint));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -2134,6 +2135,22 @@ namespace Tizen.NUI
             Interop.Window.InternalRetrievingLastTouchEvent(SwigCPtr, internalLastTouchEvent.SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return internalLastTouchEvent;
+        }
+
+        /// <summary>
+        /// Gets the last hover event the window gets.
+        /// </summary>
+        /// <returns>The last hover event the window gets.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Hover GetLastHoverEvent()
+        {
+            if(internalLastHoverEvent == null)
+            {
+                internalLastHoverEvent = new Hover();
+            }
+            Interop.Window.InternalRetrievingLastHoverEvent(SwigCPtr, internalLastHoverEvent.SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return internalLastHoverEvent;
         }
 
         /// <summary>


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
Since GetLastTouchEvent returns all values ​​regardless of touch or hover, it was separated into GetLastTouchEvent and GetLastHoverEvent.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/298755/ https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/298753/ https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/298752/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
