### PR TITLE
[NUI] Resolve TextLable build warning

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -1425,7 +1425,7 @@ namespace Tizen.NUI.BaseComponents
         /// <code>
         /// var textFitArray = new Tizen.NUI.Text.TextFitArray();
         /// textFitArray.Enable = true;
-        /// textFitArray.OptionList = new List<Tizen.NUI.Text.TextFitArrayOption>()
+        /// textFitArray.OptionList = new List&lt;Tizen.NUI.Text.TextFitArrayOption&gt;()
         /// {
         ///     new Tizen.NUI.Text.TextFitArrayOption(12, 18),
         ///     new Tizen.NUI.Text.TextFitArrayOption(24, 40),
@@ -1441,14 +1441,14 @@ namespace Tizen.NUI.BaseComponents
         /// [Binary search possible]
         /// |            | List index  |  0 |  1 |  2 |  3 |
         /// | OptionList | PointSize   | 24 | 28 | 32 | 48 |
-        /// |            | MinLineSize | 40 | 48 | 48 | 62 | << MinLineSize sorted in ascending order
+        /// |            | MinLineSize | 40 | 48 | 48 | 62 | &lt;&lt; MinLineSize sorted in ascending order
         ///                                    ^    ^
         ///                                    same values ​are not a problem
         ///
         /// [Binary search not possible]
         /// |            | List index  |  0 |  1 |  2 |  3 |
         /// | OptionList | PointSize   | 24 | 28 | 32 | 48 |
-        /// |            | MinLineSize | 40 | 48 | 38 | 62 | << MinLineSize is not sorted in ascending order
+        /// |            | MinLineSize | 40 | 48 | 38 | 62 | &lt;&lt; MinLineSize is not sorted in ascending order
         ///                                         ^
         /// </code>
         /// </example>


### PR DESCRIPTION
Reference documents : https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/

To refer to XML elements (for example, your function processes specific XML elements that you want to describe in an XML documentation comment), you can use the standard quoting mechanism (&lt; and &gt;).

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
