### PR TITLE
[NUI.XamlBuild] Remove unused event : Element.DescendantAdded / Removed 

### DIFF
--- a/src/Tizen.NUI.XamlBuild/src/internal/XamlBinding/Element.cs
+++ b/src/Tizen.NUI.XamlBuild/src/internal/XamlBinding/Element.cs
@@ -471,11 +471,12 @@ namespace Tizen.NUI.Binding
 
             child.ApplyBindings(skipBindingContext: false, fromBindingContextChanged:true);
 
-            ChildAdded?.Invoke(this, new ElementEventArgs(child));
+            // 2023-11-08 : Just ignore Tizen.NUI don't using logics.
+            // ChildAdded?.Invoke(this, new ElementEventArgs(child));
 
-            OnDescendantAdded(child);
-            foreach (Element element in child.Descendants())
-                OnDescendantAdded(element);
+            // OnDescendantAdded(child);
+            // foreach (Element element in child.Descendants())
+            //     OnDescendantAdded(element);
         }
 
         /// <summary>
@@ -488,11 +489,12 @@ namespace Tizen.NUI.Binding
         {
             child.Parent = null;
 
-            ChildRemoved?.Invoke(child, new ElementEventArgs(child));
+            // 2023-11-08 : Just ignore Tizen.NUI don't using logics.
+            // ChildRemoved?.Invoke(child, new ElementEventArgs(child));
 
-            OnDescendantRemoved(child);
-            foreach (Element element in child.Descendants())
-                OnDescendantRemoved(element);
+            // OnDescendantRemoved(child);
+            // foreach (Element element in child.Descendants())
+            //     OnDescendantRemoved(element);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/XamlBinding/Element.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Element.cs
@@ -372,11 +372,12 @@ namespace Tizen.NUI.Binding
 
             child.ApplyBindings(skipBindingContext: false, fromBindingContextChanged: true);
 
-            ChildAdded?.Invoke(this, new ElementEventArgs(child));
+            // 2023-11-08 : Just ignore Tizen.NUI don't using logics.
+            // ChildAdded?.Invoke(this, new ElementEventArgs(child));
 
-            OnDescendantAdded(child);
-            foreach (Element element in child.Descendants())
-                OnDescendantAdded(element);
+            // OnDescendantAdded(child);
+            // foreach (Element element in child.Descendants())
+            //     OnDescendantAdded(element);
         }
 
         /// <summary>
@@ -395,11 +396,12 @@ namespace Tizen.NUI.Binding
 
             child.Parent = null;
 
-            ChildRemoved?.Invoke(child, new ElementEventArgs(child));
+            // 2023-11-08 : Just ignore Tizen.NUI don't using logics.
+            // ChildRemoved?.Invoke(child, new ElementEventArgs(child));
 
-            OnDescendantRemoved(child);
-            foreach (Element element in child.Descendants())
-                OnDescendantRemoved(element);
+            // OnDescendantRemoved(child);
+            // foreach (Element element in child.Descendants())
+            //     OnDescendantRemoved(element);
         }
 
         /// <summary>


### PR DESCRIPTION
Those API was useless if we don't need to invoke those events.
And those try to climb-up to parent root every Add / Remove API.

It will spend heavy time if the scene tree is complex.

Those event handerl are internal, and nobody use them.
So just remove codes.