### PR TITLE
[NUI][API11] Fix a SVACE issue.

### DIFF
--- a/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
+++ b/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
@@ -252,7 +252,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public void Register(Func<CustomView> createFunction, System.Type viewType)
         {
-            if (null == viewType)
+            if (null == viewType || null == viewType.ToString())
             {
                 throw new ArgumentNullException(nameof(viewType));
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
[STATISTICAL] Value viewType.ToString(), which is result of method invocation with possible null return value, is dereferenced in method call constructorMap.Add()

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
