### PR TITLE
[NUI] Change SetMinAndMaxFrameByMarker behavior + Fix some async cases

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
@@ -410,8 +410,13 @@ namespace Tizen.NUI.BaseComponents
                     break;
 
                 case minMaxSetTypes.SetByMinAndMaxFrameByMarkerMethod:
-                    GetFrameValueFromMarkerInfo();
-                    goto case minMaxSetTypes.SetByMinAndMaxFrameMethod;
+                    base.SetMinMaxFrameByMarker(minimumFrameMarker, maximumFrameMarker);
+                    if (GetFrameValueFromMarkerInfo())
+                    {
+                        base.CurrentFrame = minimumFrame;
+                        innerCurrentFrame = minimumFrame;
+                    }
+                    break;
 
                 case minMaxSetTypes.SetByMinAndMaxFrameMethod:
                     base.SetMinMaxFrame(minimumFrame, maximumFrame);
@@ -609,7 +614,7 @@ namespace Tizen.NUI.BaseComponents
 
 
         #region Internal
-        internal void GetFrameValueFromMarkerInfo()
+        internal bool GetFrameValueFromMarkerInfo()
         {
             bool minimumMarkerFoundSuccess = false;
             bool maximumMarkerFoundSuccess = false;
@@ -617,12 +622,6 @@ namespace Tizen.NUI.BaseComponents
             int foundedMaximumFrame = 0;
 
             NUILog.Debug($" [{GetId()}] GetFrameValueFromMarkerInfo : marker = (minimumFrameMarker:{minimumFrameMarker}, maximumFrameMarker:{maximumFrameMarker})");
-
-            // Note : let we insure to get marker frame value only one time per each frame marker setter
-            if (minimumFrameMarker == null)
-            {
-                return;
-            }
 
             var markerInfoList = GetMarkerInfo();
             if (markerInfoList != null)
@@ -661,13 +660,20 @@ namespace Tizen.NUI.BaseComponents
                 {
                     NUILog.Debug($" [{GetId()}] minimumFrame:{minimumFrame} > maximumFrame:{maximumFrame})");
                 }
+
+                // Note : let we insure to get marker frame value only one time per each frame marker setter
                 minimumFrameMarker = maximumFrameMarker = null;
+                isMinMaxFrameSet = minMaxSetTypes.SetByMinAndMaxFrameMethod;
+                return true;
             }
             else
             {
+                Tizen.Log.Error("NUI", $"Fail to get frame from marker = (minimumFrameMarker:{minimumFrameMarker}, maximumFrameMarker:{maximumFrameMarker}). Maybe file is not loaded yet, or invalid marker used. url : {resourceUrl}\n");
+
                 minimumFrame = 0;
                 maximumFrame = totalFrameNum - 1;
                 NUILog.Debug($" [{GetId()}] GetFrameValueFromMarkerInfo Failed! frame set as {minimumFrame} ~ {maximumFrame} : marker = (minimumFrameMarker:{minimumFrameMarker}, maximumFrameMarker:{maximumFrameMarker})");
+                return false;
             }
         }
         #endregion Internal

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -302,6 +302,11 @@ namespace Tizen.NUI.BaseComponents
 
                     currentStates.totalFrame = ret;
                     NUILog.Debug($"TotalFrameNumber get! ret={ret}");
+
+                    if (ret <= 0)
+                    {
+                        Tizen.Log.Error("NUI", $"Fail to get TotalFrame. Maybe file is not loaded yet, or invalid url used. url : {currentStates.url}\n");
+                    }
                 }
                 return ret;
             }
@@ -606,38 +611,41 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap imageMap = base.Image;
             if (imageMap != null)
             {
-                PropertyValue val = imageMap.Find(ImageVisualProperty.ContentInfo);
-                PropertyMap contentMap = new PropertyMap();
-                if (val?.Get(ref contentMap) == true)
+                if (TotalFrame > 0) // Check whether image file loaded successfuly.
                 {
-                    currentStates.contentInfo = new List<Tuple<string, int, int>>();
-                    for (uint i = 0; i < contentMap.Count(); i++)
+                    PropertyValue val = imageMap.Find(ImageVisualProperty.ContentInfo);
+                    PropertyMap contentMap = new PropertyMap();
+                    if (val?.Get(ref contentMap) == true)
                     {
-                        using PropertyKey propertyKey = contentMap.GetKeyAt(i);
-                        string key = propertyKey.StringKey;
-
-                        using PropertyValue arrVal = contentMap.GetValue(i);
-                        using PropertyArray arr = new PropertyArray();
-                        if (arrVal.Get(arr))
+                        currentStates.contentInfo = new List<Tuple<string, int, int>>();
+                        for (uint i = 0; i < contentMap.Count(); i++)
                         {
-                            int startFrame = -1;
-                            using PropertyValue start = arr.GetElementAt(0);
-                            start?.Get(out startFrame);
+                            using PropertyKey propertyKey = contentMap.GetKeyAt(i);
+                            string key = propertyKey.StringKey;
 
-                            int endFrame = -1;
-                            using PropertyValue end = arr.GetElementAt(1);
-                            end?.Get(out endFrame);
+                            using PropertyValue arrVal = contentMap.GetValue(i);
+                            using PropertyArray arr = new PropertyArray();
+                            if (arrVal.Get(arr))
+                            {
+                                int startFrame = -1;
+                                using PropertyValue start = arr.GetElementAt(0);
+                                start?.Get(out startFrame);
 
-                            NUILog.Debug($"[{i}] layer name={key}, startFrame={startFrame}, endFrame={endFrame}");
+                                int endFrame = -1;
+                                using PropertyValue end = arr.GetElementAt(1);
+                                end?.Get(out endFrame);
 
-                            Tuple<string, int, int> item = new Tuple<string, int, int>(key, startFrame, endFrame);
+                                NUILog.Debug($"[{i}] layer name={key}, startFrame={startFrame}, endFrame={endFrame}");
 
-                            currentStates.contentInfo?.Add(item);
+                                Tuple<string, int, int> item = new Tuple<string, int, int>(key, startFrame, endFrame);
+
+                                currentStates.contentInfo?.Add(item);
+                            }
                         }
                     }
+                    contentMap.Dispose();
+                    val?.Dispose();
                 }
-                contentMap.Dispose();
-                val?.Dispose();
             }
             NUILog.Debug($">");
 
@@ -662,38 +670,41 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap imageMap = base.Image;
             if (imageMap != null)
             {
-                PropertyValue val = imageMap.Find(ImageVisualProperty.MarkerInfo);
-                PropertyMap markerMap = new PropertyMap();
-                if (val?.Get(ref markerMap) == true)
+                if (TotalFrame > 0) // Check whether image file loaded successfuly.
                 {
-                    currentStates.markerInfo = new List<Tuple<string, int, int>>();
-                    for (uint i = 0; i < markerMap.Count(); i++)
+                    PropertyValue val = imageMap.Find(ImageVisualProperty.MarkerInfo);
+                    PropertyMap markerMap = new PropertyMap();
+                    if (val?.Get(ref markerMap) == true)
                     {
-                        using PropertyKey propertyKey = markerMap.GetKeyAt(i);
-                        string key = propertyKey.StringKey;
-
-                        using PropertyValue arrVal = markerMap.GetValue(i);
-                        using PropertyArray arr = new PropertyArray();
-                        if (arrVal.Get(arr))
+                        currentStates.markerInfo = new List<Tuple<string, int, int>>();
+                        for (uint i = 0; i < markerMap.Count(); i++)
                         {
-                            int startFrame = -1;
-                            using PropertyValue start = arr.GetElementAt(0);
-                            start?.Get(out startFrame);
+                            using PropertyKey propertyKey = markerMap.GetKeyAt(i);
+                            string key = propertyKey.StringKey;
 
-                            int endFrame = -1;
-                            using PropertyValue end = arr.GetElementAt(1);
-                            end?.Get(out endFrame);
+                            using PropertyValue arrVal = markerMap.GetValue(i);
+                            using PropertyArray arr = new PropertyArray();
+                            if (arrVal.Get(arr))
+                            {
+                                int startFrame = -1;
+                                using PropertyValue start = arr.GetElementAt(0);
+                                start?.Get(out startFrame);
 
-                            NUILog.Debug($"[{i}] marker name={key}, startFrame={startFrame}, endFrame={endFrame}");
+                                int endFrame = -1;
+                                using PropertyValue end = arr.GetElementAt(1);
+                                end?.Get(out endFrame);
 
-                            Tuple<string, int, int> item = new Tuple<string, int, int>(key, startFrame, endFrame);
+                                NUILog.Debug($"[{i}] marker name={key}, startFrame={startFrame}, endFrame={endFrame}");
 
-                            currentStates.markerInfo?.Add(item);
+                                Tuple<string, int, int> item = new Tuple<string, int, int>(key, startFrame, endFrame);
+
+                                currentStates.markerInfo?.Add(item);
+                            }
                         }
                     }
+                    markerMap.Dispose();
+                    val?.Dispose();
                 }
-                markerMap.Dispose();
-                val?.Dispose();
             }
             NUILog.Debug($">");
 


### PR DESCRIPTION
Let we allow to call SetMinAndMaxFrameByMarker API even if load is not finished. Instead, let we just call some log if the file is not loaded yet.

Plus, Some API (GetContentInfo, GetMarkerInfo) might cache wrong values when we use async load

Before try to get correct value, let we check whether the resource is loaded or not.

