### PR TITLE
[NUI] Support to get Marker list information from lottie

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -150,6 +150,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 // Reset cached infomations.
                 currentStates.contentInfo = null;
+                currentStates.markerInfo = null;
                 currentStates.mark1 = null;
                 currentStates.mark2 = null;
                 currentStates.framePlayRangeMin = -1;
@@ -617,6 +618,62 @@ namespace Tizen.NUI.BaseComponents
             NUILog.Debug($">");
 
             return currentStates.contentInfo;
+        }
+
+        /// <summary>
+        /// Get the list of markers' information such as the start frame and the end frame in the Lottie file.
+        /// </summary>
+        /// <returns>List of Tuple (string of marker name, integer of start frame, integer of end frame)</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<Tuple<string, int, int>> GetMarkerInfo()
+        {
+            if (currentStates.markerInfo != null)
+            {
+                return currentStates.markerInfo;
+            }
+
+            NUILog.Debug($"<");
+
+            PropertyMap imageMap = base.Image;
+            if (imageMap != null)
+            {
+                PropertyValue val = imageMap.Find(ImageVisualProperty.MarkerInfo);
+                PropertyMap markerMap = new PropertyMap();
+                if (val?.Get(ref markerMap) == true)
+                {
+                    currentStates.markerInfo = new List<Tuple<string, int, int>>();
+                    for (uint i = 0; i < markerMap.Count(); i++)
+                    {
+                        using PropertyKey propertyKey = markerMap.GetKeyAt(i);
+                        string key = propertyKey.StringKey;
+
+                        using PropertyValue arrVal = markerMap.GetValue(i);
+                        using PropertyArray arr = new PropertyArray();
+                        if (arrVal.Get(arr))
+                        {
+                            int startFrame = -1;
+                            using PropertyValue start = arr.GetElementAt(0);
+                            start?.Get(out startFrame);
+
+                            int endFrame = -1;
+                            using PropertyValue end = arr.GetElementAt(1);
+                            end?.Get(out endFrame);
+
+                            NUILog.Debug($"[{i}] marker name={key}, startFrame={startFrame}, endFrame={endFrame}");
+
+                            Tuple<string, int, int> item = new Tuple<string, int, int>(key, startFrame, endFrame);
+
+                            currentStates.markerInfo?.Add(item);
+                        }
+                    }
+                }
+                markerMap.Dispose();
+                val?.Dispose();
+            }
+            NUILog.Debug($">");
+
+            return currentStates.markerInfo;
         }
 
         /// <summary>
@@ -1144,6 +1201,7 @@ namespace Tizen.NUI.BaseComponents
             internal float scale;
             internal PlayStateType playState;
             internal List<Tuple<string, int, int>> contentInfo;
+            internal List<Tuple<string, int, int>> markerInfo;
             internal string mark1, mark2;
             internal bool redrawInScalingDown;
             internal int desiredWidth, desiredHeight;

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -977,6 +977,16 @@ namespace Tizen.NUI
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly int FastTrackUploading = NDalic.ImageVisualOrientationCorrection + 13;
+
+        /// <summary>
+        /// @brief The marker information the AnimatedVectorImageVisual will use.
+        /// @details Type Property::MAP.
+        /// The map contains the marker name as a key and Property::Array as a value.
+        /// And the array contains 2 integer values which are the frame numbers, the start frame number and the end frame number of the marker.
+        /// @note This property is read-only.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly int MarkerInfo = NDalic.ImageVisualOrientationCorrection + 15;
     }
 
     /// <summary>


### PR DESCRIPTION
Let we allow to get the list of markers what current lottie image has now.

And also, Implement min/max frame index by marker, which is legacy feature of VD FLUX code.

Relative dali patches :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/301038
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/301040
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-extension/+/301039
