### PR TITLE
[Build] Fixed an error that could not find the dotnet_resolving.info file

### DIFF
--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -223,10 +223,10 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
-touch %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
-echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
-echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
-echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+touch %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
 
 %files
 %license LICENSE

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -222,10 +222,10 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
-touch %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
-echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
-echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
-echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{buildroot}%{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+touch %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
+echo "db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION}" >> %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
 
 %files
 %license LICENSE


### PR DESCRIPTION
The ```dotnet_resolving.info``` file was not found in the post script.
```
16:24:32,854 INFO  - /bin/touch: cannot touch `/home/abuild/rpmbuild/BUILDROOT/csapi-tizenfx-10.0.0.17777+nui22146-1.aarch64/usr/share/dotnet.tizen/lib/dotnet_resolving.info': No such file or directory
16:24:32,856 INFO  - /var/tmp/rpm-tmp.c7su3V: line 7: /home/abuild/rpmbuild/BUILDROOT/csapi-tizenfx-10.0.0.17777+nui22146-1.aarch64/usr/share/dotnet.tizen/lib/dotnet_resolving.info: No such file or directory
16:24:32,858 INFO  - /var/tmp/rpm-tmp.c7su3V: line 8: /home/abuild/rpmbuild/BUILDROOT/csapi-tizenfx-10.0.0.17777+nui22146-1.aarch64/usr/share/dotnet.tizen/lib/dotnet_resolving.info: No such file or directory
16:24:32,860 INFO  - /var/tmp/rpm-tmp.c7su3V: line 9: /home/abuild/rpmbuild/BUILDROOT/csapi-tizenfx-10.0.0.17777+nui22146-1.aarch64/usr/share/dotnet.tizen/lib/dotnet_resolving.info: No such file or directory
16:24:32,862 INFO  - warning: %post(csapi-tizenfx-10.0.0.17777+nui22146-1.noarch) scriptlet failed, exit status 1
16:24:32,863 INFO  - WARNING: (csapi-tizenfx-10.0.0.17777+nui22146-1.noarch.rpm) Post script failed
```