### PR TITLE
[WiFi] Fix ASAN crash

### DIFF
--- a/src/Tizen.Network.WiFi/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.WiFi/Interop/Interop.Libraries.cs
@@ -20,6 +20,5 @@ internal static partial class Interop
     {
         public const string WiFi = "libcapi-network-wifi-manager.so.1";
         public const string Glib = "libglib-2.0.so.0";
-        public const string Libc = "libc.so.6";
     }
 }

--- a/src/Tizen.Network.WiFi/Interop/Interop.WiFi.cs
+++ b/src/Tizen.Network.WiFi/Interop/Interop.WiFi.cs
@@ -353,9 +353,9 @@ internal static partial class Interop
 
     }
 
-    internal static partial class Libc
+    internal static partial class Glib
     {
-        [DllImport(Libraries.Libc, EntryPoint = "free")]
+        [DllImport(Libraries.Glib, EntryPoint = "g_free", CallingConvention = CallingConvention.Cdecl)]
         public static extern void Free(IntPtr userData);
     }
 }

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAddressInformation.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiAddressInformation.cs
@@ -252,7 +252,7 @@ namespace Tizen.Network.WiFi
             string addr = Marshal.PtrToStringAnsi(addrPtr);
             if (addr == null || addr.Length == 0)
                 return DefaultIPAddress();
-            Interop.Libc.Free(addrPtr);
+            Interop.Glib.Free(addrPtr);
             return System.Net.IPAddress.Parse(addr);
         }
 

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiNetwork.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiNetwork.cs
@@ -54,7 +54,7 @@ namespace Tizen.Network.WiFi
                     else
                     {
                         _essid = Marshal.PtrToStringAnsi(strPtr);
-                        Interop.Libc.Free(strPtr);
+                        Interop.Glib.Free(strPtr);
                     }
                 }
                 return _essid;
@@ -83,7 +83,7 @@ namespace Tizen.Network.WiFi
                 {
                     rawSsid = new byte[length];
                     Marshal.Copy(ptr, rawSsid, 0, length);
-                    Interop.Libc.Free(ptr);
+                    Interop.Glib.Free(ptr);
                 }
                 return rawSsid;
             }
@@ -364,7 +364,7 @@ namespace Tizen.Network.WiFi
                 else
                 {
                     code = Marshal.PtrToStringAnsi(strPtr);
-                    Interop.Libc.Free(strPtr);
+                    Marshal.FreeHGlobal(strPtr);
                 }
                 return code;
             }


### PR DESCRIPTION
### Description of Change ###
- Use g_free() when allocating memory using glib.
- Otherwise, use Marshal.FreeHGlobl() instead of free()

### Related PR ###
https://github.com/Samsung/TizenFX/pull/5631