### PR TITLE
[NUI] Supports set/get full screen window

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -393,6 +393,13 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_KeyboardUnGrab")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool KeyboardUnGrab(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetFullScreen")]
+            public static extern void SetFullScreen(global::System.Runtime.InteropServices.HandleRef window, bool fullscreen);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetFullScreen")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool GetFullScreen(global::System.Runtime.InteropServices.HandleRef window);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2424,6 +2424,32 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Sets to resize window with full screen.
+        /// If full screen size is set for the window,
+        /// window will be resized with full screen.
+        /// In addition, the full screen sized window's z-order is the highest.
+        /// </summary>
+        /// <param name="fullscreen"> If fullscreen is true, set fullscreen or unset.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetFullScreen(bool fullscreen)
+        {
+            Interop.Window.SetFullScreen(SwigCPtr, fullscreen);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Gets whether the full screen sized window or not.
+        /// </summary>
+        /// <returns>Returns true if the full screen sized window is.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool GetFullScreen()
+        {
+            bool ret = Interop.Window.GetFullScreen(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+              return ret;
+        }
+
+        /// <summary>
         /// Get Native Window handle.
         /// <example>
         /// How to get Native Window handle

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowTest.cs
@@ -179,6 +179,16 @@ namespace Tizen.NUI.Samples
                     case KEY_NUM_7:
                         mainWin.SetMimimumSize(new Size2D(100, 100));
                         break;
+                    case KEY_NUM_8:
+                        if(mainWin.GetFullScreen() == false)
+                        {
+                            mainWin.SetFullScreen(true);
+                        }
+                        else
+                        {
+                            mainWin.SetFullScreen(false);
+                        }
+                        break;
 
                     default:
                         log.Fatal(tag, $"no test!");

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Window/TSWindow.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Window/TSWindow.cs
@@ -1625,5 +1625,29 @@ namespace Tizen.NUI.Devel.Tests
 
             tlog.Debug(tag, $"WindowRequestResizeToServer END (OK)");
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("Window SetFullScreen")]
+        [Property("SPEC", "Tizen.NUI.Window.SetFullScreen M")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "MR")]
+        public void SetFullScreen()
+        {
+            tlog.Debug(tag, $"SetFullScreen START");
+
+            try
+            {
+                win.SetFullScreen(true);
+                Assert.IsTrue(win.GetFullScreen());
+            }
+            catch (Exception e)
+            {
+                tlog.Debug(tag, e.Message.ToString());
+                Assert.Fail("Caught Exception : Failed!");
+            }
+
+            tlog.Debug(tag, $"SetFullScreen END (OK)");
+        }
     }
 }


### PR DESCRIPTION
Supports set/get full screen window.

The full screen window means the window's size is same of full screen size.
The related DALi's patches are the belows.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/300078/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/300079/

Recently, Taskbar application was added to platform applications.
The Taskbar application is always floating on the home application. The application's window is the highest of the other window.
If the Taskbar application works, the other application window should be resized excepted Taskbar window's size.
The other requirement, some application want their windows are resized with full screen although Taskbar works.
To do that, the window uses full screen option.

The guide is 
--------------------------------------------------------------------------------------
                        if(mainWin.GetFullScreen() == false)
                        {
                            mainWin.SetFullScreen(true);
                        }
                        else
                        {
                            mainWin.SetFullScreen(false);
                        }
--------------------------------------------------------------------------------------
If you want to use the related sample, refer the example, please
TizenFX/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/WindowTest.cs


