### PR TITLE
[NUI] BaseHandle without Registry but own memory

### DIFF
--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -69,6 +69,29 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        internal BaseHandle(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister)
+        {
+            //to catch derived classes dali native exceptions
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            DebugFileLogging.Instance.WriteLog($"BaseHandle.contructor with cMemeryOwn:{cMemoryOwn} and cRegister:{cRegister} START");
+
+            registerMe = cRegister;
+            swigCMemOwn = cMemoryOwn;
+            swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            if (registerMe)
+            {
+                // Register this instance of BaseHandle in the registry.
+                Registry.Register(this);
+            }
+
+            disposeDebuggingCtor();
+            DebugFileLogging.Instance.WriteLog($" BaseHandle.contructor with cMemeryOwn and cRegister END");
+            DebugFileLogging.Instance.WriteLog($"=============================");
+        }
+
         internal BaseHandle(global::System.IntPtr cPtr, bool cMemoryOwn)
         {
             //to catch derived classes dali native exceptions
@@ -511,6 +534,15 @@ namespace Tizen.NUI
             PropertySet?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
+        internal void UnregisterFromRegistry()
+        {
+            if (registerMe)
+            {
+                Registry.Unregister(this);
+                registerMe = false;
+            }
+        }
+
         /// <summary>
         /// Dispose.
         /// </summary>
@@ -537,10 +569,7 @@ namespace Tizen.NUI
             //because the execution order of Finalizes is non-deterministic.
 
             //Unreference this instance from Registry.
-            if (registerMe)
-            {
-                Registry.Unregister(this);
-            }
+            UnregisterFromRegistry();
 
             disposeDebuggingDispose(type);
 

--- a/src/Tizen.NUI/src/public/Events/Hover.cs
+++ b/src/Tizen.NUI/src/public/Events/Hover.cs
@@ -52,7 +52,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        {
+        }
+
+        internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Touch.cs
+++ b/src/Tizen.NUI/src/public/Events/Touch.cs
@@ -42,7 +42,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Touch(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Touch(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        {
+        }
+
+        internal Touch(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Wheel.cs
+++ b/src/Tizen.NUI/src/public/Events/Wheel.cs
@@ -53,7 +53,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Wheel(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Wheel(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        {
+        }
+
+        internal Wheel(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
@@ -56,7 +56,12 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PixelBuffer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PixelBuffer(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, false)
+        {
+            // Note : PixelBuffer don't need to be register in Registry default. So we can create this class from worker thread.
+        }
+
+        internal PixelBuffer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Images/PixelData.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelData.cs
@@ -72,7 +72,12 @@ namespace Tizen.NUI
 
         }
 
-        internal PixelData(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PixelData(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, false)
+        {
+            // Note : PixelData don't need to be register in Registry default. So we can create this class from worker thread.
+        }
+
+        internal PixelData(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Input/Key.cs
+++ b/src/Tizen.NUI/src/public/Input/Key.cs
@@ -49,7 +49,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Key(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Key(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        {
+        }
+
+        internal Key(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2112,22 +2112,14 @@ namespace Tizen.NUI
         /// We will use weak reference of last key events.
         /// Return value will be invalidated if last key event changed internally.
         /// </remarks>
-        /// <remarks>
-        /// Do not Dispose this value.
-        /// </remarks>
         /// <returns>The last key event the window gets.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Key GetLastKeyEvent()
         {
             if (internalLastKeyEvent == null)
             {
-                // TODO : We need to make automatically release memory of these cached events in future.
-                if (!(internalLastKeyEvent?.IsNativeHandleInvalid() ?? true))
-                {
-                    Interop.Key.DeleteKey(internalLastKeyEvent.SwigCPtr);
-                }
                 // Create empty event handle without register.
-                internalLastKeyEvent = new Key(Interop.Key.New(), false);
+                internalLastKeyEvent = new Key(Interop.Key.New(), true, false);
             }
             Interop.Window.InternalRetrievingLastKeyEvent(SwigCPtr, internalLastKeyEvent.SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -2141,22 +2133,14 @@ namespace Tizen.NUI
         /// We will use weak reference of last touch events.
         /// Return value will be invalidated if last touch event changed internally.
         /// </remarks>
-        /// <remarks>
-        /// Do not Dispose this value.
-        /// </remarks>
         /// <returns>The last touch event the window gets.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Touch GetLastTouchEvent()
         {
             if (internalLastTouchEvent == null)
             {
-                // TODO : We need to make automatically release memory of these cached events in future.
-                if (!(internalLastTouchEvent?.IsNativeHandleInvalid() ?? true))
-                {
-                    Interop.Touch.DeleteTouch(internalLastTouchEvent.SwigCPtr);
-                }
                 // Create empty event handle without register.
-                internalLastTouchEvent = new Touch(Interop.Touch.NewTouch(), false);
+                internalLastTouchEvent = new Touch(Interop.Touch.NewTouch(), true, false);
             }
             Interop.Window.InternalRetrievingLastTouchEvent(SwigCPtr, internalLastTouchEvent.SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -2170,22 +2154,14 @@ namespace Tizen.NUI
         /// We will use weak reference of last hover events.
         /// Return value will be invalidated if last hover event changed internally.
         /// </remarks>
-        /// <remarks>
-        /// Do not Dispose this value.
-        /// </remarks>
         /// <returns>The last hover event the window gets.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Hover GetLastHoverEvent()
         {
             if (internalLastHoverEvent == null)
             {
-                // TODO : We need to make automatically release memory of these cached events in future.
-                if (!(internalLastHoverEvent?.IsNativeHandleInvalid() ?? true))
-                {
-                    Interop.Hover.DeleteHover(internalLastHoverEvent.SwigCPtr);
-                }
                 // Create empty event handle without register.
-                internalLastHoverEvent = new Hover(Interop.Hover.New(0u), false);
+                internalLastHoverEvent = new Hover(Interop.Hover.New(0u), true, false);
             }
             Interop.Window.InternalRetrievingLastHoverEvent(SwigCPtr, internalLastHoverEvent.SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -2273,20 +2249,6 @@ namespace Tizen.NUI
                 childLayers.Clear();
 
                 localController?.Dispose();
-
-                // TODO : We need to make automatically release memory of these cached events in future.
-                if (!(internalLastKeyEvent?.IsNativeHandleInvalid() ?? true))
-                {
-                    Interop.Key.DeleteKey(internalLastKeyEvent.SwigCPtr);
-                }
-                if (!(internalLastTouchEvent?.IsNativeHandleInvalid() ?? true))
-                {
-                    Interop.Touch.DeleteTouch(internalLastTouchEvent.SwigCPtr);
-                }
-                if (!(internalLastHoverEvent?.IsNativeHandleInvalid() ?? true))
-                {
-                    Interop.Hover.DeleteHover(internalLastHoverEvent.SwigCPtr);
-                }
 
                 internalLastKeyEvent?.Dispose();
                 internalLastKeyEvent = null;


### PR DESCRIPTION
There are some usecase s.t. we have to call ReleaseSwigCPtr but don't want register to Registry.

For example, PixelBuffer and PixelData dont need to be create only for main thread.