### PR TITLE
[NUI] Support EncodedImageBuffer ImageType property + Upgrade Encoded…

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.EncodedImageBuffer.cs
@@ -27,6 +27,9 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_New")]
             public static extern IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_New__SWIG_1")]
+            public static extern IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1, int imageType);
+
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_EncodedImageBuffer__SWIG_0")]
             public static extern IntPtr NewEncodedImageBuffer();
 
@@ -35,6 +38,12 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EncodedImageBuffer")]
             public static extern void DeleteEncodedImageBuffer(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_SetImageType")]
+            public static extern void SetImageType(global::System.Runtime.InteropServices.HandleRef jarg1, int imageType);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GetImageType")]
+            public static extern int GetImageType(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EncodedImageBuffer_GetRawBuffer")]
             public static extern IntPtr GetRawBuffer(IntPtr handle);

--- a/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
@@ -38,6 +38,37 @@ namespace Tizen.NUI
         private VectorUnsignedChar mCachedBuffer = null; // cached encoded raw buffer
 
         /// <summary>
+        /// The list of type of encoded image buffer.
+        /// It will be used when we want to specify the buffer data type.
+        /// </summary>
+        /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1717:Only FlagsAttribute enums should have plural names")]
+        public enum ImageTypes
+        {
+            /// <summary>
+            /// Regular images.
+            /// </summary>
+            /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            RegularImage = 0,
+
+            /// <summary>
+            /// Vector rasterize images.
+            /// </summary>
+            /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            VectorImage,
+
+            /// <summary>
+            /// Animated vector rasterize images.
+            /// </summary>
+            /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            AnimatedVectorImage,
+        }
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="stream">The Stream of the image file.</param>
@@ -45,19 +76,58 @@ namespace Tizen.NUI
         /// <exception cref="InvalidOperationException"> Thrown when stream don't have any data. </exception>
         /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public EncodedImageBuffer(System.IO.Stream stream) : this(GetRawBuffrFromStreamHelper(stream))
+        public EncodedImageBuffer(System.IO.Stream stream) : this(GetRawBuffrFromStreamHelper(stream), ImageTypes.RegularImage)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal EncodedImageBuffer(VectorUnsignedChar buffer) : this(Interop.EncodedImageBuffer.New(VectorUnsignedChar.getCPtr(buffer)), true)
+        /// <summary>
+        /// Constructor with image type.
+        /// </summary>
+        /// <param name="stream">The Stream of the image file.</param>
+        /// <param name="imageType">The type of the image stream.</param>
+        /// <exception cref="ArgumentNullException"> Thrown when stream is null. </exception>
+        /// <exception cref="InvalidOperationException"> Thrown when stream don't have any data. </exception>
+        /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public EncodedImageBuffer(System.IO.Stream stream, ImageTypes imageType) : this(GetRawBuffrFromStreamHelper(stream), imageType)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal EncodedImageBuffer(VectorUnsignedChar buffer, ImageTypes imageType) : this(Interop.EncodedImageBuffer.New(VectorUnsignedChar.getCPtr(buffer), (int)imageType), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             mCachedBuffer = buffer;
         }
 
-        internal EncodedImageBuffer(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal EncodedImageBuffer(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, false)
         {
+            // Note : EncodedImageBuffer don't need to be register in Registry default. So we can create this class from worker thread.
+        }
+
+        internal EncodedImageBuffer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        {
+        }
+
+        /// <summary>
+        /// The type of image for this EncodedImageBuffer.
+        /// </summary>
+        /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ImageTypes ImageType
+        {
+            set
+            {
+                Interop.EncodedImageBuffer.SetImageType(SwigCPtr, (int)value);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
+            get
+            {
+                ImageTypes ret = (ImageTypes)Interop.EncodedImageBuffer.GetImageType(SwigCPtr);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return ret;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
…ImageBuffer demo

Let we allow to give the type of buffer s.t. what buffer is mean. We can load svg and lottie image as encoded image buffer now.

+

Let we make EncodedImageBuffer can be created at worker thread. And make the demo to load buffer asynchronously.

This patch have dependency with below dali patch :

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/301314
