### PR TITLE
[NUI] Make DaliAccessibilityDetachAccessibleObject called at main thread

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -103,6 +103,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(bool disposing)
         {
+            // Note : We can clean dictionaries even this API called from GC Thread.
             CleanCallbackDictionaries();
             base.Dispose(disposing);
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -388,37 +388,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void Dispose(bool disposing)
-        {
-            if (disposed)
-            {
-                return;
-            }
-
-            internalName = null;
-
-            Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
-            if (disposing == false)
-            {
-                if (IsNativeHandleInvalid() || SwigCMemOwn == false)
-                {
-                    // at this case, implicit nor explicit dispose is not required. No native object is made.
-                    disposed = true;
-                    return;
-                }
-            }
-
-            if (disposing)
-            {
-                Unparent();
-            }
-
-            base.Dispose(disposing);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
         protected static readonly string AccessibilityActivateAction = "activate";
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected static readonly string AccessibilityReadingSkippedAction = "ReadingSkipped";

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1346,6 +1346,12 @@ namespace Tizen.NUI.BaseComponents
 
             disposeDebugging(type);
 
+            internalName = "";
+            Unparent();
+
+            Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
             //_mergedStyle = null;
 
             internalMaximumSize?.Dispose();
@@ -1387,7 +1393,6 @@ namespace Tizen.NUI.BaseComponents
             tapGestureDetector = null;
             rotationGestureDetector?.Dispose();
             rotationGestureDetector = null;
-
 
             internalCurrentParentOrigin?.Dispose();
             internalCurrentParentOrigin = null;


### PR DESCRIPTION
void Dispose(bool) can be called from worker thread, when disposing value is false.

To ensure we detach AccessibileObject in main thread, let we remove it at Dispose(DisposeTypes), instead of Dispose(bool)