### PR TITLE
[NUI] Fix the SVACE issue.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Button.cs
+++ b/src/Tizen.NUI.Components/Controls/Button.cs
@@ -790,7 +790,15 @@ namespace Tizen.NUI.Components
         }
         private StringSelector InternalIconURLSelector
         {
-            get => buttonIcon?.ResourceUrlSelector == null ? null : new StringSelector(buttonIcon.ResourceUrlSelector);
+            get
+            {
+                Selector<string> resourceUrlSelector = buttonIcon?.ResourceUrlSelector;
+                if(resourceUrlSelector == null)
+                {
+                    return null;
+                }
+                return new StringSelector(resourceUrlSelector);
+            }
             set
             {
                 if (value == null || buttonIcon == null)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Value buttonIcon.ResourceUrlSelector, which is result of method invocation with possible null return value, is dereferenced in constructor of the type StringSelector (passed via parameter buttonIcon.ResourceUrlSelector)

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
