### PR TITLE
[NUI] Make View.TooltipText return valid value

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -866,12 +866,24 @@ namespace Tizen.NUI.BaseComponents
             {
                 using (var propertyValue = GetProperty(Property.TOOLTIP))
                 {
-                    if (propertyValue != null && propertyValue.Get(out string retrivedValue))
+                    using var propertyMap = new PropertyMap();
+                    if (propertyValue != null && propertyValue.Get(propertyMap))
                     {
-                        return retrivedValue;
+                        using var retrivedContentValue = propertyMap?.Find(NDalic.TooltipContent);
+                        if (retrivedContentValue != null)
+                        {
+                            using var contextPropertyMap = new PropertyMap();
+                            if (retrivedContentValue.Get(contextPropertyMap))
+                            {
+                                using var retrivedTextValue = contextPropertyMap?.Find(NDalic.TextVisualText);
+                                if (retrivedTextValue != null && retrivedTextValue.Get(out string retrivedValue))
+                                {
+                                    return retrivedValue;
+                                }
+                            }
+                        }
                     }
-                    NUILog.Error($"[ERROR] Fail to get TooltipText! Return error MSG (error to get TooltipText)!");
-                    return "error to get TooltipText";
+                    return "";
                 }
             }
             set

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/public/TSView.cs
@@ -207,5 +207,24 @@ namespace Tizen.NUI.Devel.Tests
 
             testView.Dispose();
         }
+
+
+        [Test]
+        [Category("P1")]
+        [Description("Get value test for View.ToolTipText")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.View.ToolTipText")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRW")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void ToolTipText_GET_SET_VALUE()
+        {
+            /* TEST CODE */
+            View testView = new View();
+
+            testView.TooltipText = "tooltipText";
+            Assert.AreEqual("tooltipText", testView.TooltipText, "Should get equal string value what we set before");
+
+            testView.Dispose();
+        }
     }
 }


### PR DESCRIPTION
Let we remove useless error message + Make getter return valid setting value for View.TooltipText property.