### PR TITLE
[Packagemanager] Fix Tizen.Applications.Package for performance

### DIFF
--- a/src/Tizen.Applications.PackageManager/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.Libraries.cs
@@ -20,5 +20,7 @@ internal static partial class Interop
     {
         public const string PackageManager = "libcapi-appfw-package-manager.so.0";
         public const string PackageManagerInternal = "libpkgmgr-client.so.0";
+        public const string PackageManagerInfoInternal = "libpkgmgr-info.so.0";
+        public const string Libc = "libc.so.6";
     }
 }

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.Package.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.Package.cs
@@ -64,9 +64,6 @@ internal static partial class Interop
         [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_app_from_package")]
         internal static extern ErrorCode PackageInfoForeachAppInfo(IntPtr handle, AppType appType, PackageInfoAppInfoCallback callback, IntPtr userData);
 
-        [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_cert_info")]
-        internal static extern ErrorCode PackageInfoForeachCertificateInfo(IntPtr handle, PackageInfoCertificateInfoCallback callback, IntPtr user_data);
-
         [DllImport(Libraries.PackageManager, EntryPoint = "package_info_foreach_privilege_info")]
         internal static extern ErrorCode PackageInfoForeachPrivilegeInfo(IntPtr handle, PackageInfoPrivilegeInfoCallback callback, IntPtr userData);
 

--- a/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManagerInfoInternal.cs
+++ b/src/Tizen.Applications.PackageManager/Interop/Interop.PackageManagerInfoInternal.cs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+using CertificateType = Interop.Package.CertificateType;
+
+internal static partial class Interop
+{
+    internal static partial class PackageManagerInfoInternal
+    {
+        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_create_certinfo")]
+        internal static extern int PkgmgrinfoPkginfoCreateCertinfo(out IntPtr handle);
+
+        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_destroy_certinfo")]
+        internal static extern int PkgmgrinfoPkginfoDestroyCertinfo(IntPtr handle);
+
+        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_load_certinfo")]
+        internal static extern int PkgmgrinfoPkginfoLoadCertinfo(string pkgid, IntPtr handle, int uid);
+
+        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_get_cert_value")]
+        internal static extern int PkgmgrinfoPkginfoGetCertValue(IntPtr handle, CertificateType certType, out IntPtr value);
+
+        [DllImport(Libraries.PackageManagerInfoInternal, EntryPoint = "pkgmgrinfo_pkginfo_foreach_depends_on_by_pkgid")]
+        internal static extern int PkgmgrinfoPkginfoForeachDependsOnByPkgId(string pkgid, Interop.Package.PackageInfoDependencyInfoCallback callback, IntPtr userData, int uid);
+
+        [DllImport(Libraries.Libc, EntryPoint = "getuid")]
+        internal static extern int GetUID();
+    }
+}

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageCertificate.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageCertificate.cs
@@ -57,53 +57,55 @@ namespace Tizen.Applications
         /// <since_tizen> 3 </since_tizen>
         public string Signer { get { return _signer; } }
 
-        internal static IReadOnlyDictionary<CertificateType, PackageCertificate> GetPackageCertificates(IntPtr packageInfoHandle)
+        internal static IReadOnlyDictionary<CertificateType, PackageCertificate> GetPackageCertificates(string packageId)
         {
-            Dictionary<Interop.Package.CertificateType, string> nativeCertificates = new Dictionary<Interop.Package.CertificateType, string>();
-            Interop.Package.PackageInfoCertificateInfoCallback certificateInfoCb = (handle, certType, certValue, userData) =>
-            {
-                if (certValue == null) certValue = string.Empty;
-                try
-                {
-                    nativeCertificates.Add(certType, certValue);
-                }
-                catch (ArgumentException ex)
-                {
-                    Log.Warn(LogTag, string.Format("Failed to add cert value. certType = {0}, err = {1}", certType, ex.Message));
-                }
-                return true;
-            };
+            Dictionary<CertificateType, PackageCertificate> certificates = new Dictionary<CertificateType, PackageCertificate>();
 
-            Interop.PackageManager.ErrorCode err = Interop.Package.PackageInfoForeachCertificateInfo(packageInfoHandle, certificateInfoCb, IntPtr.Zero);
-            if (err != Interop.PackageManager.ErrorCode.None)
+            int ret = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoCreateCertinfo(out IntPtr handle);
+            if (ret != 0)
             {
-                Log.Warn(LogTag, string.Format("Failed to get certificate info. err = {0}", err));
+                Log.Error(LogTag, string.Format("Failed to create cert info handle"));
+                return certificates;
             }
 
-            Dictionary<CertificateType, PackageCertificate> certificates = new Dictionary<CertificateType, PackageCertificate>();
-            string authorRootCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.AuthorRootCertificate);
-            string authorIntermediateCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.AuthorIntermediateCertificate);
-            string aurthorSignerCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.AuthorSignerCertificate);
+            ret = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoLoadCertinfo(packageId, handle, Interop.PackageManagerInfoInternal.GetUID());
+            if (ret != 0)
+            {
+                Log.Error(LogTag, string.Format("Failed to load cert info of {0}", packageId));
+                return certificates;
+            }
+
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.AuthorRootCertificate, out IntPtr authorRootCertificatePtr);
+            string authorRootCertificate = authorRootCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(authorRootCertificatePtr) : string.Empty;
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.AuthorIntermediateCertificate, out IntPtr authorIntermediateCertificatePtr);
+            string authorIntermediateCertificate = authorIntermediateCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(authorIntermediateCertificatePtr) : string.Empty;
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.AuthorSignerCertificate, out IntPtr aurthorSignerCertificatePtr);
+            string aurthorSignerCertificate = aurthorSignerCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(aurthorSignerCertificatePtr) : string.Empty;
             certificates.Add(CertificateType.Author, new PackageCertificate(authorRootCertificate, authorIntermediateCertificate, aurthorSignerCertificate));
 
-            string distRootCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.DistributorRootCertificate);
-            string distIntermediateCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.DistributorIntermediateCertificate);
-            string distSignerCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.DistributorSignerCertificate);
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.DistributorRootCertificate, out IntPtr distRootCertificatePtr);
+            string distRootCertificate = distRootCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(distRootCertificatePtr) : string.Empty;
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.DistributorIntermediateCertificate, out IntPtr distIntermediateCertificatePtr);
+            string distIntermediateCertificate = distIntermediateCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(distIntermediateCertificatePtr) : string.Empty;
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.DistributorSignerCertificate, out IntPtr distSignerCertificatePtr);
+            string distSignerCertificate = distSignerCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(distSignerCertificatePtr) : string.Empty;
             certificates.Add(CertificateType.Distributor, new PackageCertificate(distRootCertificate, distIntermediateCertificate, distSignerCertificate));
 
-            string dist2RootCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.Distributor2RootCertificate);
-            string dist2IntermediateCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.Distributor2IntermediateCertificate);
-            string dist2SignerCertificate = GetValue(nativeCertificates, Interop.Package.CertificateType.Distributor2SignerCertificate);
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.Distributor2RootCertificate, out IntPtr dist2RootCertificatePtr);
+            string dist2RootCertificate = dist2RootCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(dist2RootCertificatePtr) : string.Empty;
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.Distributor2IntermediateCertificate, out IntPtr dist2IntermediateCertificatePtr);
+            string dist2IntermediateCertificate = dist2IntermediateCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(dist2IntermediateCertificatePtr) : string.Empty;
+            _ = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoGetCertValue(handle, Interop.Package.CertificateType.Distributor2SignerCertificate, out IntPtr dist2SignerCertificatePtr);
+            string dist2SignerCertificate = dist2SignerCertificatePtr != IntPtr.Zero ? Marshal.PtrToStringAnsi(dist2SignerCertificatePtr) : string.Empty;
             certificates.Add(CertificateType.Distributor2, new PackageCertificate(dist2RootCertificate, dist2IntermediateCertificate, dist2SignerCertificate));
 
-            return certificates;
-        }
+            ret = Interop.PackageManagerInfoInternal.PkgmgrinfoPkginfoDestroyCertinfo(handle);
+            if (ret != 0)
+            {
+                Log.Warn(LogTag, string.Format("Failed to destroy cert info handle"));
+            }
 
-        private static string GetValue(IDictionary<Interop.Package.CertificateType, string> dict, Interop.Package.CertificateType key)
-        {
-            string value;
-            dict.TryGetValue(key, out value);
-            return value;
+            return certificates;
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
Adjust lazy initialization on DependencyFrom, Certificate property. These properties need additional IPC platform internally, so make these property initialized lazily for performance.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
