### PR TITLE
[Packagemanager] Fix SetPackageManagerEventStatus

### DIFF
--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -36,6 +36,7 @@ namespace Tizen.Applications
 
         private static SafePackageManagerHandle s_handle = new SafePackageManagerHandle();
         private static Interop.PackageManager.EventStatus s_eventStatus = Interop.PackageManager.EventStatus.All;
+        private static Interop.PackageManager.EventStatus s_registered_eventStatus = Interop.PackageManager.EventStatus.All;
         private static event EventHandler<PackageManagerEventArgs> s_installEventHandler;
         private static event EventHandler<PackageManagerEventArgs> s_uninstallEventHandler;
         private static event EventHandler<PackageManagerEventArgs> s_updateEventHandler;
@@ -1298,6 +1299,9 @@ namespace Tizen.Applications
             if (s_installEventHandler != null && s_uninstallEventHandler != null && s_updateEventHandler != null && s_moveEventHandler != null && s_clearDataEventHandler != null)
                 return;
 
+            if ((s_registered_eventStatus & s_eventStatus) == s_eventStatus)
+                return;
+
             var err = Interop.PackageManager.ErrorCode.None;
 
             if (!Handle.IsInvalid)
@@ -1309,7 +1313,10 @@ namespace Tizen.Applications
             }
             if (err != Interop.PackageManager.ErrorCode.None)
             {
+                s_registered_eventStatus = Interop.PackageManager.EventStatus.All;
                 Log.Warn(LogTag, string.Format("Failed to register callback for package manager event. err = {0}", err));
+            } else {
+                s_registered_eventStatus = s_eventStatus;
             }
         }
 
@@ -1368,6 +1375,7 @@ namespace Tizen.Applications
                 {
                     throw PackageManagerErrorFactory.GetException(err, "Failed to unregister package manager event event.");
                 }
+                s_registered_eventStatus = Interop.PackageManager.EventStatus.All;
             }
         }
     }


### PR DESCRIPTION
이미 listen하고 있는 이벤트를 register하려는 경우 다시 event를 register할 필요가 없어 이를 제거한 패치입니다