### PR TITLE
[NUI] Resolve many problems relative with BaseHandle

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/KeyInputFocusManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyInputFocusManager.cs
@@ -37,7 +37,22 @@ namespace Tizen.NUI
 
         public static KeyInputFocusManager Get()
         {
-            KeyInputFocusManager ret = new KeyInputFocusManager(Interop.KeyInputFocusManager.Get(), true);
+            global::System.IntPtr cPtr = Interop.KeyInputFocusManager.Get();
+
+            KeyInputFocusManager ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as KeyInputFocusManager;
+            if (ret != null)
+            {
+                object dummyObect = new object();
+
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new KeyInputFocusManager(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/Common/LinearConstrainer.cs
+++ b/src/Tizen.NUI/src/internal/Common/LinearConstrainer.cs
@@ -46,11 +46,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal LinearConstrainer(LinearConstrainer handle) : this(Interop.LinearConstrainer.NewLinearConstrainer(LinearConstrainer.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal LinearConstrainer Assign(LinearConstrainer rhs)
         {
             LinearConstrainer ret = new LinearConstrainer(Interop.LinearConstrainer.Assign(SwigCPtr, LinearConstrainer.getCPtr(rhs)), false);

--- a/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
+++ b/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
@@ -22,7 +22,11 @@ namespace Tizen.NUI
 {
     internal class ObjectRegistry : BaseHandle
     {
-        internal ObjectRegistry(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal ObjectRegistry(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal ObjectRegistry(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 
@@ -156,12 +160,7 @@ namespace Tizen.NUI
         }
 
 
-        public ObjectRegistry() : this(Interop.ObjectRegistry.NewObjectRegistry(), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        public ObjectRegistry(ObjectRegistry handle) : this(Interop.ObjectRegistry.NewObjectRegistry(ObjectRegistry.getCPtr(handle)), true)
+        public ObjectRegistry() : this(Interop.ObjectRegistry.NewObjectRegistry(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/internal/Common/PathConstrainer.cs
+++ b/src/Tizen.NUI/src/internal/Common/PathConstrainer.cs
@@ -47,11 +47,6 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal PathConstrainer(PathConstrainer handle) : this(Interop.PathConstrainer.NewPathConstrainer(PathConstrainer.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal PathConstrainer Assign(PathConstrainer rhs)
         {
             PathConstrainer ret = new PathConstrainer(Interop.PathConstrainer.Assign(SwigCPtr, PathConstrainer.getCPtr(rhs)), false);

--- a/src/Tizen.NUI/src/internal/Common/RenderTaskList.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTaskList.cs
@@ -52,14 +52,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public RenderTaskList(RenderTaskList handle) : this(Interop.RenderTask.NewRenderTaskList(RenderTaskList.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        public RenderTaskList Assign(RenderTaskList rhs)
+        internal RenderTaskList Assign(RenderTaskList rhs)
         {
             RenderTaskList ret = new RenderTaskList(Interop.RenderTask.RenderTaskListAssign(SwigCPtr, RenderTaskList.getCPtr(rhs)), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/internal/Utility/Builder.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Builder.cs
@@ -237,14 +237,40 @@ namespace Tizen.NUI
 
         internal PathConstrainer GetPathConstrainer(string pathConstrainerName)
         {
-            PathConstrainer ret = new PathConstrainer(Interop.Builder.GetPathConstrainer(SwigCPtr, pathConstrainerName), true);
+            global::System.IntPtr cPtr = Interop.Builder.GetPathConstrainer(SwigCPtr, pathConstrainerName);
+
+            PathConstrainer ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as PathConstrainer;
+            if (ret != null)
+            {
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new PathConstrainer(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 
         internal LinearConstrainer GetLinearConstrainer(string linearConstrainerName)
         {
-            LinearConstrainer ret = new LinearConstrainer(Interop.Builder.GetLinearConstrainer(SwigCPtr, linearConstrainerName), true);
+            global::System.IntPtr cPtr = Interop.Builder.GetLinearConstrainer(SwigCPtr, linearConstrainerName);
+
+            LinearConstrainer ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as LinearConstrainer;
+            if (ret != null)
+            {
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new LinearConstrainer(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
@@ -700,7 +700,22 @@ namespace Tizen.NUI.Accessibility
 
         internal static AccessibilityManager Get()
         {
-            AccessibilityManager ret = new AccessibilityManager(Interop.AccessibilityManager.Get(), true);
+            global::System.IntPtr cPtr = Interop.AccessibilityManager.Get();
+
+            AccessibilityManager ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as AccessibilityManager;
+            if (ret != null)
+            {
+                object dummyObect = new object();
+
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new AccessibilityManager(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Common/PropertyCondition.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyCondition.cs
@@ -29,12 +29,16 @@ namespace Tizen.NUI
         /// Create a property condition instance.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public PropertyCondition() : this(Interop.PropertyCondition.NewPropertyCondition(), true)
+        public PropertyCondition() : this(Interop.PropertyCondition.NewPropertyCondition(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PropertyCondition(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PropertyCondition(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal PropertyCondition(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyNotification.cs
@@ -36,7 +36,7 @@ namespace Tizen.NUI
         /// Create a instance of PropertyNotification.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public PropertyNotification() : this(Interop.PropertyNotification.NewPropertyNotification(), true)
+        public PropertyNotification() : this(Interop.PropertyNotification.NewPropertyNotification(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -45,12 +45,16 @@ namespace Tizen.NUI
         /// Create a instance of PropertyNotification.
         /// </summary>
         /// <since_tizen> 4 </since_tizen>
-        public PropertyNotification(PropertyNotification handle) : this(Interop.PropertyNotification.NewPropertyNotification(PropertyNotification.getCPtr(handle)), true)
+        public PropertyNotification(PropertyNotification handle) : this(Interop.PropertyNotification.NewPropertyNotification(PropertyNotification.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PropertyNotification(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PropertyNotification(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal PropertyNotification(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 
@@ -170,7 +174,20 @@ namespace Tizen.NUI
         /// <since_tizen> 4 </since_tizen>
         public PropertyCondition GetCondition()
         {
-            PropertyCondition ret = new PropertyCondition(Interop.PropertyNotification.GetCondition(SwigCPtr), true);
+            global::System.IntPtr cPtr = Interop.PropertyNotification.GetCondition(SwigCPtr);
+
+            PropertyCondition ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as PropertyCondition;
+            if (ret != null)
+            {
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new PropertyCondition(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -43,7 +43,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         [Obsolete("Deprecated in API9, will be removed in API11. Use ThemeManager instead.")]
-        public StyleManager() : this(Interop.StyleManager.NewStyleManager(), true)
+        public StyleManager() : this(Interop.StyleManager.NewStyleManager(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -101,7 +101,22 @@ namespace Tizen.NUI
         [Obsolete("Deprecated in API9, will be removed in API11. Use ThemeManager instead.")]
         public static StyleManager Get()
         {
-            StyleManager ret = new StyleManager(Interop.StyleManager.Get(), true);
+            global::System.IntPtr cPtr = Interop.StyleManager.Get();
+
+            StyleManager ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as StyleManager;
+            if (ret != null)
+            {
+                object dummyObect = new object();
+
+                HandleRef CPtr = new HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new StyleManager(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -212,7 +227,11 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal StyleManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal StyleManager(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal StyleManager(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/TypeInfo.cs
+++ b/src/Tizen.NUI/src/public/Common/TypeInfo.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
         /// Creates TypeInfo object.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TypeInfo() : this(Interop.TypeInfo.NewTypeInfo(), true)
+        public TypeInfo() : this(Interop.TypeInfo.NewTypeInfo(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Common/TypeRegistry.cs
+++ b/src/Tizen.NUI/src/public/Common/TypeRegistry.cs
@@ -26,8 +26,11 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class TypeRegistry : BaseHandle
     {
+        internal TypeRegistry(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
 
-        internal TypeRegistry(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal TypeRegistry(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 
@@ -46,7 +49,22 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static TypeRegistry Get()
         {
-            TypeRegistry ret = new TypeRegistry(Interop.TypeRegistry.Get(), true);
+            global::System.IntPtr cPtr = Interop.TypeRegistry.Get();
+
+            TypeRegistry ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TypeRegistry;
+            if (ret != null)
+            {
+                object dummyObect = new object();
+
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new TypeRegistry(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -56,12 +74,12 @@ namespace Tizen.NUI
         /// </summary>
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TypeRegistry() : this(Interop.TypeRegistry.NewTypeRegistry(), true)
+        public TypeRegistry() : this(Interop.TypeRegistry.NewTypeRegistry(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal TypeRegistry(TypeRegistry handle) : this(Interop.TypeRegistry.NewTypeRegistry(TypeRegistry.getCPtr(handle)), true)
+        internal TypeRegistry(TypeRegistry handle) : this(Interop.TypeRegistry.NewTypeRegistry(TypeRegistry.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -82,7 +100,20 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public Tizen.NUI.TypeInfo GetTypeInfo(string uniqueTypeName)
         {
-            Tizen.NUI.TypeInfo ret = new Tizen.NUI.TypeInfo(Interop.TypeRegistry.GetTypeInfo(SwigCPtr, uniqueTypeName), true);
+            global::System.IntPtr cPtr = Interop.TypeRegistry.GetTypeInfo(SwigCPtr, uniqueTypeName);
+
+            Tizen.NUI.TypeInfo ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Tizen.NUI.TypeInfo;
+            if (ret != null)
+            {
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new Tizen.NUI.TypeInfo(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Events/Hover.cs
+++ b/src/Tizen.NUI/src/public/Events/Hover.cs
@@ -47,11 +47,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Hover(Hover other) : this(Interop.Hover.NewHover(Hover.getCPtr(other)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Events/Touch.cs
+++ b/src/Tizen.NUI/src/public/Events/Touch.cs
@@ -32,12 +32,7 @@ namespace Tizen.NUI
         /// Calling member functions with an uninitialized touch handle is not allowed.<br />
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public Touch() : this(Interop.Touch.NewTouch(), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        internal Touch(Touch other) : this(Interop.Touch.NewTouch(Touch.getCPtr(other)), true)
+        public Touch() : this(Interop.Touch.NewTouch(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
@@ -56,11 +56,6 @@ namespace Tizen.NUI
             mCachedBuffer = buffer;
         }
 
-        internal EncodedImageBuffer(EncodedImageBuffer handle) : this(Interop.EncodedImageBuffer.NewEncodedImageBuffer(EncodedImageBuffer.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal EncodedImageBuffer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }

--- a/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PixelBuffer(PixelBuffer handle) : this(Interop.PixelBuffer.NewPixelBuffer(PixelBuffer.getCPtr(handle)), true)
+        internal PixelBuffer(PixelBuffer handle) : this(Interop.PixelBuffer.NewPixelBuffer(PixelBuffer.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Input/AutofillContainer.cs
+++ b/src/Tizen.NUI/src/public/Input/AutofillContainer.cs
@@ -105,11 +105,15 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal AutofillContainer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal AutofillContainer(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
 
-        internal AutofillContainer(AutofillContainer autofillContainer) : this(Interop.AutofillContainer.NewAutofillContainer(AutofillContainer.getCPtr(autofillContainer)), true)
+        internal AutofillContainer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        {
+        }
+
+        internal AutofillContainer(AutofillContainer autofillContainer) : this(Interop.AutofillContainer.NewAutofillContainer(AutofillContainer.getCPtr(autofillContainer)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -38,11 +38,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal FontClient(FontClient handle) : this(Interop.FontClient.NewFontClient(FontClient.getCPtr(handle)), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         internal static uint DefaultPointSize
         {
             get
@@ -291,7 +286,22 @@ namespace Tizen.NUI
 
         internal static FontClient Get()
         {
-            FontClient ret = new FontClient(Interop.FontClient.Get(), true);
+            global::System.IntPtr cPtr = Interop.FontClient.Get();
+
+            FontClient ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as FontClient;
+            if (ret != null)
+            {
+                object dummyObect = new object();
+
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new FontClient(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
+++ b/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
@@ -30,16 +30,20 @@ namespace Tizen.NUI
         private static readonly TTSPlayer instance = TTSPlayer.Get();
         private StateChangedEventCallbackType stateChangedEventCallback;
 
-        internal TTSPlayer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(Interop.TtsPlayer.Upcast(cPtr), cMemoryOwn)
+        internal TTSPlayer(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
 
-        internal TTSPlayer() : this(Interop.TtsPlayer.NewTtsPlayer(), true)
+        internal TTSPlayer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        {
+        }
+
+        internal TTSPlayer() : this(Interop.TtsPlayer.NewTtsPlayer(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal TTSPlayer(TTSPlayer handle) : this(Interop.TtsPlayer.NewTtsPlayer(TTSPlayer.getCPtr(handle)), true)
+        internal TTSPlayer(TTSPlayer handle) : this(Interop.TtsPlayer.NewTtsPlayer(TTSPlayer.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -145,7 +149,22 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public static TTSPlayer Get(TTSMode mode)
         {
-            TTSPlayer ret = new TTSPlayer(Interop.TtsPlayer.Get((int)mode), true);
+            global::System.IntPtr cPtr = Interop.TtsPlayer.Get((int)mode);
+
+            TTSPlayer ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TTSPlayer;
+            if (ret != null)
+            {
+                object dummyObect = new object();
+
+                HandleRef CPtr = new HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new TTSPlayer(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -157,7 +176,22 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public static TTSPlayer Get()
         {
-            TTSPlayer ret = new TTSPlayer(Interop.TtsPlayer.Get(), true);
+            global::System.IntPtr cPtr = Interop.TtsPlayer.Get();
+
+            TTSPlayer ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TTSPlayer;
+            if (ret != null)
+            {
+                object dummyObect = new object();
+
+                HandleRef CPtr = new HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new TTSPlayer(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Utility/Timer.cs
+++ b/src/Tizen.NUI/src/public/Utility/Timer.cs
@@ -53,12 +53,16 @@ namespace Tizen.NUI
 
             NUILog.Debug($"(0x{SwigCPtr.Handle:X})  Timer({milliSec}) Constructor!");
         }
-        internal Timer(Timer timer) : this(Interop.Timer.NewTimer(Timer.getCPtr(timer)), true)
+        internal Timer(Timer timer) : this(Interop.Timer.NewTimer(Timer.getCPtr(timer)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Timer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Timer(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal Timer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
             timerTickCallbackDelegate = OnTick;
             timerTickCallbackOfNative = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate<System.Delegate>(timerTickCallbackDelegate);

--- a/src/Tizen.NUI/src/public/Visuals/VisualBase.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualBase.cs
@@ -33,16 +33,21 @@ namespace Tizen.NUI
         /// Creates an empty visual handle.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public VisualBase() : this(Interop.VisualBase.NewVisualBase(), true)
+        public VisualBase() : this(Interop.VisualBase.NewVisualBase(), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal VisualBase(VisualBase handle) : this(Interop.VisualBase.NewVisualBase(VisualBase.getCPtr(handle)), true)
+        internal VisualBase(VisualBase handle) : this(Interop.VisualBase.NewVisualBase(VisualBase.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
-        internal VisualBase(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+
+        internal VisualBase(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal VisualBase(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
@@ -31,11 +31,11 @@ namespace Tizen.NUI
         /// </summary>
         private static VisualFactory instance;
 
-        internal VisualFactory(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        private VisualFactory(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }
 
-        internal VisualFactory() : this(Interop.VisualFactory.NewVisualFactory(), true)
+        private VisualFactory() : this(Interop.VisualFactory.NewVisualFactory(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -195,10 +195,15 @@ namespace Tizen.NUI
 
         }
 
-        internal WidgetView(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal WidgetView(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
-        internal WidgetView(WidgetView handle) : this(Interop.WidgetView.NewWidgetView(WidgetView.getCPtr(handle)), true)
+
+        internal WidgetView(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, true, cRegister)
+        {
+        }
+
+        internal WidgetView(WidgetView handle) : this(Interop.WidgetView.NewWidgetView(WidgetView.getCPtr(handle)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1634,7 +1634,20 @@ namespace Tizen.NUI
 
         internal ObjectRegistry GetObjectRegistry()
         {
-            ObjectRegistry ret = new ObjectRegistry(Interop.Stage.GetObjectRegistry(stageCPtr), true);
+            global::System.IntPtr cPtr = Interop.Stage.GetObjectRegistry(stageCPtr);
+
+            ObjectRegistry ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as ObjectRegistry;
+            if (ret != null)
+            {
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new ObjectRegistry(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
 - Ensure to get 'already registered, or create new one' what we get item from DALi engine
 - Let we also ensure create only one items if we use static ::Get() API
 - Do not register to Registry if we copy the reference.
  - Remove some useless copy constructor.
 - Do not register to Registry if we create empty object.