### PR TITLE
[NUI] Binding DispatchTouchMotion and DispatchHoverMotion

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -221,6 +221,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_Property_UPDATE_AREA_HINT_get")]
             public static extern int UpdateAreaHintGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_DISPATCH_TOUCH_MOTION_get")]
+            public static extern int DispatchTouchMotionGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_DISPATCH_HOVER_MOTION_get")]
+            public static extern int DispatchHoverMotionGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2583,6 +2583,42 @@ namespace Tizen.NUI.BaseComponents
         });
 
         /// <summary>
+        /// DispatchTouchMotionProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty DispatchTouchMotionProperty = BindableProperty.Create(nameof(DispatchTouchMotion), typeof(bool), typeof(View), false, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            if (newValue != null)
+            {
+                instance.InternalDispatchTouchMotion = (bool)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            return instance.InternalDispatchTouchMotion;
+        });
+
+        /// <summary>
+        /// DispatchHoverMotionProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty DispatchHoverMotionProperty = BindableProperty.Create(nameof(DispatchHoverMotion), typeof(bool), typeof(View), false, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            if (newValue != null)
+            {
+                instance.InternalDispatchHoverMotion = (bool)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (Tizen.NUI.BaseComponents.View)bindable;
+            return instance.InternalDispatchHoverMotion;
+        });
+
+        /// <summary>
         /// Gets View's Size2D set by user.
         /// </summary>
         internal Size2D GetUserSize2D()

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -264,6 +264,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int AccessibilityHidden = Interop.ViewProperty.AccessibilityHiddenGet();
             internal static readonly int AutomationId = Interop.ViewProperty.AutomationIdGet();
             internal static readonly int UpdateAreaHint = Interop.ActorProperty.UpdateAreaHintGet();
+            internal static readonly int DispatchTouchMotion = Interop.ActorProperty.DispatchTouchMotionGet();
+            internal static readonly int DispatchHoverMotion = Interop.ActorProperty.DispatchHoverMotionGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -104,8 +104,6 @@ namespace Tizen.NUI.BaseComponents
         private bool dispatchParentHoverEvents = true;
         private bool dispatchGestureEvents = true;
         private bool dispatchParentGestureEvents = true;
-        private bool dispatchTouchMotion = true;
-        private bool dispatchHoverMotion = true;
 
 
         /// <summary>
@@ -842,12 +840,6 @@ namespace Tizen.NUI.BaseComponents
             TouchEventArgs e = new TouchEventArgs();
             e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);
 
-            // If DispatchTouchMotion is false, Motion event is not dispatched.
-            if (DispatchTouchMotion == false && e.Touch.GetState(0) == PointStateType.Motion)
-            {
-                return true;
-            }
-
             bool consumed = false;
 
             if (interceptTouchDataEventHandler != null)
@@ -875,13 +867,6 @@ namespace Tizen.NUI.BaseComponents
 
             TouchEventArgs e = new TouchEventArgs();
             e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);
-
-            // If DispatchTouchMotion is false, Motion event is not dispatched.
-            if (DispatchTouchMotion == false && e.Touch.GetState(0) == PointStateType.Motion)
-            {
-                return true;
-            }
-
 
             bool consumed = false;
 
@@ -921,12 +906,6 @@ namespace Tizen.NUI.BaseComponents
 
             HoverEventArgs e = new HoverEventArgs();
             e.Hover = Tizen.NUI.Hover.GetHoverFromPtr(hoverEvent);
-
-            // If DispatchHoverMotion is false, Motion event is not dispatched.
-            if (DispatchHoverMotion == false && e.Hover.GetState(0) == PointStateType.Motion)
-            {
-                return true;
-            }
 
             bool consumed = false;
 
@@ -1677,11 +1656,24 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return dispatchTouchMotion;
+                return (bool)GetValue(DispatchTouchMotionProperty);
             }
             set
             {
-                dispatchTouchMotion = value;
+                SetValue(DispatchTouchMotionProperty, value);
+            }
+        }
+
+        private bool InternalDispatchTouchMotion
+        {
+            get
+            {
+                return Object.InternalGetPropertyBool(SwigCPtr, View.Property.DispatchTouchMotion);
+            }
+            set
+            {
+                Object.InternalSetPropertyBool(SwigCPtr, View.Property.DispatchTouchMotion, value);
+                NotifyPropertyChanged();
             }
         }
 
@@ -1694,13 +1686,25 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return dispatchHoverMotion;
+                return (bool)GetValue(DispatchHoverMotionProperty);
             }
             set
             {
-                dispatchHoverMotion = value;
+                SetValue(DispatchHoverMotionProperty, value);
             }
         }
 
+        private bool InternalDispatchHoverMotion
+        {
+            get
+            {
+                return Object.InternalGetPropertyBool(SwigCPtr, View.Property.DispatchHoverMotion);
+            }
+            set
+            {
+                Object.InternalSetPropertyBool(SwigCPtr, View.Property.DispatchHoverMotion, value);
+                NotifyPropertyChanged();
+            }
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/WindowEvent.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowEvent.cs
@@ -636,6 +636,42 @@ namespace Tizen.NUI
             }
         }
 
+        /// <summary>
+        /// Gets or sets the status of whether motion event of Touch can be dispatched.
+        /// If a Window's DispatchTouchMotion is set to false, then it's can not will receive motion event of TouchEvent.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DispatchTouchMotion
+        {
+            get
+            {
+                return Object.InternalGetPropertyBool(Layer.getCPtr(GetRootLayer()), View.Property.DispatchTouchMotion);
+            }
+            set
+            {
+                Object.InternalSetPropertyBool(Layer.getCPtr(GetRootLayer()), View.Property.DispatchTouchMotion, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the status of whether motion event of Hover can be dispatched.
+        /// If a Window's DispatchHoverMotion is set to false, then it's can not will receive motion event of HoverEvent.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool DispatchHoverMotion
+        {
+            get
+            {
+                return Object.InternalGetPropertyBool(Layer.getCPtr(GetRootLayer()), View.Property.DispatchHoverMotion);
+            }
+            set
+            {
+                Object.InternalSetPropertyBool(Layer.getCPtr(GetRootLayer()), View.Property.DispatchHoverMotion, value);
+                NotifyPropertyChanged();
+            }
+        }
+
         private event EventHandler<FocusChangedEventArgs> windowFocusChangedEventHandler;
         private event EventHandler<TouchEventArgs> rootLayerTouchDataEventHandler;
         private ReturnTypeEventHandler<object, TouchEventArgs, bool> rootLayerInterceptTouchDataEventHandler;


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
These determine whether to send touch and hover motion events or not. This is used when the user does not want to receive motion events.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/299176/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/299177/



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
