### PR TITLE
[NUI][API10] Make DaliAccessibilityDetachAccessibleObject called at main thread

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -102,6 +102,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(bool disposing)
         {
+            // Note : We can clean dictionaries even this API called from GC Thread.
             CleanCallbackDictionaries();
             base.Dispose(disposing);
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -368,37 +368,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected override void Dispose(bool disposing)
-        {
-            if (disposed)
-            {
-                return;
-            }
-
-            internalName = null;
-
-            Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
-            if (disposing == false)
-            {
-                if (IsNativeHandleInvalid() || SwigCMemOwn == false)
-                {
-                    // at this case, implicit nor explicit dispose is not required. No native object is made.
-                    disposed = true;
-                    return;
-                }
-            }
-
-            if (disposing)
-            {
-                Unparent();
-            }
-
-            base.Dispose(disposing);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
         protected static readonly string AccessibilityActivateAction = "activate";
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected static readonly string AccessibilityReadingSkippedAction = "ReadingSkipped";

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1231,6 +1231,12 @@ namespace Tizen.NUI.BaseComponents
 
             disposeDebugging(type);
 
+            internalName = "";
+            Unparent();
+
+            Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
             //_mergedStyle = null;
 
             internalMaximumSize?.Dispose();
@@ -1272,7 +1278,6 @@ namespace Tizen.NUI.BaseComponents
             tapGestureDetector = null;
             rotationGestureDetector?.Dispose();
             rotationGestureDetector = null;
-
 
             internalCurrentParentOrigin?.Dispose();
             internalCurrentParentOrigin = null;


### PR DESCRIPTION
void Dispose(bool) can be called from worker thread, when disposing value is false.

To ensure we detach AccessibileObject in main thread, let we remove it at Dispose(DisposeTypes), instead of Dispose(bool).

To avoid this kind of error in future, let we remove View.Dispose(bool) and let we only use Dispose(DisposeTypes).

Follow : #5674