### PR TITLE
[DoNotMerge]Test - Grab accessibility highlight according to View hierarchy

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -374,6 +374,11 @@ namespace Tizen.NUI.BaseComponents
                 parentChildren.Remove(this);
                 parentChildren.Add(this);
 
+                if (Accessibility.Accessibility.IsEnabled)
+                {
+                    this.GrabAccessibilityHighlight();
+                }
+
                 LayoutGroup layout = Layout as LayoutGroup;
                 layout?.ChangeLayoutSiblingOrder(parentChildren.Count - 1);
 
@@ -400,6 +405,15 @@ namespace Tizen.NUI.BaseComponents
             {
                 parentChildren.Remove(this);
                 parentChildren.Insert(0, this);
+
+                if (Accessibility.Accessibility.IsEnabled && (this == Accessibility.Accessibility.GetCurrentlyHighlightedView()))
+                {
+                    if (GetParent() is View parentView)
+                    {
+                        uint index = parentView.ChildCount;
+                        parentView.GetChildAt(index - 1).GrabAccessibilityHighlight();
+                    }
+                }
 
                 LayoutGroup layout = Layout as LayoutGroup;
                 layout?.ChangeLayoutSiblingOrder(0);


### PR DESCRIPTION


### Description of Change ###
- When one child calls `RaiseToTop()`, it should get the accessibility highlight. 
- On the other hand, when a child calls `LowerToBottom()` and gets the highlight focus, 
  then the highlight should move to the child on the top.

### API Changes ###
- N/A