### PR TITLE
[NUI] Add AnchorColor Property

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -198,9 +198,15 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_STRIKETHROUGH_get")]
             public static extern int StrikethroughGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_COLOR_get")]
+            public static extern int AnchorColorGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_CLICKED_COLOR_get")]
+            public static extern int AnchorClickedColorGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
@@ -314,6 +314,26 @@ namespace Tizen.NUI.BaseComponents
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.fontSizeScale;
         });
+        public static readonly BindableProperty AnchorColorProperty = BindableProperty.Create(nameof(AnchorColor), typeof(Color), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            textLabelStyle.anchorColor = (Color)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            return textLabelStyle.anchorColor;
+        });
+        public static readonly BindableProperty AnchorClickedColorProperty = BindableProperty.Create(nameof(AnchorClickedColor), typeof(Color), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            textLabelStyle.anchorClickedColor = (Color)newValue;
+        },
+        defaultValueCreator: (bindable) =>
+        {
+            var textLabelStyle = (TextLabelStyle)bindable;
+            return textLabelStyle.anchorClickedColor;
+        });
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -377,6 +397,8 @@ namespace Tizen.NUI.BaseComponents
         private PropertyMap fontStyle;
         private float? characterSpacing;
         private float? fontSizeScale;
+        private Color anchorColor;
+        private Color anchorClickedColor;
 
         static TextLabelStyle() { }
 
@@ -571,6 +593,20 @@ namespace Tizen.NUI.BaseComponents
         {
             get => (float?)GetValue(FontSizeScaleProperty);
             set => SetValue(FontSizeScaleProperty, value);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color AnchorColor
+        {
+            get => (Color)GetValue(AnchorColorProperty);
+            set => SetValue(AnchorColorProperty, value);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color AnchorClickedColor
+        {
+            get => (Color)GetValue(AnchorClickedColorProperty);
+            set => SetValue(AnchorClickedColorProperty, value);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -108,6 +108,8 @@ namespace Tizen.NUI.BaseComponents
         private bool hasSystemFontTypeChanged = false;
 
         private Color internalTextColor;
+        private Color internalAnchorColor;
+        private Color internalAnchorClickedColor;
 
         /// <summary>
         /// Creates the TextLabel control.
@@ -1548,6 +1550,54 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// The AnchorColor property.<br />
+        /// The color of the anchor.<br />
+        /// This property is used as the default color of the markup anchor tag.<br />
+        /// If there is a color attribute in the markup anchor tag, the markup attribute takes precedence.
+        /// </summary>
+        /// <remarks>
+        /// The property cascade chaining set is possible. For example, this (textLabel.AnchorColor.X = 0.1f;) is possible.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color AnchorColor
+        {
+            get
+            {
+                Color color = (Color)GetValue(AnchorColorProperty);
+                return new Color(OnAnchorColorChanged, color.R, color.G, color.B, color.A);
+            }
+            set
+            {
+                SetValue(AnchorColorProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The AnchorClickedColor property.<br />
+        /// The color of the clicked anchor.<br />
+        /// This property is used as the default clicked color of the markup anchor tag.<br />
+        /// If there is a color attribute in the markup anchor tag, the markup attribute takes precedence.
+        /// </summary>
+        /// <remarks>
+        /// The property cascade chaining set is possible. For example, this (textLabel.AnchorClickedColor.X = 0.1f;) is possible.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Color AnchorClickedColor
+        {
+            get
+            {
+                Color color = (Color)GetValue(AnchorClickedColorProperty);
+                return new Color(OnAnchorClickedColorChanged, color.R, color.G, color.B, color.A);
+            }
+            set
+            {
+                SetValue(AnchorClickedColorProperty, value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
         /// The FontSizeScale property for scaling the specified font size up or down. <br />
         /// The default value is 1.0. <br />
         /// The given font size scale value is used for multiplying the specified font size before querying fonts. <br />
@@ -1667,6 +1717,8 @@ namespace Tizen.NUI.BaseComponents
             }
 
             internalTextColor?.Dispose();
+            internalAnchorColor?.Dispose();
+            internalAnchorClickedColor?.Dispose();
 
             if (hasSystemLanguageChanged)
             {
@@ -1850,6 +1902,9 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int EllipsisPosition = Interop.TextLabel.EllipsisPositionGet();
             internal static readonly int Strikethrough = Interop.TextLabel.StrikethroughGet();
             internal static readonly int CharacterSpacing = Interop.TextLabel.CharacterSpacingGet();
+            internal static readonly int AnchorColor = Interop.TextLabel.AnchorColorGet();
+            internal static readonly int AnchorClickedColor = Interop.TextLabel.AnchorClickedColorGet();
+
 
             internal static void Preload()
             {
@@ -1872,6 +1927,14 @@ namespace Tizen.NUI.BaseComponents
         private void OnUnderlineColorChanged(float x, float y, float z, float w)
         {
             UnderlineColor = new Vector4(x, y, z, w);
+        }
+        private void OnAnchorColorChanged(float r, float g, float b, float a)
+        {
+            AnchorColor = new Color(r, g, b, a);
+        }
+        private void OnAnchorClickedColorChanged(float r, float g, float b, float a)
+        {
+            AnchorClickedColor = new Color(r, g, b, a);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -251,6 +251,48 @@ namespace Tizen.NUI.BaseComponents
             return textLabel.internalTextColor;
         }));
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty AnchorColorProperty = BindableProperty.Create(nameof(TextLabel.AnchorColor), typeof(Color), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            if (newValue != null)
+            {
+                Object.InternalSetPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.AnchorColor, ((Color)newValue).SwigCPtr);
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textLabel = (TextLabel)bindable;
+
+            if (textLabel.internalAnchorColor == null)
+            {
+                textLabel.internalAnchorColor = new Color(0, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.TextColor, textLabel.internalAnchorColor.SwigCPtr);
+            return textLabel.internalAnchorColor;
+        }));
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty AnchorClickedColorProperty = BindableProperty.Create(nameof(TextLabel.AnchorClickedColor), typeof(Color), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        {
+            var textLabel = (TextLabel)bindable;
+            if (newValue != null)
+            {
+                Object.InternalSetPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.AnchorClickedColor, ((Color)newValue).SwigCPtr);
+            }
+        }),
+        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        {
+            var textLabel = (TextLabel)bindable;
+
+            if (textLabel.internalAnchorClickedColor == null)
+            {
+                textLabel.internalAnchorClickedColor = new Color(0, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.TextColor, textLabel.internalAnchorClickedColor.SwigCPtr);
+            return textLabel.internalAnchorClickedColor;
+        }));
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableMarkupProperty = BindableProperty.Create(nameof(EnableMarkup), typeof(bool), typeof(TextLabel), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>

--- a/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
+++ b/src/Tizen.NUI/src/public/Theme/DefaultThemeCommon.cs
@@ -45,6 +45,8 @@ namespace Tizen.NUI
                 AutoScrollGap = 50.0f,
                 AutoScrollSpeed = 80,
                 FontSizeScale = Tizen.NUI.FontSizeScale.UseSystemSetting,
+                AnchorColor = Color.MediumBlue,
+                AnchorClickedColor = Color.DarkMagenta,
             });
 
             // TextField style.


### PR DESCRIPTION
AnchorColor(or AnchorClickedColor) property is
used as the default color of the markup anchor tag.

If there is a color attribute in the markup anchor tag, the markup attribute takes precedence.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/302984/ https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/302985/
