### PR TITLE
[NUI] Fix svace issue of Marshal.Copy

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -186,18 +186,17 @@ namespace Tizen.NUI.BaseComponents
                 if (textures != null)
                 {
                     int count = textures.Count;
-                    int intptrBytes = checked(Marshal.SizeOf(typeof(IntPtr)) * count);
-                    if (intptrBytes > 0)
+                    if (count > 0)
                     {
                         IntPtr[] texturesArray = new IntPtr[count];
                         for (int i = 0; i < count; i++)
                         {
                             texturesArray[i] = HandleRef.ToIntPtr(Texture.getCPtr(textures[i]));
                         }
-                        IntPtr unmanagedPointer = Marshal.AllocHGlobal(intptrBytes);
-                        Marshal.Copy(texturesArray, 0, unmanagedPointer, texturesArray.Length);
+                        IntPtr unmanagedPointer = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(IntPtr)) * count);
+                        Marshal.Copy(texturesArray, 0, unmanagedPointer, count);
 
-                        Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, texturesArray.Length);
+                        Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, count);
                         Marshal.FreeHGlobal(unmanagedPointer);
                     }
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
WID:25598476 Writing count elements of type System.IntPtr into buffer unmanagedPointer can exceed its size
SVACE Server Link : https://sa.sec.samsung.net/dm/tizen80/sb2/main/review#PRJID=2&WGID=87888
This may be caused by inconsistent texturesArray length and count.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
