### PR TITLE
[NUI] Fix some SVACE issues.

### DIFF
--- a/src/Tizen.NUI.Physics2D/src/internal/chipmunk/NativeInterop.cs
+++ b/src/Tizen.NUI.Physics2D/src/internal/chipmunk/NativeInterop.cs
@@ -81,6 +81,9 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         public static IntPtr AllocStructure<T>()
         {
             int size = SizeOf<T>();
+
+            Debug.Assert(size>0, "The memory size to be allocated should be greater than 0");
+
             return Marshal.AllocHGlobal(size);
         }
 

--- a/src/Tizen.NUI.Physics2D/src/internal/chipmunk/cpSpaceDebugDrawOptions.cs
+++ b/src/Tizen.NUI.Physics2D/src/internal/chipmunk/cpSpaceDebugDrawOptions.cs
@@ -104,10 +104,6 @@ namespace Tizen.NUI.Physics2D.Chipmunk
         private IntPtr ToPointer()
         {
             IntPtr drawOptionsPtr = NativeInterop.AllocStructure<cpSpaceDebugDrawOptions>();
-            if (Marshal.SizeOf(typeof(cpSpaceDebugDrawOptions)) == 0)
-            {
-                throw new ArgumentNullException("The size of type cpSpaceDebugDrawOptions should not be 0.");
-            }
 
             Marshal.StructureToPtr<cpSpaceDebugDrawOptions>(this, drawOptionsPtr, false);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -186,18 +186,19 @@ namespace Tizen.NUI.BaseComponents
                 
                 if (textures != null)
                 {
-                    int intptrBytes = checked(sizeof(IntPtr) * textures.Count);
+                    int count = textures.Count;
+                    int intptrBytes = checked(sizeof(IntPtr) * count);
                     if (intptrBytes>0)
                     {
                         IntPtr unmanagedPointer = Marshal.AllocHGlobal(intptrBytes);
-                        IntPtr[] texturesArray = new IntPtr[textures.Count];
-                        for (int i = 0; i < textures.Count; i++)
+                        IntPtr[] texturesArray = new IntPtr[count];
+                        for (int i = 0; i < count; i++)
                         {
                             texturesArray[i] = HandleRef.ToIntPtr(Texture.getCPtr(textures[i]));
                         }
-                        System.Runtime.InteropServices.Marshal.Copy(texturesArray, 0, unmanagedPointer, textures.Count);
+                        Marshal.Copy(texturesArray, 0, unmanagedPointer, count);
 
-                        Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, textures.Count);
+                        Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, count);
                         Marshal.FreeHGlobal(unmanagedPointer);
                     }
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

1.Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
WID:21884917 Writing textures.Count elements of type System.IntPtr into buffer unmanagedPointer can exceed its size
SVACE Server Link  :  https://sa.sec.samsung.net/dm/tizen80/sb2/main/review#PRJID=35&WGID=21075
This may caused  by inconsistent return value of textures.Count

2. Tizen.NUI.Physics2D/src/internal/chipmunk/cpSpaceDebugDrawOptions.cs
WID:21884910 Writing 1 element of type Tizen.NUI.Physics2D.Chipmunk.cpSpaceDebugDrawOptions into buffer drawOptionsPtr can exceed its size
SVACE Server Link  :  https://sa.sec.samsung.net/dm/tizen80/sb2/main/review#PRJID=35&WGID=71057




### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
