### PR TITLE
[NUI] Fix text padding issue

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -2818,7 +2818,7 @@ namespace Tizen.NUI.BaseComponents
             GrabHandleColor = new Color(r, g, b, a);
         }
 
-        private class TextEditorLayout : LayoutItem
+        internal class TextEditorLayout : LayoutItem
         {
             protected override void OnMeasure(MeasureSpecification widthMeasureSpec, MeasureSpecification heightMeasureSpec)
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -2825,7 +2825,7 @@ namespace Tizen.NUI.BaseComponents
             GrabHandleColor = new Color(r, g, b, a);
         }
 
-        private class TextFieldLayout : LayoutItem
+        internal class TextFieldLayout : LayoutItem
         {
             protected override void OnMeasure(MeasureSpecification widthMeasureSpec, MeasureSpecification heightMeasureSpec)
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -33,7 +33,7 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class TextLabel : View
     {
-        private class TextLayout : LayoutItem
+        internal class TextLabelLayout : LayoutItem
         {
             protected override void OnMeasure(MeasureSpecification widthMeasureSpec, MeasureSpecification heightMeasureSpec)
             {
@@ -1659,7 +1659,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal override LayoutItem CreateDefaultLayout()
         {
-            return new TextLayout();
+            return new TextLabelLayout();
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -3008,7 +3008,13 @@ namespace Tizen.NUI.BaseComponents
                             setMargin = true;
                         }
 
-                        if (padding.Top != 0 || padding.Bottom != 0 || padding.Start != 0 || padding.End != 0)
+                        // The calculation of the native size of the text component requires padding.
+                        // Don't overwrite the zero padding.
+                        bool isTextLayout = (value is Tizen.NUI.BaseComponents.TextLabel.TextLabelLayout) ||
+                                            (value is Tizen.NUI.BaseComponents.TextField.TextFieldLayout) ||
+                                            (value is Tizen.NUI.BaseComponents.TextEditor.TextEditorLayout);
+
+                        if (!isTextLayout && (padding.Top != 0 || padding.Bottom != 0 || padding.Start != 0 || padding.End != 0))
                         {
                             // If View already has a padding set then store it in Layout instead.
                             value.Padding = padding;


### PR DESCRIPTION
This patch solves the problem that text with padding does not work in nui layout.

For text components, the control's padding is used to calculatie size in native, so it should not be set to zero value.

This avoids setting padding to zero when it comes to text layout.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
