### PR TITLE
[NUI] Fix svace issue: An overflow in the arithmetic expression Marshal.SizeOf(typeof(IntPtr)) * count

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -193,11 +193,18 @@ namespace Tizen.NUI.BaseComponents
                         {
                             texturesArray[i] = HandleRef.ToIntPtr(Texture.getCPtr(textures[i]));
                         }
-                        IntPtr unmanagedPointer = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(IntPtr)) * count);
-                        Marshal.Copy(texturesArray, 0, unmanagedPointer, count);
+                        try
+                        {
+                            IntPtr unmanagedPointer = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(IntPtr)) * count);
+                            Marshal.Copy(texturesArray, 0, unmanagedPointer, count);
 
-                        Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, count);
-                        Marshal.FreeHGlobal(unmanagedPointer);
+                            Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, count);
+                            Marshal.FreeHGlobal(unmanagedPointer);
+                        }
+                        catch (Exception e)
+                        {
+                            Tizen.Log.Fatal("NUI", $"[Error] Got exception during BindTextureResources, Message: {e.Message} Stack Trace: {e.StackTrace}");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Fix svace issue of Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs.
WID:31088670 An overflow in the arithmetic expression Marshal.SizeOf(typeof(IntPtr)) * count which is used in Marshal.AllocHGlobal(Marshal.SizeOf(typeof(IntPtr)) * count) may occur. Please use checked arithmetic to throw IntegerOverflowException in case of overflow instead of possible memory damage
SVACE Server Link : https://sa.sec.samsung.net/dm/tizen80/sb2/main/review#PRJID=6&WGID=89407

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
