### PR TITLE
[NUI][AT-SPI] Detach NUIViewAccessible in View.Dispose()

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -539,6 +539,9 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetAccessibilityDelegate")]
             public static extern IntPtr DaliAccessibilitySetAccessibilityDelegate(IntPtr arg1_accessibilityDelegate, uint arg2_accessibilityDelegateSize);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_DetachAccessibleObject")]
+            public static extern void DaliAccessibilityDetachAccessibleObject(HandleRef arg1_control);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -397,6 +397,9 @@ namespace Tizen.NUI.BaseComponents
 
             internalName = null;
 
+            Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
             if (disposing == false)
             {
                 if (IsNativeHandleInvalid() || SwigCMemOwn == false)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
@@ -53,7 +53,7 @@ namespace Tizen.NUI.BaseComponents
 
             if (view is null)
             {
-                NUILog.Error($"RefObject 0x{refObjectPtr:x} is not a View");
+                throw new ArgumentException($"RefObject 0x{refObjectPtr:x} is not a View", nameof(refObjectPtr));
             }
 
             return view;
@@ -70,9 +70,7 @@ namespace Tizen.NUI.BaseComponents
                 return atspiInterface;
             }
 
-            NUILog.Error($"RefObject 0x{refObjectPtr:x} is not a {typeof(T).FullName}");
-
-            return default(T);
+            throw new ArgumentException($"RefObject 0x{refObjectPtr:x} is not a {typeof(T).FullName}", nameof(refObjectPtr));
         }
 
         private static IntPtr DuplicateString(string value)
@@ -113,8 +111,6 @@ namespace Tizen.NUI.BaseComponents
         private static ulong AccessibilityCalculateStatesWrapper(IntPtr self, ulong initialStates)
         {
             View view = GetViewFromRefObject(self);
-            if (view == null)
-                return 0UL;
 
             ulong bitMask = 0UL;
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

The application may crash if the View is disposed but the Accessibility infrastructure calls one of the View methods. Detaching the NUIViewAccessible proxy object in View.Dispose() should prevent that.

Dependency: https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/300277/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
