### PR TITLE
[NUI] Fix Registry exception for custom view wrapper

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
@@ -389,11 +389,30 @@ namespace Tizen.NUI
 
         private void DirectorOnSizeAnimation(global::System.IntPtr animation, global::System.IntPtr targetSize)
         {
-            var ani = new Animation(animation, true);
+            bool useRegisterAnimation = false;
+
+            var ani = Registry.GetManagedBaseHandleFromNativePtr(animation) as Animation;
+            if (ani != null)
+            {
+                HandleRef CPtr = new HandleRef(this, animation);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new HandleRef(null, global::System.IntPtr.Zero);
+
+                useRegisterAnimation = true;
+            }
+            else
+            {
+                ani = new Animation(animation, true);
+            }
             var vector3 = new Vector3(targetSize, false);
             OnSizeAnimation?.Invoke(ani, vector3);
-            ani.Dispose();
             vector3.Dispose();
+
+            // Dispose only if we create new Animation here.
+            if (!useRegisterAnimation)
+            {
+                ani.Dispose();
+            }
         }
 
         private bool DirectorOnKey(global::System.IntPtr arg0)
@@ -469,9 +488,28 @@ namespace Tizen.NUI
 
         private void DirectorOnStyleChange(global::System.IntPtr styleManager, int change)
         {
-            var styleManger = new StyleManager(styleManager, true);
-            OnStyleChange?.Invoke(styleManger, (StyleChangeType)change);
-            styleManger.Dispose();
+            bool useRegisterStyleManager = false;
+
+            var nuiStyleManger = Registry.GetManagedBaseHandleFromNativePtr(styleManager) as StyleManager;
+            if (nuiStyleManger != null)
+            {
+                HandleRef CPtr = new HandleRef(this, styleManager);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new HandleRef(null, global::System.IntPtr.Zero);
+
+                useRegisterStyleManager = true;
+            }
+            else
+            {
+                nuiStyleManger = new StyleManager(styleManager, true);
+            }
+            OnStyleChange?.Invoke(nuiStyleManger, (StyleChangeType)change);
+
+            // Dispose only if we create new StyleManager here.
+            if (!useRegisterStyleManager)
+            {
+                nuiStyleManger.Dispose();
+            }
         }
 
         private bool DirectorOnAccessibilityActivated()
@@ -481,7 +519,8 @@ namespace Tizen.NUI
 
         private bool DirectorOnAccessibilityPan(global::System.IntPtr gesture)
         {
-            var panGesture = new PanGesture(gesture, true);
+            // Take memory ownership, but do not register into Registry.
+            var panGesture = new PanGesture(gesture, true, false);
             var ret = OnAccessibilityPan?.Invoke(panGesture) ?? false;
             panGesture.Dispose();
             return ret;

--- a/src/Tizen.NUI/src/public/Events/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Events/Gesture.cs
@@ -37,7 +37,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Gesture(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Gesture(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal Gesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
@@ -35,7 +35,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal LongPressGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal LongPressGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal LongPressGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/PanGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGesture.cs
@@ -49,7 +49,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PanGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.PanGestureDetector.PanGestureUpcast(cPtr), cMemoryOwn)
+        internal PanGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : this(Interop.PanGestureDetector.PanGestureUpcast(cPtr), cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal PanGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(Interop.PanGestureDetector.PanGestureUpcast(cPtr), cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/PinchGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGesture.cs
@@ -25,7 +25,11 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class PinchGesture : Gesture
     {
-        internal PinchGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PinchGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal PinchGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/RotationGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGesture.cs
@@ -26,8 +26,11 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class RotationGesture : Gesture
     {
+        internal RotationGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
 
-        internal RotationGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal RotationGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/TapGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGesture.cs
@@ -36,7 +36,11 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal TapGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal TapGesture(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal TapGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 


### PR DESCRIPTION
1. PanGesture from Accessibility create new handle in dali csharp side. We need to have memory ownership, but don't need to register it on NUI side. We can ignore it.

2. For Animation and StyleManager, it is possible to use that 'already registered' BaseHandle. But in this case, we should not dispose it by our self.