### PR TITLE
[NUI] Implement defaut key construct

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Key.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Key.cs
@@ -33,6 +33,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_New")]
             public static extern global::System.IntPtr New(string jarg1, string jarg2, int jarg3, int jarg4, uint jarg5, int jarg6);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Key_New__SWIG_1")]
+            public static extern global::System.IntPtr New();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Key")]
             public static extern void DeleteKey(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Input/Key.cs
+++ b/src/Tizen.NUI/src/public/Input/Key.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
         /// The default constructor.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public Key() : this(Interop.Key.New("", "", 0, 0, 0u, 0), true)
+        public Key() : this(Interop.Key.New(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2119,7 +2119,7 @@ namespace Tizen.NUI
             if (internalLastKeyEvent == null || !internalLastKeyEvent.HasBody())
             {
                 // Create empty event handle without register.
-                internalLastKeyEvent = new Key(Interop.Key.New("", "", 0, 0, 0u, 0), false);
+                internalLastKeyEvent = new Key(Interop.Key.New(), false);
             }
             Interop.Window.InternalRetrievingLastKeyEvent(SwigCPtr, internalLastKeyEvent.SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();


### PR DESCRIPTION
Let we use default key creation API if we only need to use empty key handle.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
