### PR TITLE
[NUI] Fix some SVACE issues.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSource/MarshalingObservableCollection.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSource/MarshalingObservableCollection.cs
@@ -110,7 +110,7 @@ namespace Tizen.NUI.Components
 
         void Move(NotifyCollectionChangedEventArgs args)
         {
-            var count = args.OldItems.Count;
+            int count = args.OldItems?.Count ?? 0;
 
             for (int n = 0; n < count; n++)
             {
@@ -124,7 +124,8 @@ namespace Tizen.NUI.Components
 
         void Remove(NotifyCollectionChangedEventArgs args)
         {
-            var startIndex = args.OldStartingIndex + args.OldItems.Count - 1;
+            int count=args.OldItems?.Count ?? 0;
+            int startIndex = args.OldStartingIndex + count - 1;
             for (int n = startIndex; n >= args.OldStartingIndex; n--)
             {
                 RemoveAt(n);

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSource/ObservableGroupedSource.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSource/ObservableGroupedSource.cs
@@ -337,7 +337,7 @@ namespace Tizen.NUI.Components
             }
 
             // If we have a start index, we can be more clever about removing the group(s) (and get the nifty animations)
-            var groupCount = args.OldItems.Count;
+            int groupCount = args.OldItems?.Count ?? 0;
 
             var absolutePosition = GetAbsolutePosition(groups[groupIndex], 0);
 
@@ -360,9 +360,15 @@ namespace Tizen.NUI.Components
 
         void Replace(NotifyCollectionChangedEventArgs args)
         {
-            var groupCount = args.NewItems.Count;
-
-            if (groupCount != args.OldItems.Count)
+            var newItems = args.NewItems;
+            var oldItems = args.OldItems;
+            if(newItems == null || oldItems == null)
+            {
+                return;
+            }       
+            int groupCount = newItems.Count;
+            int oldCount = oldItems.Count;
+            if (groupCount != oldCount)
             {
                 // The original and replacement sets are of unequal size; this means that most everything currently in 
                 // view will have to be updated. So just reload the whole thing.
@@ -370,8 +376,8 @@ namespace Tizen.NUI.Components
                 return;
             }
 
-            var newStartIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : groupSource.IndexOf(args.NewItems[0]);
-            var oldStartIndex = args.OldStartingIndex > -1 ? args.OldStartingIndex : groupSource.IndexOf(args.OldItems[0]);
+            var newStartIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : groupSource.IndexOf(newItems[0]);
+            var oldStartIndex = args.OldStartingIndex > -1 ? args.OldStartingIndex : groupSource.IndexOf(oldItems[0]);
 
             var newItemCount = CountItemsInGroups(newStartIndex, groupCount);
             var oldItemCount = CountItemsInGroups(oldStartIndex, groupCount);
@@ -402,7 +408,7 @@ namespace Tizen.NUI.Components
 
         void Move(NotifyCollectionChangedEventArgs args)
         {
-            var itemCount = CountItemsInGroups(args.OldStartingIndex, args.OldItems.Count);
+            var itemCount = CountItemsInGroups(args.OldStartingIndex, args.OldItems?.Count ?? 0);
             var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
             var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + itemCount;
 

--- a/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSource/ObservableItemSource.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/ItemSource/ObservableItemSource.cs
@@ -187,7 +187,7 @@ namespace Tizen.NUI.Components
             startIndex = AdjustPositionForHeader(startIndex);
 
             // If we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
-            var count = args.OldItems.Count;
+            int count = args.OldItems?.Count ?? 0;
 
             if (count == 1)
             {
@@ -200,11 +200,18 @@ namespace Tizen.NUI.Components
 
         void Replace(NotifyCollectionChangedEventArgs args)
         {
+            var newItems = args.NewItems;
+            var oldItems = args.OldItems;
+            if (newItems == null || oldItems == null)
+            {
+                return;
+            }
             var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
             startIndex = AdjustPositionForHeader(startIndex);
-            var newCount = args.NewItems.Count;
-
-            if (newCount == args.OldItems.Count)
+            
+            int newCount = newItems.Count;
+            int oldCount = oldItems.Count;
+            if (newCount == oldCount)
             {
                 // We are replacing one set of items with a set of equal size; we can do a simple item or range 
                 // notification to the adapter


### PR DESCRIPTION
 Value args.OldItems, which is result of method invocation with possible null return value, is dereferenced in member access expression args.OldItems.Count

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
