### PR TITLE
[NUI] DragAndDrop : Allow to get mimetype for Enter and Move events

### DIFF
--- a/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
+++ b/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
@@ -194,6 +194,7 @@ namespace Tizen.NUI
                 if (type == DragType.Enter)
                 {
                     ev.DragType = type;
+                    ev.MimeType = Interop.DragAndDrop.GetMimeType(dragEvent);
                     callback(targetView, ev);
                 }
                 else if (type == DragType.Leave)
@@ -204,6 +205,7 @@ namespace Tizen.NUI
                 else if (type == DragType.Move)
                 {
                     ev.DragType = type;
+                    ev.MimeType = Interop.DragAndDrop.GetMimeType(dragEvent);
                     callback(targetView, ev);
                 }
                 else if (type == DragType.Drop)


### PR DESCRIPTION
[NUI] DragAndDrop : Allow to get mimetype for Enter and Move events

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
