### PR TITLE
[NUI] Fix some SVACE issues of null reference.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/TabButton.cs
+++ b/src/Tizen.NUI.Components/Controls/TabButton.cs
@@ -301,10 +301,10 @@ namespace Tizen.NUI.Components
                 // Text only
                 if (isEmptyIcon && !isEmptyText)
                 {
-                    if (tabButtonStyle.Size != null)
+                    if (tabButtonStyle.Size  is var size && size  != null)
                     {
-                        WidthSpecification = (int)tabButtonStyle.Size.Width;
-                        HeightSpecification = (int)tabButtonStyle.Size.Height;
+                        WidthSpecification = (int)size.Width;
+                        HeightSpecification = (int)size.Height;
                     }
 
                     if ((tabButtonStyle.Text != null) && (tabButtonStyle.Text.PixelSize != null) && (tabButtonStyle.Text.PixelSize.Normal != null))
@@ -335,11 +335,11 @@ namespace Tizen.NUI.Components
                         WidthSpecification = (int)tabButtonStyle.SizeWithIcon.Width;
                         HeightSpecification = (int)tabButtonStyle.SizeWithIcon.Height;
                     }
-
-                    if ((tabButtonStyle.Icon != null) && (tabButtonStyle.Icon.Size != null))
+                    var size = tabButtonStyle.Icon?.Size;
+                    if (size != null)
                     {
-                        Icon.WidthSpecification = (int)tabButtonStyle.Icon.Size.Width;
-                        Icon.HeightSpecification = (int)tabButtonStyle.Icon.Size.Height;
+                        Icon.WidthSpecification = (int)size.Width;
+                        Icon.HeightSpecification = (int)size.Height;
                     }
 
                     TextLabel.PixelSize = tabButtonStyle.TextSizeWithIcon;
@@ -347,10 +347,10 @@ namespace Tizen.NUI.Components
                 // Nothing
                 else
                 {
-                    if (tabButtonStyle.Size != null)
+                    if (tabButtonStyle.Size is var size && size != null)
                     {
-                        WidthSpecification = (int)tabButtonStyle.Size.Width;
-                        HeightSpecification = (int)tabButtonStyle.Size.Height;
+                        WidthSpecification = (int)size.Width;
+                        HeightSpecification = (int)size.Height;
                     }
                 }
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

WID:13452033 [STATISTICAL] Value tabButtonStyle.Icon.Size, which is result of method invocation with possible null return value, is dereferenced in member access expression tabButtonStyle.Icon.Size.Width
WID:13451996 [STATISTICAL] Value tabButtonStyle.Size, which is result of method invocation with possible null return value, is dereferenced in member access expression tabButtonStyle.Size.Width

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
