### PR TITLE
[NUI] Do not register when we try to copy instance

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Camera.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Camera.cs
@@ -32,7 +32,11 @@ namespace Tizen.NUI.Scene3D
     /// <since_tizen> 10 </since_tizen>
     public partial class Camera : View
     {
-        internal Camera(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Camera(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal Camera(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, true, cRegister)
         {
         }
 
@@ -50,7 +54,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="camera">The Camera object to be copied.</param>
         /// <since_tizen> 10 </since_tizen>
-        public Camera(Camera camera) : this(Interop.Camera.NewCamera(Camera.getCPtr(camera)), true)
+        public Camera(Camera camera) : this(Interop.Camera.NewCamera(Camera.getCPtr(camera)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -76,7 +76,11 @@ namespace Tizen.NUI.Scene3D
     /// <since_tizen> 10 </since_tizen>
     public partial class Model : View
     {
-        internal Model(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Model(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal Model(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, true, cRegister)
         {
         }
 
@@ -114,7 +118,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="model">Source object to copy.</param>
         /// <since_tizen> 10 </since_tizen>
-        public Model(Model model) : this(Interop.Model.NewModel(Model.getCPtr(model)), true)
+        public Model(Model model) : this(Interop.Model.NewModel(Model.getCPtr(model)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             this.PositionUsesPivotPoint = model.PositionUsesPivotPoint;

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -72,7 +72,11 @@ namespace Tizen.NUI.Scene3D
         private Animation cameraTransition;
         private string skyboxUrl;
 
-        internal SceneView(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal SceneView(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal SceneView(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, true, cRegister)
         {
         }
 
@@ -90,7 +94,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="sceneView">The source object.</param>
         /// <since_tizen> 10 </since_tizen>
-        public SceneView(SceneView sceneView) : this(Interop.SceneView.NewScene(SceneView.getCPtr(sceneView)), true)
+        public SceneView(SceneView sceneView) : this(Interop.SceneView.NewScene(SceneView.getCPtr(sceneView)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI.Scene3D/src/public/Light/Light.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Light/Light.cs
@@ -53,7 +53,11 @@ namespace Tizen.NUI.Scene3D
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Light : View
     {
-        internal Light(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Light(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal Light(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, true, cRegister)
         {
         }
 
@@ -71,7 +75,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="light">Source object to copy.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Light(Light light) : this(Interop.Light.NewLight(Light.getCPtr(light)), true)
+        public Light(Light light) : this(Interop.Light.NewLight(Light.getCPtr(light)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI.Scene3D/src/public/ModelComponents/Material.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelComponents/Material.cs
@@ -43,7 +43,11 @@ namespace Tizen.NUI.Scene3D
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Material : BaseHandle
     {
-        internal Material(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Material(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal Material(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 
@@ -61,7 +65,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="material">Source object to copy.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Material(Material material) : this(Interop.Material.NewMaterial(Material.getCPtr(material)), true)
+        public Material(Material material) : this(Interop.Material.NewMaterial(Material.getCPtr(material)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelNode.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelNode.cs
@@ -47,7 +47,11 @@ namespace Tizen.NUI.Scene3D
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ModelNode : View
     {
-        internal ModelNode(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal ModelNode(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal ModelNode(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, true, cRegister)
         {
         }
 
@@ -66,7 +70,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="modelNode">Source object to copy.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ModelNode(ModelNode modelNode) : this(Interop.ModelNode.NewModelNode(ModelNode.getCPtr(modelNode)), true)
+        public ModelNode(ModelNode modelNode) : this(Interop.ModelNode.NewModelNode(ModelNode.getCPtr(modelNode)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelPrimitive.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelPrimitive.cs
@@ -42,7 +42,11 @@ namespace Tizen.NUI.Scene3D
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ModelPrimitive : BaseHandle
     {
-        internal ModelPrimitive(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal ModelPrimitive(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal ModelPrimitive(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 
@@ -60,7 +64,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="modelPrimitive">Source object to copy.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ModelPrimitive(ModelPrimitive modelPrimitive) : this(Interop.ModelPrimitive.NewModelPrimitive(ModelPrimitive.getCPtr(modelPrimitive)), true)
+        public ModelPrimitive(ModelPrimitive modelPrimitive) : this(Interop.ModelPrimitive.NewModelPrimitive(ModelPrimitive.getCPtr(modelPrimitive)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionData.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionData.cs
@@ -117,7 +117,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="motionData">Source object to copy.</param>
         /// <since_tizen> 11 </since_tizen>
-        public MotionData(MotionData motionData) : this(Interop.MotionData.NewMotionData(MotionData.getCPtr(motionData)), true)
+        public MotionData(MotionData motionData) : this(Interop.MotionData.NewMotionData(MotionData.getCPtr(motionData)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -134,7 +134,11 @@ namespace Tizen.NUI.Scene3D
             return ret;
         }
 
-        internal MotionData(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal MotionData(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal MotionData(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/BlendShapeIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/BlendShapeIndex.cs
@@ -113,7 +113,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="blendShapeIndex">Source object to copy.</param>
         /// <since_tizen> 11 </since_tizen>
-        public BlendShapeIndex(BlendShapeIndex blendShapeIndex) : this(Interop.MotionIndex.NewBlendShapeIndex(BlendShapeIndex.getCPtr(blendShapeIndex)), true)
+        public BlendShapeIndex(BlendShapeIndex blendShapeIndex) : this(Interop.MotionIndex.NewBlendShapeIndex(BlendShapeIndex.getCPtr(blendShapeIndex)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -130,7 +130,11 @@ namespace Tizen.NUI.Scene3D
             return ret;
         }
 
-        internal BlendShapeIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal BlendShapeIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal BlendShapeIndex(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionIndex.cs
@@ -49,7 +49,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="motionIndex">Source object to copy.</param>
         /// <since_tizen> 11 </since_tizen>
-        public MotionIndex(MotionIndex motionIndex) : this(Interop.MotionIndex.NewMotionIndex(MotionIndex.getCPtr(motionIndex)), true)
+        public MotionIndex(MotionIndex motionIndex) : this(Interop.MotionIndex.NewMotionIndex(MotionIndex.getCPtr(motionIndex)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -66,7 +66,11 @@ namespace Tizen.NUI.Scene3D
             return ret;
         }
 
-        internal MotionIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal MotionIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal MotionIndex(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionPropertyIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionPropertyIndex.cs
@@ -81,7 +81,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="motionPropertyIndex">Source object to copy.</param>
         /// <since_tizen> 11 </since_tizen>
-        public MotionPropertyIndex(MotionPropertyIndex motionPropertyIndex) : this(Interop.MotionIndex.NewMotionPropertyIndex(MotionPropertyIndex.getCPtr(motionPropertyIndex)), true)
+        public MotionPropertyIndex(MotionPropertyIndex motionPropertyIndex) : this(Interop.MotionIndex.NewMotionPropertyIndex(MotionPropertyIndex.getCPtr(motionPropertyIndex)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -98,7 +98,11 @@ namespace Tizen.NUI.Scene3D
             return ret;
         }
 
-        internal MotionPropertyIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal MotionPropertyIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal MotionPropertyIndex(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionTransformIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionTransformIndex.cs
@@ -146,7 +146,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="motionTransformIndex">Source object to copy.</param>
         /// <since_tizen> 11 </since_tizen>
-        public MotionTransformIndex(MotionTransformIndex motionTransformIndex) : this(Interop.MotionIndex.NewMotionTransformIndex(MotionTransformIndex.getCPtr(motionTransformIndex)), true)
+        public MotionTransformIndex(MotionTransformIndex motionTransformIndex) : this(Interop.MotionIndex.NewMotionTransformIndex(MotionTransformIndex.getCPtr(motionTransformIndex)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -163,7 +163,11 @@ namespace Tizen.NUI.Scene3D
             return ret;
         }
 
-        internal MotionTransformIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal MotionTransformIndex(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal MotionTransformIndex(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionValue.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionValue.cs
@@ -94,7 +94,7 @@ namespace Tizen.NUI.Scene3D
         /// </summary>
         /// <param name="motionValue">Source object to copy.</param>
         /// <since_tizen> 11 </since_tizen>
-        public MotionValue(MotionValue motionValue) : this(Interop.MotionValue.NewMotionValue(MotionValue.getCPtr(motionValue)), true)
+        public MotionValue(MotionValue motionValue) : this(Interop.MotionValue.NewMotionValue(MotionValue.getCPtr(motionValue)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -111,7 +111,11 @@ namespace Tizen.NUI.Scene3D
             return ret;
         }
 
-        internal MotionValue(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal MotionValue(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal MotionValue(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
@@ -37,21 +37,23 @@ namespace Tizen.NUI
             var gaussianBlurView = (GaussianBlurView)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty(gaussianBlurView.swigCPtr, gaussianBlurView.GetBlurStrengthPropertyIndex(), new Tizen.NUI.PropertyValue((float)newValue));
+                Tizen.NUI.Object.SetProperty(gaussianBlurView.SwigCPtr, gaussianBlurView.GetBlurStrengthPropertyIndex(), new Tizen.NUI.PropertyValue((float)newValue));
             }
         },
         defaultValueCreator: (bindable) =>
         {
             var gaussianBlurView = (GaussianBlurView)bindable;
             float temp;
-            Tizen.NUI.Object.GetProperty(gaussianBlurView.swigCPtr, gaussianBlurView.GetBlurStrengthPropertyIndex()).Get(out temp);
+            Tizen.NUI.Object.GetProperty(gaussianBlurView.SwigCPtr, gaussianBlurView.GetBlurStrengthPropertyIndex()).Get(out temp);
             return temp;
         });
-        private global::System.Runtime.InteropServices.HandleRef swigCPtr;
 
-        internal GaussianBlurView(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal GaussianBlurView(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
-            swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+        }
+
+        internal GaussianBlurView(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        {
         }
 
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
@@ -193,7 +195,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public GaussianBlurView(GaussianBlurView handle) : this(Interop.GaussianBlurView.NewGaussianBlurView(GaussianBlurView.getCPtr(handle)), true)
+        public GaussianBlurView(GaussianBlurView handle) : this(Interop.GaussianBlurView.NewGaussianBlurView(GaussianBlurView.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -205,7 +207,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Activate()
         {
-            Interop.GaussianBlurView.Activate(swigCPtr);
+            Interop.GaussianBlurView.Activate(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -218,7 +220,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ActivateOnce()
         {
-            Interop.GaussianBlurView.ActivateOnce(swigCPtr);
+            Interop.GaussianBlurView.ActivateOnce(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -229,13 +231,13 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Deactivate()
         {
-            Interop.GaussianBlurView.Deactivate(swigCPtr);
+            Interop.GaussianBlurView.Deactivate(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         private int GetBlurStrengthPropertyIndex()
         {
-            int ret = Interop.GaussianBlurView.GetBlurStrengthPropertyIndex(swigCPtr);
+            int ret = Interop.GaussianBlurView.GetBlurStrengthPropertyIndex(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -243,27 +245,27 @@ namespace Tizen.NUI
 
         internal void SetBackgroundColor(Vector4 color)
         {
-            Interop.GaussianBlurView.SetBackgroundColor(swigCPtr, Vector4.getCPtr(color));
+            Interop.GaussianBlurView.SetBackgroundColor(SwigCPtr, Vector4.getCPtr(color));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         internal Vector4 GetBackgroundColor()
         {
-            Vector4 ret = new Vector4(Interop.GaussianBlurView.GetBackgroundColor(swigCPtr), true);
+            Vector4 ret = new Vector4(Interop.GaussianBlurView.GetBackgroundColor(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         private GaussianBlurViewSignal FinishedSignal()
         {
-            GaussianBlurViewSignal ret = new GaussianBlurViewSignal(Interop.GaussianBlurView.FinishedSignal(swigCPtr), false);
+            GaussianBlurViewSignal ret = new GaussianBlurViewSignal(Interop.GaussianBlurView.FinishedSignal(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         internal void SetUserImageAndOutputRenderTarget(Texture inputTexture, FrameBuffer outputRenderTarget)
         {
-            Interop.GaussianBlurView.SetUserImageAndOutputRenderTarget(swigCPtr, Texture.getCPtr(inputTexture), FrameBuffer.getCPtr(outputRenderTarget));
+            Interop.GaussianBlurView.SetUserImageAndOutputRenderTarget(SwigCPtr, Texture.getCPtr(inputTexture), FrameBuffer.getCPtr(outputRenderTarget));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }

--- a/src/Tizen.NUI/src/public/Animation/Animatable.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animatable.cs
@@ -39,10 +39,13 @@ namespace Tizen.NUI
         public Animatable() : this(Interop.Handle.New(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
         }
 
-        internal Animatable(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Animatable(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal Animatable(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Animation/TransitionData.cs
+++ b/src/Tizen.NUI/src/public/Animation/TransitionData.cs
@@ -51,12 +51,16 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="handle">Handle to an object.</param>
         /// <since_tizen> 3 </since_tizen>
-        public TransitionData(TransitionData handle) : this(Interop.TransitionData.NewTransitionData(TransitionData.getCPtr(handle)), true)
+        public TransitionData(TransitionData handle) : this(Interop.TransitionData.NewTransitionData(TransitionData.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal TransitionData(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal TransitionData(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal TransitionData(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -143,12 +143,16 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="handle">Handle to copy from.</param>
         /// <since_tizen> 3 </since_tizen>
-        public TableView(TableView handle) : this(Interop.TableView.NewTableView(TableView.getCPtr(handle)), true)
+        public TableView(TableView handle) : this(Interop.TableView.NewTableView(TableView.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal TableView(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal TableView(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal TableView(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, true, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -94,11 +94,6 @@ namespace Tizen.NUI.BaseComponents
             SetVisible(shown);
         }
 
-        internal TextEditor(TextEditor handle, bool shown = true) : this(Interop.TextEditor.NewTextEditor(TextEditor.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal TextEditor(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true, TextEditorStyle style = null) : base(cPtr, cMemoryOwn, style)
         {
             if (!shown)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -115,11 +115,6 @@ namespace Tizen.NUI.BaseComponents
             TextChanged += TextFieldTextChanged;
         }
 
-        internal TextField(TextField handle, bool shown = true) : this(Interop.TextField.NewTextField(TextField.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal enum ExceedPolicyType
         {
             ExceedPolicyOriginal,

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -156,16 +156,6 @@ namespace Tizen.NUI.BaseComponents
             SetVisible(shown);
         }
 
-        internal TextLabel(TextLabel handle, bool shown = true) : this(Interop.TextLabel.NewTextLabel(TextLabel.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
-            if (!shown)
-            {
-                SetVisible(false);
-            }
-        }
-
         internal TextLabel(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(cPtr, cMemoryOwn, viewStyle)
         {
             if (!shown)

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -190,11 +190,6 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal VideoView(VideoView videoView) : this(Interop.VideoView.NewVideoView(VideoView.getCPtr(videoView)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal VideoView(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -186,23 +186,16 @@ namespace Tizen.NUI.BaseComponents
             SetVisible(shown);
         }
 
-        internal View(View uiControl, bool shown = true) : this(Interop.View.NewView(View.getCPtr(uiControl)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            if (!shown)
-            {
-                SetVisible(false);
-            }
-
-            backgroundExtraData = uiControl.backgroundExtraData == null ? null : new BackgroundExtraData(uiControl.backgroundExtraData);
-        }
-
         internal View(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : this(cPtr, cMemoryOwn, shown)
         {
             InitializeStyle(viewStyle);
         }
 
-        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : base(cPtr, cMemoryOwn)
+        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : this(cPtr, cMemoryOwn, shown, cMemoryOwn)
+        {
+        }
+
+        internal View(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
             if (HasBody())
             {

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -59,8 +59,9 @@ namespace Tizen.NUI
         /// Create an instance of BaseHandle.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public BaseHandle() : this(Interop.BaseHandle.NewBaseHandle())
+        public BaseHandle() : this(Interop.BaseHandle.NewBaseHandle(), true, false)
         {
+            // Note : Empty BaseHandle instance don't need to be register in Registry.
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -69,8 +70,9 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="handle">The BaseHandle instance.</param>
         /// <since_tizen> 3 </since_tizen>
-        public BaseHandle(BaseHandle handle) : this(Interop.BaseHandle.NewBaseHandle(BaseHandle.getCPtr(handle)))
+        public BaseHandle(BaseHandle handle) : this(Interop.BaseHandle.NewBaseHandle(BaseHandle.getCPtr(handle)), true, false)
         {
+            // Note : Copyed BaseHandle instance don't need to be register in Registry.
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -50,7 +50,12 @@ namespace Tizen.NUI
             var temporalXamlStyleProperty = XamlStyleProperty;
         }
 
-        internal Container(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Container(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+            // No un-managed data hence no need to store a native ptr
+        }
+
+        internal Container(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
             // No un-managed data hence no need to store a native ptr
         }

--- a/src/Tizen.NUI/src/public/Common/TypeInfo.cs
+++ b/src/Tizen.NUI/src/public/Common/TypeInfo.cs
@@ -40,12 +40,16 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="handle">This copy constructor is required for (smart) pointer semantics.</param>
         /// <since_tizen> 3 </since_tizen>
-        public TypeInfo(TypeInfo handle) : this(Interop.TypeInfo.NewTypeInfo(TypeInfo.getCPtr(handle)), true)
+        public TypeInfo(TypeInfo handle) : this(Interop.TypeInfo.NewTypeInfo(TypeInfo.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal TypeInfo(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal TypeInfo(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal TypeInfo(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Events/Gesture.cs
@@ -32,7 +32,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="rhs">A reference to the copied handle</param>
         /// <since_tizen> 3 </since_tizen>
-        public Gesture(Gesture rhs) : this(Interop.Gesture.NewGesture(Gesture.getCPtr(rhs)), true)
+        public Gesture(Gesture rhs) : this(Interop.Gesture.NewGesture(Gesture.getCPtr(rhs)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Events/GestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/GestureDetector.cs
@@ -41,17 +41,21 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Constructor.
+        /// The copy Constructor.
         /// </summary>
         /// <param name="handle">A reference to the copied handle</param>
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public GestureDetector(GestureDetector handle) : this(Interop.GestureDetector.NewGestureDetector(GestureDetector.getCPtr(handle)), true)
+        public GestureDetector(GestureDetector handle) : this(Interop.GestureDetector.NewGestureDetector(GestureDetector.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal GestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal GestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal GestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGestureDetector.cs
@@ -72,12 +72,16 @@ namespace Tizen.NUI
         /// <param name="handle">A reference to the copied handle</param>
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public LongPressGestureDetector(LongPressGestureDetector handle) : this(Interop.LongPressGestureDetector.NewLongPressGestureDetector(LongPressGestureDetector.getCPtr(handle)), true)
+        public LongPressGestureDetector(LongPressGestureDetector handle) : this(Interop.LongPressGestureDetector.NewLongPressGestureDetector(LongPressGestureDetector.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal LongPressGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal LongPressGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal LongPressGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -45,12 +45,16 @@ namespace Tizen.NUI
         /// <param name="handle">A reference to the copied handle</param>
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PanGestureDetector(PanGestureDetector handle) : this(Interop.PanGestureDetector.NewPanGestureDetector(PanGestureDetector.getCPtr(handle)), true)
+        public PanGestureDetector(PanGestureDetector handle) : this(Interop.PanGestureDetector.NewPanGestureDetector(PanGestureDetector.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PanGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PanGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal PanGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGestureDetector.cs
@@ -45,12 +45,16 @@ namespace Tizen.NUI
         /// <param name="handle">A reference to the copied handle</param>
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PinchGestureDetector(PinchGestureDetector handle) : this(Interop.PinchGesture.NewPinchGestureDetector(PinchGestureDetector.getCPtr(handle)), true)
+        public PinchGestureDetector(PinchGestureDetector handle) : this(Interop.PinchGesture.NewPinchGestureDetector(PinchGestureDetector.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PinchGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.PinchGesture.PinchGestureDetectorUpcast(cPtr), cMemoryOwn)
+        internal PinchGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal PinchGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGestureDetector.cs
@@ -45,12 +45,16 @@ namespace Tizen.NUI
         /// <param name="handle">A reference to the copied handle</param>
         /// This will be made public in the next tizen release after an ACR is done. Till then, it needs to be hidden as an inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public RotationGestureDetector(RotationGestureDetector handle) : this(Interop.RotationGesture.NewRotationGestureDetector(RotationGestureDetector.getCPtr(handle)), true)
+        public RotationGestureDetector(RotationGestureDetector handle) : this(Interop.RotationGesture.NewRotationGestureDetector(RotationGestureDetector.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal RotationGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.RotationGesture.RotationGestureDetectorUpcast(cPtr), cMemoryOwn)
+        internal RotationGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal RotationGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGestureDetector.cs
@@ -49,10 +49,24 @@ namespace Tizen.NUI
         public TapGestureDetector(uint tapsRequired) : this(Interop.TapGestureDetector.New(tapsRequired), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
         }
 
-        internal TapGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        /// <summary>
+        /// The copy constructor.
+        /// </summary>
+        /// <param name="handle">A reference to the copied handle</param>
+        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TapGestureDetector(TapGestureDetector handle) : this(Interop.TapGestureDetector.NewTapGestureDetector(TapGestureDetector.getCPtr(handle)), true, false)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal TapGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal TapGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 
@@ -88,17 +102,6 @@ namespace Tizen.NUI
                     DetectedSignal().Disconnect(_detectedCallback);
                 }
             }
-        }
-
-        /// <summary>
-        /// The copy constructor.
-        /// </summary>
-        /// <param name="handle">A reference to the copied handle</param>
-        /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public TapGestureDetector(TapGestureDetector handle) : this(Interop.TapGestureDetector.NewTapGestureDetector(TapGestureDetector.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
+++ b/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
@@ -63,16 +63,6 @@ namespace Tizen.NUI.ParticleSystem
             mProxy = new ParticleEmitterProxy(this);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
-        
-        /// <summary>
-        /// Copy constructor.
-        /// </summary>
-        /// <param name="particleEmitter">Source object to copy.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ParticleEmitter( ParticleEmitter particleEmitter) : this(Interop. ParticleEmitter.New( ParticleEmitter.getCPtr(particleEmitter)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
 
         /// <summary>
         /// Dispose.

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -132,12 +132,17 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="webView">WebView to copy. The copied WebView will point at the same implementation</param>
         /// <since_tizen> 9 </since_tizen>
-        public WebView(WebView webView) : this(Interop.WebView.NewWebView(WebView.getCPtr(webView)), true)
+        public WebView(WebView webView) : this(Interop.WebView.NewWebView(WebView.getCPtr(webView)), true, false)
         {
+            // TODO : Please deprecate this API.
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal WebView(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.WebView.Upcast(cPtr), cMemoryOwn)
+        internal WebView(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal WebView(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(Interop.WebView.Upcast(cPtr), cMemoryOwn, true, cRegister)
         {
             screenshotAcquiredProxyCallback = OnScreenshotAcquired;
             hitTestFinishedProxyCallback = OnHitTestFinished;


### PR DESCRIPTION
Since we register to registry by BaseObjectPtr(), it is impossible to register duplicated handle.

So, actually, we have to deplicate copy BaseHandle constructor. But for now, just make we don't register into registry now.