### PR TITLE
[NUI] Support NativeImageQueue creation with queue count

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
@@ -25,6 +25,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_NativeImageQueuePtr")]
             public static extern IntPtr NewHandle(uint width, uint height, int colorFormat);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_NativeImageQueuePtr_2")]
+            public static extern IntPtr NewHandle(uint queueCount, uint width, uint height, int colorFormat);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GetPtr")]
             public static extern IntPtr Get(IntPtr queue);
 
@@ -40,6 +43,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_EnqueueBuffer")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool EnqueueBuffer(IntPtr queue, IntPtr buffer);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GetQueueCount")]
+            public static extern uint GetQueueCount(IntPtr queue);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GenerateUrl")]
             public static extern IntPtr GenerateUrl(IntPtr queue);

--- a/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
@@ -87,7 +87,21 @@ namespace Tizen.NUI
         /// <param name="colorFormat">A color format of queue.</param>
         /// <returns>A NativeImageQueue.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public NativeImageQueue(uint width, uint height, ColorFormat colorFormat) : this(Interop.NativeImageQueue.NewHandle(width, height, (int)colorFormat), true)
+        public NativeImageQueue(uint width, uint height, ColorFormat colorFormat) : this(0, width, height, colorFormat)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Creates an initialized NativeImageQueue with queue count and size and color format.
+        /// </summary>
+        /// <param name="queueCount">The number of queue count. Use system default value if it is 0.</param>
+        /// <param name="width">A Width of queue.</param>
+        /// <param name="height">A Height of queue.</param>
+        /// <param name="colorFormat">A color format of queue.</param>
+        /// <returns>A NativeImageQueue.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public NativeImageQueue(uint queueCount, uint width, uint height, ColorFormat colorFormat) : this(Interop.NativeImageQueue.NewHandle(queueCount, width, height, (int)colorFormat), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -95,6 +109,18 @@ namespace Tizen.NUI
         internal NativeImageQueue(IntPtr cPtr, bool cMemoryOwn) : base(Interop.NativeImageQueue.Get(cPtr), cMemoryOwn)
         {
             handle = cPtr;
+        }
+
+        /// <summary>
+        /// The number of queue.
+        /// </summary>
+        /// <remarks>Hidden API: Only for inhouse or developing usage. The behavior and interface can be changed anytime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint GetQueueCount()
+        {
+            uint ret = Interop.NativeImageQueue.GetQueueCount(this.SwigCPtr.Handle);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            return ret;
         }
 
         /// <summary>


### PR DESCRIPTION
Let we allow to create NativeImageQueue with queue count. Previously, we only allow to create the NativeImageQueue based on the environment value "DALI_TBM_SURFACE_QUEUE_SIZE". (This value is 3 as default)

It will be useful if some user want to reduce the queue count for some cases, not for whole queue.

relative DALi patches :

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/303523 https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/303524
