### PR TITLE
[NUI] Consider WeakReference resurrection at Registry.

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Registry.cs
+++ b/src/Tizen.NUI/src/internal/Common/Registry.cs
@@ -58,7 +58,7 @@ namespace Tizen.NUI
 
             RegistryCurrentThreadCheck();
 
-            if (Instance._controlMap.TryAdd(refCptr, new WeakReference(baseHandle, false)) != true)
+            if (Instance._controlMap.TryAdd(refCptr, new WeakReference(baseHandle, true)) != true)
             {
                 WeakReference weakReference;
                 if(Instance._controlMap.TryGetValue(refCptr, out weakReference))


### PR DESCRIPTION
Since NUI use DisposeQueue system instead of GC directly, the lifecycle of WeakReference may need to be alive more times.

If we make trackResurrection as false, WeakReference.Target become null when the item is in DisposeQueue.