### PR TITLE
[NUI] revert default key construct

### DIFF
--- a/src/Tizen.NUI/src/public/Input/Key.cs
+++ b/src/Tizen.NUI/src/public/Input/Key.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
         /// The default constructor.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public Key() : this(Interop.Key.New(), true)
+        public Key() : this(Interop.Key.New("","",0,0,0u,0), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
[NUI] revert default key construct
refer : https://github.com/Samsung/TizenFX/pull/5589/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
