### PR TITLE
[NUI] Fix Navigator to support Page with Transitions

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
+++ b/src/Tizen.NUI.Components/Controls/Navigation/Navigator.cs
@@ -998,7 +998,16 @@ namespace Tizen.NUI.Components
 
             if (!pushTransition || newTopPage is DialogPage == false)
             {
-                View transitionView = (currentTopPage is ContentPage) ? (currentTopPage as ContentPage).Content : (currentTopPage as DialogPage).Content;
+                View transitionView = currentTopPage;
+                if (currentTopPage is ContentPage)
+                {
+                    transitionView = (currentTopPage as ContentPage).Content;
+                }
+                else if (currentTopPage is DialogPage)
+                {
+                    transitionView = (currentTopPage as DialogPage).Content;
+                }
+
                 if (currentTopPage.DisappearingTransition != null && transitionView != null)
                 {
                     TransitionItemBase disappearingTransition = currentTopPage.DisappearingTransition.CreateTransition(transitionView, false);
@@ -1012,7 +1021,16 @@ namespace Tizen.NUI.Components
             }
             if (pushTransition || currentTopPage is DialogPage == false)
             {
-                View transitionView = (newTopPage is ContentPage) ? (newTopPage as ContentPage).Content : (newTopPage as DialogPage).Content;
+                View transitionView = newTopPage;
+                if (newTopPage is ContentPage)
+                {
+                    transitionView = (newTopPage as ContentPage).Content;
+                }
+                else if (newTopPage is DialogPage)
+                {
+                    transitionView = (newTopPage as DialogPage).Content;
+                }
+
                 if (newTopPage.AppearingTransition != null && transitionView != null)
                 {
                     TransitionItemBase appearingTransition = newTopPage.AppearingTransition.CreateTransition(transitionView, true);


### PR DESCRIPTION
Previously, PushWithTransition and PopWithTransition did not support Page. It supported either ContentPage or DialogPage.

Now, PushWithTransition and PopWithTransition supports Page as well.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
