### PR TITLE
[NUI] Make NativeImageQueue generate valid url

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/NativeImageInterface.cs
+++ b/src/Tizen.NUI/src/internal/Common/NativeImageInterface.cs
@@ -77,5 +77,12 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
+
+        public virtual ImageUrl GenerateUrl()
+        {
+            ImageUrl ret = new ImageUrl(Interop.NativeImageInterface.GenerateUrl(SwigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageInterface.cs
@@ -44,6 +44,9 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool RequiresBlending(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GenerateUrl")]
+            public static extern global::System.IntPtr GenerateUrl(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_SWIGUpcast")]
             public static extern global::System.IntPtr Upcast(global::System.IntPtr jarg1);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
@@ -40,6 +40,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_EnqueueBuffer")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool EnqueueBuffer(IntPtr queue, IntPtr buffer);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GenerateUrl")]
+            public static extern IntPtr GenerateUrl(IntPtr queue);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
@@ -105,10 +105,10 @@ namespace Tizen.NUI
         /// </remarks>
         /// <returns>The ImageUrl of NativeImageQueue.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ImageUrl GenerateUrl()
+        public override ImageUrl GenerateUrl()
         {
-            ImageUrl ret = new ImageUrl(Interop.NativeImageSource.GenerateUrl(this.SwigCPtr.Handle), true);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
+            ImageUrl ret = new ImageUrl(Interop.NativeImageQueue.GenerateUrl(this.SwigCPtr.Handle), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 

--- a/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
@@ -44,10 +44,10 @@ namespace Tizen.NUI
         /// This API should not be called at worker thread.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ImageUrl GenerateUrl()
+        public override ImageUrl GenerateUrl()
         {
             ImageUrl ret = new ImageUrl(Interop.NativeImageSource.GenerateUrl(this.SwigCPtr.Handle), true);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 


### PR DESCRIPTION
Previously NativeImageQueue.GenerateUrl() binded to invalid csharp API.

It will make some crash. So let we use valid bind API instead.

Required dali patches:
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/300505
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/300513