### PR TITLE
[Build] Set the dotnet_core_runtime_version value to 6.0

### DIFF
--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -13,7 +13,7 @@
 %define DOTNET_NUGET_SOURCE /nuget
 
 %define TIZEN_NET_RUNTIME_IDENTIFIERS 4.0.0:5.0.0:5.5.0:6.0.0:6.5.0:7.0.0:8.0.0
-%define TIZEN_NET_TARGET_FRAMEWORK_MONIKERS tizen11.0:tizen10.0:tizen90:tizen80:tizen70:tizen60:tizen50:tizen40
+%define TIZEN_NET_TARGET_FRAMEWORK_MONIKERS tizen10.0:tizen90:tizen80:tizen70:tizen60:tizen50:tizen40
 %define DOTNET_CORE_RUNTIME_VERSION 6.0
 
 %define UPGRADE_SCRIPT_PATH /usr/share/upgrade/scripts

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -13,7 +13,7 @@
 
 %define TIZEN_NET_RUNTIME_IDENTIFIERS @rid_version@
 %define TIZEN_NET_TARGET_FRAMEWORK_MONIKERS @tfm_support@
-%define DOTNET_CORE_RUNTIME_VERSION @dotnet_core_version@
+%define DOTNET_CORE_RUNTIME_VERSION 6.0
 
 %define UPGRADE_SCRIPT_PATH /usr/share/upgrade/scripts
 


### PR DESCRIPTION
Set the dotnet_core_runtime_version value to 6.0. The dotnet_core_runtime_version value will be removed from tizenfx. Also, the script that creates the TFM list will be modified.