### PR TITLE
[NUI] Skip text getter when Text never setted before

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -100,6 +100,9 @@ namespace Tizen.NUI.BaseComponents
         private TextLabelSelectorData selectorData;
         private string fontFamily = defaultFontFamily;
         private float fontSizeScale = 1.0f;
+
+        private bool textIsEmpty = true;
+
         private bool hasSystemLanguageChanged = false;
         private bool hasSystemFontSizeChanged = false;
         private bool hasSystemFontTypeChanged = false;
@@ -141,6 +144,7 @@ namespace Tizen.NUI.BaseComponents
         public TextLabel(string text) : this(Interop.TextLabel.New(text, ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            textIsEmpty = string.IsNullOrEmpty(text);
         }
 
         /// <summary>
@@ -153,6 +157,7 @@ namespace Tizen.NUI.BaseComponents
         public TextLabel(string text, bool shown) : this(Interop.TextLabel.New(text, ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            textIsEmpty = string.IsNullOrEmpty(text);
             SetVisible(shown);
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -71,7 +71,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 
-            return Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.TEXT);
+            // Do not try to get string if we know that previous text was empty.
+            return textLabel.textIsEmpty ? "" : Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.TEXT);
         }));
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -898,6 +899,7 @@ namespace Tizen.NUI.BaseComponents
         {
             if (value != null)
             {
+                textIsEmpty = string.IsNullOrEmpty(value);
 
                 Object.InternalSetPropertyString(SwigCPtr, TextLabel.Property.TEXT, value);
                 RequestLayout();


### PR DESCRIPTION
If we never set text into TextLabel before, the result of Text propert getter is always empty. To avoid useless C# - native network, let we just ignore text getter function if we can assume that previous text was empty.