### PR TITLE
[NUI] Let us not dispose cached LastEvents

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1269,7 +1269,7 @@ namespace Tizen.NUI
         {
             if (touchPoint == null)
             {
-                using Hover hover = GetLastHoverEvent();
+                Hover hover = GetLastHoverEvent();
                 if (hover == null || hover.GetPointCount() < 1)
                 {
                     return;
@@ -2112,12 +2112,20 @@ namespace Tizen.NUI
         /// We will use weak reference of last key events.
         /// Return value will be invalidated if last key event changed internally.
         /// </remarks>
+        /// <remarks>
+        /// Do not Dispose this value.
+        /// </remarks>
         /// <returns>The last key event the window gets.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Key GetLastKeyEvent()
         {
-            if (internalLastKeyEvent == null || !internalLastKeyEvent.HasBody())
+            if (internalLastKeyEvent == null)
             {
+                // TODO : We need to make automatically release memory of these cached events in future.
+                if (!(internalLastKeyEvent?.IsNativeHandleInvalid() ?? true))
+                {
+                    Interop.Key.DeleteKey(internalLastKeyEvent.SwigCPtr);
+                }
                 // Create empty event handle without register.
                 internalLastKeyEvent = new Key(Interop.Key.New(), false);
             }
@@ -2133,12 +2141,20 @@ namespace Tizen.NUI
         /// We will use weak reference of last touch events.
         /// Return value will be invalidated if last touch event changed internally.
         /// </remarks>
+        /// <remarks>
+        /// Do not Dispose this value.
+        /// </remarks>
         /// <returns>The last touch event the window gets.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Touch GetLastTouchEvent()
         {
-            if (internalLastTouchEvent == null || !internalLastTouchEvent.HasBody())
+            if (internalLastTouchEvent == null)
             {
+                // TODO : We need to make automatically release memory of these cached events in future.
+                if (!(internalLastTouchEvent?.IsNativeHandleInvalid() ?? true))
+                {
+                    Interop.Touch.DeleteTouch(internalLastTouchEvent.SwigCPtr);
+                }
                 // Create empty event handle without register.
                 internalLastTouchEvent = new Touch(Interop.Touch.NewTouch(), false);
             }
@@ -2154,12 +2170,20 @@ namespace Tizen.NUI
         /// We will use weak reference of last hover events.
         /// Return value will be invalidated if last hover event changed internally.
         /// </remarks>
+        /// <remarks>
+        /// Do not Dispose this value.
+        /// </remarks>
         /// <returns>The last hover event the window gets.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Hover GetLastHoverEvent()
         {
-            if (internalLastHoverEvent == null || !internalLastHoverEvent.HasBody())
+            if (internalLastHoverEvent == null)
             {
+                // TODO : We need to make automatically release memory of these cached events in future.
+                if (!(internalLastHoverEvent?.IsNativeHandleInvalid() ?? true))
+                {
+                    Interop.Hover.DeleteHover(internalLastHoverEvent.SwigCPtr);
+                }
                 // Create empty event handle without register.
                 internalLastHoverEvent = new Hover(Interop.Hover.New(0u), false);
             }
@@ -2250,10 +2274,26 @@ namespace Tizen.NUI
 
                 localController?.Dispose();
 
+                // TODO : We need to make automatically release memory of these cached events in future.
+                if (!(internalLastKeyEvent?.IsNativeHandleInvalid() ?? true))
+                {
+                    Interop.Key.DeleteKey(internalLastKeyEvent.SwigCPtr);
+                }
+                if (!(internalLastTouchEvent?.IsNativeHandleInvalid() ?? true))
+                {
+                    Interop.Touch.DeleteTouch(internalLastTouchEvent.SwigCPtr);
+                }
+                if (!(internalLastHoverEvent?.IsNativeHandleInvalid() ?? true))
+                {
+                    Interop.Hover.DeleteHover(internalLastHoverEvent.SwigCPtr);
+                }
+
                 internalLastKeyEvent?.Dispose();
                 internalLastKeyEvent = null;
                 internalLastTouchEvent?.Dispose();
                 internalLastTouchEvent = null;
+                internalLastHoverEvent?.Dispose();
+                internalLastHoverEvent = null;
 
                 internalHoverTimer?.Stop();
                 internalHoverTimer?.Dispose();


### PR DESCRIPTION
Since we create new DALi handle internally, we also delete them.
But if we mark cMemOwn as false, we dont call deletr autimatically.

The GetLast~~Events are special cases that have there own handle, but not have memory ownership
So we need to call Delete function hardly, by our selfs.

TODO : We need to find more good way to fix this Dispose issue. Currently just remark to user that dont call Dispose for it l.