### PR TITLE
[NUI] DetachAccessibleObject at Dispose time well

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -397,12 +397,6 @@ namespace Tizen.NUI.BaseComponents
 
             internalName = null;
 
-            if (SwigCPtr.Handle != IntPtr.Zero && global::System.Threading.Thread.CurrentThread.ManagedThreadId == Registry.Instance.SavedApplicationThread.ManagedThreadId)
-            {
-                Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-
             if (disposing == false)
             {
                 if (IsNativeHandleInvalid() || SwigCMemOwn == false)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1346,6 +1346,12 @@ namespace Tizen.NUI.BaseComponents
 
             disposeDebugging(type);
 
+            if (SwigCMemOwn && !IsNativeHandleInvalid())
+            {
+                Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
+
             //_mergedStyle = null;
 
             internalMaximumSize?.Dispose();


### PR DESCRIPTION
There was several problem when we call DaliAccessibilityDetachAccessibleObject at Dispose(bool) function

 - It will detach accessibility even if view doesn't owned the handle memory
 - Dispose(bool) can be called at worker thread (during GC) so we need to check thread here

I make to DaliAccessibilityDetachAccessibleObject function at Dispose(DisposeTypes) that we can ensure it called at main thread clearly.
