### PR TITLE
[NUI] Support FrameUpdateCallback get world transform

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
@@ -43,6 +43,14 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool FrameCallbackInterfaceGetPositionAndSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector, global::System.Runtime.InteropServices.HandleRef vector2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetWorldPositionScaleAndSize")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceGetWorldPositionScaleAndSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector, global::System.Runtime.InteropServices.HandleRef vector2, global::System.Runtime.InteropServices.HandleRef vector3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetWorldTransformAndSize")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceGetWorldTransformAndSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector, global::System.Runtime.InteropServices.HandleRef vector2, global::System.Runtime.InteropServices.HandleRef rotation, global::System.Runtime.InteropServices.HandleRef vector3);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetSize")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool FrameCallbackInterfaceGetSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);

--- a/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
@@ -233,6 +233,32 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool GetWorldPositionScaleAndSize(uint id, Vector3 Position, Vector3 Scale, Vector3 Size)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceGetWorldPositionScaleAndSize(proxyIntPtr, id, Vector3.getCPtr(Position), Vector3.getCPtr(Scale), Vector3.getCPtr(Size));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool GetWorldTransformAndSize(uint id, Vector3 Position, Vector3 Scale, Rotation Orientation, Vector3 Size)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceGetWorldTransformAndSize(proxyIntPtr, id, Vector3.getCPtr(Position), Vector3.getCPtr(Scale), Rotation.getCPtr(Orientation),Vector3.getCPtr(Size));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
         internal void AddFrameUpdateCallback(global::System.Runtime.InteropServices.HandleRef windowCPtr, global::System.Runtime.InteropServices.HandleRef layerCPtr)
         {
             Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceAddFrameUpdateCallback(windowCPtr, SwigCPtr, layerCPtr);


### PR DESCRIPTION
Let we bind some more codes that UpdateProxy in dali side already supported.

relative dali patch :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/305266