### PR TITLE
[NUI] Allow to use null rootView for FrameUpdateCallback

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2250,20 +2250,20 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddFrameUpdateCallback(FrameUpdateCallbackInterface frameUpdateCallback)
         {
-            frameUpdateCallback?.AddFrameUpdateCallback(stageCPtr, Layer.getCPtr(GetRootLayer()));
+            frameUpdateCallback?.AddFrameUpdateCallback(stageCPtr, new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero));
         }
 
         /// <summary>
         /// Add FrameUpdateCallback with root view.
         /// FrameUpdateCallbackInterface can only detach Views under given view.
         /// </summary>
+        /// <remarks>
+        /// We can give rootView as null if we want to make frameUpdateCallback don't have any dependency with some view.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddFrameUpdateCallback(FrameUpdateCallbackInterface frameUpdateCallback, View rootView)
         {
-            if(rootView != null)
-            {
-                frameUpdateCallback?.AddFrameUpdateCallback(stageCPtr, View.getCPtr(rootView));
-            }
+            frameUpdateCallback?.AddFrameUpdateCallback(stageCPtr, View.getCPtr(rootView));
         }
 
         /// <summary>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
@@ -396,6 +396,27 @@ namespace Tizen.NUI.Samples
 
         public void Deactivate()
         {
+            if(contentsView != null)
+            {
+                contentsView.Unparent();
+                contentsView.Dispose();
+            }
+            if(baseView != null)
+            {
+                baseView.Unparent();
+                baseView.Dispose();
+            }
+
+            if(frameUpdateCallback != null)
+            {
+                window.RenderingBehavior = RenderingBehaviorType.IfRequired;
+                window.RemoveFrameUpdateCallback(frameUpdateCallback);
+                animationOffTimer?.Stop();
+                animationState = TOUCH_ANIMATION_STATE.END_ANIMATION;
+
+                frameUpdateCallback = null;
+                animationOffTimer?.Dispose();
+            }
         }
 
         void Initialize()
@@ -564,7 +585,11 @@ namespace Tizen.NUI.Samples
             // Add frame callback on window.
             // OnUpdate callback of frameUpdateCallback will be called before every render frame.
             // We can set root view what given frameUpdateCallback used
+            // Or, we can skip root view as null if we don't want to make frameUpdateCallback don't have dependency with some view.
+            // For this sample, let we use controlView as root view.
+
             window.AddFrameUpdateCallback(frameUpdateCallback, controlView);
+            // window.AddFrameUpdateCallback(frameUpdateCallback, null);
 
             // compute limit position the container could go.
             leftDirectionLimit = (float)window.Size.Width - (totalSize + (float)(INITIAL_POSITION));


### PR DESCRIPTION
Let we use some global view controllable frameUpdateCallback when user skip to add RootView information.

Previously, we detach the frameUpdateCallback automatically if rootView was disposed. But now, we will never remove callback until user call RemoveFrameUpdateCallback.

relative dali patch :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/305062
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/305126
