### PR TITLE
[NUI] Add GenerateUrl in Capture

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
@@ -86,7 +86,7 @@ namespace Tizen.NUI
             public static extern IntPtr GetNativeImageSourcePtr(HandleRef jarg1);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GenerateUrl")]
-            public static extern IntPtr GenerateUrl(HandleRef capture);
+            public static extern IntPtr GenerateUrl(global::System.IntPtr handle);
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetCapturedBuffer")]
             public static extern IntPtr GetCapturedBuffer(HandleRef capture);

--- a/src/Tizen.NUI/src/public/Utility/Capture.cs
+++ b/src/Tizen.NUI/src/public/Utility/Capture.cs
@@ -343,6 +343,17 @@ namespace Tizen.NUI
         {
             return new PixelBuffer(Interop.Capture.GetCapturedBuffer(SwigCPtr), true);
         }
+
+        /// <summary>
+        /// Generate captured image's Url
+        /// </summary>
+        /// <returns>The ImageUrl representing this captured image source</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ImageUrl GenerateUrl()
+        {
+            ImageUrl ret = new ImageUrl(Interop.Capture.GenerateUrl(this.SwigCPtr.Handle), true);
+            return ret;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Add GenerateUrl in capture.
this api for using capture.

related patches:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/306064/ https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/306066/ https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/306067/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
