### PR TITLE
[NUI] Add KeepWidgetSize for control widget's size

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WidgetView.cs
@@ -55,6 +55,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_Property_EFFECT_get")]
             public static extern int EffectGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WidgetView_Property_KEEP_WIDGET_SIZE_get")]
+            public static extern int KeepWidgetSizeGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_WidgetView_Property")]
             public static extern global::System.IntPtr NewWidgetViewProperty();
 

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -138,6 +138,25 @@ namespace Tizen.NUI
             return instance.InternalEffect;
         });
 
+        /// <summary>
+        /// UpdateWidgetSizeProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty KeepWidgetSizeProperty = BindableProperty.Create(nameof(KeepWidgetSize), typeof(bool), typeof(Tizen.NUI.WidgetView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var instance = (Tizen.NUI.WidgetView)bindable;
+            if (newValue != null)
+            {
+                instance.InternalKeepWidgetSize = (bool)newValue;
+            }
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var instance = (Tizen.NUI.WidgetView)bindable;
+            return instance.InternalKeepWidgetSize;
+        });
+
+
         private EventHandler<WidgetViewEventArgs> widgetAddedEventHandler;
         private WidgetAddedEventCallbackType widgetAddedEventCallback;
         private EventHandler<WidgetViewEventArgs> widgetContentUpdatedEventHandler;
@@ -686,6 +705,42 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets or sets KeepWidgetSize
+        ///
+        /// if this value is true, WidgetView keep widget instance's size and don't resize even if WidgetView is resized.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool KeepWidgetSize
+        {
+            get
+            {
+                return (bool)GetValue(KeepWidgetSizeProperty);
+            }
+            set
+            {
+                SetValue(KeepWidgetSizeProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+        private bool InternalKeepWidgetSize
+        {
+            get
+            {
+                bool retValue = false;
+                PropertyValue keepWidgetSize = GetProperty(WidgetView.Property.KeepWidgetSize);
+                keepWidgetSize?.Get(out retValue);
+                keepWidgetSize?.Dispose();
+                return retValue;
+            }
+            set
+            {
+                PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
+                SetProperty(WidgetView.Property.KeepWidgetSize, setValue);
+                setValue.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Pauses a given widget.
         /// </summary>
         /// <returns>True on success, false otherwise.</returns>
@@ -1022,6 +1077,7 @@ namespace Tizen.NUI
             internal static readonly int RetryText = Interop.WidgetView.RetryTextGet();
             internal static readonly int EFFECT = Interop.WidgetView.EffectGet();
 
+            internal static readonly int KeepWidgetSize = Interop.WidgetView.KeepWidgetSizeGet();
 
             [Obsolete("Do not use this, that is deprecated in API9 and will be removed in API11. Use WidgetId instead.")]
             internal static readonly int WIDGET_ID = Interop.WidgetView.WidgetIdGet();


### PR DESCRIPTION
WidgetView keep widget instance's size and don't resize even if WidgetView is resized.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
