### PR TITLE
[NUI] Add DepthIndex in Material

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Material.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Material.cs
@@ -99,6 +99,9 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Material_property_SPECULAR_COLOR_FACTOR_get")]
             public static extern int PropertySpecularColorFactorIndexGet();
 
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Material_property_DEPTH_INDEX_get")]
+            public static extern int PropertyDepthIndexIndexGet();
+
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Material_SetProperty")]
             public static extern void SetProperty(global::System.Runtime.InteropServices.HandleRef model, int index, global::System.Runtime.InteropServices.HandleRef propertyValue);
 

--- a/src/Tizen.NUI.Scene3D/src/public/ModelComponents/Material.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelComponents/Material.cs
@@ -563,9 +563,49 @@ namespace Tizen.NUI.Scene3D
             }
         }
 
-
-
-
+        /// <summary>
+        /// Property to define rendering order.
+        /// </summary>
+        /// <remarks>
+        /// Depth index is used to defind rendering order. Basically,
+        /// a Renderer that has smaller depth index is rendered earlier.
+        /// In the ordinary DALI UI components has 0 as depth index by default.
+        /// (For the case of Toolkit::Control, its renderer has depth index
+        /// value between [-20, 20] as fallowing the renderer's purpose)
+        ///
+        /// In the Scene3D cases, the rendering order of each Renderer may need
+        /// to be manually defined to match scene developer's intent.
+        /// Scene3D::DepthIndex::Ranges could be used to adjust rendering order
+        /// between 3D Scene content.
+        /// Or it also could be used to manage UI component in 3D Scene independently.
+        ///
+        /// Changing the depth index only affects the rendering order, and does not
+        /// mean that objects drawn later will be drawn on top. To compute final
+        /// rendering order, whether the object is opaque or non-opaque takes precedence
+        /// over the depth index. Changing the rendering order among translucent objects
+        /// has a significant impact on the rendering results.
+        ///
+        /// The predefined depth index range is definded in <see cref="MaterialDepthIndexRange"/>.
+        /// </remarks>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int DepthIndex
+        {
+            set
+            {
+                var temp = new Tizen.NUI.PropertyValue(value);
+                SetProperty(Interop.Material.PropertyDepthIndexIndexGet(), temp);
+                temp.Dispose();
+            }
+            get
+            {
+                int temp = 0;
+                Tizen.NUI.PropertyValue pValue = GetProperty(Interop.Material.PropertyDepthIndexIndexGet());
+                pValue.Get(out temp);
+                pValue.Dispose();
+                return temp;
+            }
+        }
 
         /// <summary>
         /// Sets the texture of the ModelNode object for the specified texture type.

--- a/src/Tizen.NUI.Scene3D/src/public/ModelComponents/MaterialDepthIndexRanges.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelComponents/MaterialDepthIndexRanges.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright(c) 2023 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI.Scene3D
+{
+    /// <summary>
+    /// Depth index ranges to define rendering order.
+    /// </summary>
+    // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum MaterialDepthIndexRange
+    {
+        /// <summary>
+        /// Depth index range for 3D scene content.
+        /// </summary>
+        /// <remarks>
+        /// The range of the scene content is between [Scene, Scene + 999]
+        /// </remarks>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Scene = -2000,
+
+        /// <summary>
+        /// Depth index range for UI scene content.
+        /// </summary>
+        /// <remarks>
+        /// The range of the UI content is between [UI, UI + 999].
+        /// Some of internally created Renderer of Toolkit::Control already has
+        /// default depth index value.
+        /// Developer can fix the default values for their design.
+        /// </remarks>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        UI = 0,
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Add DepthIndex property to Material class.
This can be used to define rendering order between translucent objects.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
