### PR TITLE
[NUI] Add methods to modify base theme for fhub and fix bugs

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -566,6 +566,9 @@ namespace Tizen.NUI.BaseComponents
         {
             var source = other as ViewStyle;
 
+            IncludeDefaultStyle = source.IncludeDefaultStyle;
+            SolidNull = source.SolidNull;
+
             if (source == null || source.DirtyProperties == null || source.DirtyProperties.Count == 0)
             {
                 return;
@@ -594,9 +597,6 @@ namespace Tizen.NUI.BaseComponents
                     InternalSetValue(destinationProperty, sourceValue);
                 }
             }
-
-            IncludeDefaultStyle = source.IncludeDefaultStyle;
-            SolidNull = source.SolidNull;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -192,9 +192,9 @@ namespace Tizen.NUI
                 newTheme.Id = "NONAME";
             }
 
-            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Small, newTheme.SmallBrokenImageUrl ?? "");
-            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Normal, newTheme.BrokenImageUrl ?? "");
-            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Large, newTheme.LargeBrokenImageUrl ?? "");
+            if (newTheme.SmallBrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Small, newTheme.SmallBrokenImageUrl);
+            if (newTheme.BrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Normal, newTheme.BrokenImageUrl);
+            if (newTheme.LargeBrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Large, newTheme.LargeBrokenImageUrl);
 
             userTheme = newTheme;
             UpdateThemeForInitialize();
@@ -219,19 +219,51 @@ namespace Tizen.NUI
                 newTheme.Id = "NONAME";
             }
 
-            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Small, newTheme.SmallBrokenImageUrl ?? "");
-            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Normal, newTheme.BrokenImageUrl ?? "");
-            StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Large, newTheme.LargeBrokenImageUrl ?? "");
+            if (newTheme.SmallBrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Small, newTheme.SmallBrokenImageUrl);
+            if (newTheme.BrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Normal, newTheme.BrokenImageUrl);
+            if (newTheme.LargeBrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Large, newTheme.LargeBrokenImageUrl);
 
-            if (userTheme == null) userTheme = theme;
+            if (userTheme == null) userTheme = newTheme;
             else
             {
                 userTheme = (Theme)userTheme.Clone();
-                userTheme.MergeWithoutClone(theme);
+                userTheme.MergeWithoutClone(newTheme);
             }
 
             UpdateThemeForInitialize();
             UpdateThemeForUpdate();
+            NotifyThemeChanged();
+        }
+
+        /// <summary>
+        /// Append a theme to the current base theme and apply it.
+        /// This will change the appearance of the existing components with property <seealso cref="View.ThemeChangeSensitive"/> on.
+        /// This also affects all components created afterwards.
+        /// </summary>
+        /// <param name="theme">The theme instance to be appended.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the given theme is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AppendBaseTheme(Theme theme)
+        {
+            var newTheme = (Theme)theme?.Clone() ?? throw new ArgumentNullException(nameof(theme));
+
+            if (string.IsNullOrEmpty(newTheme.Id))
+            {
+                newTheme.Id = "NONAME";
+            }
+
+            if (newTheme.SmallBrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Small, newTheme.SmallBrokenImageUrl);
+            if (newTheme.BrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Normal, newTheme.BrokenImageUrl);
+            if (newTheme.LargeBrokenImageUrl != null) StyleManager.Instance.SetBrokenImageUrl(StyleManager.BrokenImageType.Large, newTheme.LargeBrokenImageUrl);
+
+            if (baseTheme == null) baseTheme = newTheme;
+            else
+            {
+                baseTheme = (Theme)baseTheme.Clone();
+                baseTheme.MergeWithoutClone(newTheme);
+            }
+
+            UpdateThemeForInitialize();
             NotifyThemeChanged();
         }
 

--- a/src/Tizen.NUI/src/public/Xaml/MarkupExtensions/SharedResourcePathExtension.cs
+++ b/src/Tizen.NUI/src/public/Xaml/MarkupExtensions/SharedResourcePathExtension.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.NUI.Binding;
+
+namespace Tizen.NUI.Xaml
+{
+    /// <summary>
+    /// Provide application's shared resource path for xaml.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [ContentProperty(nameof(FilePath))]
+    [AcceptEmptyServiceProvider]
+    public class SharedResourcePathExtension : IMarkupExtension<string>
+    {
+        /// <summary>
+        /// Provide application's shared resource path for xaml.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public SharedResourcePathExtension()
+        {
+        }
+
+        /// <summary> User should specify file path as a content of this extension. </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string FilePath { get; set; }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string ProvideValue(IServiceProvider serviceProvider) => Tizen.Applications.Application.Current.DirectoryInfo.SharedResource + FilePath;
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+        {
+            return (this as IMarkupExtension<string>).ProvideValue(serviceProvider);
+        }
+    }
+}


### PR DESCRIPTION
* Add ThemeManager.AppendBaseTheme : It enables outer package to modify base theme
* Add SharedResourcePathExtension for xaml supporting
* Fix the bug that broken images in a theme always overwrite existing settings
* Fix the bug that cloning a view style losts SolidNull information.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
