### PR TITLE
[NUI][API11] Fix error if LottieAnimationView set BackgroundData befo…

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -198,6 +198,18 @@ namespace Tizen.NUI.BaseComponents
 
                 Image = map;
 
+                if (backgroundExtraData != null)
+                {
+                    if (backgroundExtraData.CornerRadius != null)
+                    {
+                        UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.ContentsCornerRadius);
+                    }
+                    if (backgroundExtraData.BorderlineWidth > 0.0f)
+                    {
+                        UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.ContentsBorderline);
+                    }
+                }
+
                 // All states applied well.
                 currentStates.changed = false;
 


### PR DESCRIPTION
…re set URL

Since LottieAnimationView.URL property change whole Visual property by itself, CornerRadius / Borderline properties become ignored when we set URL.

```
lav = new LottieAnimationView();
lav.CornerRadius = new Vector4(100.0f, 100.0f, 100.0f, 100.0f);
lav.URL = "~~~.json"; ///< CornerRadius information ignored.
```

To avoid this case, let we ensure to set CornerRadius / Borderline if we set URL

Same PR with #5951