### PR TITLE
[NUI] Call Mashal.FreeHGlobal() what we allocated

### DIFF
--- a/src/Tizen.NUI.Wearable/src/public/Title.cs
+++ b/src/Tizen.NUI.Wearable/src/public/Title.cs
@@ -328,17 +328,24 @@ namespace Tizen.NUI.Components
             vertex3.position = new Vec2(0.5f, -0.5f);
             vertex4.position = new Vec2(0.5f, 0.5f);
 
-
             TexturedQuadVertex[] texturedQuadVertexData = new TexturedQuadVertex[4] { vertex1, vertex2, vertex3, vertex4 };
 
-            int lenght = Marshal.SizeOf(vertex1);
-            IntPtr pA = Marshal.AllocHGlobal(lenght * 4);
+            int length = Marshal.SizeOf(vertex1);
+            IntPtr pA = Marshal.AllocHGlobal(checked(length * 4));
 
-            for (int i = 0; i < 4; i++)
+            try
             {
-                Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * lenght, true);
+                for (int i = 0; i < 4; i++)
+                {
+                    Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * length, true);
+                }
+                vertexData.SetData(pA, 4);
             }
-            vertexData.SetData(pA, 4);
+            finally
+            {
+                // Free AllocHGlobal memory after call PropertyBuffer.SetData()
+                Marshal.FreeHGlobal(pA);
+            }
 
             Geometry geometry = new Geometry();
             geometry.AddVertexBuffer(vertexData);

--- a/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
@@ -292,8 +292,15 @@ namespace Tizen.NUI
             public Vec2 position;
         };
 
-        private IntPtr RectangleDataPtr()
+        private PropertyBuffer CreateQuadPropertyBuffer()
         {
+            /* Create Property buffer */
+            PropertyValue value = new PropertyValue((int)PropertyType.Vector2);
+            PropertyMap vertexFormat = new PropertyMap();
+            vertexFormat.Add("aPosition", value);
+
+            PropertyBuffer vertexBuffer = new PropertyBuffer(vertexFormat);
+            
             TexturedQuadVertex vertex1 = new TexturedQuadVertex();
             TexturedQuadVertex vertex2 = new TexturedQuadVertex();
             TexturedQuadVertex vertex3 = new TexturedQuadVertex();
@@ -305,33 +312,38 @@ namespace Tizen.NUI
 
             TexturedQuadVertex[] texturedQuadVertexData = new TexturedQuadVertex[4] { vertex1, vertex2, vertex3, vertex4 };
 
-            int lenght = Marshal.SizeOf(vertex1);
-            IntPtr pA = Marshal.AllocHGlobal(lenght * 4);
+            int length = Marshal.SizeOf(vertex1);
+            IntPtr pA = Marshal.AllocHGlobal(checked(length * 4));
 
-            for (int i = 0; i < 4; i++)
+            try
             {
-                Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * lenght, true);
+                for (int i = 0; i < 4; i++)
+                {
+                    Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * length, true);
+                }
+
+                vertexBuffer.SetData(pA, 4);
+            }
+            finally
+            {
+                // Free AllocHGlobal memory after call PropertyBuffer.SetData()
+                Marshal.FreeHGlobal(pA);
             }
 
-            return pA;
+            value.Dispose();
+            vertexFormat.Dispose();
+
+            return vertexBuffer;
         }
 
         private Geometry CreateQuadGeometry()
         {
-            /* Create Property buffer */
-            PropertyValue value = new PropertyValue((int)PropertyType.Vector2);
-            PropertyMap vertexFormat = new PropertyMap();
-            vertexFormat.Add("aPosition", value);
-
-            PropertyBuffer vertexBuffer = new PropertyBuffer(vertexFormat);
-            vertexBuffer.SetData(RectangleDataPtr(), 4);
+            PropertyBuffer vertexBuffer = CreateQuadPropertyBuffer();
 
             Geometry geometry = new Geometry();
             geometry.AddVertexBuffer(vertexBuffer);
             geometry.SetType(Geometry.Type.TRIANGLE_STRIP);
 
-            value.Dispose();
-            vertexFormat.Dispose();
             vertexBuffer.Dispose();
 
             return geometry;

--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -195,10 +195,15 @@ namespace Tizen.NUI.BaseComponents
                             texturesArray[i] = HandleRef.ToIntPtr(Texture.getCPtr(textures[i]));
                         }
                         IntPtr unmanagedPointer = Marshal.AllocHGlobal(intptrBytes);
-                        Marshal.Copy(texturesArray, 0, unmanagedPointer, texturesArray.Length);
-
-                        Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, texturesArray.Length);
-                        Marshal.FreeHGlobal(unmanagedPointer);
+                        try
+                        {
+                            Marshal.Copy(texturesArray, 0, unmanagedPointer, texturesArray.Length);
+                            Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, texturesArray.Length);
+                        }
+                        finally
+                        {
+                            Marshal.FreeHGlobal(unmanagedPointer);
+                        }
                     }
                 }
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityWrappers.cs
@@ -45,6 +45,9 @@ namespace Tizen.NUI.BaseComponents
 
             Marshal.StructureToPtr(ad, ptr, false);
             Interop.ControlDevel.DaliAccessibilitySetAccessibilityDelegate(ptr, Convert.ToUInt32(size));
+
+            // Do not free AllocHGlobal memory, for performance. It will be used for native side very frequencly.
+            // Note that Marshal.AllocHGlobal memory will be freed after process terminated.
         }
 
         private static View GetViewFromRefObject(IntPtr refObjectPtr)

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI
     /// <remarks>
     /// Internal Dali resources with BaseHandle has reference count internally.<br/>
     /// And Dali resources will release the object only if reference count become zero.<br/>
-    /// It mean, even we call <see cref="Dispose"/>, the reousrce will not be released if some native has reference count.
+    /// It mean, even we call <see cref="Dispose()"/>, the reousrce will not be released if some native has reference count.
     /// </remarks>
     /// <since_tizen> 3 </since_tizen>
     public class BaseHandle : Element, global::System.IDisposable

--- a/src/Tizen.NUI/src/public/Rendering/VertexBuffer.cs
+++ b/src/Tizen.NUI/src/public/Rendering/VertexBuffer.cs
@@ -63,12 +63,21 @@ namespace Tizen.NUI
             int structSize = Marshal.SizeOf<VertexType>();
             global::System.IntPtr buffer = Marshal.AllocHGlobal(checked(structSize * vertices.Length));
 
-            for (int i = 0; i < vertices.Length; i++)
+            try
             {
-                Marshal.StructureToPtr(vertices[i], buffer + i * structSize, true);
+                for (int i = 0; i < vertices.Length; i++)
+                {
+                    Marshal.StructureToPtr(vertices[i], buffer + i * structSize, true);
+                }
+
+                Interop.VertexBuffer.SetData(SwigCPtr, buffer, (uint)vertices.Length);
+            }
+            finally
+            {
+                // Free AllocHGlobal memory after call Interop.VertexBuffer.SetData()
+                Marshal.FreeHGlobal(buffer);
             }
 
-            Interop.VertexBuffer.SetData(SwigCPtr, buffer, (uint)vertices.Length);
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION
Let we free allocated heap memory by Mashal.

It might cause memory leak issue if user try to use VertexBuffer.

And also, let we also fix FrameBrokerBase implementation that might be the guideline who want to use custom Geometry class.