### PR TITLE
[NUI] Fix some incorrect implements when we get Texture relative items

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
@@ -66,10 +66,17 @@ namespace Tizen.NUI
 
         public Texture GetColorTexture()
         {
-            //to fix memory leak issue, match the handle count with native side.
             global::System.IntPtr cPtr = Interop.FrameBuffer.GetColorTexture(SwigCPtr);
-            Texture ret = this.GetInstanceSafely<Texture>(cPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            Texture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Texture;
+            if (ret != null)
+            {
+                Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, cPtr));
+            }
+            else
+            {
+                ret = new Texture(cPtr, true);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 

--- a/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionSet.cs
@@ -118,22 +118,17 @@ namespace Tizen.NUI
 
         public TransitionItemBase GetTransitionAt(uint index)
         {
-            //to fix memory leak issue, match the handle count with native side.
             IntPtr cPtr = Interop.TransitionSet.GetTransitionAt(SwigCPtr, index);
-            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
-            TransitionItemBase ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as TransitionItemBase;
-            if (cPtr != IntPtr.Zero && ret == null)
+            TransitionItemBase ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TransitionItemBase;
+            if (ret != null)
             {
-                ret = new TransitionItemBase(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending)
-                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                Interop.BaseHandle.DeleteBaseHandle(new HandleRef(this, cPtr));
             }
-            Interop.BaseHandle.DeleteBaseHandle(CPtr);
-            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            else
+            {
+                ret = new TransitionItemBase(cPtr, true);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -613,22 +613,17 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public Renderer GetRendererAt(uint index)
         {
-            //to fix memory leak issue, match the handle count with native side.
             IntPtr cPtr = Interop.Actor.GetRendererAt(SwigCPtr, index);
-            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
-            Renderer ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as Renderer;
-            if (cPtr != IntPtr.Zero && ret == null)
+            Renderer ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Renderer;
+            if (ret != null)
             {
-                ret = new Renderer(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending)
-                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                Interop.BaseHandle.DeleteBaseHandle(new HandleRef(this, cPtr));
             }
-            Interop.BaseHandle.DeleteBaseHandle(CPtr);
-            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            else
+            {
+                ret = new Renderer(cPtr, true);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 

--- a/src/Tizen.NUI/src/public/Rendering/Renderer.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Renderer.cs
@@ -766,20 +766,17 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public TextureSet GetTextures()
         {
-            //to fix memory leak issue, match the handle count with native side.
-            System.IntPtr cPtr = Interop.Renderer.GetTextures(SwigCPtr);
-            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
-            TextureSet ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as TextureSet;
-            if (cPtr != IntPtr.Zero && ret == null)
+            global::System.IntPtr cPtr = Interop.Renderer.GetTextures(SwigCPtr);
+            TextureSet ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TextureSet;
+            if (ret != null)
             {
-                ret = new TextureSet(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, cPtr));
             }
-            Interop.BaseHandle.DeleteBaseHandle(CPtr);
-            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            else
+            {
+                ret = new TextureSet(cPtr, true);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 

--- a/src/Tizen.NUI/src/public/Rendering/TextureSet.cs
+++ b/src/Tizen.NUI/src/public/Rendering/TextureSet.cs
@@ -60,20 +60,17 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public Texture GetTexture(uint index)
         {
-            //to fix memory leak issue, match the handle count with native side.
-            System.IntPtr cPtr = Interop.TextureSet.GetTexture(SwigCPtr, index);
-            HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
-            Texture ret = Registry.GetManagedBaseHandleFromNativePtr(CPtr.Handle) as Texture;
-            if (cPtr != System.IntPtr.Zero && ret == null)
+            global::System.IntPtr cPtr = Interop.TextureSet.GetTexture(SwigCPtr, index);
+            Texture ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Texture;
+            if (ret != null)
             {
-                ret = new Texture(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, cPtr));
             }
-            Interop.BaseHandle.DeleteBaseHandle(CPtr);
-            CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            else
+            {
+                ret = new Texture(cPtr, true);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 
@@ -97,10 +94,17 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public Sampler GetSampler(uint index)
         {
-            //to fix memory leak issue, match the handle count with native side.
-            System.IntPtr cPtr = Interop.TextureSet.GetSampler(SwigCPtr, index);
-            Sampler ret = this.GetInstanceSafely<Sampler>(cPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            global::System.IntPtr cPtr = Interop.TextureSet.GetSampler(SwigCPtr, index);
+            Sampler ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Sampler;
+            if (ret != null)
+            {
+                Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, cPtr));
+            }
+            else
+            {
+                ret = new Sampler(cPtr, true);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 


### PR DESCRIPTION
Since now we have a unified pattern to avoid memory leak problem between NUI and Native side handle count problem,
Let we change some mis-implementated codes relative with Texture.