### PR TITLE
[NUI] Make we flush DisposeQueue before app start

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
+++ b/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
@@ -52,6 +52,11 @@ namespace Tizen.NUI
         {
             Tizen.Log.Debug("NUI", $"DisposeQueue is destroyed\n");
             initialied = false;
+            if (processorRegistered && ProcessorController.Instance.Initialized)
+            {
+                processorRegistered = false;
+                ProcessorController.Instance.ProcessorOnceEvent -= TriggerProcessDisposables;
+            }
         }
 
         public static DisposeQueue Instance
@@ -90,10 +95,19 @@ namespace Tizen.NUI
                 disposables.Add(disposable);
             }
 
-            if (initialied && eventThreadCallback != null && !eventThreadCallbackTriggered)
+            if (initialied && eventThreadCallback != null)
             {
-                eventThreadCallbackTriggered = true;
-                eventThreadCallback.Trigger();
+                if (!eventThreadCallbackTriggered)
+                {
+                    eventThreadCallbackTriggered = true;
+                    eventThreadCallback.Trigger();
+                }
+            }
+            else
+            {
+                // Flush Disposable queue synchronously if it is not initialized yet.
+                // TODO : Need to check thread here if we need.
+                ProcessDisposables();
             }
         }
 
@@ -101,10 +115,19 @@ namespace Tizen.NUI
         {
             processorRegistered = false;
 
-            if (eventThreadCallback != null && !eventThreadCallbackTriggered)
+            if (initialied && eventThreadCallback != null)
             {
-                eventThreadCallbackTriggered = true;
-                eventThreadCallback.Trigger();
+                if (!eventThreadCallbackTriggered)
+                {
+                    eventThreadCallbackTriggered = true;
+                    eventThreadCallback.Trigger();
+                }
+            }
+            else
+            {
+                // Flush Disposable queue synchronously if it is not initialized yet.
+                // TODO : Need to check thread here if we need.
+                ProcessDisposables();
             }
         }
 

--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -129,6 +129,8 @@ namespace Tizen.NUI
             internalProcessorOnceEvent[1] = null;
             ProcessorEvent = null;
             LayoutProcessorEvent = null;
+            initialied = false;
+
             GC.SuppressFinalize(this);
 
             base.Dispose(type);


### PR DESCRIPTION
If we don't call DisposeQueue.Instance.Initialize(), it might not flush the dispose queue.

Before #5806 and until currently, we didn't allow to call ProcessDisposables() before Initialize(). It might occure memory leak if app try to create & dispose unlimitly before Application start.

To make ensure it, let we make ProcessDisposables() API can be called even if DisposeQueue is not initialized.
