### PR TITLE
[NUI] Make AddFrameUpdateCallback with root view

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2219,6 +2219,19 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Add FrameUpdateCallback with root view.
+        /// FrameUpdateCallbackInterface can only detach Views under given view.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddFrameUpdateCallback(FrameUpdateCallbackInterface frameUpdateCallback, View rootView)
+        {
+            if(rootView != null)
+            {
+                frameUpdateCallback?.AddFrameUpdateCallback(stageCPtr, View.getCPtr(rootView));
+            }
+        }
+
+        /// <summary>
         /// Remove FrameUpdateCallback
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
@@ -540,7 +540,8 @@ namespace Tizen.NUI.Samples
 
       // Add frame callback on window.
       // OnUpdate callback of frameUpdateCallback will be called before every render frame.
-      window.AddFrameUpdateCallback(frameUpdateCallback);
+      // We can set root view what given frameUpdateCallback used
+      window.AddFrameUpdateCallback(frameUpdateCallback, controlView);
 
       // compute limit position the container could go.
       leftDirectionLimit = (float)window.Size.Width - (totalSize + (float)(INITIAL_POSITION));


### PR DESCRIPTION
Previously, we can only add the root view of FrameUpdateCallback as root layer of window.

Now let we add some API that user can set specific view for given FrameUpdateCallback will use.

This API will be used when we want to optimize callback behaviour.