### PR TITLE
[NUI] Remove old frame range if we set marker + Minor fix up when marker invalid

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -288,7 +288,8 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Get the number of total frames
+        /// Get the number of total frames.
+        /// If resouce is still not be loaded, or invalid resource, the value is 0.
         /// </summary>
         /// <since_tizen> 7 </since_tizen>
         public int TotalFrame
@@ -552,6 +553,10 @@ namespace Tizen.NUI.BaseComponents
                 currentStates.framePlayRangeMin = minFrame;
                 currentStates.framePlayRangeMax = maxFrame;
 
+                // Remove marker information.
+                currentStates.mark1 = null;
+                currentStates.mark2 = null;
+
                 Interop.View.InternalUpdateVisualPropertyIntPair(this.SwigCPtr, ImageView.Property.IMAGE, ImageVisualProperty.PlayRange, currentStates.framePlayRangeMin, currentStates.framePlayRangeMax);
 
                 NUILog.Debug($"  [{GetId()}] currentStates.min:({currentStates.framePlayRangeMin}, max:{currentStates.framePlayRangeMax})>");
@@ -714,7 +719,7 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// A marker has its start frame and end frame.
         /// Animation will play between the start frame and the end frame of the marker if one marker is specified.
-        /// Or animation will play between the start frame of the first marker and the end frame of the second marker if two markers are specified.   *
+        /// Or animation will play between the start frame of the first marker and the end frame of the second marker if two markers are specified.
         /// </summary>
         /// <param name="marker1">First marker</param>
         /// <param name="marker2">Second marker</param>
@@ -722,13 +727,18 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetMinMaxFrameByMarker(string marker1, string marker2 = null)
         {
-            if (currentStates.mark1 != marker1 || currentStates.mark2 != marker2)
+            string marker1OrEmpty = marker1 ?? ""; // mark1 should not be null
+            if (currentStates.mark1 != marker1OrEmpty || currentStates.mark2 != marker2)
             {
-                NUILog.Debug($"< [{GetId()}] SetMinMaxFrameByMarker({marker1}, {marker2})");
+                NUILog.Debug($"< [{GetId()}] SetMinMaxFrameByMarker({marker1OrEmpty}, {marker2})");
 
                 currentStates.changed = true;
-                currentStates.mark1 = marker1;
+                currentStates.mark1 = marker1OrEmpty;
                 currentStates.mark2 = marker2;
+
+                // Remove frame information.
+                currentStates.framePlayRangeMin = -1;
+                currentStates.framePlayRangeMax = -1;
 
                 if (string.IsNullOrEmpty(currentStates.mark2))
                 {


### PR DESCRIPTION
LottieAnimationView cache both frame range as int, and marker. But two API set same property - PlayRange.

So if some code like below thing was not working well

```
  // Let "marker" frame range is 10~20

  lottieView.SetMinMaxFrame(30, 40); // play range become 30~40
  lottieView.SetMinMaxFrameByMarker(marker); // play range become 10~20
  lottieView.SetMinMaxFrame(30, 40); // play range need to be 30~40 again, but it didn't due to the cache.
```

To avoid like above case, let we clean cache explicit parameter.

Also, Let we add some more error check if app use invalid marker (Lottie file not loaded, or marker is invalid.)

In this case, let we just follow minMaxSetTypes.NotSetByUser logic then.
