### PR TITLE
[Applications.Common] Use Marshal.FreeHGlobal() instead of Libc.Free()

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libc.cs
@@ -23,9 +23,6 @@ internal static partial class Interop
 {
     internal static partial class Libc
     {
-        [DllImport(Libraries.Libc, EntryPoint = "free", CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int Free(IntPtr ptr);
-
         [DllImport(Libraries.Libc, EntryPoint = "getenv")]
         internal static extern IntPtr GetEnvironmentVariable(string name);
 

--- a/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/AppControl.cs
@@ -1335,9 +1335,9 @@ namespace Tizen.Applications
                     {
                         IntPtr charArr = Marshal.ReadIntPtr(valuePtr, IntPtr.Size * i);
                         stringList.Add(Marshal.PtrToStringAnsi(charArr));
-                        _ = Interop.Libc.Free(charArr);
+                        Marshal.FreeHGlobal(charArr);
                     }
-                    _ = Interop.Libc.Free(valuePtr);
+                    Marshal.FreeHGlobal(valuePtr);
                     value = stringList;
                     return true;
                 }
@@ -1491,9 +1491,9 @@ namespace Tizen.Applications
                     {
                         IntPtr charArr = Marshal.ReadIntPtr(valuePtr, IntPtr.Size * i);
                         valueArray.Add(Marshal.PtrToStringAnsi(charArr));
-                        _ = Interop.Libc.Free(charArr);
+                        Marshal.FreeHGlobal(charArr);
                     }
-                    _ = Interop.Libc.Free(valuePtr);
+                    Marshal.FreeHGlobal(valuePtr);
                 }
                 return valueArray;
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This patch changes using free() to using Marshal.FreeHGlobal().
To avoid crash issues in the asan binary, the library should not use Libc.Free() function directly as possible.
