### PR TITLE
[NUI] Do not recreate visual when we change ImageColor only

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1634,7 +1634,7 @@ namespace Tizen.NUI.BaseComponents
                         }
                     }
                 }
-                imagePropertyUpdatedFlag = true;
+                imagePropertyUpdatedFlag |= requiredVisualCreation;
                 cachedImagePropertyMap[key] = value;
 
                 // Lazy update only if visual creation required, and _resourceUrl is not empty, and ProcessAttachedFlag is false.

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -581,7 +581,10 @@ namespace Tizen.NUI.BaseComponents
             if (newValue != null)
             {
                 imageView.UpdateImage(Visual.Property.Opacity, new PropertyValue(((Color)newValue).A), false);
-                imageView.UpdateImage(Visual.Property.MixColor, new PropertyValue((Color)newValue));
+                imageView.UpdateImage(Visual.Property.MixColor, new PropertyValue((Color)newValue), false);
+
+                // Update property
+                Interop.View.InternalUpdateVisualPropertyVector4(imageView.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.MixColor, Vector4.getCPtr((Color)newValue));
             }
         },
         defaultValueCreator: (bindable) =>


### PR DESCRIPTION
Since we don't need to re-create the visual if we only chage the ImageColor property, let we use UpdateProperty Action.