### PR TITLE
[NUI] Added collider mesh setter

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
@@ -14,13 +14,27 @@
  * limitations under the License.
  *
  */
-
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 namespace Tizen.NUI.Scene3D
 {
     internal static partial class Interop
     {
         internal static partial class Model
         {
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct Vec3
+            {
+                internal float x, y, z;
+            }
+        
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct ElementIndex
+            {
+                internal Int32 index;
+            }
+            
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_New_SWIG_0")]
             public static extern global::System.IntPtr ModelNew(string modelUrl, string resourcePasth);
 
@@ -106,6 +120,13 @@ namespace Tizen.NUI.Scene3D
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_LoadFacialAnimation_2")]
             public static extern global::System.IntPtr LoadBlendShapeAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef model, string jsonBuffer, int jsonBufferLength);
+            
+            // Signals
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_MeshHitSignal_Connect")]
+            public static extern void MeshHitSignalConnect(global::System.Runtime.InteropServices.HandleRef model, global::System.Runtime.InteropServices.HandleRef handler);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionData_MeshHitSignal_Disconnect")]
+            public static extern void MeshHitSignalDisconnect(global::System.Runtime.InteropServices.HandleRef model, global::System.Runtime.InteropServices.HandleRef handler);
         }
     }
 }

--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.ModelNode.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.ModelNode.cs
@@ -15,12 +15,27 @@
  *
  */
 
+using System;
+using System.Runtime.InteropServices;
+
 namespace Tizen.NUI.Scene3D
 {
     internal static partial class Interop
     {
         internal static partial class ModelNode
         {
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct Vec3
+            {
+                internal float x, y, z;
+            }
+        
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct ElementIndex
+            {
+                internal Int32 index;
+            }
+            
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_Node_New_SWIG_0")]
             public static extern global::System.IntPtr ModelNodeNew();
 
@@ -62,6 +77,11 @@ namespace Tizen.NUI.Scene3D
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_Node_GetChildModelNodeAt")]
             public static extern global::System.IntPtr GetChildModelNodeAt(global::System.Runtime.InteropServices.HandleRef model, uint index);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_ModelNode_SetColliderMesh")]
+            public static extern global::System.IntPtr SetColliderMesh(global::System.Runtime.InteropServices.HandleRef modelNode,
+                Vec3[] vPtr,
+                Vec3[] nPtr, int vLength, int[] iPtr, int iLength);            
         }
     }
 }

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 using Tizen.NUI;
@@ -186,7 +187,7 @@ namespace Tizen.NUI.Scene3D
                 return GetModelRoot();
             }
         }
-
+        
         /// <summary>
         /// Adds modelNode to this Model.
         /// </summary>
@@ -685,6 +686,76 @@ namespace Tizen.NUI.Scene3D
         protected override void ReleaseSwigCPtr(global::System.Runtime.InteropServices.HandleRef swigCPtr)
         {
             Interop.Model.DeleteModel(swigCPtr);
+        }
+        
+        
+        private EventHandler<MeshHitEventArgs> meshHitEventHandler;
+        private MeshHitCallbackType meshHitCallback;
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void MeshHitCallbackType(IntPtr motionData);
+
+        /// <summary>
+        /// MeshHitEventArgs
+        /// Contains arguments when MeshHitSignal called
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public class MeshHitEventArgs : EventArgs
+        {
+            private ModelNode modelNode;
+            
+            /// <summary>
+            /// ModelNode that's been hit
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public ModelNode ModelNode
+            {
+                get
+                {
+                    return modelNode;
+                }
+                set
+                {
+                    modelNode = value;
+                }
+            }
+        }
+        
+        /// <summary>
+        /// EventHandler event.
+        /// It will be invoked when collider mesh is hit.
+        /// </summary>
+        public event EventHandler<MeshHitEventArgs> MeshHitSignal
+        {
+            add
+            {
+                if (meshHitEventHandler == null)
+                {
+                    meshHitCallback = MeshHitCollision;
+                    Interop.Model.MeshHitSignalConnect(SwigCPtr, meshHitCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                meshHitEventHandler += value;
+            }
+            remove
+            {
+                meshHitEventHandler -= value;
+                if (meshHitEventHandler == null && meshHitCallback != null)
+                {
+                    Interop.Model.MeshHitSignalDisconnect(SwigCPtr, meshHitCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    meshHitCallback = null;
+                }
+            }
+        }
+
+        private void MeshHitCollision(IntPtr modelNode)
+        {
+            if (meshHitEventHandler != null)
+            {
+                var args = new MeshHitEventArgs();
+                args.ModelNode = new ModelNode(modelNode, false);
+                meshHitEventHandler(this, args);
+            }
         }
     }
 }

--- a/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelNode.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelNode.cs
@@ -16,6 +16,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
 using System.Collections.Generic;
@@ -201,6 +202,40 @@ namespace Tizen.NUI.Scene3D
             }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+        
+        /// <summary>
+        /// Sets collider mesh on current node
+        /// </summary>
+        /// <param name="vertexList">List of vertices</param>
+        /// <param name="normalList">List of vertex normals</param>
+        /// <param name="indexList">List of mesh indices</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetColliderMesh(List<Vector3> vertexList, List<Vector3> normalList, List<int> indexList)
+        {
+            var vertices = new Interop.ModelNode.Vec3[vertexList.Count];
+            var idx = 0;
+            foreach (var vertex in vertexList)
+            {
+                vertices[idx].x = vertex.X;
+                vertices[idx].y = vertex.Y;
+                vertices[idx].z = vertex.Z;
+                ++idx;
+            }
+            
+            var normals = new Interop.ModelNode.Vec3[normalList.Count];
+            idx = 0;
+            foreach (var normal in normalList)
+            {
+                normals[idx].x = normal.X;
+                normals[idx].y = normal.Y;
+                normals[idx].z = normal.Z;
+                ++idx;
+            }
+            
+            Interop.ModelNode.SetColliderMesh(SwigCPtr,vertices, normals, vertexList.Count, indexList.ToArray(), indexList.Count);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// <summary>


### PR DESCRIPTION
Model.SetColliderMesh() function allows creating and setting a collider mesh on the node of model.

Node of model is selected by name (string).
Collider mesh data consists:
List<Vector3> - list of vertices
List<int> - list of indices (3 indices are a triangle face)

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
