### PR TITLE
Fix defect that is detected by static analisys tool

### DIFF
--- a/src/Tizen.Uix.VoiceControlManager/Tizen.Uix.VoiceControlManager/VoiceCommandsGroup.cs
+++ b/src/Tizen.Uix.VoiceControlManager/Tizen.Uix.VoiceControlManager/VoiceCommandsGroup.cs
@@ -128,13 +128,19 @@ namespace Tizen.Uix.VoiceControlManager
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
-                foreach (VoiceCommand item in e.NewItems)
-                    Add(item);
+                if (e.NewItems!= null && e.NewItems.Count > 0)
+                {
+                    foreach (VoiceCommand item in e.NewItems)
+                        Add(item);
+                }
             }
             else if (e.Action == NotifyCollectionChangedAction.Remove)
             {
-                foreach (VoiceCommand item in e.OldItems)
-                    Remove(item);
+                if (e.OldItems!= null && e.OldItems.Count > 0)
+                {
+                    foreach (VoiceCommand item in e.OldItems)
+                        Remove(item);
+                }
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

There is a potential problem with the code involving the variable 'e.OldItems'. This variable is the result of a method invocation, and the tool is warning that the method might return a null value, which can cause dereferencing a null reference. It might cause it to crash or behave unpredictably.

Therefore, to prevent this, the variable 'e.OldItems' should be checked if it is null or not before use.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - No ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
