### PR TITLE
[NUI] Initialize C# items for ProcessorController if required

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -40,8 +40,12 @@ namespace Tizen.NUI
         {
         }
 
-        private ProcessorController(bool initializeOnConstructor) : this(initializeOnConstructor ? Interop.ProcessorController.New() : Interop.ProcessorController.NewWithoutInitialize(), true)
+        private ProcessorController(bool initializeOnConstructor) : this(Interop.ProcessorController.NewWithoutInitialize(), true)
         {
+            if (initializeOnConstructor)
+            {
+                Initialize();
+            }
         }
 
         internal ProcessorController(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)


### PR DESCRIPTION
We have create ProcessorController constructor without initalize as default.

If NUI core want to change this policy, we can initialize at constructor time whenever we want.

But this case code has some error. It didn't create C# side objects and only create native side.

Let we make constructor with initialize works well now.
