### PR TITLE
[NUI] bug fixed about cMemoryOwn

### DIFF
--- a/src/Tizen.NUI/src/public/Events/Hover.cs
+++ b/src/Tizen.NUI/src/public/Events/Hover.cs
@@ -52,7 +52,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Touch.cs
+++ b/src/Tizen.NUI/src/public/Events/Touch.cs
@@ -42,7 +42,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Touch(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        internal Touch(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Wheel.cs
+++ b/src/Tizen.NUI/src/public/Events/Wheel.cs
@@ -53,7 +53,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Wheel(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        internal Wheel(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Input/Key.cs
+++ b/src/Tizen.NUI/src/public/Input/Key.cs
@@ -49,7 +49,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Key(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        internal Key(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
 


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
bug fixed about cMemoryOwn
refer : https://github.com/Samsung/TizenFX/pull/5603


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
