### PR TITLE
[NUI] Enable relayout only when layout is set for the layer.

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -126,13 +126,16 @@ namespace Tizen.NUI
         {
             window.LayersChildren?.ForEach(layer =>
             {
-                layer?.Children?.ForEach(view =>
+                if(layer?.LayoutCount > 0)
                 {
-                    if (view != null)
+                    layer?.Children?.ForEach(view =>
                     {
-                        FindRootLayouts(view, windowWidth, windowHeight);
-                    }
-                });
+                        if (view != null)
+                        {
+                            FindRootLayouts(view, windowWidth, windowHeight);
+                        }
+                    });
+                }
             });
 
             transitionManager.SetupCoreAndPlayAnimation();


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
If you do not check this, all views on layers that do not have a layout set will be searched unnecessarily.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
