### PR TITLE
[NUI] Fix some SVACE issues related to methods of Marshal.

### DIFF
--- a/src/Tizen.NUI.Physics2D/src/internal/chipmunk/NativeInterop.cs
+++ b/src/Tizen.NUI.Physics2D/src/internal/chipmunk/NativeInterop.cs
@@ -111,7 +111,10 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         internal static IntPtr StructureArrayToPtr<T>(IReadOnlyList<T> items)
         {
             var size = SizeOf<T>();
-            var memory = Marshal.AllocHGlobal(size * items.Count);
+            int allocBytes = checked(size * items.Count);
+            Debug.Assert(allocBytes > 0, "The memory to be allocated should be greater than 0");
+
+            var memory = Marshal.AllocHGlobal(allocBytes);
 
             for (var i = 0; i < items.Count; i++)
             {

--- a/src/Tizen.NUI.Physics2D/src/internal/chipmunk/cpSpaceDebugDrawOptions.cs
+++ b/src/Tizen.NUI.Physics2D/src/internal/chipmunk/cpSpaceDebugDrawOptions.cs
@@ -104,8 +104,15 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         private IntPtr ToPointer()
         {
             IntPtr drawOptionsPtr = NativeInterop.AllocStructure<cpSpaceDebugDrawOptions>();
-
-            Marshal.StructureToPtr<cpSpaceDebugDrawOptions>(this, drawOptionsPtr, false);
+            try
+            {
+                Marshal.StructureToPtr<cpSpaceDebugDrawOptions>(this, drawOptionsPtr, false);
+            }
+            catch (Exception exception)
+            {
+                Tizen.Log.Fatal("NUI", "[Error] got exception during Marshal.StructureToPtr, this should not occur, message : " + exception.Message);
+            }
+      
             return drawOptionsPtr;
         }
 

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/Body.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/Body.cs
@@ -728,11 +728,12 @@ namespace Tizen.NUI.Physics2D.Chipmunk
             get
             {
                 int count = NativeMethods.cpBodyGetContactedBodiesCount(body);
+                int intptrBytes = checked(IntPtr.Size * count);
 
-                if (count == 0)
+                if (intptrBytes == 0)
                     return Array.Empty<Body>();
 
-                IntPtr ptrBodies = Marshal.AllocHGlobal(IntPtr.Size * count);
+                IntPtr ptrBodies = Marshal.AllocHGlobal(intptrBytes);
                 NativeMethods.cpBodyGetUserDataContactedBodies(body, ptrBodies);
 
                 IntPtr[] userDataArray = new IntPtr[count];

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/Space.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/Space.cs
@@ -607,11 +607,12 @@ namespace Tizen.NUI.Physics2D.Chipmunk
             get
             {
                 int count = NativeMethods.cpSpaceGetBodyCount(space);
+                int intptrBytes = checked(IntPtr.Size * count);
 
-                if (count == 0)
+                if (intptrBytes == 0)
                     return Array.Empty<Body>();
 
-                IntPtr ptrBodies = Marshal.AllocHGlobal(IntPtr.Size * count);
+                IntPtr ptrBodies = Marshal.AllocHGlobal(intptrBytes);
                 NativeMethods.cpSpaceGetBodiesUserDataArray(space, ptrBodies);
 
                 IntPtr[] userDataArray = new IntPtr[count];
@@ -641,11 +642,12 @@ namespace Tizen.NUI.Physics2D.Chipmunk
             get
             {
                 int count = NativeMethods.cpSpaceGetDynamicBodyCount(space);
+                int intptrBytes = checked(IntPtr.Size * count);
 
-                if (count == 0)
+                if (intptrBytes == 0)
                     return Array.Empty<Body>();
 
-                IntPtr ptrBodies = Marshal.AllocHGlobal(IntPtr.Size * count);
+                IntPtr ptrBodies = Marshal.AllocHGlobal(intptrBytes);
                 NativeMethods.cpSpaceGetDynamicBodiesUserDataArray(space, ptrBodies);
 
                 IntPtr[] userDataArray = new IntPtr[count];

--- a/src/Tizen.NUI.Physics2D/src/public/chipmunk/SpaceRef.cs
+++ b/src/Tizen.NUI.Physics2D/src/public/chipmunk/SpaceRef.cs
@@ -526,11 +526,12 @@ namespace Tizen.NUI.Physics2D.Chipmunk
             get
             {
                 int count = NativeMethods.cpSpaceGetBodyCount(space);
+                int intptrBytes = checked(IntPtr.Size * count);
 
-                if (count == 0)
+                if (intptrBytes == 0)
                     return Array.Empty<Body>();
 
-                IntPtr ptrBodies = Marshal.AllocHGlobal(IntPtr.Size * count);
+                IntPtr ptrBodies = Marshal.AllocHGlobal(intptrBytes);
                 NativeMethods.cpSpaceGetBodiesUserDataArray(space, ptrBodies);
 
                 IntPtr[] userDataArray = new IntPtr[count];
@@ -560,11 +561,12 @@ namespace Tizen.NUI.Physics2D.Chipmunk
             get
             {
                 int count = NativeMethods.cpSpaceGetDynamicBodyCount(space);
+                int intptrBytes = checked(IntPtr.Size * count);
 
-                if (count == 0)
+                if (intptrBytes == 0)
                     return Array.Empty<Body>();
 
-                IntPtr ptrBodies = Marshal.AllocHGlobal(IntPtr.Size * count);
+                IntPtr ptrBodies = Marshal.AllocHGlobal(intptrBytes);
                 NativeMethods.cpSpaceGetDynamicBodiesUserDataArray(space, ptrBodies);
 
                 IntPtr[] userDataArray = new IntPtr[count];


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
fix some SVACE  issues
1,overflow may happen when Intptr.Size * count is 0. WID:12816660. An overflow in the arithmetic expression Intptr.Size * count which is used in Marshal.AllocHGlobal(IntPtr.Size  *  count) may occur. Please use checked arithmetic  to throw IntegerOverflowException in case of overflow instead of possible memory damage.
2,cpSpaceDebugDrawOptions.cs
bufffer size may be 0, element byte size is 108. WID:12806918.Writing 1 element of type Tizen.NUI.Physics2D.Chipmunk.cpSpaceDebugDrawOptions into buffer drawOptionsPtr can exceed its size.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
