### PR TITLE
[Build] Create a dotnet library dir from the post script

### DIFF
--- a/packaging/csapi-tizenfx.spec
+++ b/packaging/csapi-tizenfx.spec
@@ -182,7 +182,6 @@ mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_RES_PATH}
 mkdir -p %{buildroot}%{DOTNET_NUGET_SOURCE}
 mkdir -p %{buildroot}%{DOTNET_TOOLS_PATH}
 mkdir -p %{buildroot}%{DOTNET_PRELOAD_PATH}
-mkdir -p %{buildroot}%{DOTNET_LIBRARY_PATH}
 
 # Install Runtime Assemblies
 install -p -m 644 Artifacts/bin/public/*.dll %{buildroot}%{DOTNET_ASSEMBLY_PATH}
@@ -222,6 +221,7 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
+mkdir -p %{DOTNET_LIBRARY_PATH}
 touch %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
 echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
 echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info

--- a/packaging/csapi-tizenfx.spec.in
+++ b/packaging/csapi-tizenfx.spec.in
@@ -181,7 +181,6 @@ mkdir -p %{buildroot}%{DOTNET_ASSEMBLY_RES_PATH}
 mkdir -p %{buildroot}%{DOTNET_NUGET_SOURCE}
 mkdir -p %{buildroot}%{DOTNET_TOOLS_PATH}
 mkdir -p %{buildroot}%{DOTNET_PRELOAD_PATH}
-mkdir -p %{buildroot}%{DOTNET_LIBRARY_PATH}
 
 # Install Runtime Assemblies
 install -p -m 644 Artifacts/bin/public/*.dll %{buildroot}%{DOTNET_ASSEMBLY_PATH}
@@ -221,6 +220,7 @@ install -p -m 755 packaging/500.tizenfx_upgrade.sh %{buildroot}%{UPGRADE_SCRIPT_
 /usr/bin/vconftool set -t string db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS} -f
 /usr/bin/vconftool set -t string db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS} -f
 /usr/bin/vconftool set -t string db/dotnet/runtime_version %{DOTNET_CORE_RUNTIME_VERSION} -f
+mkdir -p %{DOTNET_LIBRARY_PATH}
 touch %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
 echo "db/dotnet/tizen_rid_version %{TIZEN_NET_RUNTIME_IDENTIFIERS}" > %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info
 echo "db/dotnet/tizen_tfm_support %{TIZEN_NET_TARGET_FRAMEWORK_MONIKERS}" >> %{DOTNET_LIBRARY_PATH}/dotnet_resolving.info


### PR DESCRIPTION
Create a dotnet library dir from the post script
```
17:15:40,648 INFO  - /bin/touch: cannot touch `/usr/share/dotnet.tizen/lib/dotnet_resolving.info': No such file or directory
17:15:40,650 INFO  - /var/tmp/rpm-tmp.34KWLT: line 7: /usr/share/dotnet.tizen/lib/dotnet_resolving.info: No such file or directory
17:15:40,652 INFO  - /var/tmp/rpm-tmp.34KWLT: line 8: /usr/share/dotnet.tizen/lib/dotnet_resolving.info: No such file or directory
17:15:40,654 INFO  - /var/tmp/rpm-tmp.34KWLT: line 9: /usr/share/dotnet.tizen/lib/dotnet_resolving.info: No such file or directory
17:15:40,656 INFO  - warning: %post(csapi-tizenfx-10.0.0.17778+nui22146-1.noarch) scriptlet failed, exit status 1
17:15:40,657 INFO  - WARNING: (csapi-tizenfx-10.0.0.17778+nui22146-1.noarch.rpm) Post script failed
```