### PR TITLE
[Build] Create vconf related to .NET as a file in RO location

### DIFF
--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -9,6 +9,7 @@
 %define DOTNET_ASSEMBLY_RES_PATH %{DOTNET_ASSEMBLY_PATH}/res
 %define DOTNET_TOOLS_PATH /usr/share/dotnet.tizen/tools
 %define DOTNET_PRELOAD_PATH /usr/share/dotnet.tizen/preload
+%define DOTNET_LIBRARY_PATH /usr/share/dotnet.tizen/lib
 %define DOTNET_NUGET_SOURCE /nuget
 
 %define TIZEN_NET_RUNTIME_IDENTIFIERS 4.0.0:5.0.0:5.5.0:6.0.0:6.5.0:7.0.0:8.0.0:9.0.0
@@ -182,6 +183,7 @@ mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_RES_PATH}
 mkdir -p %{buildroot}%{DOTNET_NUGET_SOURCE}
 mkdir -p %{buildroot}%{DOTNET_TOOLS_PATH}
 mkdir -p %{buildroot}%{DOTNET_PRELOAD_PATH}
+mkdir -p %{buildroot}%{DOTNET_LIBRARY_PATH}
 
 # Install Runtime Assemblies
 install -p -m 644 Artifacts/bin/public/*.dll %{buildroot}%{DOTNET_ASSEMBLY_PATH}
@@ -221,6 +223,10 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
+touch %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
 
 %files
 %license LICENSE

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -8,6 +8,7 @@
 %define DOTNET_ASSEMBLY_RES_PATH %{DOTNET_ASSEMBLY_PATH}/res
 %define DOTNET_TOOLS_PATH /usr/share/dotnet.tizen/tools
 %define DOTNET_PRELOAD_PATH /usr/share/dotnet.tizen/preload
+%define DOTNET_LIBRARY_PATH /usr/share/dotnet.tizen/lib
 %define DOTNET_NUGET_SOURCE /nuget
 
 %define TIZEN_NET_RUNTIME_IDENTIFIERS @rid_version@
@@ -181,6 +182,7 @@ mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_RES_PATH}
 mkdir -p %{buildroot}%{DOTNET_NUGET_SOURCE}
 mkdir -p %{buildroot}%{DOTNET_TOOLS_PATH}
 mkdir -p %{buildroot}%{DOTNET_PRELOAD_PATH}
+mkdir -p %{buildroot}%{DOTNET_LIBRARY_PATH}
 
 # Install Runtime Assemblies
 install -p -m 644 Artifacts/bin/public/*.dll %{buildroot}%{DOTNET_ASSEMBLY_PATH}
@@ -220,6 +222,10 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
+touch %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
 
 %files
 %license LICENSE


### PR DESCRIPTION
Guided by Appfw, vconf daemon does not run at mic stage. So, ```vconf_get_*``` api does not work normally. Therefore, it provides a second chance to read the file when ```vconf_get_*``` is null. So, Create vconf related to .NET as a file in RO location.