### PR TITLE
[Build] Create vconf related to .NET as a file in RO location

### DIFF
--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -9,6 +9,7 @@
 %define DOTNET_ASSEMBLY_RES_PATH %{DOTNET_ASSEMBLY_PATH}/res
 %define DOTNET_TOOLS_PATH /usr/share/dotnet.tizen/tools
 %define DOTNET_PRELOAD_PATH /usr/share/dotnet.tizen/preload
+%define DOTNET_LIBRARY_PATH /usr/share/dotnet.tizen/lib
 %define DOTNET_NUGET_SOURCE /nuget
 
 %define TIZEN_NET_RUNTIME_IDENTIFIERS 4.0.0:5.0.0:5.5.0:6.0.0:6.5.0:7.0.0:8.0.0
@@ -181,6 +182,7 @@ mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_RES_PATH}
 mkdir -p %{buildroot}%{DOTNET_NUGET_SOURCE}
 mkdir -p %{buildroot}%{DOTNET_TOOLS_PATH}
 mkdir -p %{buildroot}%{DOTNET_PRELOAD_PATH}
+mkdir -p %{buildroot}%{DOTNET_LIBRARY_PATH}
 
 # Install Runtime Assemblies
 install -p -m 644 Artifacts/bin/public/*.dll %{buildroot}%{DOTNET_ASSEMBLY_PATH}
@@ -220,6 +222,10 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
+touch %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
 
 %files
 %license LICENSE

--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -11,8 +11,9 @@
 %define DOTNET_PRELOAD_PATH /usr/share/dotnet.tizen/preload
 %define DOTNET_NUGET_SOURCE /nuget
 
-%define TIZEN_NET_RUNTIME_IDENTIFIERS 4.0.0:5.0.0:5.5.0:6.0.0:6.5.0:7.0.0
-%define TIZEN_NET_TARGET_FRAMEWORK_MONIKERS tizen10.0:tizen90:tizen80:tizen70:tizen60:tizen50:tizen40
+%define TIZEN_NET_RUNTIME_IDENTIFIERS 4.0.0:5.0.0:5.5.0:6.0.0:6.5.0:7.0.0:8.0.0
+%define TIZEN_NET_TARGET_FRAMEWORK_MONIKERS tizen11.0:tizen10.0:tizen90:tizen80:tizen70:tizen60:tizen50:tizen40
+%define DOTNET_CORE_RUNTIME_VERSION 6.0
 
 %define UPGRADE_SCRIPT_PATH /usr/share/upgrade/scripts
 
@@ -218,6 +219,7 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_api_path %{DOTNET_ASSEMBLY_PATH} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
+/usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
 
 %files
 %license LICENSE

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -12,6 +12,7 @@
 
 %define TIZEN_NET_RUNTIME_IDENTIFIERS @rid_version@
 %define TIZEN_NET_TARGET_FRAMEWORK_MONIKERS @tfm_support@
+%define DOTNET_CORE_RUNTIME_VERSION @dotnet_core_version@
 
 %define UPGRADE_SCRIPT_PATH /usr/share/upgrade/scripts
 
@@ -217,6 +218,7 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_api_path %{DOTNET_ASSEMBLY_PATH} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
+/usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
 
 %files
 %license LICENSE

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -8,6 +8,7 @@
 %define DOTNET_ASSEMBLY_RES_PATH %{DOTNET_ASSEMBLY_PATH}/res
 %define DOTNET_TOOLS_PATH /usr/share/dotnet.tizen/tools
 %define DOTNET_PRELOAD_PATH /usr/share/dotnet.tizen/preload
+%define DOTNET_LIBRARY_PATH /usr/share/dotnet.tizen/lib
 %define DOTNET_NUGET_SOURCE /nuget
 
 %define TIZEN_NET_RUNTIME_IDENTIFIERS @rid_version@
@@ -180,6 +181,7 @@ mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_RES_PATH}
 mkdir -p %{buildroot}%{DOTNET_NUGET_SOURCE}
 mkdir -p %{buildroot}%{DOTNET_TOOLS_PATH}
 mkdir -p %{buildroot}%{DOTNET_PRELOAD_PATH}
+mkdir -p %{buildroot}%{DOTNET_LIBRARY_PATH}
 
 # Install Runtime Assemblies
 install -p -m 644 Artifacts/bin/public/*.dll %{buildroot}%{DOTNET_ASSEMBLY_PATH}
@@ -219,6 +221,10 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
+touch %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
+echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_vconf.info
 
 %files
 %license LICENSE

--- a/packaging/makeruntimeversion.py
+++ b/packaging/makeruntimeversion.py
@@ -7,31 +7,25 @@ nuspec_file = os.path.join(scrpit_dir, "../pkg/Tizen.NET/Tizen.NET.nuspec")
 tree = ET.parse(nuspec_file)
 root = tree.getroot()
 
-tfm_list1 = []
-tfm_list2 = []
+runtime_list = []
 for meta_child in root.iter():
     if meta_child.tag == "{http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd}metadata":
         for depen_child in meta_child:
             if depen_child.tag == "{http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd}dependencies":
                 for group in depen_child:
                     tfm = group.attrib["targetFramework"].lower()
-                    if tfm.startswith("tizen"):
-                        if len(tfm) == 8:
-                            tfm_list1.append(tfm.replace(".", "").strip())
-                        else:
-                            tfm_list2.append(tfm.strip())
+                    if tfm.startswith(".net"):
+                        if len(tfm) != 15:
+                            runtime_list.append(tfm.replace(".net", "").strip())
 
-tfm_list1 = list(set(tfm_list1))
-tfm_list1.sort(reverse=True)
-tfm_list2 = list(set(tfm_list2))
-tfm_list2.sort(reverse=True)
-tfm_list = tfm_list2 + tfm_list1
+runtime_list = list(set(runtime_list))
+runtime_list.sort(reverse=True)
 
 f = open(spec_dir,'r')
 origin_data = f.read()
 f.close()
 
-new_data = origin_data.replace("@tfm_support@", ':'.join(tfm_list))
+new_data = origin_data.replace("@dotnet_core_version@", ':'.join(runtime_list))
 
 f = open(spec_dir, 'w')
 f.write(new_data)

--- a/packaging/makespec.sh
+++ b/packaging/makespec.sh
@@ -30,3 +30,6 @@ python $SCRIPT_DIR/makerid.py
 
 # Update TFM
 python $SCRIPT_DIR/maketfm.py
+
+# Update Runtime Version
+python $SCRIPT_DIR/makeruntimeversion.py


### PR DESCRIPTION
Guided by Appfw, vconf daemon does not run at mic stage. So, ```vconf_get_*``` api does not work normally. Therefore, it provides a second chance to read the file when ```vconf_get_*``` is null. So, Create vconf related to .NET as a file in RO location.