### PR TITLE
[System.Feedback] Add internal API to support get ids

### DIFF
--- a/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
+++ b/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
@@ -67,5 +67,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.Feedback, EntryPoint = "feedback_stop_type_internal")]
         internal static extern int StopTypeInternal(FeedbackType type);
+
+        [DllImport(Libraries.Feedback, EntryPoint = "feedback_get_theme_ids_internal", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int GetThemeIdsInternal(FeedbackType type, out uint coundOfTheme, out IntPtr themeIds);
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Allows getting feedback theme id array supported.

This is newly added to System.Feedback.
- public uint[] GetThemeIdsInternal(FeedbackType type)
    -> It returns the available id array defined in the conf file according to feedback type.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
