### PR TITLE
[NUI] Fix TotalFrame getter bug when async load

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -296,7 +296,7 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 int ret = currentStates.totalFrame;
-                if (ret == -1)
+                if (ret <= 0)
                 {
                     Interop.View.InternalRetrievingVisualPropertyInt(this.SwigCPtr, ImageView.Property.IMAGE, ImageVisualProperty.TotalFrameNumber, out ret);
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LottieAnimationTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LottieAnimationTest.cs
@@ -8,11 +8,25 @@ namespace Tizen.NUI.Samples
         public void Activate()
         {
             lav = new LottieAnimationView();
+            lav.SynchronousLoading = false;
             lav.URL = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "a.json";
             lav.LoopCount = -1;
             lav.BackgroundColor = Color.White;
             NUIApplication.GetDefaultWindow().GetDefaultLayer().Add(lav);
-            lav.Play();
+            Tizen.Log.Error("NUI", $"Total frame before resource ready : {lav.TotalFrame} / might be 0 if still load images. or, might be valid value if load finished during above logic running.\n");
+
+            lav.ResourceReady += (o, e) =>
+            {
+                if (lav.LoadingStatus == ImageView.LoadingStatusType.Failed)
+                {
+                    Tizen.Log.Error("NUI", $"Load failed!\n");
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", $"Total frame after resource ready : {lav.TotalFrame}\n");
+                    lav.Play();
+                }
+            };
         }
         public void Deactivate()
         {


### PR DESCRIPTION
There was some bug when we try to get TotalFrame when async load json file.

DALi engine side default total frame number is 0, and NUI is -1. So, if we try to get TotalFrame from dali which is still loading, it will cache the internal total frame as 0. After than, we can never get valid value.

To avoid this problem, we have 2 choice

1. Wait until async load finished, and then get total frame at dali side.
2. Just get 0 for now, and try again when total frame cached as 0.

Solution 1 need some time to resolve it. So now just make 2.
