### PR TITLE
[NUI] Fix some SVACE issues.

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -346,8 +346,9 @@ namespace Tizen.NUI
 
         internal static bool HandleAppControl(AppControlReceivedEventArgs args)
         {
-            if (!args.ReceivedAppControl.ExtraData.TryGet("__K_GADGET_RES_TYPE", out string resourceType) ||
-                !args.ReceivedAppControl.ExtraData.TryGet("__K_GADGET_CLASS_NAME", out string className))
+            var extraData = args.ReceivedAppControl?.ExtraData;
+            if (extraData == null||!extraData.TryGet("__K_GADGET_RES_TYPE", out string resourceType) ||
+                !extraData.TryGet("__K_GADGET_CLASS_NAME", out string className))
             {
                 return false;
             }

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/BoundingBox.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/BoundingBox.cs
@@ -111,16 +111,19 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            var hashCode = -1064806749;
+            unchecked
+            {
+                var hashCode = -1064806749;
 
 #pragma warning disable RECS0025 // Non-readonly field referenced in 'GetHashCode()'
-            hashCode = hashCode * -1521134295 + left.GetHashCode();
-            hashCode = hashCode * -1521134295 + bottom.GetHashCode();
-            hashCode = hashCode * -1521134295 + right.GetHashCode();
-            hashCode = hashCode * -1521134295 + top.GetHashCode();
+                hashCode = hashCode * -1521134295 + left.GetHashCode();
+                hashCode = hashCode * -1521134295 + bottom.GetHashCode();
+                hashCode = hashCode * -1521134295 + right.GetHashCode();
+                hashCode = hashCode * -1521134295 + top.GetHashCode();
 #pragma warning restore RECS0025 // Non-readonly field referenced in 'GetHashCode()'
 
-            return hashCode;
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/ContactPoint.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/ContactPoint.cs
@@ -108,13 +108,16 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            var hashCode = -1285340573;
+            unchecked
+            {
+                var hashCode = -1285340573;
 
-            hashCode = hashCode * -1521134295 + pointA.GetHashCode();
-            hashCode = hashCode * -1521134295 + pointB.GetHashCode();
-            hashCode = hashCode * -1521134295 + distance.GetHashCode();
+                hashCode = hashCode * -1521134295 + pointA.GetHashCode();
+                hashCode = hashCode * -1521134295 + pointB.GetHashCode();
+                hashCode = hashCode * -1521134295 + distance.GetHashCode();
 
-            return hashCode;
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/ContactPointSet.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/ContactPointSet.cs
@@ -88,13 +88,16 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            var hashCode = -475635172;
+            unchecked
+            {
+                var hashCode = -475635172;
 
-            hashCode = hashCode * -1521134295 + count.GetHashCode();
-            hashCode = hashCode * -1521134295 + normal.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<ContactPoint[]>.Default.GetHashCode(points);
+                hashCode = hashCode * -1521134295 + count.GetHashCode();
+                hashCode = hashCode * -1521134295 + normal.GetHashCode();
+                hashCode = hashCode * -1521134295 + EqualityComparer<ContactPoint[]>.Default.GetHashCode(points);
 
-            return hashCode;
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/DebugColor.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/DebugColor.cs
@@ -114,14 +114,17 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            var hashCode = -1813971818;
+            unchecked
+            {
+                var hashCode = -1813971818;
 
-            hashCode = hashCode * -1521134295 + red.GetHashCode();
-            hashCode = hashCode * -1521134295 + green.GetHashCode();
-            hashCode = hashCode * -1521134295 + blue.GetHashCode();
-            hashCode = hashCode * -1521134295 + alpha.GetHashCode();
+                hashCode = hashCode * -1521134295 + red.GetHashCode();
+                hashCode = hashCode * -1521134295 + green.GetHashCode();
+                hashCode = hashCode * -1521134295 + blue.GetHashCode();
+                hashCode = hashCode * -1521134295 + alpha.GetHashCode();
 
-            return hashCode;
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/SegmentQueryInfo.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/SegmentQueryInfo.cs
@@ -167,12 +167,15 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            var hashCode = -1275187100;
-            hashCode = hashCode * -1521134295 + shape.GetHashCode();
-            hashCode = hashCode * -1521134295 + point.GetHashCode();
-            hashCode = hashCode * -1521134295 + normal.GetHashCode();
-            hashCode = hashCode * -1521134295 + alpha.GetHashCode();
-            return hashCode;
+            unchecked
+            {
+                var hashCode = -1275187100;
+                hashCode = hashCode * -1521134295 + shape.GetHashCode();
+                hashCode = hashCode * -1521134295 + point.GetHashCode();
+                hashCode = hashCode * -1521134295 + normal.GetHashCode();
+                hashCode = hashCode * -1521134295 + alpha.GetHashCode();
+                return hashCode;
+            }
         }
     }
 }

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/Transform.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/Transform.cs
@@ -156,16 +156,19 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            var hashCode = -884009331;
+            unchecked
+            {
+                var hashCode = -884009331;
 #pragma warning disable RECS0025 // Non-readonly field referenced in 'GetHashCode()'
-            hashCode = hashCode * -1521134295 + a.GetHashCode();
-            hashCode = hashCode * -1521134295 + b.GetHashCode();
-            hashCode = hashCode * -1521134295 + c.GetHashCode();
-            hashCode = hashCode * -1521134295 + d.GetHashCode();
-            hashCode = hashCode * -1521134295 + tx.GetHashCode();
-            hashCode = hashCode * -1521134295 + ty.GetHashCode();
+                hashCode = hashCode * -1521134295 + a.GetHashCode();
+                hashCode = hashCode * -1521134295 + b.GetHashCode();
+                hashCode = hashCode * -1521134295 + c.GetHashCode();
+                hashCode = hashCode * -1521134295 + d.GetHashCode();
+                hashCode = hashCode * -1521134295 + tx.GetHashCode();
+                hashCode = hashCode * -1521134295 + ty.GetHashCode();
 #pragma warning restore RECS0025 // Non-readonly field referenced in 'GetHashCode()'
-            return hashCode;
+                return hashCode;
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
+++ b/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
@@ -568,13 +568,16 @@ namespace Tizen.NUI.ParticleSystem
         
         internal T Get(IntPtr cPtr)
         {
-            var result = mBasePtr.FindIndex(0, x => x == cPtr );
-            if (result >= 0)
+            lock (mBasePtr)
             {
-                return mInterfaces[result];
-            }
+                var result = mBasePtr.FindIndex(0, x => x == cPtr);
+                if (result >= 0)
+                {
+                    return mInterfaces[result];
+                }
 
-            return null;
+                return null;
+            }
         }
         
         private List<IntPtr> mBasePtr = new List<IntPtr>();


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Fix some SVACE issues.

1.NUIGadgetManager.cs 
problem: Value args.ReceivedAppControl, which is result of method invocation with possible null return value, is dereferenced in member access expression args.ReceivedAppControl.ExtraData
SVACE : http://10.240.209.78:12000/v2/warning/warningListView#PRJID=2&WGID=33587

2. BoundingBox.cs ContactPoint.cs  ContactPointSet.cs DebugColor.cs SegmentQueryInfo.cs Transform.cs
problem: An overflow in the arithmetic  expression hashcode
SVACE : http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71080
http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71079
http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71078
http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71077
http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71076
http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71075

3.ParticleEmitter.cs
problem: possible missing lock before accessing the mInterfaces
SVACE : http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71083
             http://10.240.209.78:12000/v2/warning/warningListView#PRJID=6&WGID=71082
### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
