### PR TITLE
[NUI] Revert dispose synchronously logic when APP is not started

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
+++ b/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
@@ -107,7 +107,9 @@ namespace Tizen.NUI
             {
                 // Flush Disposable queue synchronously if it is not initialized yet.
                 // TODO : Need to check thread here if we need.
-                ProcessDisposables();
+
+                // 2023-12-18 Block this logic since some APP call some thread-dependency objects before application start.
+                // ProcessDisposables();
             }
         }
 
@@ -127,7 +129,9 @@ namespace Tizen.NUI
             {
                 // Flush Disposable queue synchronously if it is not initialized yet.
                 // TODO : Need to check thread here if we need.
-                ProcessDisposables();
+
+                // 2023-12-18 Block this logic since some APP call some thread-dependency objects before application start.
+                // ProcessDisposables();
             }
         }
 


### PR DESCRIPTION
We add some logic to dispose items when application created & disposed before application initialized.

But some app just have some issue when some thread dependency items disposed before application started.

To avoid this cases, let we block dispose sync logic and revert we always dispose queue ensure in main thread.

