### PR TITLE
[NUI] Fix some SVACE issues.

### DIFF
--- a/src/Tizen.NUI.Physics2D/src/internal/chipmunk/cpSpaceDebugDrawOptions.cs
+++ b/src/Tizen.NUI.Physics2D/src/internal/chipmunk/cpSpaceDebugDrawOptions.cs
@@ -104,15 +104,13 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         private IntPtr ToPointer()
         {
             IntPtr drawOptionsPtr = NativeInterop.AllocStructure<cpSpaceDebugDrawOptions>();
-            try
+            if (Marshal.SizeOf(typeof(cpSpaceDebugDrawOptions)) == 0)
             {
-                Marshal.StructureToPtr<cpSpaceDebugDrawOptions>(this, drawOptionsPtr, false);
+                throw new ArgumentNullException("The size of type cpSpaceDebugDrawOptions should not be 0.");
             }
-            catch (Exception exception)
-            {
-                Tizen.Log.Fatal("NUI", "[Error] got exception during Marshal.StructureToPtr, this should not occur, message : " + exception.Message);
-            }
-      
+
+            Marshal.StructureToPtr<cpSpaceDebugDrawOptions>(this, drawOptionsPtr, false);
+
             return drawOptionsPtr;
         }
 

--- a/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/CreateValuesVisitor.cs
@@ -202,9 +202,9 @@ namespace Tizen.NUI.Xaml
 
                 Values[node] = value;
             }
-
-            if (value != null && value is BindableObject)
-                NameScope.SetNameScope(value as BindableObject, node.Namescope);
+            var bindableObject = value as BindableObject;
+            if (bindableObject != null)
+                NameScope.SetNameScope(bindableObject, node.Namescope);
         }
 
         public void Visit(RootNode node, INode parentNode)

--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -183,18 +183,23 @@ namespace Tizen.NUI.BaseComponents
         {
             unsafe
             {
-                if (textures != null && sizeof(IntPtr) * textures.Count > 0)
+                
+                if (textures != null)
                 {
-                    IntPtr unmanagedPointer = Marshal.AllocHGlobal(checked(sizeof(IntPtr) * textures.Count));
-                    IntPtr[] texturesArray = new IntPtr[textures.Count];
-                    for (int i = 0; i < textures.Count; i++)
+                    int intptrBytes = checked(sizeof(IntPtr) * textures.Count);
+                    if (intptrBytes>0)
                     {
-                        texturesArray[i] = HandleRef.ToIntPtr(Texture.getCPtr(textures[i]));
-                    }
-                    System.Runtime.InteropServices.Marshal.Copy(texturesArray, 0, unmanagedPointer, textures.Count);
+                        IntPtr unmanagedPointer = Marshal.AllocHGlobal(intptrBytes);
+                        IntPtr[] texturesArray = new IntPtr[textures.Count];
+                        for (int i = 0; i < textures.Count; i++)
+                        {
+                            texturesArray[i] = HandleRef.ToIntPtr(Texture.getCPtr(textures[i]));
+                        }
+                        System.Runtime.InteropServices.Marshal.Copy(texturesArray, 0, unmanagedPointer, textures.Count);
 
-                    Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, textures.Count);
-                    Marshal.FreeHGlobal(unmanagedPointer);
+                        Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, textures.Count);
+                        Marshal.FreeHGlobal(unmanagedPointer);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1.CreateValuesVisitor.cs
ArgumentNullException can be thrown inside invocation NameScope.SetNameScope(value as BindableObject, node.Namescope)
WID:14930967 Value value as BindableObject, which was created by as-operator, so can be null, is dereferenced in method call NameScope.SetNameScope()
line 207:  NameScope.SetNameScope(value as BindableObject, node.Namescope);
2.DirectRenderingGLView.cs
buffer size may be 0
textures.Count may be 4194241
element byte size may be 8
WID:14929477 Writing textures.Count elements of type System.IntPtr into buffer unmanagedPointer can exceed its size
line 194: System.Runtime.InteropServices.Marshal.Copy(texturesArray, 0, unmanagedPointer, textures.Count);

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
