### PR TITLE
[TizenFX] Update nuspec to add net6.0 group

### DIFF
--- a/pkg/Tizen.NET/Tizen.NET.nuspec
+++ b/pkg/Tizen.NET/Tizen.NET.nuspec
@@ -40,15 +40,15 @@
         <dependency id="Tizen.NET.API10" version="10.0.0.17508" />
         <dependency id="Microsoft.NETCore.Platforms" version="3.1.0" />
       </group>
-      <group targetFramework="Tizen11.0">
-        <dependency id="Tizen.NET.API11" version="$fxversion$" />
-        <dependency id="Microsoft.NETCore.Platforms" version="6.0.9" />
-      </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Tizen.NET.API10" version="10.0.0.17508" />
         <dependency id="Microsoft.NETCore.Platforms" version="3.1.0" />
       </group>
-      <group targetFramework=".NET6.0">
+      <group targetFramework="net6.0-tizen8.0">
+        <dependency id="Tizen.NET.API11" version="11.0.0.18030" />
+        <dependency id="Microsoft.NETCore.Platforms" version="6.0.9" />
+      </group>
+      <group targetFramework="net6.0">
         <dependency id="Tizen.NET.API11" version="$fxversion$" />
         <dependency id="Microsoft.NETCore.Platforms" version="6.0.9" />
       </group>


### PR DESCRIPTION
### Description of Change ###
- This PR updates the dependencies information in nuspec file.
- `targetFramework ` values in `group`s will be used by Tizen runtime to set Tizen TFMs.


### API Changes ###
 - N/A
