### PR TITLE
[NUI] Fix some SVACE issues.

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -225,7 +225,8 @@ namespace Tizen.NUI
         // Parent not a View so assume it's a Layer which is the size of the window.
         private void MeasureAndLayout(View root, float parentWidth, float parentHeight)
         {
-            if (root.Layout != null)
+            var layout = root.Layout;
+            if (layout != null)
             {
                 // Determine measure specification for root.
                 // The root layout policy could be an exact size, be match parent or wrap children.
@@ -237,7 +238,7 @@ namespace Tizen.NUI
                 var widthMode = GetMode(root.WidthSpecification);
                 var heightMode = GetMode(root.HeightSpecification);
 
-                if (root.Layout.NeedsLayout(widthSize, heightSize, widthMode, heightMode))
+                if (layout.NeedsLayout(widthSize, heightSize, widthMode, heightMode))
                 {
                     var widthSpec = CreateMeasureSpecification(widthSize, widthMode);
                     var heightSpec = CreateMeasureSpecification(heightSize, heightMode);
@@ -251,8 +252,8 @@ namespace Tizen.NUI
                 // Start at root which was just measured.
                 PerformLayout(root, new LayoutLength(positionX),
                                      new LayoutLength(positionY),
-                                     new LayoutLength(positionX) + root.Layout.MeasuredWidth.Size,
-                                     new LayoutLength(positionY) + root.Layout.MeasuredHeight.Size);
+                                     new LayoutLength(positionX) + layout.MeasuredWidth.Size,
+                                     new LayoutLength(positionY) + layout.MeasuredHeight.Size);
             }
         }
 

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2446,7 +2446,7 @@ namespace Tizen.NUI
         {
             bool ret = Interop.Window.GetFullScreen(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-              return ret;
+            return ret;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Value rootLayout is the result of a method call with a possible null retum value, which is dereferenced in the member access expression root.Layout. MeasuredWidth
  Value rootLayout is the result of a method call with a possible null retum value, which is dereferenced in the member access expression root.Layout. MeasuredHeight
2. Nesting level does not match indentation

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
