### PR TITLE
[NUI] Add ValuePolicy for BindableProperty

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/CameraBindableProperty.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/CameraBindableProperty.cs
@@ -37,7 +37,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalProjectionMode;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// ProjectionDirectionProperty
@@ -59,7 +60,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalProjectionDirection;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// FieldOfViewProperty
@@ -76,7 +78,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalFieldOfView;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// OrthographicSizeProperty
@@ -93,7 +96,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalOrthographicSize;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// AspectRatioProperty
@@ -110,7 +114,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalAspectRatio;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// NearPlaneDistanceProperty
@@ -127,7 +132,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalNearPlaneDistance;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// FarPlaneDistanceProperty
@@ -144,7 +150,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalFarPlaneDistance;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// LeftPlaneDistanceProperty
@@ -161,7 +168,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalLeftPlaneDistance;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// RightPlaneDistanceProperty
@@ -178,7 +186,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalRightPlaneDistance;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// TopPlaneDistanceProperty
@@ -195,7 +204,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalTopPlaneDistance;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// BottomPlaneDistanceProperty
@@ -212,7 +222,8 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalBottomPlaneDistance;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// InvertYAxisProperty
@@ -229,6 +240,7 @@ namespace Tizen.NUI.Scene3D
         {
             var instance = (Tizen.NUI.Scene3D.Camera)bindable;
             return instance.InternalInvertYAxis;
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
     }
 }

--- a/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
@@ -32,7 +32,8 @@ namespace Tizen.NUI
     {
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BlurStrengthProperty = BindableProperty.Create(nameof(BlurStrength), typeof(float), typeof(GaussianBlurView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty BlurStrengthProperty = BindableProperty.Create(nameof(BlurStrength), typeof(float), typeof(GaussianBlurView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var gaussianBlurView = (GaussianBlurView)bindable;
             if (newValue != null)
@@ -46,7 +47,8 @@ namespace Tizen.NUI
             float temp;
             Tizen.NUI.Object.GetProperty(gaussianBlurView.SwigCPtr, gaussianBlurView.GetBlurStrengthPropertyIndex()).Get(out temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         internal GaussianBlurView(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {

--- a/src/Tizen.NUI/src/internal/Utility/ItemViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemViewBindableProperty.cs
@@ -26,7 +26,8 @@ namespace Tizen.NUI
         /// LayoutProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static new readonly BindableProperty LayoutProperty = BindableProperty.Create(nameof(Layout), typeof(Tizen.NUI.PropertyArray), typeof(ItemView), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static new readonly BindableProperty LayoutProperty = BindableProperty.Create(nameof(Layout), typeof(Tizen.NUI.PropertyArray), typeof(ItemView), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -38,13 +39,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalLayout;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// MinimumSwipeSpeedProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MinimumSwipeSpeedProperty = BindableProperty.Create(nameof(MinimumSwipeSpeed), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MinimumSwipeSpeedProperty = BindableProperty.Create(nameof(MinimumSwipeSpeed), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -56,13 +59,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalMinimumSwipeSpeed;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// MinimumSwipeDistanceProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MinimumSwipeDistanceProperty = BindableProperty.Create(nameof(MinimumSwipeDistance), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MinimumSwipeDistanceProperty = BindableProperty.Create(nameof(MinimumSwipeDistance), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -74,13 +79,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalMinimumSwipeDistance;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// WheelScrollDistanceStepProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty WheelScrollDistanceStepProperty = BindableProperty.Create(nameof(WheelScrollDistanceStep), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty WheelScrollDistanceStepProperty = BindableProperty.Create(nameof(WheelScrollDistanceStep), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -92,13 +99,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalWheelScrollDistanceStep;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// SnapToItemEnabledProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SnapToItemEnabledProperty = BindableProperty.Create(nameof(SnapToItemEnabled), typeof(bool), typeof(ItemView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SnapToItemEnabledProperty = BindableProperty.Create(nameof(SnapToItemEnabled), typeof(bool), typeof(ItemView), true,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -110,13 +119,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalSnapToItemEnabled;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RefreshIntervalProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RefreshIntervalProperty = BindableProperty.Create(nameof(RefreshInterval), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty RefreshIntervalProperty = BindableProperty.Create(nameof(RefreshInterval), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -128,13 +139,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalRefreshInterval;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LayoutPositionProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LayoutPositionProperty = BindableProperty.Create(nameof(LayoutPosition), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty LayoutPositionProperty = BindableProperty.Create(nameof(LayoutPosition), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -146,13 +159,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalLayoutPosition;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ScrollSpeedProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollSpeedProperty = BindableProperty.Create(nameof(ScrollSpeed), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollSpeedProperty = BindableProperty.Create(nameof(ScrollSpeed), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -164,13 +179,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalScrollSpeed;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// OvershootProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty OvershootProperty = BindableProperty.Create(nameof(Overshoot), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty OvershootProperty = BindableProperty.Create(nameof(Overshoot), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -182,13 +199,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalOvershoot;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ScrollDirectionProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollDirectionProperty = BindableProperty.Create(nameof(ScrollDirection), typeof(Tizen.NUI.Vector2), typeof(ItemView), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollDirectionProperty = BindableProperty.Create(nameof(ScrollDirection), typeof(Tizen.NUI.Vector2), typeof(ItemView), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -200,13 +219,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalScrollDirection;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LayoutOrientationProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LayoutOrientationProperty = BindableProperty.Create(nameof(LayoutOrientation), typeof(int), typeof(ItemView), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty LayoutOrientationProperty = BindableProperty.Create(nameof(LayoutOrientation), typeof(int), typeof(ItemView), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -218,13 +239,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalLayoutOrientation;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ScrollContentSizeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollContentSizeProperty = BindableProperty.Create(nameof(ScrollContentSize), typeof(float), typeof(ItemView), default(float), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollContentSizeProperty = BindableProperty.Create(nameof(ScrollContentSize), typeof(float), typeof(ItemView), default(float),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -236,6 +259,7 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalScrollContentSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/internal/XamlBinding/Interactivity/MultiCondition.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/Interactivity/MultiCondition.cs
@@ -24,7 +24,7 @@ namespace Tizen.NUI.Binding
 
         public MultiCondition()
         {
-            _aggregatedStateProperty = BindableProperty.CreateAttached("AggregatedState", typeof(bool), typeof(MultiCondition), false, propertyChanged: OnAggregatedStatePropertyChanged);
+            _aggregatedStateProperty = BindableProperty.CreateAttached("AggregatedState", typeof(bool), typeof(MultiCondition), false, propertyChanged: OnAggregatedStatePropertyChanged, valuePolicy : ValuePolicy.Default);
             Conditions = new TriggerBase.SealedList<Condition>();
         }
 

--- a/src/Tizen.NUI/src/internal/XamlBinding/MergedStyle.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/MergedStyle.cs
@@ -66,7 +66,7 @@ namespace Tizen.NUI.Binding
                     foreach (var styleClass in styleClass)
                     {
                         var classStyleProperty = BindableProperty.Create("ClassStyle", typeof(IList<XamlStyle>), typeof(View), default(IList<XamlStyle>),
-                            propertyChanged: (bindable, oldvalue, newvalue) => ((View)bindable).MergedStyle.OnClassStyleChanged());
+                            propertyChanged: (bindable, oldvalue, newvalue) => ((View)bindable).MergedStyle.OnClassStyleChanged(), valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
                         classStyleProperties.Add(classStyleProperty);
                         Target.OnSetDynamicResource(classStyleProperty, Tizen.NUI.Binding.XamlStyle.StyleClassPrefix + styleClass);
                     }
@@ -139,7 +139,7 @@ namespace Tizen.NUI.Binding
                 if (type != null)
                 {
                     BindableProperty implicitStyleProperty = BindableProperty.Create(nameof(ImplicitStyle), typeof(XamlStyle), typeof(View), default(XamlStyle),
-                            propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged());
+                            propertyChanged: (bindable, oldvalue, newvalue) => OnImplicitStyleChanged(), valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
                     implicitStyles.Add(implicitStyleProperty);
                     Target.SetDynamicResource(implicitStyleProperty, type.FullName);
                     type = type.GetTypeInfo().BaseType;

--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageViewBindableProperty.cs
@@ -38,7 +38,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedImageView)bindable;
             return instance.InternalBatchSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CacheSizeProperty
@@ -56,7 +57,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedImageView)bindable;
             return instance.InternalCacheSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FrameDelayProperty
@@ -74,7 +76,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedImageView)bindable;
             return instance.InternalFrameDelay;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LoopCountProperty
@@ -92,7 +95,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedImageView)bindable;
             return instance.InternalLoopCount;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// StopBehaviorProperty
@@ -110,7 +114,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedImageView)bindable;
             return instance.InternalStopBehavior;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CurrentFrameProperty
@@ -128,6 +133,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedImageView)bindable;
             return instance.InternalCurrentFrame;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageViewBindableProperty.cs
@@ -35,7 +35,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             return instance.InternalResourceURL;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ResourceUrlProperty
@@ -50,7 +51,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             return instance.InternalResourceUrl;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RepeatCountProperty
@@ -68,7 +70,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             return instance.InternalRepeatCount;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CurrentFrameProperty
@@ -86,7 +89,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             return instance.InternalCurrentFrame;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RepeatModeProperty
@@ -104,6 +108,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             return instance.InternalRepeatMode;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -40,7 +40,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var customView = (CustomView)bindable;
             return customView.IsKeyboardNavigationSupported();
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -56,7 +57,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var customView = (CustomView)bindable;
             return customView.IsKeyboardFocusGroup();
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Create an instance of customView.

--- a/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
@@ -47,7 +47,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)flexContainer.SwigCPtr, FlexContainer.Property.ContentDirection).Get(out temp);
             return (ContentDirectionType)temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary> Property of FlexDirection </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FlexDirectionProperty = BindableProperty.Create(nameof(FlexDirection), typeof(FlexDirectionType), typeof(FlexContainer), FlexDirectionType.Column, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -64,7 +66,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)flexContainer.SwigCPtr, FlexContainer.Property.FlexDirection).Get(out temp);
             return (FlexDirectionType)temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary> Property of FlexWrap </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FlexWrapProperty = BindableProperty.Create(nameof(FlexWrap), typeof(WrapType), typeof(FlexContainer), WrapType.NoWrap, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -81,7 +85,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)flexContainer.SwigCPtr, FlexContainer.Property.FlexWrap).Get(out temp);
             return (WrapType)temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary> Property of JustifyContent </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty JustifyContentProperty = BindableProperty.Create(nameof(JustifyContent), typeof(Justification), typeof(FlexContainer), Justification.JustifyFlexStart, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -98,7 +104,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)flexContainer.SwigCPtr, FlexContainer.Property.JustifyContent).Get(out temp);
             return (Justification)temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary> Property of AlignItems </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AlignItemsProperty = BindableProperty.Create(nameof(AlignItems), typeof(Alignment), typeof(FlexContainer), Alignment.AlignAuto, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -115,7 +123,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)flexContainer.SwigCPtr, FlexContainer.Property.AlignItems).Get(out temp);
             return (Alignment)temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary> Property of AlignContent </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AlignContentProperty = BindableProperty.Create(nameof(AlignContent), typeof(Alignment), typeof(FlexContainer), Alignment.AlignAuto, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -132,7 +142,8 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)flexContainer.SwigCPtr, FlexContainer.Property.AlignContent).Get(out temp);
             return (Alignment)temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -44,7 +44,8 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
 
             return imageView?._resourceUrl ?? "";
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -117,7 +118,8 @@ namespace Tizen.NUI.BaseComponents
             {
                 return null;
             }
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -154,7 +156,8 @@ namespace Tizen.NUI.BaseComponents
                 temp = Object.InternalGetPropertyBool(imageView.SwigCPtr, ImageView.Property.PreMultipliedAlpha);
             }
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -177,7 +180,8 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(imageView.SwigCPtr, ImageView.Property.PixelArea, imageView.internalPixelArea.SwigCPtr);
             return imageView.internalPixelArea;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -200,7 +204,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageView = (ImageView)bindable;
             return imageView._border;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -209,15 +214,6 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
-                if (oldValue != null)
-                {
-                    bool oldBool = (bool)oldValue;
-                    bool newBool = (bool)newValue;
-                    if (oldBool == newBool)
-                    {
-                        return;
-                    }
-                }
                 imageView.UpdateImage(NpatchImageVisualProperty.BorderOnly, new PropertyValue((bool)newValue));
             }
         },
@@ -229,7 +225,8 @@ namespace Tizen.NUI.BaseComponents
             imageView.GetCachedImageVisualProperty(NpatchImageVisualProperty.BorderOnly)?.Get(out ret);
 
             return ret;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -238,15 +235,6 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
-                if (oldValue != null)
-                {
-                    bool oldBool = (bool)oldValue;
-                    bool newBool = (bool)newValue;
-                    if (oldBool == newBool)
-                    {
-                        return;
-                    }
-                }
                 // Note : We need to create new visual if previous visual was async, and now we set value as sync.
                 imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue), (bool)newValue);
             }
@@ -259,7 +247,8 @@ namespace Tizen.NUI.BaseComponents
             imageView.GetCachedImageVisualProperty(ImageVisualProperty.SynchronousLoading)?.Get(out ret);
 
             return ret;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_7.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -268,15 +257,6 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
-                if (oldValue != null)
-                {
-                    bool oldBool = (bool)oldValue;
-                    bool newBool = (bool)newValue;
-                    if (oldBool == newBool)
-                    {
-                        return;
-                    }
-                }
                 // Note : We need to create new visual if previous visual was async, and now we set value as sync.
                 imageView.UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue((bool)newValue), (bool)newValue);
             }
@@ -289,7 +269,8 @@ namespace Tizen.NUI.BaseComponents
             imageView.GetCachedImageVisualProperty(ImageVisualProperty.SynchronousLoading)?.Get(out ret);
 
             return ret;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -298,15 +279,6 @@ namespace Tizen.NUI.BaseComponents
             var imageView = (ImageView)bindable;
             if (newValue != null)
             {
-                if (oldValue != null)
-                {
-                    bool oldBool = (bool)oldValue;
-                    bool newBool = (bool)newValue;
-                    if (oldBool == newBool)
-                    {
-                        return;
-                    }
-                }
                 imageView.UpdateImage(ImageVisualProperty.OrientationCorrection, new PropertyValue((bool)newValue));
             }
         },
@@ -319,7 +291,8 @@ namespace Tizen.NUI.BaseComponents
             imageView.GetCachedImageVisualProperty(ImageVisualProperty.OrientationCorrection)?.Get(out ret);
 
             return ret;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// MaskingModeProperty
@@ -337,7 +310,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalMaskingMode;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FastTrackUploadingProperty
@@ -355,7 +329,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalFastTrackUploading;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ImageMapProperty
@@ -373,7 +348,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalImageMap;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AlphaMaskURLProperty
@@ -391,7 +367,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalAlphaMaskURL;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CropToMaskProperty
@@ -409,7 +386,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalCropToMask;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FittingModeProperty
@@ -427,7 +405,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalFittingMode;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DesiredWidthProperty
@@ -445,7 +424,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalDesiredWidth;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DesiredHeightProperty
@@ -463,7 +443,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalDesiredHeight;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ReleasePolicyProperty
@@ -481,7 +462,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalReleasePolicy;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// WrapModeUProperty
@@ -499,7 +481,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalWrapModeU;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// WrapModeVProperty
@@ -517,7 +500,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.InternalWrapModeV;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AdjustViewSizeProperty
@@ -535,7 +519,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return instance.adjustViewSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PlaceHolderUrlProperty
@@ -553,7 +538,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageView = (Tizen.NUI.BaseComponents.ImageView)bindable;
             return Object.InternalGetPropertyString(imageView.SwigCPtr, ImageView.Property.PlaceHolderUrl);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Intenal used, will never be opened.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -569,7 +555,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageView = (ImageView)bindable;
             return Object.InternalGetPropertyBool(imageView.SwigCPtr, ImageView.Property.TransitionEffect);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ImageColorProperty
@@ -595,6 +582,7 @@ namespace Tizen.NUI.BaseComponents
             imageView.GetCachedImageVisualProperty(Visual.Property.MixColor)?.Get(ret);
 
             return ret;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationViewBindableProperty.cs
@@ -38,7 +38,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.LottieAnimationView)bindable;
             return instance.InternalURL;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CurrentFrameProperty
@@ -56,7 +57,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.LottieAnimationView)bindable;
             return instance.InternalCurrentFrame;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LoopingModeProperty
@@ -74,7 +76,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.LottieAnimationView)bindable;
             return instance.InternalLoopingMode;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LoopCountProperty
@@ -92,7 +95,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.LottieAnimationView)bindable;
             return instance.InternalLoopCount;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// StopBehaviorProperty
@@ -110,7 +114,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.LottieAnimationView)bindable;
             return instance.InternalStopBehavior;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RedrawInScalingDownProperty
@@ -128,7 +133,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.LottieAnimationView)bindable;
             return instance.InternalRedrawInScalingDown;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// EnableFrameCacheProperty
@@ -146,6 +152,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.LottieAnimationView)bindable;
             return instance.InternalEnableFrameCache;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
@@ -44,7 +44,9 @@ namespace Tizen.NUI.BaseComponents
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.OvershootEffectColor).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OvershootAnimationSpeedProperty = BindableProperty.Create(nameof(OvershootAnimationSpeed), typeof(float), typeof(Scrollable), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -61,7 +63,9 @@ namespace Tizen.NUI.BaseComponents
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.OvershootAnimationSpeed).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OvershootEnabledProperty = BindableProperty.Create(nameof(OvershootEnabled), typeof(bool), typeof(Scrollable), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -78,7 +82,9 @@ namespace Tizen.NUI.BaseComponents
             bool temp = false;
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.OvershootEnabled).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OvershootSizeProperty = BindableProperty.Create(nameof(OvershootSize), typeof(Vector2), typeof(Scrollable), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -95,7 +101,9 @@ namespace Tizen.NUI.BaseComponents
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.OvershootSize).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollToAlphaFunctionProperty = BindableProperty.Create(nameof(ScrollToAlphaFunction), typeof(int), typeof(Scrollable), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -112,7 +120,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollToAlphaFunction).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollRelativePositionProperty = BindableProperty.Create(nameof(ScrollRelativePosition), typeof(Vector2), typeof(Scrollable), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -129,7 +139,9 @@ namespace Tizen.NUI.BaseComponents
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollRelativePosition).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollPositionMinProperty = BindableProperty.Create(nameof(ScrollPositionMin), typeof(Vector2), typeof(Scrollable), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -146,7 +158,9 @@ namespace Tizen.NUI.BaseComponents
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollPositionMin).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollPositionMaxProperty = BindableProperty.Create(nameof(ScrollPositionMax), typeof(Vector2), typeof(Scrollable), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -163,7 +177,9 @@ namespace Tizen.NUI.BaseComponents
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollPositionMax).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CanScrollVerticalProperty = BindableProperty.Create(nameof(CanScrollVertical), typeof(bool), typeof(Scrollable), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -180,7 +196,9 @@ namespace Tizen.NUI.BaseComponents
             bool temp = false;
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.CanScrollVertical).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CanScrollHorizontalProperty = BindableProperty.Create(nameof(CanScrollHorizontal), typeof(bool), typeof(Scrollable), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -197,7 +215,8 @@ namespace Tizen.NUI.BaseComponents
             bool temp = false;
             Tizen.NUI.Object.GetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.CanScrollHorizontal).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private DaliEventHandler<object, StartedEventArgs> scrollableStartedEventHandler;
         private StartedCallbackDelegate scrollableStartedCallbackDelegate;

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ImageViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ImageViewStyle.cs
@@ -37,7 +37,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageViewStyle = (ImageViewStyle)bindable;
             return imageViewStyle.resourceUrl;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty BorderProperty = BindableProperty.Create(nameof(Border), typeof(Selector<Rectangle>), typeof(ImageViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -49,7 +51,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageViewStyle = (ImageViewStyle)bindable;
             return imageViewStyle.border;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty BorderOnlyProperty = BindableProperty.Create(nameof(BorderOnly), typeof(bool?), typeof(ImageViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -61,7 +65,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageViewStyle = (ImageViewStyle)bindable;
             return imageViewStyle.borderOnly;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SynchronosLoadingProperty = BindableProperty.Create(nameof(SynchronousLoading), typeof(bool?), typeof(ImageViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -73,7 +79,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageViewStyle = (ImageViewStyle)bindable;
             return imageViewStyle.synchronousLoading;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_7.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SynchronousLoadingProperty = BindableProperty.Create(nameof(SynchronousLoading), typeof(bool?), typeof(ImageViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -85,7 +93,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageViewStyle = (ImageViewStyle)bindable;
             return imageViewStyle.synchronousLoading;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OrientationCorrectionProperty = BindableProperty.Create(nameof(OrientationCorrection), typeof(bool?), typeof(ImageViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
@@ -97,7 +107,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var imageViewStyle = (ImageViewStyle)bindable;
             return imageViewStyle.orientationCorrection;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private bool? borderOnly;
         private bool? synchronousLoading;

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextEditorStyle.cs
@@ -31,232 +31,273 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).fontFamily = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).fontFamily);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).fontFamily,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of PointSize. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty PointSizeProperty = BindableProperty.Create(nameof(PointSize), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).pointSize = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).pointSize);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).pointSize,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of PixelSize. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty PixelSizeProperty = BindableProperty.Create(nameof(PixelSize), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).pixelSize = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).pixelSize);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).pixelSize,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of TextColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Vector4), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).textColor = (Vector4)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).textColor);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).textColor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of PlaceholderTextColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty PlaceholderTextColorProperty = BindableProperty.Create(nameof(PlaceholderTextColor), typeof(Color), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).placeholderTextColor = (Color)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).placeholderTextColor);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).placeholderTextColor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of PrimaryCursorColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty PrimaryCursorColorProperty = BindableProperty.Create(nameof(PrimaryCursorColor), typeof(Vector4), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).primaryCursorColor = (Vector4)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).primaryCursorColor);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).primaryCursorColor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of HorizontalAlignment. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).horizontalAlignment = (HorizontalAlignment?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).horizontalAlignment);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).horizontalAlignment,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of VerticalAlignment. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).verticalAlignment = (VerticalAlignment?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).verticalAlignment);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).verticalAlignment,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of SecondaryCursorColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty SecondaryCursorColorProperty = BindableProperty.Create(nameof(SecondaryCursorColor), typeof(Vector4), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).secondaryCursorColor = (Vector4)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).secondaryCursorColor);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).secondaryCursorColor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of EnableCursorBlink. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty EnableCursorBlinkProperty = BindableProperty.Create(nameof(EnableCursorBlink), typeof(bool?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).enableCursorBlink = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).enableCursorBlink);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).enableCursorBlink,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of CursorBlinkInterval. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty CursorBlinkIntervalProperty = BindableProperty.Create(nameof(CursorBlinkInterval), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).cursorBlinkInterval = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).cursorBlinkInterval);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).cursorBlinkInterval,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of CursorBlinkDuration. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty CursorBlinkDurationProperty = BindableProperty.Create(nameof(CursorBlinkDuration), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).cursorBlinkDuration = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).cursorBlinkDuration);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).cursorBlinkDuration,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of CursorWidth. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty CursorWidthProperty = BindableProperty.Create(nameof(CursorWidth), typeof(int?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).cursorWidth = (int?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).cursorWidth);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).cursorWidth,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of GrabHandleColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty GrabHandleColorProperty = BindableProperty.Create(nameof(GrabHandleColor), typeof(Color), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).grabHandleColor = (Color)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).grabHandleColor);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).grabHandleColor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of GrabHandleImage. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty GrabHandleImageProperty = BindableProperty.Create(nameof(GrabHandleImage), typeof(string), typeof(TextEditorStyle), String.Empty,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).grabHandleImage = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).grabHandleImage);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).grabHandleImage,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of GrabHandlePressedImage. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly BindableProperty GrabHandlePressedImageProperty = BindableProperty.Create(nameof(GrabHandlePressedImage), typeof(string), typeof(TextEditorStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).grabHandlePressedImage = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).grabHandlePressedImage);
+        internal static readonly BindableProperty GrabHandlePressedImageProperty = BindableProperty.Create(nameof(GrabHandlePressedImage), typeof(string), typeof(TextEditorStyle), String.Empty,
+            propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).grabHandlePressedImage = (string)newValue,
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).grabHandlePressedImage,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of SelectionHandleImageLeft. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty SelectionHandleImageLeftProperty = BindableProperty.Create(nameof(SelectionHandleImageLeft), typeof(PropertyMap), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).selectionHandleImageLeft = (PropertyMap)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).selectionHandleImageLeft);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).selectionHandleImageLeft,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of SelectionHandleImageRight. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty SelectionHandleImageRightProperty = BindableProperty.Create(nameof(SelectionHandleImageRight), typeof(PropertyMap), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).selectionHandleImageRight = (PropertyMap)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).selectionHandleImageRight);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).selectionHandleImageRight,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of ScrollThreshold. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty ScrollThresholdProperty = BindableProperty.Create(nameof(ScrollThreshold), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).scrollThreshold = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollThreshold);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollThreshold,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of ScrollSpeed. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty ScrollSpeedProperty = BindableProperty.Create(nameof(ScrollSpeed), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).scrollSpeed = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollSpeed);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollSpeed,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of SelectionHighlightColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty SelectionHighlightColorProperty = BindableProperty.Create(nameof(SelectionHighlightColor), typeof(Vector4), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).selectionHighlightColor = (Vector4)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).selectionHighlightColor);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).selectionHighlightColor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of DecorationBoundingBox. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty DecorationBoundingBoxProperty = BindableProperty.Create(nameof(DecorationBoundingBox), typeof(Rectangle), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).decorationBoundingBox = (Rectangle)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).decorationBoundingBox);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).decorationBoundingBox,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of InputColor. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty InputColorProperty = BindableProperty.Create(nameof(InputColor), typeof(Vector4), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputColor = (Vector4)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputColor);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputColor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
 
         /// <summary> The bindable property of InputFontFamily. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal static readonly BindableProperty InputFontFamilyProperty = BindableProperty.Create(nameof(InputFontFamily), typeof(string), typeof(TextEditorStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputFontFamily = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputFontFamily);
+        internal static readonly BindableProperty InputFontFamilyProperty = BindableProperty.Create(nameof(InputFontFamily), typeof(string), typeof(TextEditorStyle), String.Empty,
+            propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputFontFamily = (string)newValue,
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputFontFamily,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of InputPointSize. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty InputPointSizeProperty = BindableProperty.Create(nameof(InputPointSize), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputPointSize = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputPointSize);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputPointSize,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of InputUnderline. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty InputUnderlineProperty = BindableProperty.Create(nameof(InputUnderline), typeof(string), typeof(TextEditorStyle), String.Empty,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputUnderline = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputUnderline);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputUnderline,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of InputShadow. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(InputShadow), typeof(string), typeof(TextEditorStyle), String.Empty,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputShadow = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputShadow);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputShadow,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of Emboss. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextEditorStyle), String.Empty,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).emboss = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).emboss);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).emboss,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of InputEmboss. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty InputEmbossProperty = BindableProperty.Create(nameof(InputEmboss), typeof(string), typeof(TextEditorStyle), String.Empty,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputEmboss = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputEmboss);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputEmboss,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of InputOutline. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty InputOutlineProperty = BindableProperty.Create(nameof(InputOutline), typeof(string), typeof(TextEditorStyle), String.Empty,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).inputOutline = (string)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputOutline);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).inputOutline,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of SmoothScroll. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty SmoothScrollProperty = BindableProperty.Create(nameof(SmoothScroll), typeof(bool?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).smoothScroll = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).smoothScroll);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).smoothScroll,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of SmoothScrollDuration. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty SmoothScrollDurationProperty = BindableProperty.Create(nameof(SmoothScrollDuration), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).smoothScrollDuration = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).smoothScrollDuration);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).smoothScrollDuration,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of EnableScrollBar. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty EnableScrollBarProperty = BindableProperty.Create(nameof(EnableScrollBar), typeof(bool?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).enableScrollBar = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).enableScrollBar);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).enableScrollBar,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of ScrollBarShowDuration. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty ScrollBarShowDurationProperty = BindableProperty.Create(nameof(ScrollBarShowDuration), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).scrollBarShowDuration = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollBarShowDuration);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollBarShowDuration,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of ScrollBarFadeDuration. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty ScrollBarFadeDurationProperty = BindableProperty.Create(nameof(ScrollBarFadeDuration), typeof(float?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).scrollBarFadeDuration = (float?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollBarFadeDuration);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).scrollBarFadeDuration,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of EnableSelection. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableSelectionProperty = BindableProperty.Create(nameof(EnableSelection), typeof(bool?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).enableSelection = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).enableSelection);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).enableSelection,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of MatchSystemLanguageDirection. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).matchSystemLanguageDirection = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).matchSystemLanguageDirection);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).matchSystemLanguageDirection,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of FontStyleProperty. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextEditorStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((TextEditorStyle)bindable).fontStyle = (PropertyMap)newValue,
-            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).fontStyle);
+            defaultValueCreator: (bindable) => ((TextEditorStyle)bindable).fontStyle,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool?), typeof(TextEditorStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             textEditorStyle.ellipsis = (bool?)newValue;
@@ -265,11 +306,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             return textEditorStyle.ellipsis;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of LineSpacingProperty. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LineSpacingProperty = BindableProperty.Create(nameof(LineSpacing), typeof(float?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty LineSpacingProperty = BindableProperty.Create(nameof(LineSpacing), typeof(float?), typeof(TextEditorStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             textEditorStyle.lineSpacing = (float?)newValue;
@@ -278,11 +321,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             return textEditorStyle.lineSpacing;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of MinLineSizeProperty. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MinLineSizeProperty = BindableProperty.Create(nameof(MinLineSize), typeof(float?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MinLineSizeProperty = BindableProperty.Create(nameof(MinLineSize), typeof(float?), typeof(TextEditorStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             textEditorStyle.minLineSize = (float?)newValue;
@@ -291,11 +336,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             return textEditorStyle.minLineSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> The bindable property of RelativeLineHeightProperty. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float?), typeof(TextEditorStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             textEditorStyle.relativeLineHeight = (float?)newValue;
@@ -304,10 +351,12 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             return textEditorStyle.relativeLineHeight;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextEditorStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             textEditorStyle.fontSizeScale = (float?)newValue;
@@ -316,10 +365,12 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             return textEditorStyle.fontSizeScale;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SelectionPopupStyleProperty = BindableProperty.Create(nameof(SelectionPopupStyle), typeof(PropertyMap), typeof(TextEditorStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SelectionPopupStyleProperty = BindableProperty.Create(nameof(SelectionPopupStyle), typeof(PropertyMap), typeof(TextEditorStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             textEditorStyle.selectionPopupStyle = (PropertyMap)newValue;
@@ -328,7 +379,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditorStyle = (TextEditorStyle)bindable;
             return textEditorStyle.selectionPopupStyle;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private HorizontalAlignment? horizontalAlignment;
         private VerticalAlignment? verticalAlignment;

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextFieldStyle.cs
@@ -28,7 +28,8 @@ namespace Tizen.NUI.BaseComponents
     public class TextFieldStyle : ViewStyle
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.fontFamily = (string)newValue;
@@ -37,10 +38,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.fontFamily;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PointSizeProperty = BindableProperty.Create(nameof(PointSize), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PointSizeProperty = BindableProperty.Create(nameof(PointSize), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.pointSize = (float?)newValue;
@@ -49,9 +53,12 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.pointSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.fontSizeScale = (float?)newValue;
@@ -60,10 +67,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.fontSizeScale;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.textColor = (Color)newValue;
@@ -72,10 +82,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.textColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PlaceholderTextColorProperty = BindableProperty.Create(nameof(PlaceholderTextColor), typeof(Vector4), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PlaceholderTextColorProperty = BindableProperty.Create(nameof(PlaceholderTextColor), typeof(Vector4), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.placeholderTextColor = (Vector4)newValue;
@@ -84,10 +97,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.placeholderTextColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PrimaryCursorColorProperty = BindableProperty.Create(nameof(PrimaryCursorColor), typeof(Vector4), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PrimaryCursorColorProperty = BindableProperty.Create(nameof(PrimaryCursorColor), typeof(Vector4), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.primaryCursorColor = (Vector4)newValue;
@@ -96,11 +112,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.primaryCursorColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PlaceholderTextProperty = BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PlaceholderTextProperty = BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.placeholderText = (string)newValue;
@@ -109,10 +127,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.placeholderText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PlaceholderTextFocusedProperty = BindableProperty.Create(nameof(PlaceholderTextFocused), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PlaceholderTextFocusedProperty = BindableProperty.Create(nameof(PlaceholderTextFocused), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.placeholderTextFocused = (string)newValue;
@@ -121,10 +142,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.placeholderTextFocused;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.maxLength = (int?)newValue;
@@ -133,10 +157,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.maxLength;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ExceedPolicyProperty = BindableProperty.Create(nameof(ExceedPolicy), typeof(int?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ExceedPolicyProperty = BindableProperty.Create(nameof(ExceedPolicy), typeof(int?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.exceedPolicy = (int?)newValue;
@@ -145,10 +172,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.exceedPolicy;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.horizontalAlignment = (HorizontalAlignment?)newValue;
@@ -157,10 +187,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.horizontalAlignment;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.verticalAlignment = (VerticalAlignment?)newValue;
@@ -169,10 +202,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.verticalAlignment;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SecondaryCursorColorProperty = BindableProperty.Create(nameof(SecondaryCursorColor), typeof(Vector4), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SecondaryCursorColorProperty = BindableProperty.Create(nameof(SecondaryCursorColor), typeof(Vector4), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.secondaryCursorColor = (Vector4)newValue;
@@ -181,10 +217,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.secondaryCursorColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EnableCursorBlinkProperty = BindableProperty.Create(nameof(EnableCursorBlink), typeof(bool?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EnableCursorBlinkProperty = BindableProperty.Create(nameof(EnableCursorBlink), typeof(bool?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.enableCursorBlink = (bool?)newValue;
@@ -193,10 +232,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.enableCursorBlink;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CursorBlinkIntervalProperty = BindableProperty.Create(nameof(CursorBlinkInterval), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty CursorBlinkIntervalProperty = BindableProperty.Create(nameof(CursorBlinkInterval), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.cursorBlinkInterval = (float?)newValue;
@@ -205,10 +247,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.cursorBlinkInterval;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CursorBlinkDurationProperty = BindableProperty.Create(nameof(CursorBlinkDuration), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty CursorBlinkDurationProperty = BindableProperty.Create(nameof(CursorBlinkDuration), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.cursorBlinkDuration = (float?)newValue;
@@ -217,10 +262,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.cursorBlinkDuration;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CursorWidthProperty = BindableProperty.Create(nameof(CursorWidth), typeof(int?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty CursorWidthProperty = BindableProperty.Create(nameof(CursorWidth), typeof(int?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.cursorWidth = (int?)newValue;
@@ -229,10 +277,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.cursorWidth;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty GrabHandleColorProperty = BindableProperty.Create(nameof(GrabHandleColor), typeof(Color), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty GrabHandleColorProperty = BindableProperty.Create(nameof(GrabHandleColor), typeof(Color), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.grabHandleColor = (Color)newValue;
@@ -241,10 +292,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.grabHandleColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty GrabHandleImageProperty = BindableProperty.Create(nameof(GrabHandleImage), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty GrabHandleImageProperty = BindableProperty.Create(nameof(GrabHandleImage), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.grabHandleImage = (string)newValue;
@@ -253,10 +307,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.grabHandleImage;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty GrabHandlePressedImageProperty = BindableProperty.Create(nameof(GrabHandlePressedImage), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty GrabHandlePressedImageProperty = BindableProperty.Create(nameof(GrabHandlePressedImage), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.grabHandlePressedImage = (string)newValue;
@@ -265,10 +322,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.grabHandlePressedImage;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SelectionHandleImageLeftProperty = BindableProperty.Create(nameof(SelectionHandleImageLeft), typeof(PropertyMap), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SelectionHandleImageLeftProperty = BindableProperty.Create(nameof(SelectionHandleImageLeft), typeof(PropertyMap), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.selectionHandleImageLeft = (PropertyMap)newValue;
@@ -277,10 +337,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.selectionHandleImageLeft;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SelectionHandleImageRightProperty = BindableProperty.Create(nameof(SelectionHandleImageRight), typeof(PropertyMap), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SelectionHandleImageRightProperty = BindableProperty.Create(nameof(SelectionHandleImageRight), typeof(PropertyMap), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.selectionHandleImageRight = (PropertyMap)newValue;
@@ -289,10 +352,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.selectionHandleImageRight;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollThresholdProperty = BindableProperty.Create(nameof(ScrollThreshold), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollThresholdProperty = BindableProperty.Create(nameof(ScrollThreshold), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.scrollThreshold = (float?)newValue;
@@ -301,10 +367,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.scrollThreshold;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollSpeedProperty = BindableProperty.Create(nameof(ScrollSpeed), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollSpeedProperty = BindableProperty.Create(nameof(ScrollSpeed), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.scrollSpeed = (float?)newValue;
@@ -313,10 +382,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.scrollSpeed;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SelectionHighlightColorProperty = BindableProperty.Create(nameof(SelectionHighlightColor), typeof(Vector4), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SelectionHighlightColorProperty = BindableProperty.Create(nameof(SelectionHighlightColor), typeof(Vector4), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.selectionHighlightColor = (Vector4)newValue;
@@ -325,10 +397,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.selectionHighlightColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty DecorationBoundingBoxProperty = BindableProperty.Create(nameof(DecorationBoundingBox), typeof(Rectangle), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty DecorationBoundingBoxProperty = BindableProperty.Create(nameof(DecorationBoundingBox), typeof(Rectangle), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.decorationBoundingBox = (Rectangle)newValue;
@@ -337,10 +412,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.decorationBoundingBox;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty InputColorProperty = BindableProperty.Create(nameof(InputColor), typeof(Vector4), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty InputColorProperty = BindableProperty.Create(nameof(InputColor), typeof(Vector4), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.inputColor = (Vector4)newValue;
@@ -349,10 +427,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EnableMarkupProperty = BindableProperty.Create(nameof(EnableMarkup), typeof(bool?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EnableMarkupProperty = BindableProperty.Create(nameof(EnableMarkup), typeof(bool?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.enableMarkup = (bool?)newValue;
@@ -361,10 +442,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.enableMarkup;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty InputFontFamilyProperty = BindableProperty.Create(nameof(InputFontFamily), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty InputFontFamilyProperty = BindableProperty.Create(nameof(InputFontFamily), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.inputFontFamily = (string)newValue;
@@ -373,10 +457,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputFontFamily;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty InputPointSizeProperty = BindableProperty.Create(nameof(InputPointSize), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty InputPointSizeProperty = BindableProperty.Create(nameof(InputPointSize), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.inputPointSize = (float?)newValue;
@@ -385,10 +472,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputPointSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty InputUnderlineProperty = BindableProperty.Create(nameof(InputUnderline), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty InputUnderlineProperty = BindableProperty.Create(nameof(InputUnderline), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.inputUnderline = (string)newValue;
@@ -397,11 +487,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputUnderline;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(InputShadow), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(InputShadow), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.inputShadow = (string)newValue;
@@ -410,10 +502,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputShadow;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.emboss = (string)newValue;
@@ -422,10 +517,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.emboss;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty InputEmbossProperty = BindableProperty.Create(nameof(InputEmboss), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty InputEmbossProperty = BindableProperty.Create(nameof(InputEmboss), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.inputEmboss = (string)newValue;
@@ -434,10 +532,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputEmboss;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty InputOutlineProperty = BindableProperty.Create(nameof(InputOutline), typeof(string), typeof(TextFieldStyle), String.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty InputOutlineProperty = BindableProperty.Create(nameof(InputOutline), typeof(string), typeof(TextFieldStyle), String.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.inputOutline = (string)newValue;
@@ -446,10 +547,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.inputOutline;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PixelSizeProperty = BindableProperty.Create(nameof(PixelSize), typeof(float?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PixelSizeProperty = BindableProperty.Create(nameof(PixelSize), typeof(float?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.pixelSize = (float?)newValue;
@@ -458,10 +562,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.pixelSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EnableSelectionProperty = BindableProperty.Create(nameof(EnableSelection), typeof(bool?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EnableSelectionProperty = BindableProperty.Create(nameof(EnableSelection), typeof(bool?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.enableSelection = (bool?)newValue;
@@ -470,10 +577,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.enableSelection;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.ellipsis = (bool?)newValue;
@@ -482,10 +592,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.ellipsis;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.matchSystemLanguageDirection = (bool?)newValue;
@@ -494,10 +607,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.matchSystemLanguageDirection;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.fontStyle = (PropertyMap)newValue;
@@ -506,10 +622,12 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.fontStyle;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SelectionPopupStyleProperty = BindableProperty.Create(nameof(SelectionPopupStyle), typeof(PropertyMap), typeof(TextFieldStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SelectionPopupStyleProperty = BindableProperty.Create(nameof(SelectionPopupStyle), typeof(PropertyMap), typeof(TextFieldStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             textFieldStyle.selectionPopupStyle = (PropertyMap)newValue;
@@ -518,7 +636,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var textFieldStyle = (TextFieldStyle)bindable;
             return textFieldStyle.selectionPopupStyle;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private string placeholderText;
         private string placeholderTextFocused;

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/TextLabelStyle.cs
@@ -28,58 +28,73 @@ namespace Tizen.NUI.BaseComponents
     {
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TranslatableTextSelectorProperty = BindableProperty.Create(nameof(TranslatableText), typeof(Selector<string>), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty TranslatableTextSelectorProperty = BindableProperty.Create(nameof(TranslatableText), typeof(Selector<string>), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((TextLabelStyle)bindable).translatableTextSelector = ((Selector<string>)newValue)?.Clone();
         },
         defaultValueCreator: (bindable) =>
         {
             return ((TextLabelStyle)bindable).translatableTextSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TextSelectorProperty = BindableProperty.Create(nameof(Text), typeof(Selector<string>), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty TextSelectorProperty = BindableProperty.Create(nameof(Text), typeof(Selector<string>), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((TextLabelStyle)bindable).textSelector = ((Selector<string>)newValue)?.Clone();
         },
         defaultValueCreator: (bindable) =>
         {
             return ((TextLabelStyle)bindable).textSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FontFamilySelectorProperty = BindableProperty.Create(nameof(FontFamily), typeof(Selector<string>), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty FontFamilySelectorProperty = BindableProperty.Create(nameof(FontFamily), typeof(Selector<string>), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((TextLabelStyle)bindable).fontFamilySelector = ((Selector<string>)newValue)?.Clone();
         },
         defaultValueCreator: (bindable) =>
         {
             return ((TextLabelStyle)bindable).fontFamilySelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PointSizeSelectorProperty = BindableProperty.Create(nameof(PointSize), typeof(Selector<float?>), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PointSizeSelectorProperty = BindableProperty.Create(nameof(PointSize), typeof(Selector<float?>), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((TextLabelStyle)bindable).pointSizeSelector = ((Selector<float?>)newValue)?.Clone();
         },
         defaultValueCreator: (bindable) =>
         {
             return ((TextLabelStyle)bindable).pointSizeSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TextColorSelectorProperty = BindableProperty.Create(nameof(TextColor), typeof(Selector<Color>), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty TextColorSelectorProperty = BindableProperty.Create(nameof(TextColor), typeof(Selector<Color>), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((TextLabelStyle)bindable).textColorSelector = ((Selector<Color>)newValue)?.Clone();
         },
         defaultValueCreator: (bindable) =>
         {
             return ((TextLabelStyle)bindable).textColorSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MultiLineProperty = BindableProperty.Create(nameof(MultiLine), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MultiLineProperty = BindableProperty.Create(nameof(MultiLine), typeof(bool?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.multiLine = (bool?)newValue;
@@ -88,10 +103,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.multiLine;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.horizontalAlignment = (HorizontalAlignment?)newValue;
@@ -100,10 +118,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.horizontalAlignment;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.verticalAlignment = (VerticalAlignment?)newValue;
@@ -112,10 +133,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.verticalAlignment;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EnableMarkupProperty = BindableProperty.Create(nameof(EnableMarkup), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EnableMarkupProperty = BindableProperty.Create(nameof(EnableMarkup), typeof(bool?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.enableMarkup = (bool?)newValue;
@@ -124,10 +148,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.enableMarkup;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EnableAutoScrollProperty = BindableProperty.Create(nameof(EnableAutoScroll), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EnableAutoScrollProperty = BindableProperty.Create(nameof(EnableAutoScroll), typeof(bool?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.enableAutoScroll = (bool?)newValue;
@@ -136,10 +163,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.enableAutoScroll;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AutoScrollSpeedProperty = BindableProperty.Create(nameof(AutoScrollSpeed), typeof(int?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty AutoScrollSpeedProperty = BindableProperty.Create(nameof(AutoScrollSpeed), typeof(int?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.autoScrollSpeed = (int?)newValue;
@@ -148,10 +178,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.autoScrollSpeed;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AutoScrollLoopCountProperty = BindableProperty.Create(nameof(AutoScrollLoopCount), typeof(int?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty AutoScrollLoopCountProperty = BindableProperty.Create(nameof(AutoScrollLoopCount), typeof(int?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.autoScrollLoopCount = (int?)newValue;
@@ -160,10 +193,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.autoScrollLoopCount;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AutoScrollGapProperty = BindableProperty.Create(nameof(AutoScrollGap), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty AutoScrollGapProperty = BindableProperty.Create(nameof(AutoScrollGap), typeof(float?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.autoScrollGap = (float?)newValue;
@@ -172,10 +208,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.autoScrollGap;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LineSpacingProperty = BindableProperty.Create(nameof(LineSpacing), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty LineSpacingProperty = BindableProperty.Create(nameof(LineSpacing), typeof(float?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.lineSpacing = (float?)newValue;
@@ -184,10 +223,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.lineSpacing;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary> The bindable property of RelativeLineHeightProperty. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.relativeLineHeight = (float?)newValue;
@@ -196,10 +238,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.relativeLineHeight;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.emboss = (string)newValue;
@@ -208,20 +253,26 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.emboss;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PixelSizeSelectorProperty = BindableProperty.Create(nameof(PixelSize), typeof(Selector<float?>), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PixelSizeSelectorProperty = BindableProperty.Create(nameof(PixelSize), typeof(Selector<float?>), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((TextLabelStyle)bindable).pixelSizeSelector = ((Selector<float?>)newValue)?.Clone();
         },
         defaultValueCreator: (bindable) =>
         {
             return ((TextLabelStyle)bindable).pixelSizeSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.ellipsis = (bool?)newValue;
@@ -230,10 +281,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.ellipsis;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AutoScrollLoopDelayProperty = BindableProperty.Create(nameof(AutoScrollLoopDelay), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty AutoScrollLoopDelayProperty = BindableProperty.Create(nameof(AutoScrollLoopDelay), typeof(float?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.autoScrollLoopDelay = (float?)newValue;
@@ -242,10 +296,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.autoScrollLoopDelay;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AutoScrollStopModeProperty = BindableProperty.Create(nameof(AutoScrollStopMode), typeof(AutoScrollStopMode?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty AutoScrollStopModeProperty = BindableProperty.Create(nameof(AutoScrollStopMode), typeof(AutoScrollStopMode?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.autoScrollStopMode = (AutoScrollStopMode?)newValue;
@@ -254,10 +311,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.autoScrollStopMode;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LineWrapModeProperty = BindableProperty.Create(nameof(LineWrapMode), typeof(LineWrapMode?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty LineWrapModeProperty = BindableProperty.Create(nameof(LineWrapMode), typeof(LineWrapMode?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.lineWrapMode = (LineWrapMode?)newValue;
@@ -266,10 +326,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.lineWrapMode;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty VerticalLineAlignmentProperty = BindableProperty.Create(nameof(VerticalLineAlignment), typeof(VerticalLineAlignment?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty VerticalLineAlignmentProperty = BindableProperty.Create(nameof(VerticalLineAlignment), typeof(VerticalLineAlignment?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.verticalLineAlignment = (VerticalLineAlignment?)newValue;
@@ -278,10 +341,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.verticalLineAlignment;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.ellipsisPosition = (EllipsisPosition?)newValue;
@@ -290,10 +356,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.ellipsisPosition;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(nameof(CharacterSpacing), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(nameof(CharacterSpacing), typeof(float?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.characterSpacing = (float?)newValue;
@@ -302,9 +371,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.characterSpacing;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
+        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.fontSizeScale = (float?)newValue;
@@ -313,8 +386,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.fontSizeScale;
-        });
-        public static readonly BindableProperty AnchorColorProperty = BindableProperty.Create(nameof(AnchorColor), typeof(Color), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
+        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty AnchorColorProperty = BindableProperty.Create(nameof(AnchorColor), typeof(Color), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.anchorColor = (Color)newValue;
@@ -323,8 +401,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.anchorColor;
-        });
-        public static readonly BindableProperty AnchorClickedColorProperty = BindableProperty.Create(nameof(AnchorClickedColor), typeof(Color), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
+        /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty AnchorClickedColorProperty = BindableProperty.Create(nameof(AnchorClickedColor), typeof(Color), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.anchorClickedColor = (Color)newValue;
@@ -333,10 +416,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.anchorClickedColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool?), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.matchSystemLanguageDirection = (bool?)newValue;
@@ -345,20 +431,26 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.matchSystemLanguageDirection;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// A BindableProperty for ImageShadow
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TextShadowProperty = BindableProperty.Create(nameof(TextShadow), typeof(Selector<TextShadow>), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty TextShadowProperty = BindableProperty.Create(nameof(TextShadow), typeof(Selector<TextShadow>), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             ((TextLabelStyle)bindable).textShadow = ((Selector<TextShadow>)newValue)?.Clone();
         },
         defaultValueCreator: (bindable) =>
         {
             return ((TextLabelStyle)bindable).textShadow;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextLabelStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextLabelStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             textLabelStyle.fontStyle = (PropertyMap)newValue;
@@ -367,7 +459,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabelStyle = (TextLabelStyle)bindable;
             return textLabelStyle.fontStyle;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private bool? multiLine;
         private HorizontalAlignment? horizontalAlignment;

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyleBindableProperty.cs
@@ -23,7 +23,8 @@ namespace Tizen.NUI.BaseComponents
     {
         /// <summary> Bindable property of BackgroundImage. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BackgroundImageProperty = BindableProperty.Create(nameof(BackgroundImage), typeof(Selector<string>), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty BackgroundImageProperty = BindableProperty.Create(nameof(BackgroundImage), typeof(Selector<string>), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
 
@@ -40,33 +41,37 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((ViewStyle)bindable).backgroundImageSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of Focusable. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FocusableProperty = BindableProperty.Create(nameof(Focusable), typeof(bool?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).focusable = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).focusable
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).focusable,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of FocusableChildren. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FocusableChildrenProperty = BindableProperty.Create(nameof(FocusableChildren), typeof(bool?), typeof(ViewStyle), true,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).focusableChildren = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).focusableChildren
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).focusableChildren,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
-
 
         /// <summary> Bindable property of FocusableInTouch. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FocusableInTouchProperty = BindableProperty.Create(nameof(FocusableInTouch), typeof(bool?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).focusableInTouch = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).focusableInTouch
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).focusableInTouch,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of Focusable. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty Size2DProperty = BindableProperty.Create(nameof(Size2D), typeof(Size2D), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty Size2DProperty = BindableProperty.Create(nameof(Size2D), typeof(Size2D), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             viewStyle.size = newValue == null ? null : new Size((Size2D)newValue);
@@ -75,18 +80,21 @@ namespace Tizen.NUI.BaseComponents
         {
             var viewStyle = (ViewStyle)bindable;
             return viewStyle.size == null ? null : (Size2D)viewStyle.size;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of Opacity. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OpacityProperty = BindableProperty.Create(nameof(Opacity), typeof(Selector<float?>), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).opacitySelector = (Selector<float?>)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).opacitySelector
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).opacitySelector,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of Position2D. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty Position2DProperty = BindableProperty.Create(nameof(Position2D), typeof(Position2D), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty Position2DProperty = BindableProperty.Create(nameof(Position2D), typeof(Position2D), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             viewStyle.position = newValue == null ? null : new Position((Position2D)newValue);
@@ -95,32 +103,37 @@ namespace Tizen.NUI.BaseComponents
         {
             var viewStyle = (ViewStyle)bindable;
             return viewStyle.position == null ? null : new Position2D(viewStyle.position);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of PositionUsesPivotPoint. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PositionUsesPivotPointProperty = BindableProperty.Create(nameof(PositionUsesPivotPoint), typeof(bool?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).positionUsesPivotPoint = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).positionUsesPivotPoint
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).positionUsesPivotPoint,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of ParentOrigin. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ParentOriginProperty = BindableProperty.Create(nameof(ParentOrigin), typeof(Position), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).parentOrigin = (Position)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).parentOrigin
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).parentOrigin,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of PivotPoint. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PivotPointProperty = BindableProperty.Create(nameof(PivotPoint), typeof(Position), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).pivotPoint = (Position)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).pivotPoint
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).pivotPoint,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of SizeWidth. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SizeWidthProperty = BindableProperty.Create(nameof(SizeWidth), typeof(float?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SizeWidthProperty = BindableProperty.Create(nameof(SizeWidth), typeof(float?), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             if (newValue != null)
@@ -135,11 +148,13 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((ViewStyle)bindable).size?.Width;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of SizeHeight. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SizeHeightProperty = BindableProperty.Create(nameof(SizeHeight), typeof(float?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SizeHeightProperty = BindableProperty.Create(nameof(SizeHeight), typeof(float?), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             if (newValue != null)
@@ -154,11 +169,13 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((ViewStyle)bindable).size?.Height;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of Position. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PositionProperty = BindableProperty.Create(nameof(Position), typeof(Position), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PositionProperty = BindableProperty.Create(nameof(Position), typeof(Position), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             viewStyle.position = (Position)newValue;
@@ -171,11 +188,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var viewStyle = (ViewStyle)bindable;
             return viewStyle.position;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of PositionX. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PositionXProperty = BindableProperty.Create(nameof(PositionX), typeof(float?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PositionXProperty = BindableProperty.Create(nameof(PositionX), typeof(float?), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             if (newValue != null)
@@ -190,11 +209,13 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((ViewStyle)bindable).position?.X;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of PositionY. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PositionYProperty = BindableProperty.Create(nameof(PositionY), typeof(float?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PositionYProperty = BindableProperty.Create(nameof(PositionY), typeof(float?), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             if (newValue != null)
@@ -209,88 +230,101 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((ViewStyle)bindable).position?.Y;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of Orientation. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OrientationProperty = BindableProperty.Create(nameof(Orientation), typeof(Rotation), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).orientation = (Rotation)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).orientation
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).orientation,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of DrawMode. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty DrawModeProperty = BindableProperty.Create(nameof(DrawMode), typeof(DrawModeType?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).drawMode = (DrawModeType?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).drawMode
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).drawMode,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of SizeModeFactor. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SizeModeFactorProperty = BindableProperty.Create(nameof(SizeModeFactor), typeof(Vector3), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).sizeModeFactor = (Vector3)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).sizeModeFactor
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).sizeModeFactor,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of WidthResizePolicy. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty WidthResizePolicyProperty = BindableProperty.Create(nameof(WidthResizePolicy), typeof(ResizePolicyType?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).widthResizePolicy = (ResizePolicyType?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).widthResizePolicy
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).widthResizePolicy,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of HeightResizePolicy. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty HeightResizePolicyProperty = BindableProperty.Create(nameof(HeightResizePolicy), typeof(ResizePolicyType?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).heightResizePolicy = (ResizePolicyType?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).heightResizePolicy
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).heightResizePolicy,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of WidthForHeight. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty WidthForHeightProperty = BindableProperty.Create(nameof(WidthForHeight), typeof(bool?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).widthForHeight = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).widthForHeight
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).widthForHeight,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of HeightForWidth. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty HeightForWidthProperty = BindableProperty.Create(nameof(HeightForWidth), typeof(bool?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).heightForWidth = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).heightForWidth
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).heightForWidth,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of Padding. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PaddingProperty = BindableProperty.Create(nameof(Padding), typeof(Extents), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).padding = (Extents)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).padding
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).padding,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of MinimumSize. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MinimumSizeProperty = BindableProperty.Create(nameof(MinimumSize), typeof(Size2D), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).minimumSize = (Size2D)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).minimumSize
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).minimumSize,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of MaximumSize. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MaximumSizeProperty = BindableProperty.Create(nameof(MaximumSize), typeof(Size2D), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).maximumSize = (Size2D)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).maximumSize
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).maximumSize,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of ClippingMode. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ClippingModeProperty = BindableProperty.Create(nameof(ClippingMode), typeof(ClippingModeType?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).clippingMode = (ClippingModeType?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).clippingMode
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).clippingMode,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of Size. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
             viewStyle.size = (Size)newValue;
@@ -303,18 +337,21 @@ namespace Tizen.NUI.BaseComponents
         {
             var viewStyle = (ViewStyle)bindable;
             return viewStyle.size;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of Margin. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MarginProperty = BindableProperty.Create(nameof(Margin), typeof(Extents), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).margin = (Extents)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).margin
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).margin,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of BackgroundColor. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Selector<Color>), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Selector<Color>), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
 
@@ -332,25 +369,29 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((ViewStyle)bindable).backgroundColorSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of ColorSelector. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Selector<Color>), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).colorSelector = (Selector<Color>)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).colorSelector
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).colorSelector,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of BackgroundImageBorder. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty BackgroundImageBorderProperty = BindableProperty.Create(nameof(BackgroundImageBorder), typeof(Selector<Rectangle>), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).backgroundImageBorderSelector = (Selector<Rectangle>)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).backgroundImageBorderSelector
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).backgroundImageBorderSelector,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of ImageShadow. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ImageShadowProperty = BindableProperty.Create(nameof(ImageShadow), typeof(Selector<ImageShadow>), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ImageShadowProperty = BindableProperty.Create(nameof(ImageShadow), typeof(Selector<ImageShadow>), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
 
@@ -365,11 +406,13 @@ namespace Tizen.NUI.BaseComponents
         {
             var viewStyle = (ViewStyle)bindable;
             return ((ViewStyle)bindable).imageShadow;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of BoxShadow. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BoxShadowProperty = BindableProperty.Create(nameof(BoxShadow), typeof(Selector<Shadow>), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty BoxShadowProperty = BindableProperty.Create(nameof(BoxShadow), typeof(Selector<Shadow>), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
 
@@ -384,39 +427,45 @@ namespace Tizen.NUI.BaseComponents
         {
             var viewStyle = (ViewStyle)bindable;
             return ((ViewStyle)bindable).boxShadow;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of CornerRadius. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(Vector4), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            ((ViewStyle)bindable).cornerRadius = (Vector4)newValue;
-        }, defaultValueCreator: (bindable) => ((ViewStyle)bindable).cornerRadius);
+        public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(Vector4), typeof(ViewStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).cornerRadius = (Vector4)newValue,
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).cornerRadius,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
+        );
 
         /// <summary> Bindable property of CornerRadiusPolicy. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CornerRadiusPolicyProperty = BindableProperty.Create(nameof(CornerRadiusPolicy), typeof(VisualTransformPolicyType?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).cornerRadiusPolicy = (VisualTransformPolicyType?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).cornerRadiusPolicy
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).cornerRadiusPolicy,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> Bindable property of BorderlineWidth. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BorderlineWidthProperty = BindableProperty.Create(nameof(BorderlineWidth), typeof(float?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            ((ViewStyle)bindable).borderlineWidth = (float?)newValue;
-        }, defaultValueCreator: (bindable) => ((ViewStyle)bindable).borderlineWidth);
+        public static readonly BindableProperty BorderlineWidthProperty = BindableProperty.Create(nameof(BorderlineWidth), typeof(float?), typeof(ViewStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).borderlineWidth = (float?)newValue,
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).borderlineWidth,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
+        );
 
         /// <summary> Bindable property of BorderlineColor. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BorderlineColorProperty = BindableProperty.Create(nameof(BorderlineColor), typeof(Color), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            ((ViewStyle)bindable).borderlineColor = (Color)newValue;
-        }, defaultValueCreator: (bindable) => ((ViewStyle)bindable).borderlineColor ?? Tizen.NUI.Color.Black);
+        public static readonly BindableProperty BorderlineColorProperty = BindableProperty.Create(nameof(BorderlineColor), typeof(Color), typeof(ViewStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).borderlineColor = (Color)newValue,
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).borderlineColor ?? Tizen.NUI.Color.Black,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
+        );
 
         /// <summary> Bindable property of BorderlineColorSelector. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BorderlineColorSelectorProperty = BindableProperty.Create(nameof(BorderlineColorSelector), typeof(Selector<Color>), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty BorderlineColorSelectorProperty = BindableProperty.Create(nameof(BorderlineColorSelector), typeof(Selector<Color>), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var viewStyle = (ViewStyle)bindable;
 
@@ -432,25 +481,29 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((ViewStyle)bindable).borderlineColorSelector;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary> Bindable property of BorderlineOffset. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BorderlineOffsetProperty = BindableProperty.Create(nameof(BorderlineOffset), typeof(float?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
-        {
-            ((ViewStyle)bindable).borderlineOffset = (float?)newValue;
-        }, defaultValueCreator: (bindable) => ((ViewStyle)bindable).borderlineOffset);
+        public static readonly BindableProperty BorderlineOffsetProperty = BindableProperty.Create(nameof(BorderlineOffset), typeof(float?), typeof(ViewStyle), null,
+            propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).borderlineOffset = (float?)newValue,
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).borderlineOffset,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
+        );
 
         /// <summary> Bindable property of ThemeChangeSensitive. Do not open it. </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ThemeChangeSensitiveProperty = BindableProperty.Create(nameof(ThemeChangeSensitive), typeof(bool?), typeof(ViewStyle), null,
             propertyChanged: (bindable, oldValue, newValue) => ((ViewStyle)bindable).themeChangeSensitive = (bool?)newValue,
-            defaultValueCreator: (bindable) => ((ViewStyle)bindable).themeChangeSensitive
+            defaultValueCreator: (bindable) => ((ViewStyle)bindable).themeChangeSensitive,
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool?), typeof(ViewStyle), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty IsEnabledProperty = BindableProperty.Create(nameof(IsEnabled), typeof(bool?), typeof(ViewStyle), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var buttonStyle = (ViewStyle)bindable;
             buttonStyle.isEnabled = (bool?)newValue;
@@ -459,6 +512,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var buttonStyle = (ViewStyle)bindable;
             return buttonStyle.isEnabled;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -47,7 +47,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((HandleRef)tableView.SwigCPtr, TableView.Property.ROWS).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ColumnsProperty = BindableProperty.Create(nameof(Columns), typeof(int), typeof(TableView), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -64,7 +66,9 @@ namespace Tizen.NUI.BaseComponents
             int temp = 0;
             Tizen.NUI.Object.GetProperty((HandleRef)tableView.SwigCPtr, TableView.Property.COLUMNS).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CellPaddingProperty = BindableProperty.Create(nameof(CellPadding), typeof(Vector2), typeof(TableView), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -81,7 +85,9 @@ namespace Tizen.NUI.BaseComponents
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((HandleRef)tableView.SwigCPtr, TableView.Property.CellPadding).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LayoutRowsProperty = BindableProperty.Create(nameof(LayoutRows), typeof(PropertyMap), typeof(TableView), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -98,7 +104,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((HandleRef)tableView.SwigCPtr, TableView.Property.LayoutRows).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LayoutColumnsProperty = BindableProperty.Create(nameof(LayoutColumns), typeof(PropertyMap), typeof(TableView), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -115,8 +123,8 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((HandleRef)tableView.SwigCPtr, TableView.Property.LayoutColumns).Get(temp);
             return temp;
-        }));
-
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Creates the default TableView view.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditorBindableProperty.cs
@@ -44,7 +44,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.TEXT);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Vector4), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -66,7 +68,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.TextColor, textEditor.internalTextColor.SwigCPtr);
             return textEditor.internalTextColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -81,7 +85,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
             return textEditor.InternalFontFamily;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -98,7 +104,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.FontStyle).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PointSizeProperty = BindableProperty.Create(nameof(PointSize), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -115,7 +123,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PointSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment), typeof(TextEditor), HorizontalAlignment.Begin, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -134,7 +144,9 @@ namespace Tizen.NUI.BaseComponents
 
             temp = Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.HorizontalAlignment);
             return temp.GetValueByDescription<HorizontalAlignment>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment), typeof(TextEditor), VerticalAlignment.Bottom, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
@@ -152,7 +164,9 @@ namespace Tizen.NUI.BaseComponents
 
             temp = Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.VerticalAlignment);
             return temp.GetValueByDescription<VerticalAlignment>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollThresholdProperty = BindableProperty.Create(nameof(ScrollThreshold), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -169,7 +183,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollThreshold);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollSpeedProperty = BindableProperty.Create(nameof(ScrollSpeed), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -186,7 +202,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollSpeed);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PrimaryCursorColorProperty = BindableProperty.Create(nameof(PrimaryCursorColor), typeof(Vector4), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -208,7 +226,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PrimaryCursorColor, textEditor.internalPrimaryCursorColor.SwigCPtr);
             return textEditor.internalPrimaryCursorColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SecondaryCursorColorProperty = BindableProperty.Create(nameof(SecondaryCursorColor), typeof(Vector4), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -230,7 +250,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SecondaryCursorColor, textEditor.internalSecondaryCursorColor.SwigCPtr);
             return textEditor.internalSecondaryCursorColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableCursorBlinkProperty = BindableProperty.Create(nameof(EnableCursorBlink), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -247,7 +269,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableCursorBlink);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CursorBlinkIntervalProperty = BindableProperty.Create(nameof(CursorBlinkInterval), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -264,7 +288,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkInterval);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CursorBlinkDurationProperty = BindableProperty.Create(nameof(CursorBlinkDuration), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -281,7 +307,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CursorBlinkDuration);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CursorWidthProperty = BindableProperty.Create(nameof(CursorWidth), typeof(int), typeof(TextEditor), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -298,7 +326,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.CursorWidth);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty GrabHandleImageProperty = BindableProperty.Create(nameof(GrabHandleImage), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -315,7 +345,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandleImage);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty GrabHandlePressedImageProperty = BindableProperty.Create(nameof(GrabHandlePressedImage), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -332,7 +364,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.GrabHandlePressedImage);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionPopupStyleProperty = BindableProperty.Create(nameof(SelectionPopupStyle), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -349,7 +382,8 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionPopupStyle).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -367,7 +401,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionHandleImageLeft).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandleImageRightProperty = BindableProperty.Create(nameof(SelectionHandleImageRight), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -384,7 +420,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionHandleImageRight).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandlePressedImageLeftProperty = BindableProperty.Create(nameof(SelectionHandlePressedImageLeft), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -401,7 +439,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionHandlePressedImageLeft).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandlePressedImageRightProperty = BindableProperty.Create(nameof(SelectionHandlePressedImageRight), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -418,7 +458,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionHandlePressedImageRight).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandleMarkerImageLeftProperty = BindableProperty.Create(nameof(SelectionHandleMarkerImageLeft), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -435,7 +477,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionHandleMarkerImageLeft).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandleMarkerImageRightProperty = BindableProperty.Create(nameof(SelectionHandleMarkerImageRight), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -452,7 +496,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SelectionHandleMarkerImageRight).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHighlightColorProperty = BindableProperty.Create(nameof(SelectionHighlightColor), typeof(Vector4), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -474,7 +520,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.SelectionHighlightColor, textEditor.internalSelectionHighlightColor.SwigCPtr);
             return textEditor.internalSelectionHighlightColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty DecorationBoundingBoxProperty = BindableProperty.Create(nameof(DecorationBoundingBox), typeof(Rectangle), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -491,7 +539,9 @@ namespace Tizen.NUI.BaseComponents
             Rectangle temp = new Rectangle(0, 0, 0, 0);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.DecorationBoundingBox).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableMarkupProperty = BindableProperty.Create(nameof(EnableMarkup), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -508,7 +558,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableMarkup);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputColorProperty = BindableProperty.Create(nameof(InputColor), typeof(Vector4), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -530,7 +582,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.InputColor, textEditor.internalInputColor.SwigCPtr);
             return textEditor.internalInputColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputFontFamilyProperty = BindableProperty.Create(nameof(InputFontFamily), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -547,7 +601,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputFontFamily);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputFontStyleProperty = BindableProperty.Create(nameof(InputFontStyle), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -564,7 +620,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputFontStyle).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputPointSizeProperty = BindableProperty.Create(nameof(InputPointSize), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -581,7 +639,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputPointSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LineSpacingProperty = BindableProperty.Create(nameof(LineSpacing), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -598,7 +658,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.LineSpacing);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputLineSpacingProperty = BindableProperty.Create(nameof(InputLineSpacing), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -615,7 +677,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.InputLineSpacing);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
@@ -631,7 +695,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.RelativeLineHeight);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineProperty = BindableProperty.Create(nameof(Underline), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -648,7 +714,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.UNDERLINE).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputUnderlineProperty = BindableProperty.Create(nameof(InputUnderline), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -665,7 +733,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputUnderline);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -683,7 +752,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.SHADOW).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(InputShadow), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -700,7 +771,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputShadow);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -717,7 +790,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.EMBOSS);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputEmbossProperty = BindableProperty.Create(nameof(InputEmboss), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -734,7 +809,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputEmboss);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OutlineProperty = BindableProperty.Create(nameof(Outline), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -751,7 +828,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.OUTLINE).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputOutlineProperty = BindableProperty.Create(nameof(InputOutline), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -768,7 +847,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.InputOutline);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SmoothScrollProperty = BindableProperty.Create(nameof(SmoothScroll), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -785,7 +866,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.SmoothScroll);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SmoothScrollDurationProperty = BindableProperty.Create(nameof(SmoothScrollDuration), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -802,7 +885,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.SmoothScrollDuration);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableScrollBarProperty = BindableProperty.Create(nameof(EnableScrollBar), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -819,7 +904,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableScrollBar);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollBarShowDurationProperty = BindableProperty.Create(nameof(ScrollBarShowDuration), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -836,7 +923,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarShowDuration);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollBarFadeDurationProperty = BindableProperty.Create(nameof(ScrollBarFadeDuration), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -853,7 +942,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.ScrollBarFadeDuration);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PixelSizeProperty = BindableProperty.Create(nameof(PixelSize), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -870,7 +961,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.PixelSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PlaceholderTextProperty = BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(TextEditor), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -887,7 +980,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyString(textEditor.SwigCPtr, TextEditor.Property.PlaceholderText);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PlaceholderTextColorProperty = BindableProperty.Create(nameof(PlaceholderTextColor), typeof(Color), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -909,7 +1004,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.PlaceholderTextColor, textEditor.internalPlaceholderTextColor.SwigCPtr);
             return textEditor.internalPlaceholderTextColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableSelectionProperty = BindableProperty.Create(nameof(EnableSelection), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -926,7 +1023,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableSelection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -943,7 +1042,9 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.PropertyMap temp = new Tizen.NUI.PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.PLACEHOLDER).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LineWrapModeProperty = BindableProperty.Create(nameof(LineWrapMode), typeof(LineWrapMode), typeof(TextEditor), LineWrapMode.Word, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -960,7 +1061,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.LineWrapMode);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableShiftSelectionProperty = BindableProperty.Create(nameof(TextEditor.EnableShiftSelection), typeof(bool), typeof(TextEditor), true, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -978,7 +1081,9 @@ namespace Tizen.NUI.BaseComponents
             //textEditor.mShiftSelectionFlag(true);
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableShiftSelection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(TextEditor.MatchSystemLanguageDirection), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -995,7 +1100,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.MatchSystemLanguageDirection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int), typeof(TextEditor), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1012,7 +1119,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.MaxLength);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float), typeof(TextEditor), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1027,7 +1135,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var textEditor = (TextEditor)bindable;
             return textEditor.InternalFontSizeScale;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableFontSizeScaleProperty = BindableProperty.Create(nameof(EnableFontSizeScale), typeof(bool), typeof(TextEditor), default(bool), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1044,7 +1153,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableFontSizeScale);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1067,7 +1177,8 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textEditor.SwigCPtr, TextEditor.Property.GrabHandleColor, textEditor.internalGrabHandleColor.SwigCPtr);
             return textEditor.internalGrabHandleColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableGrabHandleProperty = BindableProperty.Create(nameof(TextEditor.EnableGrabHandle), typeof(bool), typeof(TextEditor), true, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1084,7 +1195,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandle);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableGrabHandlePopupProperty = BindableProperty.Create(nameof(TextEditor.EnableGrabHandlePopup), typeof(bool), typeof(TextEditor), true, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1101,7 +1213,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.EnableGrabHandlePopup);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputMethodSettingsProperty = BindableProperty.Create(nameof(TextEditor.InputMethodSettings), typeof(PropertyMap), typeof(TextEditor), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1118,7 +1231,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textEditor.SwigCPtr, TextEditor.Property.InputMethodSettings).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(TextEditor.Ellipsis), typeof(bool), typeof(TextEditor), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1135,7 +1250,9 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyBool(textEditor.SwigCPtr, TextEditor.Property.ELLIPSIS);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition), typeof(TextEditor), EllipsisPosition.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1152,7 +1269,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyInt(textEditor.SwigCPtr, TextEditor.Property.EllipsisPosition);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// currently need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1170,7 +1288,8 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.MinLineSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TranslatableTextProperty
@@ -1188,7 +1307,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextEditor)bindable;
             return instance.InternalTranslatableText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TranslatablePlaceholderTextProperty
@@ -1206,7 +1326,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextEditor)bindable;
             return instance.InternalTranslatablePlaceholderText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// EnableEditingProperty
@@ -1224,7 +1345,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextEditor)bindable;
             return instance.InternalEnableEditing;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// HorizontalScrollPositionProperty
@@ -1242,7 +1364,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextEditor)bindable;
             return instance.InternalHorizontalScrollPosition;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// VerticalScrollPositionProperty
@@ -1260,7 +1383,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextEditor)bindable;
             return instance.InternalVerticalScrollPosition;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PrimaryCursorPositionProperty
@@ -1278,7 +1402,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextEditor)bindable;
             return instance.InternalPrimaryCursorPosition;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1296,6 +1421,7 @@ namespace Tizen.NUI.BaseComponents
             var textEditor = (TextEditor)bindable;
 
             return Object.InternalGetPropertyFloat(textEditor.SwigCPtr, TextEditor.Property.CharacterSpacing);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextFieldBindableProperty.cs
@@ -42,7 +42,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
             return textField.translatableText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary>
         /// StyleNameProperty
         /// </summary>
@@ -59,7 +61,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
             return textField.translatablePlaceholderText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// <summary>
         /// TranslatablePlaceholderTextFocused property
         /// </summary>
@@ -76,7 +80,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
             return textField.translatablePlaceholderTextFocused;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -95,7 +101,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.TEXT);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PlaceholderTextProperty = BindableProperty.Create(nameof(PlaceholderText), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -112,7 +120,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderText);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PlaceholderTextFocusedProperty = BindableProperty.Create(nameof(PlaceholderTextFocused), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -129,7 +139,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.PlaceholderTextFocused);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -144,7 +156,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
             return textField.InternalFontFamily;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -161,7 +175,8 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.FontStyle).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -179,7 +194,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.PointSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MaxLengthProperty = BindableProperty.Create(nameof(MaxLength), typeof(int), typeof(TextField), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -196,7 +213,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.MaxLength);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ExceedPolicyProperty = BindableProperty.Create(nameof(ExceedPolicy), typeof(int), typeof(TextField), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -213,7 +232,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.ExceedPolicy);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment), typeof(TextField), HorizontalAlignment.Begin, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -232,7 +253,9 @@ namespace Tizen.NUI.BaseComponents
 
             temp = Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.HorizontalAlignment);
             return temp.GetValueByDescription<HorizontalAlignment>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(TextField.VerticalAlignment), typeof(VerticalAlignment), typeof(TextField), VerticalAlignment.Bottom, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -251,7 +274,9 @@ namespace Tizen.NUI.BaseComponents
 
             temp = Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.VerticalAlignment);
             return temp.GetValueByDescription<VerticalAlignment>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextField.TextColor), typeof(Color), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -273,7 +298,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.TextColor, textField.internalTextColor.SwigCPtr);
             return textField.internalTextColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PlaceholderTextColorProperty = BindableProperty.Create(nameof(TextField.PlaceholderTextColor), typeof(Vector4), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -295,7 +322,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.PlaceholderTextColor, textField.internalPlaceholderTextColor.SwigCPtr);
             return textField.internalPlaceholderTextColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableGrabHandleProperty = BindableProperty.Create(nameof(TextField.EnableGrabHandle), typeof(bool), typeof(TextField), true, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -312,7 +341,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandle);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableGrabHandlePopupProperty = BindableProperty.Create(nameof(TextField.EnableGrabHandlePopup), typeof(bool), typeof(TextField), true, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -329,7 +360,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableGrabHandlePopup);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PrimaryCursorColorProperty = BindableProperty.Create(nameof(TextField.PrimaryCursorColor), typeof(Vector4), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -351,7 +384,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.PrimaryCursorColor, textField.internalPrimaryCursorColor.SwigCPtr);
             return textField.internalPrimaryCursorColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SecondaryCursorColorProperty = BindableProperty.Create(nameof(TextField.SecondaryCursorColor), typeof(Vector4), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -373,7 +408,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.SecondaryCursorColor, textField.internalSecondaryCursorColor.SwigCPtr);
             return textField.internalSecondaryCursorColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableCursorBlinkProperty = BindableProperty.Create(nameof(TextField.EnableCursorBlink), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -390,7 +427,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableCursorBlink);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CursorBlinkIntervalProperty = BindableProperty.Create(nameof(TextField.CursorBlinkInterval), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -407,7 +446,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkInterval);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CursorBlinkDurationProperty = BindableProperty.Create(nameof(TextField.CursorBlinkDuration), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -424,7 +465,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CursorBlinkDuration);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CursorWidthProperty = BindableProperty.Create(nameof(TextField.CursorWidth), typeof(int), typeof(TextField), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -441,7 +484,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.CursorWidth);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty GrabHandleImageProperty = BindableProperty.Create(nameof(TextField.GrabHandleImage), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -458,7 +503,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandleImage);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty GrabHandlePressedImageProperty = BindableProperty.Create(nameof(TextField.GrabHandlePressedImage), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -475,7 +522,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.GrabHandlePressedImage);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollThresholdProperty = BindableProperty.Create(nameof(TextField.ScrollThreshold), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -492,7 +541,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollThreshold);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ScrollSpeedProperty = BindableProperty.Create(nameof(TextField.ScrollSpeed), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -509,7 +560,8 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.ScrollSpeed);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionPopupStyleProperty = BindableProperty.Create(nameof(SelectionPopupStyle), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -526,7 +578,8 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionPopupStyle).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -544,7 +597,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionHandleImageLeft).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandleImageRightProperty = BindableProperty.Create(nameof(TextField.SelectionHandleImageRight), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -561,7 +616,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionHandleImageRight).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandlePressedImageLeftProperty = BindableProperty.Create(nameof(TextField.SelectionHandlePressedImageLeft), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -578,7 +635,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionHandlePressedImageLeft).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandlePressedImageRightProperty = BindableProperty.Create(nameof(TextField.SelectionHandlePressedImageRight), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -595,7 +654,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionHandlePressedImageRight).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandleMarkerImageLeftProperty = BindableProperty.Create(nameof(TextField.SelectionHandleMarkerImageLeft), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -612,7 +673,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionHandleMarkerImageLeft).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHandleMarkerImageRightProperty = BindableProperty.Create(nameof(TextField.SelectionHandleMarkerImageRight), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -629,7 +692,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SelectionHandleMarkerImageRight).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty SelectionHighlightColorProperty = BindableProperty.Create(nameof(TextField.SelectionHighlightColor), typeof(Vector4), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -651,7 +716,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.SelectionHighlightColor, textField.internalSelectionHighlightColor.SwigCPtr);
             return textField.internalSelectionHighlightColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty DecorationBoundingBoxProperty = BindableProperty.Create(nameof(TextField.DecorationBoundingBox), typeof(Rectangle), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -668,7 +735,9 @@ namespace Tizen.NUI.BaseComponents
             Rectangle temp = new Rectangle(0, 0, 0, 0);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.DecorationBoundingBox).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputMethodSettingsProperty = BindableProperty.Create(nameof(TextField.InputMethodSettings), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -685,7 +754,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputMethodSettings).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputColorProperty = BindableProperty.Create(nameof(TextField.InputColor), typeof(Vector4), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -707,7 +778,9 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.InputColor, textField.internalInputColor.SwigCPtr);
             return textField.internalInputColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableMarkupProperty = BindableProperty.Create(nameof(TextField.EnableMarkup), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -724,7 +797,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableMarkup);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputFontFamilyProperty = BindableProperty.Create(nameof(TextField.InputFontFamily), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -741,7 +816,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputFontFamily);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputFontStyleProperty = BindableProperty.Create(nameof(TextField.InputFontStyle), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -758,7 +835,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.InputFontStyle).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputPointSizeProperty = BindableProperty.Create(nameof(TextField.InputPointSize), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -775,7 +854,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.InputPointSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineProperty = BindableProperty.Create(nameof(TextField.Underline), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -792,7 +873,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.UNDERLINE).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputUnderlineProperty = BindableProperty.Create(nameof(TextField.InputUnderline), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -809,7 +892,8 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputUnderline);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -827,7 +911,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.SHADOW).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputShadowProperty = BindableProperty.Create(nameof(TextField.InputShadow), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -844,7 +930,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputShadow);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(TextField.Emboss), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -861,7 +949,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.EMBOSS);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputEmbossProperty = BindableProperty.Create(nameof(TextField.InputEmboss), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -878,7 +968,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputEmboss);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OutlineProperty = BindableProperty.Create(nameof(TextField.Outline), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -895,7 +987,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.OUTLINE).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty InputOutlineProperty = BindableProperty.Create(nameof(TextField.InputOutline), typeof(string), typeof(TextField), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -912,7 +1006,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyString(textField.SwigCPtr, TextField.Property.InputOutline);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty HiddenInputSettingsProperty = BindableProperty.Create(nameof(TextField.HiddenInputSettings), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -929,7 +1025,9 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.PropertyMap temp = new Tizen.NUI.PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.HiddenInputSettings).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PixelSizeProperty = BindableProperty.Create(nameof(TextField.PixelSize), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -946,7 +1044,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.PixelSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableSelectionProperty = BindableProperty.Create(nameof(TextField.EnableSelection), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -963,7 +1063,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableSelection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(TextField.Placeholder), typeof(PropertyMap), typeof(TextField), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -980,7 +1082,9 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.PropertyMap temp = new Tizen.NUI.PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textField.SwigCPtr, TextField.Property.PLACEHOLDER).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(TextField.Ellipsis), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -997,7 +1101,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.ELLIPSIS);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition), typeof(TextField), EllipsisPosition.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1014,7 +1120,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyInt(textField.SwigCPtr, TextField.Property.EllipsisPosition);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableShiftSelectionProperty = BindableProperty.Create(nameof(TextField.EnableShiftSelection), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1031,7 +1139,9 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableShiftSelection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(TextField.MatchSystemLanguageDirection), typeof(bool), typeof(TextField), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1048,7 +1158,8 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.MatchSystemLanguageDirection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1063,7 +1174,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var textField = (TextField)bindable;
             return textField.InternalFontSizeScale;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableFontSizeScaleProperty = BindableProperty.Create(nameof(EnableFontSizeScale), typeof(bool), typeof(TextField), default(bool), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1080,7 +1192,8 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyBool(textField.SwigCPtr, TextField.Property.EnableFontSizeScale);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1103,7 +1216,8 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textField.SwigCPtr, TextField.Property.GrabHandleColor, textField.internalGrabHandleColor.SwigCPtr);
             return textField.internalGrabHandleColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ShadowOffsetProperty
@@ -1121,7 +1235,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextField)bindable;
             return instance.InternalShadowOffset;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ShadowColorProperty
@@ -1139,7 +1254,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextField)bindable;
             return instance.InternalShadowColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// EnableEditingProperty
@@ -1157,7 +1273,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextField)bindable;
             return instance.InternalEnableEditing;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PrimaryCursorPositionProperty
@@ -1175,7 +1292,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextField)bindable;
             return instance.InternalPrimaryCursorPosition;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(nameof(CharacterSpacing), typeof(float), typeof(TextField), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -1192,6 +1311,7 @@ namespace Tizen.NUI.BaseComponents
             var textField = (TextField)bindable;
 
             return Object.InternalGetPropertyFloat(textField.SwigCPtr, TextField.Property.CharacterSpacing);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -50,7 +50,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
             return textLabel.translatableText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(TextLabel), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -73,7 +75,9 @@ namespace Tizen.NUI.BaseComponents
 
             // Do not try to get string if we know that previous text was empty.
             return textLabel.textIsEmpty ? "" : Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.TEXT);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(TextLabel), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -94,7 +98,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
             return textLabel.InternalFontFamily;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -112,7 +118,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.FontStyle).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PointSizeProperty = BindableProperty.Create(nameof(PointSize), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -134,7 +142,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.PointSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MultiLineProperty = BindableProperty.Create(nameof(MultiLine), typeof(bool), typeof(TextLabel), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -152,7 +162,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MultiLine);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment), typeof(TextLabel), HorizontalAlignment.Begin, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -187,7 +199,9 @@ namespace Tizen.NUI.BaseComponents
             {
                 return HorizontalAlignment.End;
             }
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment), typeof(TextLabel), VerticalAlignment.Bottom, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -222,7 +236,9 @@ namespace Tizen.NUI.BaseComponents
             {
                 return VerticalAlignment.Bottom;
             }
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -249,7 +265,8 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.TextColor, textLabel.internalTextColor.SwigCPtr);
             return textLabel.internalTextColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AnchorColorProperty = BindableProperty.Create(nameof(TextLabel.AnchorColor), typeof(Color), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -270,7 +287,8 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.TextColor, textLabel.internalAnchorColor.SwigCPtr);
             return textLabel.internalAnchorColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AnchorClickedColorProperty = BindableProperty.Create(nameof(TextLabel.AnchorClickedColor), typeof(Color), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -291,7 +309,8 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.TextColor, textLabel.internalAnchorClickedColor.SwigCPtr);
             return textLabel.internalAnchorClickedColor;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -309,7 +328,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableMarkup);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableAutoScrollProperty = BindableProperty.Create(nameof(EnableAutoScroll), typeof(bool), typeof(TextLabel), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -326,7 +347,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollSpeedProperty = BindableProperty.Create(nameof(AutoScrollSpeed), typeof(int), typeof(TextLabel), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -343,7 +366,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollLoopCountProperty = BindableProperty.Create(nameof(AutoScrollLoopCount), typeof(int), typeof(TextLabel), default(int), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -360,7 +385,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollGapProperty = BindableProperty.Create(nameof(AutoScrollGap), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -377,7 +404,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LineSpacingProperty = BindableProperty.Create(nameof(LineSpacing), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -395,7 +424,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.LineSpacing);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
@@ -411,7 +442,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineProperty = BindableProperty.Create(nameof(Underline), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -428,7 +461,8 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.UNDERLINE).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -446,7 +480,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.SHADOW).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextShadowProperty = BindableProperty.Create(nameof(TextShadow), typeof(TextShadow), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -469,7 +505,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.SHADOW).Get(temp);
             return temp.Empty() ? null : new TextShadow(temp);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextLabel), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -486,7 +524,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.EMBOSS);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OutlineProperty = BindableProperty.Create(nameof(Outline), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -503,7 +543,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.OUTLINE).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PixelSizeProperty = BindableProperty.Create(nameof(PixelSize), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -525,7 +567,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.PixelSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool), typeof(TextLabel), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -542,7 +586,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition), typeof(TextLabel), EllipsisPosition.End, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -559,7 +605,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return (EllipsisPosition)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollLoopDelayProperty = BindableProperty.Create(nameof(AutoScrollLoopDelay), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -576,7 +624,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollStopModeProperty = BindableProperty.Create(nameof(AutoScrollStopMode), typeof(AutoScrollStopMode), typeof(TextLabel), AutoScrollStopMode.FinishLoop, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -595,7 +645,9 @@ namespace Tizen.NUI.BaseComponents
 
             temp = Object.InternalGetPropertyString(textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode);
             return temp.GetValueByDescription<AutoScrollStopMode>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LineWrapModeProperty = BindableProperty.Create(nameof(LineWrapMode), typeof(LineWrapMode), typeof(TextLabel), LineWrapMode.Word, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -612,7 +664,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return (LineWrapMode)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.LineWrapMode);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty VerticalLineAlignmentProperty = BindableProperty.Create(nameof(VerticalLineAlignment), typeof(VerticalLineAlignment), typeof(TextLabel), VerticalLineAlignment.Bottom, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -629,7 +683,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return (VerticalLineAlignment)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool), typeof(TextLabel), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -646,7 +702,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CharacterSpacingProperty = BindableProperty.Create(nameof(CharacterSpacing), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -663,7 +721,9 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// Only for XAML. No need of public API. Make hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextFitProperty = BindableProperty.Create(nameof(TextFit), typeof(PropertyMap), typeof(TextLabel), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -680,7 +740,8 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.TextFit).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// Only for XAML. No need of public API. Make hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -699,7 +760,8 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.MinLineSize);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float), typeof(TextLabel), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -714,7 +776,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
             return textLabel.InternalFontSizeScale;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableFontSizeScaleProperty = BindableProperty.Create(nameof(EnableFontSizeScale), typeof(bool), typeof(TextLabel), default(bool), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -732,7 +795,8 @@ namespace Tizen.NUI.BaseComponents
             var textLabel = (TextLabel)bindable;
 
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ShadowOffsetProperty
@@ -750,7 +814,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalShadowOffset;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ShadowColorProperty
@@ -768,7 +833,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalShadowColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// UnderlineEnabledProperty
@@ -786,7 +852,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalUnderlineEnabled;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// UnderlineColorProperty
@@ -804,7 +871,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalUnderlineColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// UnderlineHeightProperty
@@ -822,7 +890,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalUnderlineHeight;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         internal Selector<string> TranslatableTextSelector
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
@@ -36,7 +36,8 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         /// ViewBoxProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ViewBoxProperty = BindableProperty.Create(nameof(ViewBox), typeof(Tizen.NUI.Size2D), typeof(Tizen.NUI.BaseComponents.VectorGraphics.CanvasView), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ViewBoxProperty = BindableProperty.Create(nameof(ViewBox), typeof(Tizen.NUI.Size2D), typeof(Tizen.NUI.BaseComponents.VectorGraphics.CanvasView), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.BaseComponents.VectorGraphics.CanvasView)bindable;
             if (newValue != null)
@@ -48,7 +49,8 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
         {
             var instance = (Tizen.NUI.BaseComponents.VectorGraphics.CanvasView)bindable;
             return instance.InternalViewBox;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Creates an initialized CanvasView.

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -43,7 +43,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((HandleRef)videoView.SwigCPtr, VideoView.Property.VIDEO).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LoopingProperty = BindableProperty.Create(nameof(Looping), typeof(bool), typeof(VideoView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -60,7 +62,9 @@ namespace Tizen.NUI.BaseComponents
             bool temp = false;
             Tizen.NUI.Object.GetProperty((HandleRef)videoView.SwigCPtr, VideoView.Property.LOOPING).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MutedProperty = BindableProperty.Create(nameof(Muted), typeof(bool), typeof(VideoView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -77,7 +81,9 @@ namespace Tizen.NUI.BaseComponents
             bool temp = false;
             Tizen.NUI.Object.GetProperty((HandleRef)videoView.SwigCPtr, VideoView.Property.MUTED).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty VolumeProperty = BindableProperty.Create(nameof(Volume), typeof(PropertyMap), typeof(VideoView), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -94,7 +100,9 @@ namespace Tizen.NUI.BaseComponents
             PropertyMap temp = new PropertyMap();
             Tizen.NUI.Object.GetProperty((HandleRef)videoView.SwigCPtr, VideoView.Property.VOLUME).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlayProperty = BindableProperty.Create(nameof(Underlay), typeof(bool), typeof(VideoView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -111,7 +119,9 @@ namespace Tizen.NUI.BaseComponents
             bool temp = false;
             Tizen.NUI.Object.GetProperty((HandleRef)videoView.SwigCPtr, VideoView.Property.UNDERLAY).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ResourceUrlProperty = BindableProperty.Create(nameof(ResourceUrl), typeof(string), typeof(VideoView), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
@@ -128,7 +138,8 @@ namespace Tizen.NUI.BaseComponents
             string temp;
             Tizen.NUI.Object.GetProperty((HandleRef)videoView.SwigCPtr, VideoView.Property.VIDEO).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private FinishedCallbackDelegate videoViewFinishedCallbackDelegate;
         private EventHandler<FinishedEventArgs> videoViewFinishedEventHandler;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -62,7 +62,8 @@ namespace Tizen.NUI.BaseComponents
             if (!string.IsNullOrEmpty(view.styleName)) return view.styleName;
 
             return Object.InternalGetPropertyString(view.SwigCPtr, View.Property.StyleName);
-        }));
+        }),
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// KeyInputFocusProperty
@@ -80,7 +81,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.KeyInputFocus);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BackgroundColorProperty
@@ -119,7 +121,8 @@ namespace Tizen.NUI.BaseComponents
                     Interop.View.InternalRetrievingVisualPropertyVector4(view.SwigCPtr, Property.BACKGROUND, ColorVisualProperty.MixColor, Color.getCPtr(view.internalBackgroundColor));
                 }
                 return view.internalBackgroundColor;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -153,7 +156,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector4(view.SwigCPtr, View.Property.COLOR, view.internalColor.SwigCPtr);
                 return view.internalColor;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -171,7 +175,8 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
 
                 return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorRed);
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -189,7 +194,8 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
 
                 return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorGreen);
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -207,7 +213,8 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
 
                 return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorBlue);
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary> BackgroundImageProperty </summary>
@@ -215,12 +222,6 @@ namespace Tizen.NUI.BaseComponents
         public static readonly BindableProperty BackgroundImageProperty = BindableProperty.Create(nameof(BackgroundImage), typeof(string), typeof(View), default(string),
             propertyChanged: (bindable, oldValue, newValue) =>
             {
-                if (String.Equals(oldValue, newValue))
-                {
-                    NUILog.Debug($"oldValue={oldValue} newValue={newValue} are same. just return here");
-                    return;
-                }
-
                 var view = (View)bindable;
 
                 if (view.themeData?.selectorData != null)
@@ -247,7 +248,8 @@ namespace Tizen.NUI.BaseComponents
                 Interop.View.InternalRetrievingVisualPropertyString(view.SwigCPtr, Property.BACKGROUND, ImageVisualProperty.URL, out backgroundImage);
 
                 return backgroundImage;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
 
@@ -274,7 +276,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return view.backgroundExtraData?.BackgroundImageBorder;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BackgroundProperty
@@ -316,7 +319,8 @@ namespace Tizen.NUI.BaseComponents
                 propertyValue.Dispose();
                 propertyValue = null;
                 return tmp;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -343,7 +347,8 @@ namespace Tizen.NUI.BaseComponents
                 case 2: return States.Disabled;
                 default: return States.Normal;
             }
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// SubStateProperty
@@ -365,7 +370,8 @@ namespace Tizen.NUI.BaseComponents
             string temp;
             temp = Object.InternalGetPropertyString(view.SwigCPtr, View.Property.SubState);
             return temp.GetValueByDescription<States>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TooltipProperty
@@ -385,7 +391,8 @@ namespace Tizen.NUI.BaseComponents
             Tizen.NUI.PropertyMap temp = new Tizen.NUI.PropertyMap();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.TOOLTIP).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FlexProperty
@@ -403,7 +410,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, FlexContainer.ChildProperty.FLEX);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AlignSelfProperty
@@ -421,7 +429,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyInt(view.SwigCPtr, FlexContainer.ChildProperty.AlignSelf);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FlexMarginProperty
@@ -441,7 +450,8 @@ namespace Tizen.NUI.BaseComponents
             Vector4 temp = new Vector4(0.0f, 0.0f, 0.0f, 0.0f);
             Object.InternalRetrievingPropertyVector4(view.SwigCPtr, FlexContainer.ChildProperty.FlexMargin, temp.SwigCPtr);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CellIndexProperty
@@ -465,7 +475,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector2(view.SwigCPtr, TableView.ChildProperty.CellIndex, view.internalCellIndex.SwigCPtr);
                 return view.internalCellIndex;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -484,7 +495,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, TableView.ChildProperty.RowSpan);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ColumnSpanProperty
@@ -502,7 +514,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, TableView.ChildProperty.ColumnSpan);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CellHorizontalAlignmentProperty
@@ -525,7 +538,8 @@ namespace Tizen.NUI.BaseComponents
             string temp;
             temp = Object.InternalGetPropertyString(view.SwigCPtr, TableView.ChildProperty.CellHorizontalAlignment);
             return temp.GetValueByDescription<HorizontalAlignmentType>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CellVerticalAlignmentProperty
@@ -548,7 +562,8 @@ namespace Tizen.NUI.BaseComponents
             string temp;
             temp = Object.InternalGetPropertyString(view.SwigCPtr, TableView.ChildProperty.CellVerticalAlignment);
             return temp.GetValueByDescription<VerticalAlignmentType>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// "DO not use this, that will be deprecated. Use 'View Weight' instead of BindableProperty"
@@ -568,7 +583,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.Weight;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LeftFocusableViewProperty
@@ -585,7 +601,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (view.LeftFocusableViewId >= 0) { return view.ConvertIdToView((uint)view.LeftFocusableViewId); }
             return null;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RightFocusableViewProperty
@@ -602,7 +619,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (view.RightFocusableViewId >= 0) { return view.ConvertIdToView((uint)view.RightFocusableViewId); }
             return null;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// UpFocusableViewProperty
@@ -619,7 +637,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (view.UpFocusableViewId >= 0) { return view.ConvertIdToView((uint)view.UpFocusableViewId); }
             return null;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DownFocusableViewProperty
@@ -636,7 +655,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (view.DownFocusableViewId >= 0) { return view.ConvertIdToView((uint)view.DownFocusableViewId); }
             return null;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ClockwiseFocusableViewProperty
@@ -653,7 +673,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (view.ClockwiseFocusableViewId >= 0) { return view.ConvertIdToView((uint)view.ClockwiseFocusableViewId); }
             return null;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CounterClockwiseFocusableViewProperty
@@ -670,7 +691,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (view.CounterClockwiseFocusableViewId >= 0) { return view.ConvertIdToView((uint)view.CounterClockwiseFocusableViewId); }
             return null;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FocusableProperty
@@ -685,7 +707,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.IsKeyboardFocusable();
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FocusableChildrenProperty
@@ -700,7 +723,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.AreChildrenKeyBoardFocusable();
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FocusableInTouchProperty
@@ -715,7 +739,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.IsFocusableInTouch();
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Size2DProperty
@@ -766,7 +791,8 @@ namespace Tizen.NUI.BaseComponents
                 Object.InternalRetrievingPropertyVector2ActualVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize2D.SwigCPtr);
 
                 return view.internalSize2D;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -793,7 +819,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.OPACITY);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Position2DProperty
@@ -817,7 +844,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector2ActualVector3(view.SwigCPtr, View.Property.POSITION, view.internalPosition2D.SwigCPtr);
                 return view.internalPosition2D;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -836,7 +864,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.PositionUsesAnchorPoint);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// SiblingOrderProperty
@@ -885,7 +914,8 @@ namespace Tizen.NUI.BaseComponents
             }
 
             return 0;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ParentOriginProperty
@@ -905,7 +935,8 @@ namespace Tizen.NUI.BaseComponents
             Position temp = new Position(0.0f, 0.0f, 0.0f);
             Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.ParentOrigin, temp.SwigCPtr);
             return temp;
-        })
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -930,7 +961,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.AnchorPoint, view.internalPivotPoint.SwigCPtr);
                 return view.internalPivotPoint;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -964,7 +996,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.SizeWidth);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// SizeHeightProperty
@@ -997,7 +1030,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.SizeHeight);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PositionProperty
@@ -1021,7 +1055,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.POSITION, view.internalPosition.SwigCPtr);
                 return view.internalPosition;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1040,7 +1075,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionX);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PositionYProperty
@@ -1058,7 +1094,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionY);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PositionZProperty
@@ -1076,7 +1113,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionZ);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// OrientationProperty
@@ -1096,7 +1134,8 @@ namespace Tizen.NUI.BaseComponents
             Rotation temp = new Rotation();
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)view.SwigCPtr, View.Property.ORIENTATION).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ScaleProperty
@@ -1120,7 +1159,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SCALE, view.internalScale.SwigCPtr);
                 return view.internalScale;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1139,7 +1179,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleX);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ScaleYProperty
@@ -1157,7 +1198,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleY);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ScaleZProperty
@@ -1175,7 +1217,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleZ);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// NameProperty
@@ -1195,7 +1238,8 @@ namespace Tizen.NUI.BaseComponents
             {
                 var view = (View)bindable;
                 return view.internalName;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1214,7 +1258,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.SENSITIVE);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// IsEnabledProperty
@@ -1233,7 +1278,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.UserInteractionEnabled);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DispatchKeyEventsProperty
@@ -1251,7 +1297,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.DispatchKeyEvents);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LeaveRequiredProperty
@@ -1269,7 +1316,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.LeaveRequired);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// InheritOrientationProperty
@@ -1287,7 +1335,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.InheritOrientation);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// InheritScaleProperty
@@ -1305,7 +1354,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.InheritScale);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DrawModeProperty
@@ -1323,7 +1373,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return (DrawModeType)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.DrawMode);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// SizeModeFactorProperty
@@ -1347,7 +1398,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SizeModeFactor, view.internalSizeModeFactor.SwigCPtr);
                 return view.internalSizeModeFactor;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1407,7 +1459,8 @@ namespace Tizen.NUI.BaseComponents
 
             temp = Object.InternalGetPropertyString(view.SwigCPtr, View.Property.WidthResizePolicy);
             return temp.GetValueByDescription<ResizePolicyType>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// HeightResizePolicyProperty
@@ -1467,7 +1520,8 @@ namespace Tizen.NUI.BaseComponents
 
             temp = Object.InternalGetPropertyString(view.SwigCPtr, View.Property.HeightResizePolicy);
             return temp.GetValueByDescription<ResizePolicyType>();
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// SizeScalePolicyProperty
@@ -1489,7 +1543,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return (SizeScalePolicyType)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.SizeScalePolicy);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// WidthForHeightProperty
@@ -1508,7 +1563,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.WidthForHeight);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// HeightForWidthProperty
@@ -1528,7 +1584,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.HeightForWidth);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PaddingProperty
@@ -1586,7 +1643,8 @@ namespace Tizen.NUI.BaseComponents
                 }
 
                 return view.internalPadding;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1646,7 +1704,8 @@ namespace Tizen.NUI.BaseComponents
                 Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize.SwigCPtr);
 
                 return view.internalSize;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1673,7 +1732,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, view.internalMinimumSize.SwigCPtr);
                 return view.internalMinimumSize;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1700,7 +1760,8 @@ namespace Tizen.NUI.BaseComponents
                 }
                 Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, view.internalMaximumSize.SwigCPtr);
                 return view.internalMaximumSize;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1720,7 +1781,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.InheritPosition);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ClippingModeProperty
@@ -1740,7 +1802,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return (ClippingModeType)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.ClippingMode);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// InheritLayoutDirectionProperty
@@ -1760,7 +1823,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.InheritLayoutDirection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LayoutDirectionProperty
@@ -1780,7 +1844,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return (ViewLayoutDirectionType)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.LayoutDirection);
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// MarginProperty
@@ -1839,7 +1904,8 @@ namespace Tizen.NUI.BaseComponents
                 }
 
                 return view.internalMargin;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -1862,7 +1928,8 @@ namespace Tizen.NUI.BaseComponents
 
             Object.InternalRetrievingPropertyVector4(view.SwigCPtr, Interop.ActorProperty.UpdateAreaHintGet(), temp.SwigCPtr);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ImageShadow Property
@@ -1896,7 +1963,8 @@ namespace Tizen.NUI.BaseComponents
 
             var shadow = new ImageShadow(map);
             return shadow.IsEmpty() ? null : shadow;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Shadow Property
@@ -1930,7 +1998,8 @@ namespace Tizen.NUI.BaseComponents
 
             var shadow = new Shadow(map);
             return shadow.IsEmpty() ? null : shadow;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CornerRadius Property
@@ -1946,7 +2015,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.backgroundExtraData == null ? 0.0f : view.backgroundExtraData.CornerRadius;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CornerRadiusPolicy Property
@@ -1966,7 +2036,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.backgroundExtraData == null ? VisualTransformPolicyType.Absolute : view.backgroundExtraData.CornerRadiusPolicy;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BorderlineWidth Property
@@ -1982,7 +2053,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.backgroundExtraData == null ? 0.0f : view.backgroundExtraData.BorderlineWidth;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BorderlineColor Property
@@ -2009,7 +2081,8 @@ namespace Tizen.NUI.BaseComponents
             {
                 var view = (View)bindable;
                 return view.backgroundExtraData == null ? Color.Black : view.backgroundExtraData.BorderlineColor;
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -2039,7 +2112,8 @@ namespace Tizen.NUI.BaseComponents
                 var view = (View)bindable;
                 var selector = view.themeData?.selectorData?.BorderlineColor?.Get();
                 return (null != selector) ? selector : new Selector<Color>();
-            }
+            },
+            valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue
         );
 
         /// <summary>
@@ -2056,7 +2130,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
             return view.backgroundExtraData == null ? 0.0f : view.backgroundExtraData.BorderlineOffset;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// EnableControlState property
@@ -2083,7 +2158,8 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((View)bindable).enableControlState;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ThemeChangeSensitive property
@@ -2113,7 +2189,8 @@ namespace Tizen.NUI.BaseComponents
         defaultValueCreator: (bindable) =>
         {
             return ((View)bindable).themeData?.ThemeChangeSensitive ?? ThemeManager.ApplicationThemeChangeSensitive;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AccessibilityNameProperty
@@ -2133,7 +2210,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyString(view.SwigCPtr, View.Property.AccessibilityName);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AccessibilityDescriptionProperty
@@ -2153,7 +2231,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyString(view.SwigCPtr, View.Property.AccessibilityDescription);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AccessibilityTranslationDomainProperty
@@ -2173,7 +2252,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyString(view.SwigCPtr, View.Property.AccessibilityTranslationDomain);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AccessibilityRoleProperty
@@ -2193,7 +2273,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return (Role)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.AccessibilityRole);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AccessibilityHighlightableProperty
@@ -2213,7 +2294,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.AccessibilityHighlightable);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AccessibilityHiddenProperty
@@ -2233,7 +2315,8 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
 
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.AccessibilityHidden);
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ExcludeLayoutingProperty
@@ -2251,7 +2334,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalExcludeLayouting;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TooltipTextProperty
@@ -2269,7 +2353,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalTooltipText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PositionUsesAnchorPointProperty
@@ -2287,7 +2372,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalPositionUsesAnchorPoint;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AnchorPointProperty
@@ -2305,7 +2391,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalAnchorPoint;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// WidthSpecificationProperty
@@ -2323,7 +2410,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalWidthSpecification;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// HeightSpecificationProperty
@@ -2341,7 +2429,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalHeightSpecification;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LayoutTransitionProperty
@@ -2359,7 +2448,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalLayoutTransition;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PaddingEXProperty
@@ -2377,7 +2467,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalPaddingEX;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LayoutProperty
@@ -2395,7 +2486,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalLayout;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BackgroundImageSynchronosLoadingProperty
@@ -2413,7 +2505,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalBackgroundImageSynchronosLoading;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BackgroundImageSynchronousLoadingProperty
@@ -2431,7 +2524,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalBackgroundImageSynchronousLoading;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// EnableControlStatePropagationProperty
@@ -2449,7 +2543,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalEnableControlStatePropagation;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PropagatableControlStatesProperty
@@ -2467,7 +2562,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalPropagatableControlStates;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// GrabTouchAfterLeaveProperty
@@ -2485,7 +2581,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalGrabTouchAfterLeave;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AllowOnlyOwnTouchProperty
@@ -2503,7 +2600,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalAllowOnlyOwnTouch;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
 
         /// <summary>
@@ -2522,7 +2620,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalBlendEquation;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TransitionOptionsProperty
@@ -2540,7 +2639,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalTransitionOptions;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// AutomationIdProperty
@@ -2560,7 +2660,8 @@ namespace Tizen.NUI.BaseComponents
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
 
             return Object.InternalGetPropertyString(instance.SwigCPtr, View.Property.AutomationId);
-        });
+        },
+        valuePolicy : ValuePolicy.GetNativeValueOnlyCreation);
 
         /// <summary>
         /// TouchAreaOffsetProperty
@@ -2578,7 +2679,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalTouchAreaOffset;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DispatchTouchMotionProperty
@@ -2596,7 +2698,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalDispatchTouchMotion;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DispatchHoverMotionProperty
@@ -2614,7 +2717,8 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalDispatchHoverMotion;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Gets View's Size2D set by user.

--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI
     {
         /// <summary> XamlStyleProperty </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty XamlStyleProperty = BindableProperty.Create(nameof(XamlStyle), typeof(XamlStyle), typeof(Container), default(XamlStyle), propertyChanged: (bindable, oldvalue, newvalue) => ((View)bindable).MergedStyle.Style = (XamlStyle)newvalue);
+        public static readonly BindableProperty XamlStyleProperty = BindableProperty.Create(nameof(XamlStyle), typeof(XamlStyle), typeof(Container), default(XamlStyle), propertyChanged: (bindable, oldvalue, newvalue) => ((View)bindable).MergedStyle.Style = (XamlStyle)newvalue, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         internal BaseHandle InternalParent;
         private List<View> childViews = new List<View>();

--- a/src/Tizen.NUI/src/public/CustomView/Spin.cs
+++ b/src/Tizen.NUI/src/public/CustomView/Spin.cs
@@ -34,7 +34,8 @@ namespace Tizen.NUI
         /// ValueProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(int), typeof(Tizen.NUI.Spin), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(int), typeof(Tizen.NUI.Spin), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -46,13 +47,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalValue;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// MinValueProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MinValueProperty = BindableProperty.Create(nameof(MinValue), typeof(int), typeof(Tizen.NUI.Spin), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MinValueProperty = BindableProperty.Create(nameof(MinValue), typeof(int), typeof(Tizen.NUI.Spin), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -64,13 +67,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalMinValue;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// MaxValueProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MaxValueProperty = BindableProperty.Create(nameof(MaxValue), typeof(int), typeof(Tizen.NUI.Spin), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MaxValueProperty = BindableProperty.Create(nameof(MaxValue), typeof(int), typeof(Tizen.NUI.Spin), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -82,13 +87,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalMaxValue;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// StepProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty StepProperty = BindableProperty.Create(nameof(Step), typeof(int), typeof(Tizen.NUI.Spin), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty StepProperty = BindableProperty.Create(nameof(Step), typeof(int), typeof(Tizen.NUI.Spin), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -100,13 +107,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalStep;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// WrappingEnabledProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty WrappingEnabledProperty = BindableProperty.Create(nameof(WrappingEnabled), typeof(bool), typeof(Tizen.NUI.Spin), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty WrappingEnabledProperty = BindableProperty.Create(nameof(WrappingEnabled), typeof(bool), typeof(Tizen.NUI.Spin), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -118,13 +127,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalWrappingEnabled;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TextPointSizeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TextPointSizeProperty = BindableProperty.Create(nameof(TextPointSize), typeof(int), typeof(Tizen.NUI.Spin), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty TextPointSizeProperty = BindableProperty.Create(nameof(TextPointSize), typeof(int), typeof(Tizen.NUI.Spin), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -136,13 +147,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalTextPointSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TextColorProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Tizen.NUI.Color), typeof(Tizen.NUI.Spin), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Tizen.NUI.Color), typeof(Tizen.NUI.Spin), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -154,13 +167,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalTextColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// MaxTextLengthProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MaxTextLengthProperty = BindableProperty.Create(nameof(MaxTextLength), typeof(int), typeof(Tizen.NUI.Spin), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MaxTextLengthProperty = BindableProperty.Create(nameof(MaxTextLength), typeof(int), typeof(Tizen.NUI.Spin), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -172,13 +187,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalMaxTextLength;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// SpinTextProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SpinTextProperty = BindableProperty.Create(nameof(SpinText), typeof(Tizen.NUI.BaseComponents.TextField), typeof(Tizen.NUI.Spin), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty SpinTextProperty = BindableProperty.Create(nameof(SpinText), typeof(Tizen.NUI.BaseComponents.TextField), typeof(Tizen.NUI.Spin), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -190,13 +207,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalSpinText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// IndicatorImageProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty IndicatorImageProperty = BindableProperty.Create(nameof(IndicatorImage), typeof(string), typeof(Tizen.NUI.Spin), string.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty IndicatorImageProperty = BindableProperty.Create(nameof(IndicatorImage), typeof(string), typeof(Tizen.NUI.Spin), string.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.Spin)bindable;
             if (newValue != null)
@@ -208,7 +227,8 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.Spin)bindable;
             return instance.InternalIndicatorImage;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private VisualBase arrowVisual;
         private TextField textField;

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -41,7 +41,7 @@ namespace Tizen.NUI
         /// FlexAlignmentSelfProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FlexAlignmentSelfProperty = BindableProperty.CreateAttached("FlexAlignmentSelf", typeof(AlignmentType), typeof(FlexLayout), AlignmentType.Auto, validateValue: ValidateEnum((int)AlignmentType.Auto, (int)AlignmentType.Stretch), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FlexAlignmentSelfProperty = BindableProperty.CreateAttached("FlexAlignmentSelf", typeof(AlignmentType), typeof(FlexLayout), AlignmentType.Auto, validateValue: ValidateEnum((int)AlignmentType.Auto, (int)AlignmentType.Stretch), propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FlexPositionTypeProperty
@@ -62,32 +62,33 @@ namespace Tizen.NUI
                 return PositionType.Absolute;
 
             return PositionType.Relative;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
 
         /// <summary>
         /// AspectRatioProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FlexAspectRatioProperty = BindableProperty.CreateAttached("FlexAspectRatio", typeof(float), typeof(FlexLayout), FlexUndefined, validateValue: (bindable, value) => (float)value > 0, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FlexAspectRatioProperty = BindableProperty.CreateAttached("FlexAspectRatio", typeof(float), typeof(FlexLayout), FlexUndefined, validateValue: (bindable, value) => (float)value > 0, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FlexBasisProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FlexBasisProperty = BindableProperty.CreateAttached("FlexBasis", typeof(float), typeof(FlexLayout), FlexUndefined, validateValue: (bindable, value) => (float)value >= 0, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FlexBasisProperty = BindableProperty.CreateAttached("FlexBasis", typeof(float), typeof(FlexLayout), FlexUndefined, validateValue: (bindable, value) => (float)value >= 0, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FlexShrinkProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FlexShrinkProperty = BindableProperty.CreateAttached("FlexShrink", typeof(float), typeof(FlexLayout), 1.0f, validateValue: (bindable, value) => (float)value >= 0, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FlexShrinkProperty = BindableProperty.CreateAttached("FlexShrink", typeof(float), typeof(FlexLayout), 1.0f, validateValue: (bindable, value) => (float)value >= 0, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FlexGrowProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FlexGrowProperty = BindableProperty.CreateAttached("FlexGrow", typeof(float), typeof(FlexLayout), FlexUndefined, validateValue: (bindable, value) => (float)value >= 0, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FlexGrowProperty = BindableProperty.CreateAttached("FlexGrow", typeof(float), typeof(FlexLayout), FlexUndefined, validateValue: (bindable, value) => (float)value >= 0, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
         private bool swigCMemOwn;

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -30,49 +30,49 @@ namespace Tizen.NUI
         /// ColumnProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ColumnProperty = BindableProperty.CreateAttached("Column", typeof(int), typeof(GridLayout), AutoColumn, validateValue: (bindable, value) => (int)value >= 0 || (int)value == AutoColumn, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty ColumnProperty = BindableProperty.CreateAttached("Column", typeof(int), typeof(GridLayout), AutoColumn, validateValue: (bindable, value) => (int)value >= 0 || (int)value == AutoColumn, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// ColumnSpanProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ColumnSpanProperty = BindableProperty.CreateAttached("ColumnSpan", typeof(int), typeof(GridLayout), 1, validateValue: (bindable, value) => (int)value >= 1, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty ColumnSpanProperty = BindableProperty.CreateAttached("ColumnSpan", typeof(int), typeof(GridLayout), 1, validateValue: (bindable, value) => (int)value >= 1, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RowProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RowProperty = BindableProperty.CreateAttached("Row", typeof(int), typeof(GridLayout), AutoRow, validateValue: (bindable, value) => (int)value >= 0 || (int)value == AutoRow, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty RowProperty = BindableProperty.CreateAttached("Row", typeof(int), typeof(GridLayout), AutoRow, validateValue: (bindable, value) => (int)value >= 0 || (int)value == AutoRow, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RowSpanProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RowSpanProperty = BindableProperty.CreateAttached("RowSpan", typeof(int), typeof(GridLayout), 1, validateValue: (bindable, value) => (int)value >= 1, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty RowSpanProperty = BindableProperty.CreateAttached("RowSpan", typeof(int), typeof(GridLayout), 1, validateValue: (bindable, value) => (int)value >= 1, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// HorizontalStretchProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty HorizontalStretchProperty = BindableProperty.CreateAttached("HorizontalStretch", typeof(StretchFlags), typeof(GridLayout), default(StretchFlags), validateValue: ValidateEnum((int)StretchFlags.None, (int)StretchFlags.ExpandAndFill), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty HorizontalStretchProperty = BindableProperty.CreateAttached("HorizontalStretch", typeof(StretchFlags), typeof(GridLayout), default(StretchFlags), validateValue: ValidateEnum((int)StretchFlags.None, (int)StretchFlags.ExpandAndFill), propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// VerticalStretchProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty VerticalStretchProperty = BindableProperty.CreateAttached("VerticalStretch", typeof(StretchFlags), typeof(GridLayout), default(StretchFlags), validateValue: ValidateEnum((int)StretchFlags.None, (int)StretchFlags.ExpandAndFill), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty VerticalStretchProperty = BindableProperty.CreateAttached("VerticalStretch", typeof(StretchFlags), typeof(GridLayout), default(StretchFlags), validateValue: ValidateEnum((int)StretchFlags.None, (int)StretchFlags.ExpandAndFill), propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// HorizontalAlignmentProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.CreateAttached("HorizontalAlignment", typeof(Alignment), typeof(GridLayout), Alignment.Start, validateValue: ValidateEnum((int)Alignment.Start, (int)Alignment.End), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.CreateAttached("HorizontalAlignment", typeof(Alignment), typeof(GridLayout), Alignment.Start, validateValue: ValidateEnum((int)Alignment.Start, (int)Alignment.End), propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// VerticalAlignmentProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.CreateAttached("VerticalAlignment", typeof(Alignment), typeof(GridLayout), Alignment.Start, validateValue: ValidateEnum((int)Alignment.Start, (int)Alignment.End), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.CreateAttached("VerticalAlignment", typeof(Alignment), typeof(GridLayout), Alignment.Start, validateValue: ValidateEnum((int)Alignment.Start, (int)Alignment.End), propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
@@ -30,73 +30,73 @@ namespace Tizen.NUI
         /// LeftTargetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LeftTargetProperty = BindableProperty.CreateAttached("LeftTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty LeftTargetProperty = BindableProperty.CreateAttached("LeftTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RightTargetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RightTargetProperty = BindableProperty.CreateAttached("RightTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty RightTargetProperty = BindableProperty.CreateAttached("RightTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TopTargetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TopTargetProperty = BindableProperty.CreateAttached("TopTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty TopTargetProperty = BindableProperty.CreateAttached("TopTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BottomTargetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BottomTargetProperty = BindableProperty.CreateAttached("BottomTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty BottomTargetProperty = BindableProperty.CreateAttached("BottomTarget", typeof(View), typeof(RelativeLayout), null, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LeftRelativeOffsetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LeftRelativeOffsetProperty = BindableProperty.CreateAttached("LeftRelativeOffset", typeof(float), typeof(RelativeLayout), 0.0f, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty LeftRelativeOffsetProperty = BindableProperty.CreateAttached("LeftRelativeOffset", typeof(float), typeof(RelativeLayout), 0.0f, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RightRelativeOffsetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RightRelativeOffsetProperty = BindableProperty.CreateAttached("RightRelativeOffset", typeof(float), typeof(RelativeLayout), 1.0f, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty RightRelativeOffsetProperty = BindableProperty.CreateAttached("RightRelativeOffset", typeof(float), typeof(RelativeLayout), 1.0f, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// TopRelativeOffsetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty TopRelativeOffsetProperty = BindableProperty.CreateAttached("TopRelativeOffset", typeof(float), typeof(RelativeLayout), 0.0f, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty TopRelativeOffsetProperty = BindableProperty.CreateAttached("TopRelativeOffset", typeof(float), typeof(RelativeLayout), 0.0f, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// BottomRelativeOffsetProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BottomRelativeOffsetProperty = BindableProperty.CreateAttached("BottomRelativeOffset", typeof(float), typeof(RelativeLayout), 1.0f, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty BottomRelativeOffsetProperty = BindableProperty.CreateAttached("BottomRelativeOffset", typeof(float), typeof(RelativeLayout), 1.0f, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// HorizontalAlignmentProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.CreateAttached("HorizontalAlignment", typeof(Alignment), typeof(RelativeLayout), default(Alignment), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty HorizontalAlignmentProperty = BindableProperty.CreateAttached("HorizontalAlignment", typeof(Alignment), typeof(RelativeLayout), default(Alignment), propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// VerticalAlignmentProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.CreateAttached("VerticalAlignment", typeof(Alignment), typeof(RelativeLayout), default(Alignment), propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty VerticalAlignmentProperty = BindableProperty.CreateAttached("VerticalAlignment", typeof(Alignment), typeof(RelativeLayout), default(Alignment), propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FillHorizontalProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FillHorizontalProperty = BindableProperty.CreateAttached("FillHorizontal", typeof(bool), typeof(RelativeLayout), false, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FillHorizontalProperty = BindableProperty.CreateAttached("FillHorizontal", typeof(bool), typeof(RelativeLayout), false, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// FillVerticalProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty FillVerticalProperty = BindableProperty.CreateAttached("FillVertical", typeof(bool), typeof(RelativeLayout), false, propertyChanged: OnChildPropertyChanged);
+        public static readonly BindableProperty FillVerticalProperty = BindableProperty.CreateAttached("FillVertical", typeof(bool), typeof(RelativeLayout), false, propertyChanged: OnChildPropertyChanged, valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// Constructor

--- a/src/Tizen.NUI/src/public/Utility/ScrollViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/Utility/ScrollViewBindableProperty.cs
@@ -27,7 +27,8 @@ namespace Tizen.NUI
     public partial class ScrollView
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty WrapEnabledProperty = BindableProperty.Create(nameof(WrapEnabled), typeof(bool), typeof(ScrollView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty WrapEnabledProperty = BindableProperty.Create(nameof(WrapEnabled), typeof(bool), typeof(ScrollView), false,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -41,9 +42,12 @@ namespace Tizen.NUI
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.WrapEnabled).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PanningEnabledProperty = BindableProperty.Create(nameof(PanningEnabled), typeof(bool), typeof(ScrollView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PanningEnabledProperty = BindableProperty.Create(nameof(PanningEnabled), typeof(bool), typeof(ScrollView), false,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -57,9 +61,12 @@ namespace Tizen.NUI
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.PanningEnabled).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AxisAutoLockEnabledProperty = BindableProperty.Create(nameof(AxisAutoLockEnabled), typeof(bool), typeof(ScrollView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty AxisAutoLockEnabledProperty = BindableProperty.Create(nameof(AxisAutoLockEnabled), typeof(bool), typeof(ScrollView), false,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -73,9 +80,12 @@ namespace Tizen.NUI
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.AxisAutoLockEnabled).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty WheelScrollDistanceStepProperty = BindableProperty.Create(nameof(WheelScrollDistanceStep), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty WheelScrollDistanceStepProperty = BindableProperty.Create(nameof(WheelScrollDistanceStep), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -89,9 +99,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.WheelScrollDistanceStep).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollPositionProperty = BindableProperty.Create(nameof(ScrollPosition), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollPositionProperty = BindableProperty.Create(nameof(ScrollPosition), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -105,9 +118,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.ScrollPosition).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollPrePositionProperty = BindableProperty.Create(nameof(ScrollPrePosition), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollPrePositionProperty = BindableProperty.Create(nameof(ScrollPrePosition), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -121,9 +137,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.ScrollPrePosition).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollPrePositionMaxProperty = BindableProperty.Create(nameof(ScrollPrePositionMax), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollPrePositionMaxProperty = BindableProperty.Create(nameof(ScrollPrePositionMax), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -137,9 +156,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.ScrollPrePositionMax).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty OvershootXProperty = BindableProperty.Create(nameof(OvershootX), typeof(float), typeof(ScrollView), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty OvershootXProperty = BindableProperty.Create(nameof(OvershootX), typeof(float), typeof(ScrollView), default(float),
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -153,9 +175,12 @@ namespace Tizen.NUI
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.OvershootX).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty OvershootYProperty = BindableProperty.Create(nameof(OvershootY), typeof(float), typeof(ScrollView), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty OvershootYProperty = BindableProperty.Create(nameof(OvershootY), typeof(float), typeof(ScrollView), default(float),
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -169,9 +194,12 @@ namespace Tizen.NUI
             float temp = 0.0f;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.OvershootY).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollFinalProperty = BindableProperty.Create(nameof(ScrollFinal), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollFinalProperty = BindableProperty.Create(nameof(ScrollFinal), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -185,9 +213,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.ScrollFinal).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty WrapProperty = BindableProperty.Create(nameof(Wrap), typeof(bool), typeof(ScrollView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty WrapProperty = BindableProperty.Create(nameof(Wrap), typeof(bool), typeof(ScrollView), false,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -201,9 +232,12 @@ namespace Tizen.NUI
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.WRAP).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PanningProperty = BindableProperty.Create(nameof(Panning), typeof(bool), typeof(ScrollView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PanningProperty = BindableProperty.Create(nameof(Panning), typeof(bool), typeof(ScrollView), false,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -217,9 +251,12 @@ namespace Tizen.NUI
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.PANNING).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollingProperty = BindableProperty.Create(nameof(Scrolling), typeof(bool), typeof(ScrollView), false, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollingProperty = BindableProperty.Create(nameof(Scrolling), typeof(bool), typeof(ScrollView), false,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -233,9 +270,12 @@ namespace Tizen.NUI
             bool temp = false;
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.SCROLLING).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollDomainSizeProperty = BindableProperty.Create(nameof(ScrollDomainSize), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollDomainSizeProperty = BindableProperty.Create(nameof(ScrollDomainSize), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -249,9 +289,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.ScrollDomainSize).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollDomainOffsetProperty = BindableProperty.Create(nameof(ScrollDomainOffset), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollDomainOffsetProperty = BindableProperty.Create(nameof(ScrollDomainOffset), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -265,9 +308,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.ScrollDomainOffset).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollPositionDeltaProperty = BindableProperty.Create(nameof(ScrollPositionDelta), typeof(Vector2), typeof(ScrollView), Vector2.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollPositionDeltaProperty = BindableProperty.Create(nameof(ScrollPositionDelta), typeof(Vector2), typeof(ScrollView), Vector2.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -281,9 +327,12 @@ namespace Tizen.NUI
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.ScrollPositionDelta).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty StartPagePositionProperty = BindableProperty.Create(nameof(StartPagePosition), typeof(Vector3), typeof(ScrollView), Vector3.Zero, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty StartPagePositionProperty = BindableProperty.Create(nameof(StartPagePosition), typeof(Vector3), typeof(ScrollView), Vector3.Zero,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -297,9 +346,12 @@ namespace Tizen.NUI
             Vector3 temp = new Vector3(0.0f, 0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty((System.Runtime.InteropServices.HandleRef)scrollView.SwigCPtr, ScrollView.Property.StartPagePosition).Get(temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScrollModeProperty = BindableProperty.Create(nameof(ScrollMode), typeof(PropertyMap), typeof(ScrollView), new PropertyMap(), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ScrollModeProperty = BindableProperty.Create(nameof(ScrollMode), typeof(PropertyMap), typeof(ScrollView), new PropertyMap(),
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var scrollView = (ScrollView)bindable;
             if (newValue != null)
@@ -314,6 +366,7 @@ namespace Tizen.NUI
             PropertyMap map = new PropertyMap();
             value.Get(map);
             return map;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -1378,7 +1378,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int LoadProgressPercentage = Interop.WebView.LoadProgressPercentageGet();
         }
 
-        private static readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(WebView), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        private static readonly BindableProperty UrlProperty = BindableProperty.Create(nameof(Url), typeof(string), typeof(WebView), string.Empty,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1392,9 +1393,11 @@ namespace Tizen.NUI.BaseComponents
             string temp;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.Url).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty UserAgentProperty = BindableProperty.Create(nameof(UserAgent), typeof(string), typeof(WebView), string.Empty, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        private static readonly BindableProperty UserAgentProperty = BindableProperty.Create(nameof(UserAgent), typeof(string), typeof(WebView), string.Empty,
+        propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1408,9 +1411,11 @@ namespace Tizen.NUI.BaseComponents
             string temp;
             Tizen.NUI.Object.GetProperty((HandleRef)webview.SwigCPtr, WebView.Property.UserAgent).Get(out temp);
             return temp;
-        }));
+        }),
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty ScrollPositionProperty = BindableProperty.Create(nameof(ScrollPosition), typeof(Vector2), typeof(WebView), null, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty ScrollPositionProperty = BindableProperty.Create(nameof(ScrollPosition), typeof(Vector2), typeof(WebView), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1424,33 +1429,41 @@ namespace Tizen.NUI.BaseComponents
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.ScrollPosition).Get(temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty ScrollSizeProperty = BindableProperty.Create(nameof(ScrollSize), typeof(Vector2), typeof(WebView), null, defaultValueCreator: (bindable) =>
+        private static readonly BindableProperty ScrollSizeProperty = BindableProperty.Create(nameof(ScrollSize), typeof(Vector2), typeof(WebView), null,
+        defaultValueCreator: (bindable) =>
         {
             var webview = (WebView)bindable;
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.ScrollSize).Get(temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty ContentSizeProperty = BindableProperty.Create(nameof(ContentSize), typeof(Vector2), typeof(WebView), null, defaultValueCreator: (bindable) =>
+        private static readonly BindableProperty ContentSizeProperty = BindableProperty.Create(nameof(ContentSize), typeof(Vector2), typeof(WebView), null,
+        defaultValueCreator: (bindable) =>
         {
             var webview = (WebView)bindable;
             Vector2 temp = new Vector2(0.0f, 0.0f);
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.ContentSize).Get(temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(WebView), string.Empty, defaultValueCreator: (bindable) =>
+        private static readonly BindableProperty TitleProperty = BindableProperty.Create(nameof(Title), typeof(string), typeof(WebView), string.Empty,
+        defaultValueCreator: (bindable) =>
         {
             var webview = (WebView)bindable;
             string title;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.Title).Get(out title);
             return title;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty VideoHoleEnabledProperty = BindableProperty.Create(nameof(VideoHoleEnabled), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty VideoHoleEnabledProperty = BindableProperty.Create(nameof(VideoHoleEnabled), typeof(bool), typeof(WebView), true,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1464,9 +1477,11 @@ namespace Tizen.NUI.BaseComponents
             bool temp;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.VideoHoleEnabled).Get(out temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty MouseEventsEnabledProperty = BindableProperty.Create(nameof(MouseEventsEnabled), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty MouseEventsEnabledProperty = BindableProperty.Create(nameof(MouseEventsEnabled), typeof(bool), typeof(WebView), true,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1480,9 +1495,11 @@ namespace Tizen.NUI.BaseComponents
             bool temp;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.MouseEventsEnabled).Get(out temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty KeyEventsEnabledProperty = BindableProperty.Create(nameof(KeyEventsEnabled), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty KeyEventsEnabledProperty = BindableProperty.Create(nameof(KeyEventsEnabled), typeof(bool), typeof(WebView), true,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1496,9 +1513,11 @@ namespace Tizen.NUI.BaseComponents
             bool temp;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.KeyEventsEnabled).Get(out temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty ContentBackgroundColorProperty = BindableProperty.Create(nameof(ContentBackgroundColor), typeof(Color), typeof(WebView), null, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty ContentBackgroundColorProperty = BindableProperty.Create(nameof(ContentBackgroundColor), typeof(Color), typeof(WebView), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1511,9 +1530,11 @@ namespace Tizen.NUI.BaseComponents
         {
             var webview = (WebView)bindable;
             return webview.contentBackgroundColor;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty TilesClearedWhenHiddenProperty = BindableProperty.Create(nameof(TilesClearedWhenHidden), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty TilesClearedWhenHiddenProperty = BindableProperty.Create(nameof(TilesClearedWhenHidden), typeof(bool), typeof(WebView), true,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1526,9 +1547,11 @@ namespace Tizen.NUI.BaseComponents
         {
             var webview = (WebView)bindable;
             return webview.tilesClearedWhenHidden;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty TileCoverAreaMultiplierProperty = BindableProperty.Create(nameof(TileCoverAreaMultiplier), typeof(float), typeof(WebView), 0.0f, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty TileCoverAreaMultiplierProperty = BindableProperty.Create(nameof(TileCoverAreaMultiplier), typeof(float), typeof(WebView), 0.0f,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1541,9 +1564,11 @@ namespace Tizen.NUI.BaseComponents
         {
             var webview = (WebView)bindable;
             return webview.tileCoverAreaMultiplier;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty CursorEnabledByClientProperty = BindableProperty.Create(nameof(CursorEnabledByClient), typeof(bool), typeof(WebView), true, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty CursorEnabledByClientProperty = BindableProperty.Create(nameof(CursorEnabledByClient), typeof(bool), typeof(WebView), true,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1556,17 +1581,21 @@ namespace Tizen.NUI.BaseComponents
         {
             var webview = (WebView)bindable;
             return webview.cursorEnabledByClient;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty SelectedTextProperty = BindableProperty.Create(nameof(SelectedText), typeof(string), typeof(WebView), string.Empty, defaultValueCreator: (bindable) =>
+        private static readonly BindableProperty SelectedTextProperty = BindableProperty.Create(nameof(SelectedText), typeof(string), typeof(WebView), string.Empty,
+        defaultValueCreator: (bindable) =>
         {
             var webview = (WebView)bindable;
             string text;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.SelectedText).Get(out text);
             return text;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty PageZoomFactorProperty = BindableProperty.Create(nameof(PageZoomFactor), typeof(float), typeof(WebView), 0.0f, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty PageZoomFactorProperty = BindableProperty.Create(nameof(PageZoomFactor), typeof(float), typeof(WebView), 0.0f,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1580,9 +1609,11 @@ namespace Tizen.NUI.BaseComponents
             float temp;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.PageZoomFactor).Get(out temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty TextZoomFactorProperty = BindableProperty.Create(nameof(TextZoomFactor), typeof(float), typeof(WebView), 0.0f, propertyChanged: (bindable, oldValue, newValue) =>
+        private static readonly BindableProperty TextZoomFactorProperty = BindableProperty.Create(nameof(TextZoomFactor), typeof(float), typeof(WebView), 0.0f,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var webview = (WebView)bindable;
             if (newValue != null)
@@ -1596,15 +1627,18 @@ namespace Tizen.NUI.BaseComponents
             float temp;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.TextZoomFactor).Get(out temp);
             return temp;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
-        private static readonly BindableProperty LoadProgressPercentageProperty = BindableProperty.Create(nameof(LoadProgressPercentage), typeof(float), typeof(WebView), 0.0f, defaultValueCreator: (bindable) =>
+        private static readonly BindableProperty LoadProgressPercentageProperty = BindableProperty.Create(nameof(LoadProgressPercentage), typeof(float), typeof(WebView), 0.0f,
+        defaultValueCreator: (bindable) =>
         {
             var webview = (WebView)bindable;
             float percentage;
             Tizen.NUI.Object.GetProperty(webview.SwigCPtr, WebView.Property.LoadProgressPercentage).Get(out percentage);
             return percentage;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         // For rooting handlers
         internal Dictionary<string, JavaScriptMessageHandler> handlerRootMap = new Dictionary<string, JavaScriptMessageHandler>();

--- a/src/Tizen.NUI/src/public/WebView/WebViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebViewBindableProperty.cs
@@ -26,7 +26,8 @@ namespace Tizen.NUI.BaseComponents
         /// CacheModelProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CacheModelProperty = BindableProperty.Create(nameof(CacheModel), typeof(CacheModel), typeof(WebView), default(CacheModel), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty CacheModelProperty = BindableProperty.Create(nameof(CacheModel), typeof(CacheModel), typeof(WebView), default(CacheModel),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             if (newValue != null)
@@ -38,13 +39,15 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             return instance.InternalCacheModel;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// CookieAcceptPolicyProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CookieAcceptPolicyProperty = BindableProperty.Create(nameof(CookieAcceptPolicy), typeof(CookieAcceptPolicy), typeof(WebView), default(CookieAcceptPolicy), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty CookieAcceptPolicyProperty = BindableProperty.Create(nameof(CookieAcceptPolicy), typeof(CookieAcceptPolicy), typeof(WebView), default(CookieAcceptPolicy),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             if (newValue != null)
@@ -56,13 +59,15 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             return instance.InternalCookieAcceptPolicy;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// EnableJavaScriptProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EnableJavaScriptProperty = BindableProperty.Create(nameof(EnableJavaScript), typeof(bool), typeof(WebView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EnableJavaScriptProperty = BindableProperty.Create(nameof(EnableJavaScript), typeof(bool), typeof(WebView), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             if (newValue != null)
@@ -74,13 +79,15 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             return instance.InternalEnableJavaScript;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LoadImagesAutomaticallyProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LoadImagesAutomaticallyProperty = BindableProperty.Create(nameof(LoadImagesAutomatically), typeof(bool), typeof(WebView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty LoadImagesAutomaticallyProperty = BindableProperty.Create(nameof(LoadImagesAutomatically), typeof(bool), typeof(WebView), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             if (newValue != null)
@@ -92,13 +99,15 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             return instance.InternalLoadImagesAutomatically;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DefaultTextEncodingNameProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty DefaultTextEncodingNameProperty = BindableProperty.Create(nameof(DefaultTextEncodingName), typeof(string), typeof(WebView), string.Empty, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty DefaultTextEncodingNameProperty = BindableProperty.Create(nameof(DefaultTextEncodingName), typeof(string), typeof(WebView), string.Empty,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             if (newValue != null)
@@ -110,13 +119,15 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             return instance.InternalDefaultTextEncodingName;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// DefaultFontSizeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty DefaultFontSizeProperty = BindableProperty.Create(nameof(DefaultFontSize), typeof(int), typeof(WebView), 0, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty DefaultFontSizeProperty = BindableProperty.Create(nameof(DefaultFontSize), typeof(int), typeof(WebView), 0,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             if (newValue != null)
@@ -128,6 +139,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var instance = (Tizen.NUI.BaseComponents.WebView)bindable;
             return instance.InternalDefaultFontSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
     }
 }

--- a/src/Tizen.NUI/src/public/Widget/WidgetView.cs
+++ b/src/Tizen.NUI/src/public/Widget/WidgetView.cs
@@ -34,7 +34,8 @@ namespace Tizen.NUI
         /// PreviewProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PreviewProperty = BindableProperty.Create(nameof(Preview), typeof(bool), typeof(Tizen.NUI.WidgetView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PreviewProperty = BindableProperty.Create(nameof(Preview), typeof(bool), typeof(Tizen.NUI.WidgetView), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             if (newValue != null)
@@ -46,13 +47,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             return instance.InternalPreview;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// LoadingTextProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty LoadingTextProperty = BindableProperty.Create(nameof(LoadingText), typeof(bool), typeof(Tizen.NUI.WidgetView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty LoadingTextProperty = BindableProperty.Create(nameof(LoadingText), typeof(bool), typeof(Tizen.NUI.WidgetView), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             if (newValue != null)
@@ -64,13 +67,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             return instance.InternalLoadingText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// WidgetStateFaultedProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty WidgetStateFaultedProperty = BindableProperty.Create(nameof(WidgetStateFaulted), typeof(bool), typeof(Tizen.NUI.WidgetView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty WidgetStateFaultedProperty = BindableProperty.Create(nameof(WidgetStateFaulted), typeof(bool), typeof(Tizen.NUI.WidgetView), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             if (newValue != null)
@@ -82,13 +87,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             return instance.InternalWidgetStateFaulted;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// PermanentDeleteProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PermanentDeleteProperty = BindableProperty.Create(nameof(PermanentDelete), typeof(bool), typeof(Tizen.NUI.WidgetView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty PermanentDeleteProperty = BindableProperty.Create(nameof(PermanentDelete), typeof(bool), typeof(Tizen.NUI.WidgetView), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             if (newValue != null)
@@ -100,13 +107,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             return instance.InternalPermanentDelete;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// RetryTextProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RetryTextProperty = BindableProperty.Create(nameof(RetryText), typeof(Tizen.NUI.PropertyMap), typeof(Tizen.NUI.WidgetView), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty RetryTextProperty = BindableProperty.Create(nameof(RetryText), typeof(Tizen.NUI.PropertyMap), typeof(Tizen.NUI.WidgetView), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             if (newValue != null)
@@ -118,13 +127,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             return instance.InternalRetryText;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// EffectProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty EffectProperty = BindableProperty.Create(nameof(Effect), typeof(Tizen.NUI.PropertyMap), typeof(Tizen.NUI.WidgetView), null, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty EffectProperty = BindableProperty.Create(nameof(Effect), typeof(Tizen.NUI.PropertyMap), typeof(Tizen.NUI.WidgetView), null,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             if (newValue != null)
@@ -136,13 +147,15 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             return instance.InternalEffect;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         /// <summary>
         /// UpdateWidgetSizeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty KeepWidgetSizeProperty = BindableProperty.Create(nameof(KeepWidgetSize), typeof(bool), typeof(Tizen.NUI.WidgetView), false, propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty KeepWidgetSizeProperty = BindableProperty.Create(nameof(KeepWidgetSize), typeof(bool), typeof(Tizen.NUI.WidgetView), false,
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             if (newValue != null)
@@ -154,7 +167,8 @@ namespace Tizen.NUI
         {
             var instance = (Tizen.NUI.WidgetView)bindable;
             return instance.InternalKeepWidgetSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
 
         private EventHandler<WidgetViewEventArgs> widgetAddedEventHandler;

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -86,7 +86,8 @@ namespace Tizen.NUI
         #region Methods
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BorderLineThicknessProperty = BindableProperty.Create(nameof(BorderLineThickness), typeof(uint), typeof(DefaultBorder), default(uint), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty BorderLineThicknessProperty = BindableProperty.Create(nameof(BorderLineThickness), typeof(uint), typeof(DefaultBorder), default(uint),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (DefaultBorder)bindable;
             if (newValue != null)
@@ -99,10 +100,12 @@ namespace Tizen.NUI
         {
             var instance = (DefaultBorder)bindable;
             return instance.borderLineThickness;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MinSizeProperty = BindableProperty.Create(nameof(MinSize), typeof(Size2D), typeof(DefaultBorder), default(Size2D), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MinSizeProperty = BindableProperty.Create(nameof(MinSize), typeof(Size2D), typeof(DefaultBorder), default(Size2D),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (DefaultBorder)bindable;
             if (newValue != null)
@@ -115,10 +118,12 @@ namespace Tizen.NUI
         {
             var instance = (DefaultBorder)bindable;
             return instance.minSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MaxSizeProperty = BindableProperty.Create(nameof(MaxSize), typeof(Size2D), typeof(DefaultBorder), default(Size2D), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty MaxSizeProperty = BindableProperty.Create(nameof(MaxSize), typeof(Size2D), typeof(DefaultBorder), default(Size2D),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (DefaultBorder)bindable;
             if (newValue != null)
@@ -131,10 +136,12 @@ namespace Tizen.NUI
         {
             var instance = (DefaultBorder)bindable;
             return instance.maxSize;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ResizePolicyProperty = BindableProperty.Create(nameof(ResizePolicy), typeof(Window.BorderResizePolicyType), typeof(DefaultBorder), default(Window.BorderResizePolicyType), propertyChanged: (bindable, oldValue, newValue) =>
+        public static readonly BindableProperty ResizePolicyProperty = BindableProperty.Create(nameof(ResizePolicy), typeof(Window.BorderResizePolicyType), typeof(DefaultBorder), default(Window.BorderResizePolicyType),
+        propertyChanged: (bindable, oldValue, newValue) =>
         {
             var instance = (DefaultBorder)bindable;
             if (newValue != null)
@@ -147,7 +154,8 @@ namespace Tizen.NUI
         {
             var instance = (DefaultBorder)bindable;
             return instance.resizePolicy;
-        });
+        },
+        valuePolicy : ValuePolicy.IgnoreOldValueWhenSetValue);
 
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableProperty.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableProperty.cs
@@ -164,7 +164,8 @@ namespace Tizen.NUI.Binding
 
         BindableProperty(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
                                  ValidateValueDelegate validateValue = null, BindingPropertyChangedDelegate propertyChanged = null, BindingPropertyChangingDelegate propertyChanging = null,
-                                 CoerceValueDelegate coerceValue = null, BindablePropertyBindingChanging bindingChanging = null, bool isReadOnly = false, CreateDefaultValueDelegate defaultValueCreator = null)
+                                 CoerceValueDelegate coerceValue = null, BindablePropertyBindingChanging bindingChanging = null, bool isReadOnly = false, CreateDefaultValueDelegate defaultValueCreator = null,
+                                 ValuePolicy valuePolicy = ValuePolicy.Default)
         {
             if (propertyName == null)
                 throw new ArgumentNullException(nameof(propertyName));
@@ -197,6 +198,7 @@ namespace Tizen.NUI.Binding
             IsReadOnly = isReadOnly;
             DefaultValueCreator = defaultValueCreator;
             ValueGetter = defaultValueCreator;
+            SetGetValuePolicy = valuePolicy;
 
             Dictionary<string, BindableProperty> nameToBindableProperty;
             bindablePropertyOfType.TryGetValue(declaringType, out nameToBindableProperty);
@@ -305,6 +307,13 @@ namespace Tizen.NUI.Binding
         /// </summary>
         public Type ReturnType { get; }
 
+        /// <summary>
+        /// Gets a value indicating if the BindableProperty is not used old value when property changed signal invoked.
+        /// It is advanced property when we want to optimize performance.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ValuePolicy SetGetValuePolicy { get; private set; }
+
         internal BindablePropertyBindingChanging BindingChanging { get; private set; }
 
         internal CoerceValueDelegate CoerceValue { get; private set; }
@@ -334,13 +343,14 @@ namespace Tizen.NUI.Binding
         /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
         /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
         /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
+        /// <param name="valuePolicy">A policy of this bindiable property when we call set/get values</param>
         /// <returns>A newly created BindableProperty.</returns>
         public static BindableProperty Create(string propertyName, Type returnType, Type declaringType, object defaultValue = null, BindingMode defaultBindingMode = BindingMode.OneWay,
                                               ValidateValueDelegate validateValue = null, BindingPropertyChangedDelegate propertyChanged = null, BindingPropertyChangingDelegate propertyChanging = null,
-                                              CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null)
+                                              CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null, ValuePolicy valuePolicy = ValuePolicy.Default)
         {
             return new BindableProperty(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue,
-                defaultValueCreator: defaultValueCreator);
+                defaultValueCreator: defaultValueCreator, valuePolicy : valuePolicy);
         }
 
         /// <summary>
@@ -356,12 +366,13 @@ namespace Tizen.NUI.Binding
         /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
         /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
         /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
+        /// <param name="valuePolicy">A policy of this bindiable property when we call set/get values</param>
         /// <returns>A newly created BindableProperty.</returns>
         public static BindableProperty CreateAttached(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
                                                       ValidateValueDelegate validateValue = null, BindingPropertyChangedDelegate propertyChanged = null, BindingPropertyChangingDelegate propertyChanging = null,
-                                                      CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null)
+                                                      CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null, ValuePolicy valuePolicy = ValuePolicy.Default)
         {
-            return CreateAttached(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, false, defaultValueCreator);
+            return CreateAttached(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, false, defaultValueCreator, valuePolicy);
         }
 
         /// <summary>
@@ -377,14 +388,15 @@ namespace Tizen.NUI.Binding
         /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
         /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
         /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
+        /// <param name="valuePolicy">A policy of this bindiable property when we call set/get values</param>
         /// <returns>A newly created attached read-only BindablePropertyKey.</returns>
         public static BindablePropertyKey CreateAttachedReadOnly(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWayToSource,
                                                                  ValidateValueDelegate validateValue = null, BindingPropertyChangedDelegate propertyChanged = null, BindingPropertyChangingDelegate propertyChanging = null,
-                                                                 CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null)
+                                                                 CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null, ValuePolicy valuePolicy = ValuePolicy.Default)
         {
             return
                 new BindablePropertyKey(CreateAttached(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, true,
-                    defaultValueCreator));
+                    defaultValueCreator, valuePolicy));
         }
 
         /// <summary>
@@ -400,29 +412,30 @@ namespace Tizen.NUI.Binding
         /// <param name="propertyChanging">A delegate to be run when the value will change. This parameter is optional. Default is null.</param>
         /// <param name="coerceValue">A delegate used to coerce the range of a value. This parameter is optional. Default is null.</param>
         /// <param name="defaultValueCreator">A Func used to initialize default value for reference types.</param>
+        /// <param name="valuePolicy">A policy of this bindiable property when we call set/get values</param>
         /// <returns>A newly created BindablePropertyKey.</returns>
         public static BindablePropertyKey CreateReadOnly(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWayToSource,
                                                          ValidateValueDelegate validateValue = null, BindingPropertyChangedDelegate propertyChanged = null, BindingPropertyChangingDelegate propertyChanging = null,
-                                                         CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null)
+                                                         CoerceValueDelegate coerceValue = null, CreateDefaultValueDelegate defaultValueCreator = null, ValuePolicy valuePolicy = ValuePolicy.Default)
         {
             return
                 new BindablePropertyKey(new BindableProperty(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue,
-                    isReadOnly: true, defaultValueCreator: defaultValueCreator));
+                    isReadOnly: true, defaultValueCreator: defaultValueCreator, valuePolicy : valuePolicy));
         }
         internal static BindableProperty Create(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode, ValidateValueDelegate validateValue,
                                                 BindingPropertyChangedDelegate propertyChanged, BindingPropertyChangingDelegate propertyChanging, CoerceValueDelegate coerceValue, BindablePropertyBindingChanging bindingChanging,
-                                                CreateDefaultValueDelegate defaultValueCreator = null)
+                                                CreateDefaultValueDelegate defaultValueCreator = null, ValuePolicy valuePolicy = ValuePolicy.Default)
         {
             return new BindableProperty(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, bindingChanging,
-                defaultValueCreator: defaultValueCreator);
+                defaultValueCreator: defaultValueCreator, valuePolicy : valuePolicy);
         }
 
         internal static BindableProperty CreateAttached(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode, ValidateValueDelegate validateValue,
                                                         BindingPropertyChangedDelegate propertyChanged, BindingPropertyChangingDelegate propertyChanging, CoerceValueDelegate coerceValue, BindablePropertyBindingChanging bindingChanging,
-                                                        bool isReadOnly, CreateDefaultValueDelegate defaultValueCreator = null)
+                                                        bool isReadOnly, CreateDefaultValueDelegate defaultValueCreator = null, ValuePolicy valuePolicy = ValuePolicy.Default)
         {
             return new BindableProperty(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, bindingChanging, isReadOnly,
-                defaultValueCreator);
+                defaultValueCreator, valuePolicy);
         }
 
         internal object GetDefaultValue(BindableObject bindable)
@@ -431,6 +444,26 @@ namespace Tizen.NUI.Binding
                 return DefaultValueCreator(bindable);
 
             return DefaultValue;
+        }
+
+        internal bool IgnoreValueGetter(bool isSetValueCase, bool isCreateCase)
+        {
+            switch (SetGetValuePolicy)
+            {
+                case ValuePolicy.IgnoreOldValueWhenSetValue:
+                {
+                    return isSetValueCase;
+                }
+                case ValuePolicy.GetNativeValueOnlyCreation:
+                {
+                    // Ignore value getter if it is SetValue, or is not creation time.
+                    return isSetValueCase || !isCreateCase;
+                }
+                default:
+                {
+                    return false;
+                }
+            }
         }
 
         internal bool TryConvert(ref object value)

--- a/src/Tizen.NUI/src/public/XamlBinding/Interactivity/BindingCondition.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Interactivity/BindingCondition.cs
@@ -36,7 +36,7 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         public BindingCondition()
         {
-            boundProperty = BindableProperty.CreateAttached("Bound", typeof(object), typeof(BindingCondition), null, propertyChanged: OnBoundPropertyChanged);
+            boundProperty = BindableProperty.CreateAttached("Bound", typeof(object), typeof(BindingCondition), null, propertyChanged: OnBoundPropertyChanged, valuePolicy : ValuePolicy.Default);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/XamlBinding/Interactivity/XamlPropertyCondition.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Interactivity/XamlPropertyCondition.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         public XamlPropertyCondition()
         {
-            stateProperty = BindableProperty.CreateAttached("State", typeof(bool), typeof(XamlPropertyCondition), false, propertyChanged: OnStatePropertyChanged);
+            stateProperty = BindableProperty.CreateAttached("State", typeof(bool), typeof(XamlPropertyCondition), false, propertyChanged: OnStatePropertyChanged, valuePolicy : ValuePolicy.Default);
         }
 
         /// This will be public opened in tizen_6.0 after ACR done. Before ACR, need to be hidden as inhouse API.

--- a/src/Tizen.NUI/src/public/XamlBinding/ValuePolicy.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/ValuePolicy.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI.Binding
+{
+    /// <summary>
+    /// The Policy of SetValue / GetValue behaviour
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum ValuePolicy
+    {
+        /// <summary>
+        /// Always ask old value to Native when we GetValue, and SetValue.
+        /// DefaultValueCreator will called when we SetValue.
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Ignore old value when we call SetValue. GetValue will ask old value to Native.
+        /// </summary>
+        IgnoreOldValueWhenSetValue,
+
+        /// <summary>
+        /// Get native value only if we create new BindableContext.
+        /// If we call SetValue before, DefaultValueCreator never be called.
+        /// Else, DefaultValueCreator called only one time.
+        /// </summary>
+        GetNativeValueOnlyCreation,
+    }
+}

--- a/src/Tizen.NUI/src/public/XamlBinding/XamlStyle.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/XamlStyle.cs
@@ -17,7 +17,7 @@ namespace Tizen.NUI.Binding
 		int cleanupThreshold = CleanupTrigger;
 
         readonly BindableProperty basedOnResourceProperty = BindableProperty.CreateAttached("BasedOnResource", typeof(XamlStyle), typeof(XamlStyle), default(XamlStyle),
-            propertyChanged: OnBasedOnResourceChanged);
+            propertyChanged: OnBasedOnResourceChanged, valuePolicy : ValuePolicy.Default);
 
         readonly List<WeakReference<BindableObject>> targets = new List<WeakReference<BindableObject>>(4);
 


### PR DESCRIPTION
"ALL" default BindableProperty.PropertyChanged events what NUI using, dont use 'oldValue'.

But due to that usecase, we always call DefaultValueCreator when we try to set value.

To make NUI platform faster, let we ignore that property getter when we only use setter.

Do not call default creator when we set value

Currently, we only apply this feature to View's bindable property. But in future, we need to create all bindable property policy as IgnoreOldValueWhenSetValue.