### PR TITLE
[NUI] Fix some SVACE issues.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Slider.cs
+++ b/src/Tizen.NUI.Components/Controls/Slider.cs
@@ -553,7 +553,15 @@ namespace Tizen.NUI.Components
         }
         private StringSelector InternalThumbImageURLSelector
         {
-            get => thumbImage?.ResourceUrlSelector == null ? null : new StringSelector(thumbImage.ResourceUrlSelector);
+            get
+            {
+                Selector<string> resourceUrlSelector = thumbImage?.ResourceUrlSelector;
+                if(resourceUrlSelector != null)
+                {
+                    return new StringSelector(resourceUrlSelector);
+                }
+                return null;
+            }
             set
             {
                 if (value == null || thumbImage == null)

--- a/src/Tizen.NUI.Components/Controls/Switch.cs
+++ b/src/Tizen.NUI.Components/Controls/Switch.cs
@@ -202,7 +202,15 @@ namespace Tizen.NUI.Components
         }
         private StringSelector InternalSwitchBackgroundImageURLSelector
         {
-            get => Icon?.ResourceUrlSelector == null ? null : new StringSelector(Icon.ResourceUrlSelector);
+            get
+            {
+                Selector<string> resourceUrlSelector = Icon?.ResourceUrlSelector;
+                if(resourceUrlSelector != null)
+                {
+                    return new StringSelector(resourceUrlSelector);
+                }
+                return null;
+            }
             set
             {
                 Debug.Assert(Icon != null);
@@ -257,7 +265,15 @@ namespace Tizen.NUI.Components
         }
         private StringSelector InternalSwitchHandlerImageURLSelector
         {
-            get => new StringSelector(thumb.ResourceUrlSelector);
+            get
+            {
+                Selector<string> resourceUrlSelector = thumb?.ResourceUrlSelector;
+                if (resourceUrlSelector != null)
+                {
+                    return new StringSelector(resourceUrlSelector);
+                }
+                return null;
+            }
             set
             {
                 Debug.Assert(thumb != null);

--- a/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
@@ -112,8 +112,10 @@ namespace Tizen.NUI
             }
 
             Interop.FrameBroker.ErrorCode err;
-            err = Interop.FrameBroker.SendLaunchRequest(handle, appControl.SafeAppControlHandle, resultCallbackMaps[requestId], null, (IntPtr)requestId);
-
+            lock (resultCallbackMaps)
+            {
+                err = Interop.FrameBroker.SendLaunchRequest(handle, appControl.SafeAppControlHandle, resultCallbackMaps[requestId], null, (IntPtr)requestId);
+            }
             if (err != Interop.FrameBroker.ErrorCode.None)
             {
                 throw FrameBrokerBaseErrorFactory.GetException(err, "Failed to send launch request");


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1，possible null return value dereferenced in constructor of stringselector
2，possible missing lock before accessing  the  resultCallbackMaps variable
by the way,the solution of issue  DirectRenderingGLView.cs is in 
https://github.com/Samsung/TizenFX/pull/5838
https://github.com/Samsung/TizenFX/pull/5839

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
