### PR TITLE
[NUI] Add API for ProcessController without Initialize

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
+++ b/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI
         private EventThreadCallback eventThreadCallback;
         private EventThreadCallback.CallbackDelegate disposeQueueProcessDisposablesDelegate;
 
-        private bool initialied = false;
+        private bool initialized = false;
         private bool processorRegistered = false;
         private bool eventThreadCallbackTriggered = false;
 
@@ -51,7 +51,7 @@ namespace Tizen.NUI
         ~DisposeQueue()
         {
             Tizen.Log.Debug("NUI", $"DisposeQueue is destroyed\n");
-            initialied = false;
+            initialized = false;
             if (processorRegistered && ProcessorController.Instance.Initialized)
             {
                 processorRegistered = false;
@@ -78,11 +78,11 @@ namespace Tizen.NUI
 
         public void Initialize()
         {
-            if (!initialied)
+            if (!initialized)
             {
                 disposeQueueProcessDisposablesDelegate = new EventThreadCallback.CallbackDelegate(ProcessDisposables);
                 eventThreadCallback = new EventThreadCallback(disposeQueueProcessDisposablesDelegate);
-                initialied = true;
+                initialized = true;
 
                 DebugFileLogging.Instance.WriteLog("DiposeTest START");
             }
@@ -95,7 +95,7 @@ namespace Tizen.NUI
                 disposables.Add(disposable);
             }
 
-            if (initialied && eventThreadCallback != null)
+            if (initialized && eventThreadCallback != null)
             {
                 if (!eventThreadCallbackTriggered)
                 {
@@ -115,7 +115,7 @@ namespace Tizen.NUI
         {
             processorRegistered = false;
 
-            if (initialied && eventThreadCallback != null)
+            if (initialized && eventThreadCallback != null)
             {
                 if (!eventThreadCallbackTriggered)
                 {

--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -34,9 +34,13 @@ namespace Tizen.NUI
     internal sealed class ProcessorController : Disposable
     {
         private static ProcessorController instance = null;
-        private bool initialied = false;
+        private bool initialized = false;
 
-        private ProcessorController() : this(Interop.ProcessorController.New(), true)
+        private ProcessorController() : this(true)
+        {
+        }
+
+        private ProcessorController(bool initializeOnConstructor) : this(initializeOnConstructor ? Interop.ProcessorController.New() : Interop.ProcessorController.NewWithoutInitialize(), true)
         {
         }
 
@@ -67,7 +71,7 @@ namespace Tizen.NUI
         public event EventHandler ProcessorEvent;
         public event EventHandler LayoutProcessorEvent;
 
-        public bool Initialized => initialied;
+        public bool Initialized => initialized;
 
         public static ProcessorController Instance
         {
@@ -75,7 +79,7 @@ namespace Tizen.NUI
             {
                 if (instance == null)
                 {
-                    instance = new ProcessorController();
+                    instance = new ProcessorController(false);
                 }
                 return instance;
             }
@@ -83,9 +87,9 @@ namespace Tizen.NUI
 
         public void Initialize()
         {
-            if (initialied == false)
+            if (initialized == false)
             {
-                initialied = true;
+                initialized = true;
 
                 Interop.ProcessorController.Initialize(SwigCPtr);
 
@@ -129,7 +133,7 @@ namespace Tizen.NUI
             internalProcessorOnceEvent[1] = null;
             ProcessorEvent = null;
             LayoutProcessorEvent = null;
-            initialied = false;
+            initialized = false;
 
             GC.SuppressFinalize(this);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
@@ -25,6 +25,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ProcessorController")]
             public static extern global::System.IntPtr New();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ProcessorController_Without_Initialize")]
+            public static extern global::System.IntPtr NewWithoutInitialize();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ProcessorController")]
             public static extern global::System.IntPtr DeleteProcessorController(global::System.Runtime.InteropServices.HandleRef processorController);
 


### PR DESCRIPTION
To keep the backword stability, let we use previous API (CSharp_Dali_new_ProcessorController) call Initialize internally and new API (CSharp_Dali_new_ProcessorController_Without_Initialize) will not call this.

Since that #5806 change the logic of ProcessorController. So some library change the logical flow.
This patch make the logical flow keep same as previous if required.

required dali patch :  https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/302596