### PR TITLE
[NUI.WindowSystem] Add SetSecondarySelection and UnsetSecondarySelection to fix typo

### DIFF
--- a/src/Tizen.NUI.WindowSystem/src/public/KVMService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/KVMService.cs
@@ -210,9 +210,31 @@ namespace Tizen.NUI.WindowSystem.Shell
 
         /// <summary>
         /// Requests to set KVM window as secondary selection window.
+        /// The request name has typo and will remove soon.
+        /// Please use SetSecondarySelection.
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
         public void SetSecondarySelction()
+        {
+           SetSecondarySelection();
+        }
+
+        /// <summary>
+        /// Requests to unset secondary selection window of KVM window.
+        /// The request name has typo and will remove soon.
+        /// Please use UnsetSecondarySelection.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        public void UnsetSecondarySelction()
+        {
+           UnsetSecondarySelection();
+        }
+
+        /// <summary>
+        /// Requests to set KVM window as secondary selection window.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        public void SetSecondarySelection()
         {
             int res = Interop.KVMService.SetSecondarySelection(_kvmService);
             _tzsh.ErrorCodeThrow(res);
@@ -222,7 +244,7 @@ namespace Tizen.NUI.WindowSystem.Shell
         /// Requests to unset secondary selection window of KVM window.
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
-        public void UnsetSecondarySelction()
+        public void UnsetSecondarySelection()
         {
             int res = Interop.KVMService.UnsetSecondarySelection(_kvmService);
             _tzsh.ErrorCodeThrow(res);

--- a/src/Tizen.NUI/src/public/Clipboard/ClipboardEvent.cs
+++ b/src/Tizen.NUI/src/public/Clipboard/ClipboardEvent.cs
@@ -98,7 +98,7 @@ namespace Tizen.NUI
         /// <example>
         /// The following example demonstrates how to use the DataSelected.
         /// <code>
-        /// kvmService.SetSecondarySelction(); // precondition
+        /// kvmService.SetSecondarySelection(); // precondition
         ///
         /// Clipboard.Instance.DataSelected += (s, e) =>
         /// {

--- a/test/NUIClipboardDataSelected/ClipboardDataSelected.cs
+++ b/test/NUIClipboardDataSelected/ClipboardDataSelected.cs
@@ -35,7 +35,7 @@ namespace NUIClipboardDataSelected
             Tizen.NUI.WindowSystem.Shell.KVMService kvmService;
             // Window that will act as KVM Service.
             kvmService = new Tizen.NUI.WindowSystem.Shell.KVMService(tzShell, Window.Instance); 
-            kvmService.SetSecondarySelction();
+            kvmService.SetSecondarySelection();
 
             // This view has nothing to do with this test, just for easy debugging.
             // If there is a view, it is exposed to the process monitor.

--- a/test/NUIWindowKVMSample/NUIWindowKVMSample.cs
+++ b/test/NUIWindowKVMSample/NUIWindowKVMSample.cs
@@ -118,7 +118,7 @@ namespace NUIWindowKVMSample
 
             tzShell = new Tizen.NUI.WindowSystem.Shell.TizenShell();
             kvmService = new Tizen.NUI.WindowSystem.Shell.KVMService(tzShell, this);
-            kvmService.SetSecondarySelction();
+            kvmService.SetSecondarySelection();
             kvmService.DragStarted += OnDragStarted;
             kvmService.DragEnded += OnDragEnded;
         }


### PR DESCRIPTION
## Description of Change ##
Add new requests for SetSecondarySelection and UnsetSecondarySelection to alternates requests SetSecondarySelction and UnsetSecondarySelction that have typo.

After all caller that typo requests have been removed, the typo request have been removed.


## API Changes ##

### Internal API Changes ###
Added:
 - void SetSecondarySelection()
 - void UnsetSecondarySelection()
