### PR TITLE
[NUI] Add test for new APIs on PropertyMap

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.PropertyMap.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.PropertyMap.cs
@@ -1,0 +1,165 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+namespace Tizen.NUI.Samples
+{
+    internal static partial class Interop
+    {
+
+        internal static partial class PropertyMap
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Map__SWIG_0")]
+            public static extern global::System.IntPtr NewPropertyMap();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property_Map")]
+            public static extern void DeletePropertyMap(global::System.IntPtr jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_ValueOfIndex__SWIG_0")]
+            public static extern global::System.IntPtr ValueOfIndex(global::System.IntPtr jarg1, string jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_ValueOfIndex__SWIG_2")]
+            public static extern global::System.IntPtr ValueOfIndex(global::System.IntPtr jarg1, int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Int__SWIG_0")]
+            public static extern void Insert(global::System.IntPtr jarg1, string jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Bool__SWIG_0")]
+            public static extern void Insert(global::System.IntPtr jarg1, string jarg2, bool jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Float__SWIG_0")]
+            public static extern void Insert(global::System.IntPtr jarg1, string jarg2, float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_String__SWIG_0")]
+            public static extern void Insert(global::System.IntPtr jarg1, string jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Vector2__SWIG_0")]
+            public static extern void Insert(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Vector3__SWIG_0")]
+            public static extern void Insert(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4, float jarg5);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Vector4__SWIG_0")]
+            public static extern void Insert(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Int__SWIG_2")]
+            public static extern void Insert(global::System.IntPtr jarg1, int jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Bool__SWIG_2")]
+            public static extern void Insert(global::System.IntPtr jarg1, int jarg2, bool jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Float__SWIG_2")]
+            public static extern void Insert(global::System.IntPtr jarg1, int jarg2, float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_String__SWIG_2")]
+            public static extern void Insert(global::System.IntPtr jarg1, int jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Vector2__SWIG_2")]
+            public static extern void Insert(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Vector3__SWIG_2")]
+            public static extern void Insert(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4, float jarg5);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Insert_Vector4__SWIG_2")]
+            public static extern void Insert(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int__SWIG_0")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, string jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Bool__SWIG_0")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, string jarg2, bool jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Float__SWIG_0")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, string jarg2, float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_String__SWIG_0")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, string jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Vector2__SWIG_0")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Vector3__SWIG_0")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4, float jarg5);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Vector4__SWIG_0")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Int__SWIG_2")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, int jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Bool__SWIG_2")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, int jarg2, bool jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Float__SWIG_2")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, int jarg2, float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_String__SWIG_2")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, int jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Vector2__SWIG_2")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Vector3__SWIG_2")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4, float jarg5);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_Add_Vector4__SWIG_2")]
+            public static extern global::System.IntPtr Add(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey_IntValue")]
+            public static extern void SetValueStringKey(global::System.IntPtr jarg1, string jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey_BoolValue")]
+            public static extern void SetValueStringKey(global::System.IntPtr jarg1, string jarg2, bool jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey_FloatValue")]
+            public static extern void SetValueStringKey(global::System.IntPtr jarg1, string jarg2, float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey_StringValue")]
+            public static extern void SetValueStringKey(global::System.IntPtr jarg1, string jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey_Vector2")]
+            public static extern void SetValueStringKey(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey_Vector4")]
+            public static extern void SetValueStringKey(global::System.IntPtr jarg1, string jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_StringKey_Rect")]
+            public static extern void SetValueStringKey(global::System.IntPtr jarg1, string jarg2, int jarg3, int jarg4, int jarg5, int jarg6);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey_IntValue")]
+            public static extern void SetValueIntKey(global::System.IntPtr jarg1, int jarg2, int jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey_BoolValue")]
+            public static extern void SetValueIntKey(global::System.IntPtr jarg1, int jarg2, bool jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey_FloatValue")]
+            public static extern void SetValueIntKey(global::System.IntPtr jarg1, int jarg2, float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey_StringValue")]
+            public static extern void SetValueIntKey(global::System.IntPtr jarg1, int jarg2, string jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey_Vector2")]
+            public static extern void SetValueIntKey(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey_Vector4")]
+            public static extern void SetValueIntKey(global::System.IntPtr jarg1, int jarg2, float jarg3, float jarg4, float jarg5, float jarg6);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Map_SetValue_IntKey_Rect")]
+            public static extern void SetValueIntKey(global::System.IntPtr jarg1, int jarg2, int jarg3, int jarg4, int jarg5, int jarg6);
+        }
+    }
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.PropertyValue.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.PropertyValue.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI.Samples
+{
+    internal static partial class Interop
+    {
+        internal static partial class PropertyValue
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_1")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool PropertyValueGet(global::System.IntPtr jarg1, out bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_3")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool PropertyValueGet(global::System.IntPtr jarg1, out int jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_5")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool GetVector2(global::System.IntPtr jarg1, global::System.IntPtr jarg2);
+        }
+    }
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.Vector.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.Vector.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI.Samples
+{
+    internal static partial class Interop
+    {
+        internal static partial class Vector2
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Vector2__SWIG_0")]
+            public static extern global::System.IntPtr NewVector2();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_X_get")]
+            public static extern float XGet(global::System.IntPtr jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_Y_get")]
+            public static extern float YGet(global::System.IntPtr jarg1);
+        }
+    }
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/NDalicPINVOKE.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/NDalicPINVOKE.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Tizen.NUI.Samples
+{
+    internal class NDalicPINVOKE
+    {
+        public const string Lib = "libdali2-csharp-binder.so";
+    }
+}

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PropertyMapSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PropertyMapSample.cs
@@ -1,16 +1,29 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Components;
 
 namespace Tizen.NUI.Samples
 {
+
     public class PropertyMapSample : IExample
     {
+        private View root;
+        private LinearLayout layout;
         private TextLabel view1;
+        private Button button1;
+        private TextLabel view2;
 
         public void Activate()
         {
             Window window = NUIApplication.GetDefaultWindow();
+
+            root = new View()
+            {
+                Size = new Size(1920, 1080)
+            };
+            layout = new LinearLayout() { LinearOrientation = LinearLayout.Orientation.Vertical };
+            root.Layout = layout;
+            window.Add(root);
 
             view1 = new TextLabel
             {
@@ -49,7 +62,129 @@ namespace Tizen.NUI.Samples
             bool isBlue = vectorValue.EqualTo(Color.Blue);
             Log.Info("test", $"color: {isBlue}");
 
-            window.Add(view1);
+            root.Add(view1);
+
+            button1 = new Button
+            {
+                Text = "Test Additional APIs",
+                BackgroundColor = Color.Yellow
+            };
+            button1.Clicked += (sender, e) =>
+            {
+                ExecuteTest();
+            };
+            root.Add(button1);
+
+            view2 = new TextLabel
+            {
+                Position = new Position(400, 400),
+                Size = new Size(600, 100),
+                Text = "Button turns Green when Test passed."
+            };
+            root.Add(view2);
+        }
+
+        void ExecuteTest()
+        {
+            var propertyMap = Interop.PropertyMap.NewPropertyMap();
+
+            bool boolValue1, boolValue2, boolValue3;
+            Interop.PropertyMap.Insert(propertyMap, 100, true);
+            Interop.PropertyMap.Insert(propertyMap, 101, false);
+            Interop.PropertyMap.SetValueIntKey(propertyMap, 102, true);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, 100), out boolValue1);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, 101), out boolValue2);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, 102), out boolValue3);
+            Console.WriteLine($"{boolValue1}, {boolValue2}, {boolValue3}");
+            if (boolValue1 != true || boolValue2 != false || boolValue3 != true)
+            {
+                FailTest();
+                return;
+            }
+
+            Interop.PropertyMap.Insert(propertyMap, "boolValue1", true);
+            Interop.PropertyMap.Insert(propertyMap, "boolValue2", false);
+            Interop.PropertyMap.SetValueStringKey(propertyMap, "boolValue3", true);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, "boolValue1"), out boolValue1);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, "boolValue2"), out boolValue2);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, "boolValue3"), out boolValue3);
+            Console.WriteLine($"{boolValue1}, {boolValue2}, {boolValue3}");
+            if (boolValue1 != true || boolValue2 != false || boolValue3 != true)
+            {
+                FailTest();
+                return;
+            }
+
+            int intValue1, intValue2;
+            Interop.PropertyMap.Insert(propertyMap, 103, 9);
+            Interop.PropertyMap.SetValueIntKey(propertyMap, 104, 9);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, 103), out intValue1);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, 104), out intValue2);
+            Console.WriteLine($"{intValue1}, {intValue2}");
+            if (intValue1 != 9 || intValue2 != 9)
+            {
+                FailTest();
+                return;
+            }
+            Interop.PropertyMap.Insert(propertyMap, "intValue1", 9);
+            Interop.PropertyMap.SetValueStringKey(propertyMap, "intValue2", 9);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, "intValue1"), out intValue1);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, "intValue2"), out intValue2);
+            Console.WriteLine($"{intValue1}, {intValue2}");
+            if (intValue1 != 9 || intValue2 != 9)
+            {
+                FailTest();
+                return;
+            }
+
+            int floatValue1, floatValue2;
+            Interop.PropertyMap.Insert(propertyMap, 105, 9.0f);
+            Interop.PropertyMap.SetValueIntKey(propertyMap, 106, 9);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, 105), out floatValue1);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, 106), out floatValue2);
+            Console.WriteLine($"{floatValue1}, {floatValue2}");
+            if (floatValue1 != 9.0f || floatValue2 != 9.0f)
+            {
+                FailTest();
+                return;
+            }
+            Interop.PropertyMap.Insert(propertyMap, "floatValue1", 9.0f);
+            Interop.PropertyMap.SetValueStringKey(propertyMap, "floatValue2", 9);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, "floatValue1"), out floatValue1);
+            Interop.PropertyValue.PropertyValueGet(Interop.PropertyMap.ValueOfIndex(propertyMap, "floatValue2"), out floatValue2);
+            Console.WriteLine($"{floatValue1}, {floatValue2}");
+            if (floatValue1 != 9.0f || floatValue2 != 9.0f)
+            {
+                FailTest();
+                return;
+            }
+
+            var vector2Value1 = Interop.Vector2.NewVector2();
+            var vector2Value2 = Interop.Vector2.NewVector2();
+            Interop.PropertyMap.Insert(propertyMap, "vectorValue1", 9.0f, 9.0f);
+            Interop.PropertyMap.SetValueStringKey(propertyMap, "vectorValue2", 10.0f, 10.0f);
+            Interop.PropertyValue.GetVector2(Interop.PropertyMap.ValueOfIndex(propertyMap, "vectorValue1"), vector2Value1);
+            Interop.PropertyValue.GetVector2(Interop.PropertyMap.ValueOfIndex(propertyMap, "vectorValue2"), vector2Value2);
+            Console.WriteLine($"Vector2: {Interop.Vector2.XGet(vector2Value1)}, {Interop.Vector2.YGet(vector2Value1)}");
+            if (Interop.Vector2.XGet(vector2Value1) != 9.0f || Interop.Vector2.YGet(vector2Value1) != 9.0f)
+            {
+                FailTest();
+                return;
+            }
+            Console.WriteLine($"Vector2: {Interop.Vector2.XGet(vector2Value2)}, {Interop.Vector2.YGet(vector2Value2)}");
+            if (Interop.Vector2.XGet(vector2Value2) != 10.0f || Interop.Vector2.YGet(vector2Value2) != 10.0f)
+            {
+                FailTest();
+                return;
+            }
+
+            Interop.PropertyMap.DeletePropertyMap(propertyMap);
+            button1.BackgroundColor = Color.Green;
+        }
+
+        void FailTest()
+        {
+            button1.BackgroundColor = Color.Red;
         }
 
         public void Deactivate()
@@ -57,7 +192,14 @@ namespace Tizen.NUI.Samples
             if (view1 != null)
             {
                 NUIApplication.GetDefaultWindow().Remove(view1);
+                NUIApplication.GetDefaultWindow().Remove(view2);
+                NUIApplication.GetDefaultWindow().Remove(button1);
                 view1.Dispose();
+                view2.Dispose();
+                button1.Dispose();
+                NUIApplication.GetDefaultWindow().Remove(root);
+                root.Dispose();
+                root = null;
             }
         }
     }


### PR DESCRIPTION
### Description of Change ###

This PR adds a test code for [the new APIs](https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/303752/) added on Dali PropertyMap.

- some Interop code has brought to Sample to test dali APIs.
- Clicking Test button executes all TCs and it turns green when it's done successfully.

> Test for `CSharp_Dali_Property_Map_Insert_String__SWIG_0` is missing at the moment. This will be updated on the later PR.


### Screenshot ###
<img src="https://github.com/Samsung/TizenFX/assets/14328614/7d449a2c-89a7-437a-bc0e-1240ceca0c61" width="400" />

button color which looked break on above actually changes to the flat green.