### PR TITLE
[NUI] revert 'Make DaliAccessibilityDetachAccessibleObject called at main thread' and check native object

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -256,7 +256,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AccessibilityStates GetAccessibilityStates()
         {
-            var result = new AccessibilityStates {BitMask = Interop.ControlDevel.DaliToolkitDevelControlGetAccessibilityStates(SwigCPtr)};
+            var result = new AccessibilityStates { BitMask = Interop.ControlDevel.DaliToolkitDevelControlGetAccessibilityStates(SwigCPtr) };
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return result;
         }
@@ -333,7 +333,7 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return new AccessibilityEvents {Owner = this};
+                return new AccessibilityEvents { Owner = this };
             }
         }
 
@@ -365,6 +365,40 @@ namespace Tizen.NUI.BaseComponents
         {
             Interop.ControlDevel.DaliAccessibilityBridgeUnregisterDefaultLabel(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            internalName = null;
+
+            if (SwigCPtr.Handle != IntPtr.Zero && global::System.Threading.Thread.CurrentThread.ManagedThreadId == Registry.Instance.SavedApplicationThread.ManagedThreadId)
+            {
+                Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+
+            if (disposing == false)
+            {
+                if (IsNativeHandleInvalid() || SwigCMemOwn == false)
+                {
+                    // at this case, implicit nor explicit dispose is not required. No native object is made.
+                    disposed = true;
+                    return;
+                }
+            }
+
+            if (disposing)
+            {
+                Unparent();
+            }
+
+            base.Dispose(disposing);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1231,12 +1231,6 @@ namespace Tizen.NUI.BaseComponents
 
             disposeDebugging(type);
 
-            internalName = "";
-            Unparent();
-
-            Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
             //_mergedStyle = null;
 
             internalMaximumSize?.Dispose();


### PR DESCRIPTION
### Description of Change ###
[NUI] revert 'Make DaliAccessibilityDetachAccessibleObject called at main thread' and check native object
- revert https://github.com/Samsung/TizenFX/pull/5674 and
- to fix crash from testhub, ATSPI's native object null check is required
- testhub crash bt =>
11-06 22:59:38.024+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(656) > SwigCPtr Error! NUI's native dali object is already disposed. OR the native dali object handle of NUI becomes null! 
11-06 22:59:38.024+0900 F/NUI      (P23231, T23231):  process:23231 thread:1, isDisposed:False, isDisposeQueued:True, me:Tizen.NUI.BaseComponents.VectorGraphics.CanvasView
11-06 22:59:38.024+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(660) > [ERROR] back trace!
11-06 22:59:38.027+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method System.Runtime.InteropServices.HandleRef get_SwigCPtr()::0
11-06 22:59:38.028+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void Dispose(Tizen.NUI.DisposeTypes)::0
11-06 22:59:38.028+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void Dispose(Tizen.NUI.DisposeTypes)::0
11-06 22:59:38.028+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void Dispose()::0
11-06 22:59:38.028+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void ProcessDisposables()::0
11-06 22:59:38.028+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void ApplicationMainLoop(System.Runtime.InteropServices.HandleRef)::0
11-06 22:59:38.028+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void MainLoop()::0
11-06 22:59:38.029+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void Run(System.String[])::0
11-06 22:59:38.029+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void Run(System.String[])::0
11-06 22:59:38.029+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void Run(System.String[])::0
11-06 22:59:38.029+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(665) >  Method Void Main(System.String[]):/var/lib/jenkins/jobs/CsharpTCT/TCT_8.0/api/tct-suite-vs/Tizen.NUI.Tests/Program.cs:144
11-06 22:59:38.029+0900 F/NUI      (P23231, T23231): BaseHandle.cs: SwigCPtr(667) > Error! just return here with null swigCPtr! this can cause unknown error or crash in next step
11-06 22:59:38.035+0900 E/STDERR   (P23231, T23231): Unhandled exception. System.ArgumentNullException: arg1_control (Parameter 'CSharp_Dali_Accessibility_DetachAccessibleObject is not allowed to take nullptr as arg1_control Inner Exception: FATAL: Exception e is null, numExceptionsPending : 0')
11-06 22:59:38.035+0900 E/STDERR   (P23231, T23231):    at Tizen.NUI.BaseComponents.View.Dispose(DisposeTypes type) in Tizen.NUI.dll:token 0x600274e+0x0
11-06 22:59:38.035+0900 E/STDERR   (P23231, T23231):    at Tizen.NUI.BaseComponents.VectorGraphics.CanvasView.Dispose(DisposeTypes type) in Tizen.NUI.dll:token 0x600289c+0x17
11-06 22:59:38.035+0900 E/STDERR   (P23231, T23231):    at Tizen.NUI.BaseHandle.Dispose() in Tizen.NUI.dll:token 0x6000e29+0x1e
11-06 22:59:38.035+0900 E/STDERR   (P23231, T23231):    at Tizen.NUI.DisposeQueue.ProcessDisposables() in Tizen.NUI.dll:token 0x6000239+0x9




### API Changes ###
none
