### PR TITLE
[NUI][API10] DetachAccessibleObject at Dispose time well

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -148,6 +148,18 @@ namespace Tizen.NUI
         }
         protected static SWIGExceptionHelper swigExceptionHelper = new SWIGExceptionHelper();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ThrowExceptionIfExists()
+        {
+            if (SWIGPendingException.Pending) throw SWIGPendingException.Retrieve();
+        }
+
+        [System.Diagnostics.Conditional("DEBUG")]
+        internal static void ThrowExceptionIfExistsDebug()
+        {
+            if (SWIGPendingException.Pending) throw SWIGPendingException.Retrieve();
+        }
+
         /// <since_tizen> 3 </since_tizen>
         public class SWIGPendingException
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -377,12 +377,6 @@ namespace Tizen.NUI.BaseComponents
 
             internalName = null;
 
-            if (SwigCPtr.Handle != IntPtr.Zero && global::System.Threading.Thread.CurrentThread.ManagedThreadId == Registry.Instance.SavedApplicationThread.ManagedThreadId)
-            {
-                Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-
             if (disposing == false)
             {
                 if (IsNativeHandleInvalid() || SwigCMemOwn == false)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1231,6 +1231,12 @@ namespace Tizen.NUI.BaseComponents
 
             disposeDebugging(type);
 
+            if (SwigCMemOwn && !IsNativeHandleInvalid())
+            {
+                Interop.ControlDevel.DaliAccessibilityDetachAccessibleObject(SwigCPtr);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
+
             //_mergedStyle = null;
 
             internalMaximumSize?.Dispose();


### PR DESCRIPTION

### Description of Change ###
There were several problems when we call DaliAccessibilityDetachAccessibleObject at Dispose(bool) function

 - It will detach accessibility even if view doesn't own the handle memory
 - Dispose(bool) can be called at worker thread (during GC) so we need to check thread here

Make to `DaliAccessibilityDetachAccessibleObject` function at Dispose(DisposeTypes) so that we can ensure it called at main thread clearly.

### API Changes ###
- N/A