### PR TITLE
[NUI][API10] Make view-wrapper signal input as weak handle

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
@@ -616,7 +616,7 @@ namespace Tizen.NUI
 
         private void SwigDirectorOnPropertySet(int index, global::System.IntPtr propertyValue)
         {
-            OnPropertySet(index, new PropertyValue(propertyValue, true));
+            OnPropertySet(index, new PropertyValue(propertyValue, false));
         }
 
         private void SwigDirectorOnSizeSet(global::System.IntPtr targetSize)
@@ -710,7 +710,7 @@ namespace Tizen.NUI
 
         private bool SwigDirectorOnAccessibilityPan(global::System.IntPtr gesture)
         {
-            return OnAccessibilityPan(new PanGesture(gesture, true));
+            return OnAccessibilityPan(new PanGesture(gesture, false));
         }
 
         private bool SwigDirectorOnAccessibilityValueChange(bool isIncrease)

--- a/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
@@ -375,7 +375,7 @@ namespace Tizen.NUI
 
         private void DirectorOnPropertySet(int index, global::System.IntPtr propertyValue)
         {
-            var value = new PropertyValue(propertyValue, true);
+            var value = new PropertyValue(propertyValue, false);
             OnPropertySet?.Invoke(index, value);
             value.Dispose();
         }
@@ -389,11 +389,26 @@ namespace Tizen.NUI
 
         private void DirectorOnSizeAnimation(global::System.IntPtr animation, global::System.IntPtr targetSize)
         {
-            var ani = new Animation(animation, true);
+            bool useRegisterAnimation = false;
+
+            var ani = Registry.GetManagedBaseHandleFromNativePtr(animation) as Animation;
+            if (ani != null)
+            {
+                useRegisterAnimation = true;
+            }
+            else
+            {
+                ani = new Animation(animation, false);
+            }
             var vector3 = new Vector3(targetSize, false);
             OnSizeAnimation?.Invoke(ani, vector3);
-            ani.Dispose();
             vector3.Dispose();
+
+            // Dispose only if we create new Animation here.
+            if (!useRegisterAnimation)
+            {
+                ani.Dispose();
+            }
         }
 
         private bool DirectorOnKey(global::System.IntPtr arg0)
@@ -469,9 +484,24 @@ namespace Tizen.NUI
 
         private void DirectorOnStyleChange(global::System.IntPtr styleManager, int change)
         {
-            var styleManger = new StyleManager(styleManager, true);
-            OnStyleChange?.Invoke(styleManger, (StyleChangeType)change);
-            styleManger.Dispose();
+            bool useRegisterStyleManager = false;
+
+            var nuiStyleManger = Registry.GetManagedBaseHandleFromNativePtr(styleManager) as StyleManager;
+            if (nuiStyleManger != null)
+            {
+                useRegisterStyleManager = true;
+            }
+            else
+            {
+                nuiStyleManger = new StyleManager(styleManager, false);
+            }
+            OnStyleChange?.Invoke(nuiStyleManger, (StyleChangeType)change);
+
+            // Dispose only if we create new StyleManager here.
+            if (!useRegisterStyleManager)
+            {
+                nuiStyleManger.Dispose();
+            }
         }
 
         private bool DirectorOnAccessibilityActivated()
@@ -481,7 +511,7 @@ namespace Tizen.NUI
 
         private bool DirectorOnAccessibilityPan(global::System.IntPtr gesture)
         {
-            var panGesture = new PanGesture(gesture, true);
+            var panGesture = new PanGesture(gesture, false);
             var ret = OnAccessibilityPan?.Invoke(panGesture) ?? false;
             panGesture.Dispose();
             return ret;


### PR DESCRIPTION
Since we don't need to control the ownership of native memory at callback side, let we just keep whole input value memory ownership as false.

relative dali patch : 
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/305413