### PR TITLE
[System.Feedback] Change feedback theme api name index to id

### DIFF
--- a/src/Tizen.System.Feedback/Feedback/Feedback.cs
+++ b/src/Tizen.System.Feedback/Feedback/Feedback.cs
@@ -595,35 +595,35 @@ namespace Tizen.System
         }
 
         /// <summary>
-        /// Gets the index of theme selected.
+        /// Gets the id of theme selected.
         /// </summary>
         /// <remarks>
         /// Now this internal API works for FeedbackType.Sound only, FeedbackType.Vibration is not supported.
-        /// Index of theme range will be 1 ~ N according to conf file.
+        /// The theme id is positive value as defined in the conf file.
         /// </remarks>
         /// <since_tizen> 10 </since_tizen>
         /// <param name="type">The feedback type.</param>
-        /// <returns>The index of theme selected as default theme according to feedback type.</returns>
+        /// <returns>The id of theme selected as default theme according to feedback type.</returns>
         /// <exception cref="ArgumentException">Thrown when failed because of an invalid arguament.</exception>
         /// <exception cref="NotSupportedException">Thrown when failed becuase the device (haptic, sound) is not supported.</exception>
         /// <exception cref="InvalidOperationException">Thrown when failed because of a system error.</exception>
         /// <example>
         /// <code>
         /// Feedback feedback = new Feedback();
-        /// uint indexOfTheme = feedback. GetThemeIndexInternal(FeedbackType.Sound);
+        /// uint idOfTheme = feedback.GetThemeIdInternal(FeedbackType.Sound);
         /// </code>
         /// </example>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint GetThemeIndexInternal(FeedbackType type)
+        public uint GetThemeIdInternal(FeedbackType type)
         {
             uint countOfTheme = 0;
             Interop.Feedback.FeedbackError res;
 
-            res = (Interop.Feedback.FeedbackError)Interop.Feedback.GetThemeIndexInternal((Interop.Feedback.FeedbackType)type, out countOfTheme);
+            res = (Interop.Feedback.FeedbackError)Interop.Feedback.GetThemeIdInternal((Interop.Feedback.FeedbackType)type, out countOfTheme);
 
             if (res != Interop.Feedback.FeedbackError.None)
             {
-                Log.Warn(LogTag, string.Format("Failed to get index of theme internal. err = {0}", res));
+                Log.Warn(LogTag, string.Format("Failed to get id of theme internal. err = {0}", res));
                 switch (res)
                 {
                     case Interop.Feedback.FeedbackError.InvalidParameter:
@@ -632,23 +632,23 @@ namespace Tizen.System
                         throw new NotSupportedException("Device is not supported");
                     case Interop.Feedback.FeedbackError.OperationFailed:
                     default:
-                        throw new InvalidOperationException("Failed to get index of theme internal");
+                        throw new InvalidOperationException("Failed to get id of theme internal");
                 }
             }
             return countOfTheme;
         }
 
         /// <summary>
-        /// Sets the index of theme according to feedback type.
+        /// Sets the id of theme according to feedback type.
         /// </summary>
         /// <remarks>
         /// Now this internal API works for FeedbackType.Sound only, FeedbackType.Vibration is not supported.
-        /// To set the index of theme for Sound type, the application should have http://tizen.org/privilege/systemsettings.admin privilege.
-        /// Index of theme range is 1 ~ N according to conf file. If you put the wrong index, operation cannot be guaranteed.
+        /// To set the id of theme for Sound type, the application should have http://tizen.org/privilege/systemsettings.admin privilege.
+        /// The theme id is positive value as defined in the conf file.
         /// </remarks>
         /// <since_tizen> 10 </since_tizen>
         /// <param name="type">The feedback type.</param>
-        /// <param name="indexOfTheme">The index of theme will be set.</param>
+        /// <param name="idOfTheme">The id of theme will be set.</param>
         /// <exception cref="ArgumentException">Thrown when failed because of an invalid arguament.</exception>
         /// <exception cref="NotSupportedException">Thrown when failed becuase the device (haptic, sound) is not supported.</exception>
         /// <exception cref="UnauthorizedAccessException">Thrown when failed because the access is not granted(No privilege)</exception>
@@ -656,20 +656,20 @@ namespace Tizen.System
         /// <example>
         /// <code>
         /// Feedback feedback = new Feedback();
-        /// uint indexOfTheme = 1;
-        /// feedback.SetThemeIndexInternal(FeedbackType.Sound, indexOfTheme);
+        /// uint idOfTheme = 1;
+        /// feedback.SetThemeIdInternal(FeedbackType.Sound, idOfTheme);
         /// </code>
         /// </example>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetThemeIndexInternal(FeedbackType type, uint indexOfTheme)
+        public void SetThemeIdInternal(FeedbackType type, uint idOfTheme)
         {
             Interop.Feedback.FeedbackError res;
 
-            res = (Interop.Feedback.FeedbackError)Interop.Feedback.SetThemeIndexInternal((Interop.Feedback.FeedbackType)type, indexOfTheme);
+            res = (Interop.Feedback.FeedbackError)Interop.Feedback.SetThemeIdInternal((Interop.Feedback.FeedbackType)type, idOfTheme);
 
             if (res != Interop.Feedback.FeedbackError.None)
             {
-                Log.Warn(LogTag, string.Format("Failed to set index of theme internal. err = {0}", res));
+                Log.Warn(LogTag, string.Format("Failed to set id of theme internal. err = {0}", res));
                 switch (res)
                 {
                     case Interop.Feedback.FeedbackError.InvalidParameter:
@@ -680,7 +680,7 @@ namespace Tizen.System
                         throw new UnauthorizedAccessException("Access is not granted");
                     case Interop.Feedback.FeedbackError.OperationFailed:
                     default:
-                        throw new InvalidOperationException("Failed to set index of theme internal");
+                        throw new InvalidOperationException("Failed to set id of theme internal");
                 }
             }
         }

--- a/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
+++ b/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
@@ -59,11 +59,11 @@ internal static partial class Interop
         [DllImport(Libraries.Feedback, EntryPoint = "feedback_get_count_of_theme_internal")]
         internal static extern int GetCountOfThemeInternal(FeedbackType type, out uint countOfTheme);
 
-        [DllImport(Libraries.Feedback, EntryPoint = "feedback_get_theme_index_internal")]
-        internal static extern int GetThemeIndexInternal(FeedbackType type, out uint indexOfTheme);
+        [DllImport(Libraries.Feedback, EntryPoint = "feedback_get_theme_id_internal")]
+        internal static extern int GetThemeIdInternal(FeedbackType type, out uint idOfTheme);
 
-        [DllImport(Libraries.Feedback, EntryPoint = "feedback_set_theme_index_internal")]
-        internal static extern int SetThemeIndexInternal(FeedbackType type, uint indexOfTheme);
+        [DllImport(Libraries.Feedback, EntryPoint = "feedback_set_theme_id_internal")]
+        internal static extern int SetThemeIdInternal(FeedbackType type, uint idOfTheme);
 
         [DllImport(Libraries.Feedback, EntryPoint = "feedback_stop_type_internal")]
         internal static extern int StopTypeInternal(FeedbackType type);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

As policies dealing with feedback themes have changed from index to id-base selection, API naming also changed from index to id.
Feedback themes are no longer treated sequentially, also not dependent on index. It is managed through a unique id.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
