### PR TITLE
[System.Feedback] Add internal API to support sound playing with priority

### DIFF
--- a/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
+++ b/src/Tizen.System.Feedback/Interop/Interop.Feedback.cs
@@ -38,6 +38,12 @@ internal static partial class Interop
             Vibration = 2,
         }
 
+        internal enum FeedbackFlag
+        {
+            None = 0,
+            PriorityBasedPlay = 1,
+        }
+
         [DllImport(Libraries.Feedback, EntryPoint = "feedback_initialize")]
         internal static extern int Initialize();
 
@@ -70,5 +76,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.Feedback, EntryPoint = "feedback_get_theme_ids_internal", CallingConvention = CallingConvention.Cdecl)]
         internal static extern int GetThemeIdsInternal(FeedbackType type, out uint coundOfTheme, out IntPtr themeIds);
+
+        [DllImport(Libraries.Feedback, EntryPoint = "feedback_play_type_with_flags_internal", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int PlayTypeWithFlagsInternal(FeedbackType type, int pattern, FeedbackFlag flag);
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

Allows sound feedback pattern playing with priority.

This is newly added to System.Feedback.
- public enum FeedbackFlag -> It determines the sound play method.
- public void PlayTypeWithFlagsInternal(FeedbackType type, String pattern, FeedbackFlag flag) -> It plays sound feedback pattern according to the FeedbackFlag value.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
