### PR TITLE
[NUI] Remove basehandle usage at Accessibility static

### DIFF
--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -212,7 +212,7 @@ namespace Tizen.NUI.Accessibility
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-            return dummyHandle.GetInstanceSafely<View>(ptr);
+            return dummyObject.GetInstanceSafely<View>(ptr);
         }
 
         /// <summary>
@@ -342,7 +342,7 @@ namespace Tizen.NUI.Accessibility
             SayFinished?.Invoke(typeof(Accessibility), new SayFinishedEventArgs(result));
         }
 
-        private static BaseHandle dummyHandle = new BaseHandle();
+        private static readonly object dummyObject = new object();
 
         #endregion Private
     }


### PR DESCRIPTION
Since we try to resolve some unusual behavior of BaseHandle, the dummyHandle in Accessibility can give us some confuse logs.

Actually, we don't need to hold it as BaseHandle type. we only need this as object type. So, let we make it as object, instead of BaseHandle.
