### PR TITLE
[ImageUtil] Remove deprecated API

### DIFF
--- a/src/Tizen.Multimedia.Util/ImageUtil/ImageUtil.cs
+++ b/src/Tizen.Multimedia.Util/ImageUtil/ImageUtil.cs
@@ -48,43 +48,6 @@ namespace Tizen.Multimedia.Util
         }
 
         /// <summary>
-        /// Calculates the size of the image buffer for the specified resolution and color-space.
-        /// </summary>
-        /// <param name="resolution">The resolution of the image.</param>
-        /// <param name="colorSpace"><see cref="ColorSpace"/> of the image.</param>
-        /// <returns>The buffer size.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">
-        ///     width of <paramref name="resolution"/> is less than or equal to zero.<br/>
-        ///     -or-<br/>
-        ///     height of <paramref name="resolution"/> is less than or equal to zero.
-        /// </exception>
-        /// <exception cref="ArgumentException"><paramref name="colorSpace"/> is invalid.</exception>
-        /// <since_tizen> 4 </since_tizen>
-        [Obsolete("Please do not use! This will be deprecated in level 6.")]
-        public static int CalculateBufferSize(Size resolution, ColorSpace colorSpace)
-        {
-            if (resolution.Width <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(resolution), resolution.Width,
-                    "width can't be less than or equal to zero.");
-            }
-            if (resolution.Height <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(resolution), resolution.Height,
-                    "height can't be less than or equal to zero.");
-            }
-
-            ValidationUtil.ValidateEnum(typeof(ColorSpace), colorSpace, nameof(colorSpace));
-
-            uint bufferSize;
-            global::Interop.ImageUtil.CalculateBufferSize(resolution.Width, resolution.Height,
-                colorSpace.ToImageColorSpace(), out bufferSize)
-                .ThrowIfFailed("Failed to calculate buffer size for given parameter");
-
-            return (int)bufferSize;
-        }
-
-        /// <summary>
         /// Extracts representative color from an image buffer.
         /// </summary>
         /// <param name="buffer">Raw image buffer.</param>

--- a/src/Tizen.Multimedia.Util/ImageUtil/ImageUtilEnums.cs
+++ b/src/Tizen.Multimedia.Util/ImageUtil/ImageUtilEnums.cs
@@ -91,6 +91,18 @@ namespace Tizen.Multimedia.Util
         Level9,
     }
 
+    internal enum AnimationType
+    {
+        /// <summary>
+        /// GIF
+        /// </summary>
+        Gif,
+        /// <summary>
+        /// WebP
+        /// </summary>
+        WebP
+    }
+
     /// <summary>
     /// Specifies how an image is rotated or flipped.
     /// </summary>

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Encode.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Encode.cs
@@ -38,41 +38,69 @@ internal static partial class Interop
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_destroy")]
             internal static extern ImageUtilError Destroy(IntPtr handle);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_resolution")]
-            internal static extern ImageUtilError SetResolution(ImageEncoderHandle handle, uint width, uint height);
-
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_colorspace")]
-            internal static extern ImageUtilError SetColorspace(ImageEncoderHandle handle, ImageColorSpace colorspace);
-
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_quality")]
             internal static extern ImageUtilError SetQuality(ImageEncoderHandle handle, int quality);
 
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_png_compression")]
             internal static extern ImageUtilError SetPngCompression(ImageEncoderHandle handle, PngCompression compression);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_gif_frame_delay_time")]
-            internal static extern ImageUtilError SetGifFrameDelayTime(ImageEncoderHandle handle, ulong delayTime);
-
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_output_path")]
-            internal static extern ImageUtilError SetOutputPath(ImageEncoderHandle handle, string path);
-
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_input_buffer")]
-            internal static extern ImageUtilError SetInputBuffer(ImageEncoderHandle handle, byte[] srcBuffer);
-
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_output_buffer")]
-            internal static extern ImageUtilError SetOutputBuffer(ImageEncoderHandle handle, out IntPtr dstBuffer);
-
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_run")]
-            internal static extern ImageUtilError Run(ImageEncoderHandle handle, out ulong size);
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_run_to_buffer")]
+            internal static extern ImageUtilError RunToBuffer(ImageEncoderHandle handle, IntPtr imageUtilHandle, out IntPtr buffer, out int size);
 
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_encode_set_lossless")]
             internal static extern ImageUtilError SetLossless(ImageEncoderHandle handle, bool lossless);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_create")]
+            internal static extern ImageUtilError AnimationCreate(AnimationType type, out IntPtr animHandle);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_loop_count")]
+            internal static extern ImageUtilError AnimationSetLoopCount(IntPtr animHandle, uint count);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_background_color")]
+            internal static extern ImageUtilError AnimationSetBackgroundColor(IntPtr animHandle, byte r, byte g, byte b, byte a);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_set_lossless")]
+            internal static extern ImageUtilError AnimationSetLossless(IntPtr animHandle, bool isLossless);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_add_frame")]
+            internal static extern ImageUtilError AnimationAddFrame(IntPtr animHandle, IntPtr utilHandle, uint delayTime);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_save_to_file")]
+            internal static extern ImageUtilError AnimationSaveToFile(IntPtr animHandle, string path);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_save_to_buffer")]
+            internal static extern ImageUtilError AnimationSaveToBuffer(IntPtr animHandle, out IntPtr dstBuffer, out ulong size);
+
+            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_anim_encode_destroy")]
+            internal static extern ImageUtilError AnimationDestroy(IntPtr animHandle);
         }
     }
 
     internal class ImageEncoderHandle : SafeHandle
     {
         protected ImageEncoderHandle() : base(IntPtr.Zero, true)
+        {
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+
+        protected override bool ReleaseHandle()
+        {
+            var ret = ImageUtil.Encode.Destroy(handle);
+            if (ret != ImageUtilError.None)
+            {
+                Log.Debug(GetType().FullName, $"Failed to release native {GetType().Name}");
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    internal class AgifImageEncoderHandle : SafeHandle
+    {
+        protected AgifImageEncoderHandle() : base(IntPtr.Zero, true)
         {
         }
 

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Transform.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.Transform.cs
@@ -45,9 +45,6 @@ internal static partial class Interop
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_colorspace")]
             internal static extern ImageUtilError SetColorspace(TransformHandle handle, ImageColorSpace colorspace);
 
-            [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_hardware_acceleration")]
-            internal static extern ImageUtilError SetHardwareAcceleration(TransformHandle handle, bool mode);
-
             [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_transform_set_rotation")]
             internal static extern ImageUtilError SetRotation(TransformHandle handle, ImageRotation rotation);
 

--- a/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.cs
+++ b/src/Tizen.Multimedia.Util/Interop/Interop.ImageUtil.cs
@@ -30,9 +30,6 @@ internal static partial class Interop
         internal static extern ImageUtilError ForeachSupportedColorspace(ImageFormat type, SupportedColorspaceCallback callback,
             IntPtr userData = default(IntPtr));
 
-        [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_calculate_buffer_size")]
-        internal static extern ImageUtilError CalculateBufferSize(int width, int height, ImageColorSpace colorspace, out uint size);
-
         [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_extract_color_from_memory")]
         internal static extern ImageUtilError ExtractColorFromMemory(byte[] buffer, int width, int height, out byte rgbR, out byte rgbG, out byte rgbB);
 
@@ -42,5 +39,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_destroy_image")]
         internal static extern ImageUtilError Destroy(IntPtr handle);
+
+        [DllImport(Libraries.ImageUtil, EntryPoint = "image_util_create_image")]
+        internal static extern ImageUtilError Create(uint width, uint height, ImageColorSpace colorSpace, byte[] srcBuffer, int size, out IntPtr handle);
     }
 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
- Remove deprecated API (public static int CalculateBufferSize) 
- Change deprecated native APIs to new one

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - TCSACR-579

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
