### PR TITLE
[NUI] Provide a way to enable legacy DALI StyleManager

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
@@ -50,7 +50,7 @@ namespace Tizen.NUI
 
         public static View New()
         {
-            View ret = new View(Interop.ViewImpl.New(), true);
+            View ret = new View(Interop.ViewImpl.New((int)View.GetDefaultViewBehaviour()), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
@@ -153,7 +153,7 @@ namespace Tizen.NUI
             base.Dispose(type);
         }
 
-        public ViewWrapperImpl(CustomViewBehaviour behaviourFlags) : this(Interop.ViewWrapperImpl.NewViewWrapperImpl((int)behaviourFlags), true)
+        public ViewWrapperImpl(CustomViewBehaviour behaviourFlags) : this(Interop.ViewWrapperImpl.NewViewWrapperImpl((int)(behaviourFlags | View.GetDefaultViewBehaviour())), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             DirectorConnect();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
@@ -41,11 +41,17 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0")]
             public static extern global::System.IntPtr New();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0_With_Behaviour")]
+            public static extern global::System.IntPtr New(int behaviour);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_1")]
             public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_2")]
             public static extern global::System.IntPtr New(string jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_2_With_Behaviour")]
+            public static extern global::System.IntPtr New(int behaviour, string jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_3")]
             public static extern global::System.IntPtr New(string jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.StyleManager.cs
@@ -21,6 +21,9 @@ namespace Tizen.NUI
     {
         internal static partial class StyleManager
         {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_StyleManager_Enabled")]
+            public static extern void SetEnabled(bool value);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_StyleManager")]
             public static extern global::System.IntPtr NewStyleManager();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
@@ -26,8 +26,14 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_New")]
             public static extern global::System.IntPtr New();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_New_With_Behaviour")]
+            public static extern global::System.IntPtr New(int behaviour);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_NewCustom")]
             public static extern global::System.IntPtr NewCustom();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_NewCustom_With_Behaviour")]
+            public static extern global::System.IntPtr NewCustom(int behaviour);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_View__SWIG_0")]
             public static extern global::System.IntPtr NewView();

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
@@ -25,6 +25,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_New")]
             public static extern global::System.IntPtr New();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_New_With_Behaviour")]
+            public static extern global::System.IntPtr New(int behaviour);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SetStyleName")]
             public static extern void SetStyleName(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -72,14 +72,14 @@ namespace Tizen.NUI.BaseComponents
         /// Creates an initialized ImageView.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public ImageView() : this(Interop.ImageView.New(), true)
+        public ImageView() : this(Interop.ImageView.New((int)GetDefaultViewBehaviour()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ImageView(ViewStyle viewStyle) : this(Interop.ImageView.New(), true, viewStyle)
+        public ImageView(ViewStyle viewStyle) : this(Interop.ImageView.New((int)GetDefaultViewBehaviour()), true, viewStyle)
         {
         }
 
@@ -89,7 +89,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ImageView(bool shown) : this(Interop.ImageView.New(), true)
+        public ImageView(bool shown) : this(Interop.ImageView.New((int)GetDefaultViewBehaviour()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -101,7 +101,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="url">The URL of the image resource to display.</param>
         /// <since_tizen> 3 </since_tizen>
-        public ImageView(string url) : this(Interop.ImageView.New(url), true)
+        public ImageView(string url) : this(Interop.ImageView.New((int)GetDefaultViewBehaviour(), url), true)
         {
             ResourceUrl = url;
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -115,7 +115,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ImageView(string url, bool shown) : this(Interop.ImageView.New(url), true)
+        public ImageView(string url, bool shown) : this(Interop.ImageView.New((int)GetDefaultViewBehaviour(), url), true)
         {
             ResourceUrl = url;
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -32,7 +32,6 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class TextEditor : View
     {
-        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextEditor";
         static private string defaultFontFamily = "TizenSans";
         private static SystemFontTypeChanged systemFontTypeChanged = new SystemFontTypeChanged();
         private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
@@ -61,7 +60,7 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextEditor control.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TextEditor() : this(Interop.TextEditor.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextEditor() : this(Interop.TextEditor.New(HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -70,7 +69,7 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextEditor with specified style.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextEditor(TextEditorStyle style) : this(Interop.TextEditor.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true, style: style)
+        public TextEditor(TextEditorStyle style) : this(Interop.TextEditor.New(HasStyle()), true, style: style)
         {
         }
 
@@ -80,7 +79,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextEditor(bool shown) : this(Interop.TextEditor.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextEditor(bool shown) : this(Interop.TextEditor.New(HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -101,9 +100,9 @@ namespace Tizen.NUI.BaseComponents
             TextChanged += TextEditorTextChanged;
         }
 
-        private bool HasStyle()
+        private static bool HasStyle()
         {
-            return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
+            return (!StyleManager.Enabled && ThemeManager.GetStyle(typeof(TextEditor)) != null);
         }
 
         /// <summary>
@@ -2245,6 +2244,12 @@ namespace Tizen.NUI.BaseComponents
                 if (fontSizeScale == value) return;
 
                 fontSizeScale = value;
+
+                if (StyleManager.Enabled && fontSizeScale == Tizen.NUI.FontSizeScale.UseSystemSetting)
+                {
+                    fontSizeScale = 1;
+                }
+
                 if (fontSizeScale == Tizen.NUI.FontSizeScale.UseSystemSetting)
                 {
                     SystemSettingsFontSize systemSettingsFontSize;

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -31,7 +31,6 @@ namespace Tizen.NUI.BaseComponents
     /// <since_tizen> 3 </since_tizen>
     public partial class TextField : View
     {
-        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextField";
         static private string defaultFontFamily = "TizenSans";
         private static SystemFontTypeChanged systemFontTypeChanged = new SystemFontTypeChanged();
         private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
@@ -61,7 +60,7 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextField control.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TextField() : this(Interop.TextField.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextField() : this(Interop.TextField.New(HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -72,7 +71,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextField(bool shown) : this(Interop.TextField.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextField(bool shown) : this(Interop.TextField.New(HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -118,9 +117,9 @@ namespace Tizen.NUI.BaseComponents
             ExceedPolicyClip
         }
 
-        private bool HasStyle()
+        private static bool HasStyle()
         {
-            return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
+            return (!StyleManager.Enabled && ThemeManager.GetStyle(typeof(TextField)) != null);
         }
 
         /// <summary>
@@ -2364,6 +2363,12 @@ namespace Tizen.NUI.BaseComponents
                 if (fontSizeScale == value) return;
 
                 fontSizeScale = value;
+
+                if (StyleManager.Enabled && fontSizeScale == Tizen.NUI.FontSizeScale.UseSystemSetting)
+                {
+                    fontSizeScale = 1;
+                }
+
                 if (fontSizeScale == Tizen.NUI.FontSizeScale.UseSystemSetting)
                 {
                     SystemSettingsFontSize systemSettingsFontSize;

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -83,7 +83,6 @@ namespace Tizen.NUI.BaseComponents
 
         private static SystemFontTypeChanged systemFontTypeChanged = new SystemFontTypeChanged();
         private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
-        static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextLabel";
         static private string defaultFontFamily = "BreezeSans";
         private string textLabelSid = null;
         private TextLabelSelectorData selectorData;
@@ -101,14 +100,14 @@ namespace Tizen.NUI.BaseComponents
         /// Creates the TextLabel control.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TextLabel() : this(Interop.TextLabel.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextLabel() : this(Interop.TextLabel.New(HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextLabel(TextLabelStyle viewStyle) : this(Interop.TextLabel.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true, viewStyle)
+        public TextLabel(TextLabelStyle viewStyle) : this(Interop.TextLabel.New(HasStyle()), true, viewStyle)
         {
         }
 
@@ -118,7 +117,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextLabel(bool shown) : this(Interop.TextLabel.New(ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextLabel(bool shown) : this(Interop.TextLabel.New(HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -129,7 +128,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="text">The text to display</param>
         /// <since_tizen> 3 </since_tizen>
-        public TextLabel(string text) : this(Interop.TextLabel.New(text, ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextLabel(string text) : this(Interop.TextLabel.New(text, HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -141,7 +140,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TextLabel(string text, bool shown) : this(Interop.TextLabel.New(text, ThemeManager.GetStyle(defaultStyleName) == null ? false : true), true)
+        public TextLabel(string text, bool shown) : this(Interop.TextLabel.New(text, HasStyle()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);
@@ -173,9 +172,10 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private bool HasStyle()
+        private static bool HasStyle()
         {
-            return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
+            bool ret = (!StyleManager.Enabled && ThemeManager.GetStyle(typeof(TextLabel)) != null);
+            return ret;
         }
 
         /// <summary>
@@ -1525,6 +1525,12 @@ namespace Tizen.NUI.BaseComponents
                 if (fontSizeScale == value) return;
 
                 fontSizeScale = value;
+
+                if (StyleManager.Enabled && fontSizeScale == Tizen.NUI.FontSizeScale.UseSystemSetting)
+                {
+                    fontSizeScale = 1;
+                }
+
                 if (fontSizeScale == Tizen.NUI.FontSizeScale.UseSystemSetting)
                 {
                     SystemSettingsFontSize systemSettingsFontSize;

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -144,12 +144,12 @@ namespace Tizen.NUI.BaseComponents
             {
                 case ViewAccessibilityMode.Custom:
                 {
-                    return Interop.View.NewCustom();
+                    return Interop.View.NewCustom((int)GetDefaultViewBehaviour());
                 }
                 case ViewAccessibilityMode.Default:
                 default:
                 {
-                    return Interop.View.New();
+                    return Interop.View.New((int)GetDefaultViewBehaviour());
                 }
             }
         }
@@ -170,7 +170,7 @@ namespace Tizen.NUI.BaseComponents
 
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public View(ViewStyle viewStyle) : this(Interop.View.New(), true, viewStyle)
+        public View(ViewStyle viewStyle) : this(Interop.View.New((int)GetDefaultViewBehaviour()), true, viewStyle)
         {
         }
 
@@ -180,7 +180,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="shown">false : Not displayed (hidden), true : displayed (shown)</param>
         /// This will be public opened in next release of tizen after ACR done. Before ACR, it is used as HiddenAPI (InhouseAPI).
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public View(bool shown) : this(Interop.View.New(), true)
+        public View(bool shown) : this(Interop.View.New((int)GetDefaultViewBehaviour()), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             SetVisible(shown);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1043,6 +1043,11 @@ namespace Tizen.NUI.BaseComponents
             return (obj == null) ? new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero) : obj.SwigCPtr;
         }
 
+        internal static CustomViewBehaviour GetDefaultViewBehaviour()
+        {
+            return StyleManager.Enabled ? CustomViewBehaviour.ViewBehaviourDefault : CustomViewBehaviour.DisableStyleChangeSignals;
+        }
+
         internal bool IsTopLevelView()
         {
             if (GetParent() is Layer)

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -93,6 +93,13 @@ namespace Tizen.NUI
             }
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool Enabled
+        {
+            get;
+            set;
+        } = false;
+
         /// <summary>
         /// Gets the singleton of StyleManager object.
         /// </summary>


### PR DESCRIPTION
Since tizen 7.0, DALI StyleManager is disabled by default. But to support fhub properly, it's needed to provide a way to enable it.

* View/ImageView/Control are created with custom flag `DisableStyleChangeSignals` only when StyleManager is disabled (default)
* Text objects does not process font scale in NUI side when DALI StyleManager is enabled.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
