### PR TITLE
Add VisualFactory.UsePrecompiledShader()

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualFactory.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualFactory.cs
@@ -44,6 +44,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_CreateVisual__SWIG_2")]
             public static extern global::System.IntPtr CreateVisual(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_UsePreCompiledShader")]
+            public static extern void UsePreCompiledShader(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
@@ -84,5 +84,22 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
+
+        /// <summary>
+        /// Compile the visual shader in advance. Afterwards,
+        /// when a visual using a new shader is requested, the pre-compiled shader is used.
+        /// </summary>
+        /// <remarks> It is recommended that this method be called at the top of the application code.</remarks>
+        /// <remarks>
+        /// Using precompiled shaders is helpful when the application is complex and uses
+        /// many different styles of visual options. On the other hand,if most visuals are the same
+        /// and the application is simple, it may use memory unnecessarily or slow down the application launching speed.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void UsePreCompiledShader()
+        {
+            Interop.VisualFactory.UsePreCompiledShader(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###
This PR adds VisualFactory.UsePrecompiledShader method.
This method is to precompile visual's shader and make newly created visual use the shaders.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
