### PR TITLE
[NUI] Support RootTranslationOnly option for motion capture data

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.MotionData.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.MotionData.cs
@@ -64,16 +64,16 @@ namespace Tizen.NUI.Scene3D
             public static extern float GetDuration(global::System.Runtime.InteropServices.HandleRef motionData);
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionData_LoadBvh")]
-            public static extern float LoadMotionCaptureAnimation(global::System.Runtime.InteropServices.HandleRef motionData, string motionCaptureFilename, global::System.Runtime.InteropServices.HandleRef scale, bool synchronousLoad);
+            public static extern void LoadMotionCaptureAnimation(global::System.Runtime.InteropServices.HandleRef motionData, string motionCaptureFilename, bool useRootTranslationOnly, global::System.Runtime.InteropServices.HandleRef scale, bool synchronousLoad);
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionData_LoadBvhFromBuffer")]
-            public static extern float LoadMotionCaptureAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef motionData, string motionCaptureBuffer, int motionCaptureBufferLength, global::System.Runtime.InteropServices.HandleRef scale, bool synchronousLoad);
+            public static extern void LoadMotionCaptureAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef motionData, string motionCaptureBuffer, int motionCaptureBufferLength, bool useRootTranslationOnly, global::System.Runtime.InteropServices.HandleRef scale, bool synchronousLoad);
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionData_LoadFacialAnimation")]
-            public static extern float LoadBlendShapeAnimation(global::System.Runtime.InteropServices.HandleRef motionData, string blendShapeFilename, bool synchronousLoad);
+            public static extern void LoadBlendShapeAnimation(global::System.Runtime.InteropServices.HandleRef motionData, string blendShapeFilename, bool synchronousLoad);
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionData_LoadFacialAnimationFromBuffer")]
-            public static extern float LoadBlendShapeAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef motionData, string blendShapeBuffer, int blendShapeBufferLength, bool synchronousLoad);
+            public static extern void LoadBlendShapeAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef motionData, string blendShapeBuffer, int blendShapeBufferLength, bool synchronousLoad);
 
             // Signals
 

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionData.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionData.cs
@@ -262,7 +262,28 @@ namespace Tizen.NUI.Scene3D
         /// <since_tizen> 11 </since_tizen>
         public void LoadMotionCaptureAnimation(string motionCaptureFilename, Vector3 scale = null, bool synchronousLoad = false)
         {
-            Interop.MotionData.LoadMotionCaptureAnimation(SwigCPtr, motionCaptureFilename, Vector3.getCPtr(scale), synchronousLoad);
+            Interop.MotionData.LoadMotionCaptureAnimation(SwigCPtr, motionCaptureFilename, false, Vector3.getCPtr(scale), synchronousLoad);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Load motion capture animation.
+        /// We support bvh format.
+        /// After load completes, <see cref="LoadCompleted"/> event will be invoked.
+        /// </summary>
+        /// <remarks>
+        /// Scale is additional scale factor of motion capture animation. It is possible that
+        /// Model's scale may not match with motion capture animation scale.
+        /// If scale is null, default value will be used: <cref name="Vector3.ONE"/>
+        /// </remarks>
+        /// <param name="motionCaptureFilename">Name of motion capture format file.</param>
+        /// <param name="useRootTranslationOnly">True to use only root translation with rotation animation.</param>
+        /// <param name="scale">Scale value of motion capture animation match with model.</param>
+        /// <param name="synchronousLoad">Load synchronously or not. Default is async load.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void LoadMotionCaptureAnimation(string motionCaptureFilename, bool useRootTranslationOnly, Vector3 scale = null, bool synchronousLoad = false)
+        {
+            Interop.MotionData.LoadMotionCaptureAnimation(SwigCPtr, motionCaptureFilename, useRootTranslationOnly, Vector3.getCPtr(scale), synchronousLoad);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -282,7 +303,28 @@ namespace Tizen.NUI.Scene3D
         /// <since_tizen> 11 </since_tizen>
         public void LoadMotionCaptureAnimationFromBuffer(string motionCaptureBuffer, Vector3 scale = null, bool synchronousLoad = false)
         {
-            Interop.MotionData.LoadMotionCaptureAnimationFromBuffer(SwigCPtr, motionCaptureBuffer, motionCaptureBuffer.Length, Vector3.getCPtr(scale), synchronousLoad);
+            Interop.MotionData.LoadMotionCaptureAnimationFromBuffer(SwigCPtr, motionCaptureBuffer, motionCaptureBuffer.Length, false, Vector3.getCPtr(scale), synchronousLoad);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Load motion capture animation from string.
+        /// We support bvh format.
+        /// After load completes, <see cref="LoadCompleted"/> event will be invoked.
+        /// </summary>
+        /// <remarks>
+        /// Scale is additional scale factor of motion capture animation. It is possible that
+        /// Model's scale may not match with motion capture animation scale.
+        /// If scale is null, default value will be used: <cref name="Vector3.ONE"/>
+        /// </remarks>
+        /// <param name="motionCaptureBuffer">Contents of motion capture format string.</param>
+        /// <param name="useRootTranslationOnly">True to use only root translation with rotation animation.</param>
+        /// <param name="scale">Scale value of motion capture animation match with model.</param>
+        /// <param name="synchronousLoad">Load synchronously or not. Default is async load.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void LoadMotionCaptureAnimationFromBuffer(string motionCaptureBuffer, bool useRootTranslationOnly, Vector3 scale = null, bool synchronousLoad = false)
+        {
+            Interop.MotionData.LoadMotionCaptureAnimationFromBuffer(SwigCPtr, motionCaptureBuffer, motionCaptureBuffer.Length, useRootTranslationOnly, Vector3.getCPtr(scale), synchronousLoad);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
### Description of Change ###
This patch allow an option to use only root translation for motion capture data.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
