### PR TITLE
[NUI] Unified native singletone class instance getter

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/KeyInputFocusManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/KeyInputFocusManager.cs
@@ -21,6 +21,7 @@ namespace Tizen.NUI
 {
     internal class KeyInputFocusManager : BaseHandle
     {
+        private static readonly KeyInputFocusManager instance = KeyInputFocusManager.GetInternal();
         internal KeyInputFocusManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }
@@ -35,13 +36,36 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// <summary>
+        /// Gets the singleton of the KeyInputFocusManager object.
+        /// </summary>
+        public static KeyInputFocusManager Instance
+        {
+            get
+            {
+                return instance;
+            }
+        }
+
+        [global::System.Obsolete("Do not use this, that will be deprecated. Use KeyInputFocusManager.Instance instead.")]
         public static KeyInputFocusManager Get()
         {
+            return KeyInputFocusManager.Instance;
+        }
+
+        private static KeyInputFocusManager GetInternal()
+        {
             global::System.IntPtr cPtr = Interop.KeyInputFocusManager.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("KeyInputFocusManager.Instance called before Application created, or after Application terminated!");
+            }
 
             KeyInputFocusManager ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as KeyInputFocusManager;
             if (ret != null)
             {
+                NUILog.ErrorBacktrace("KeyInputFocusManager.GetInternal() Should be called only one time!");
                 object dummyObect = new object();
 
                 global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
@@ -55,6 +79,18 @@ namespace Tizen.NUI
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
         }
 
         public void SetFocus(View control)

--- a/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/AccessibilityManager.cs
@@ -31,7 +31,7 @@ namespace Tizen.NUI.Accessibility
     [EditorBrowsable(EditorBrowsableState.Never)]
     public partial class AccessibilityManager : BaseHandle
     {
-        private static readonly AccessibilityManager instance = AccessibilityManager.Get();
+        private static readonly AccessibilityManager instance = AccessibilityManager.GetInternal();
 
         internal AccessibilityManager(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -698,13 +698,25 @@ namespace Tizen.NUI.Accessibility
             return ret;
         }
 
+        [Obsolete("Do not use this, that will be deprecated. Use AccessibilityManager.Instance instead.")]
         internal static AccessibilityManager Get()
         {
+            return AccessibilityManager.Instance;
+        }
+
+        private static AccessibilityManager GetInternal()
+        {
             global::System.IntPtr cPtr = Interop.AccessibilityManager.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("AccessibilityManager.Instance called before Application created, or after Application terminated!");
+            }
 
             AccessibilityManager ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as AccessibilityManager;
             if (ret != null)
             {
+                NUILog.ErrorBacktrace("AccessibilityManager.GetInternal() Should be called only one time!");
                 object dummyObect = new object();
 
                 global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
@@ -718,6 +730,19 @@ namespace Tizen.NUI.Accessibility
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
         }
 
         // Signals - AccessibilityManagerEvent.cs

--- a/src/Tizen.NUI/src/public/Clipboard/Clipboard.cs
+++ b/src/Tizen.NUI/src/public/Clipboard/Clipboard.cs
@@ -31,6 +31,8 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public partial class Clipboard : BaseHandle
     {
+        private static readonly Clipboard instance = Clipboard.GetInternal();
+
         /// <summary>
         /// User callback for clipboard event.
         /// </summary>
@@ -42,11 +44,6 @@ namespace Tizen.NUI
         internal bool hasClipboardDataReceived = false;
         internal Dictionary<uint, ClipboardCallback> receivedCallbackDictionary = new Dictionary<uint, ClipboardCallback>();
 
-        private Clipboard() : this(Interop.Clipboard.Get(), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         private Clipboard(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
         }
@@ -55,7 +52,55 @@ namespace Tizen.NUI
         /// Gets the singleton instance of Clipboard.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Clipboard Instance { get; } = new Clipboard();
+        public static Clipboard Instance
+        {
+            get
+            {
+                return instance;
+            }
+        }
+
+        private static Clipboard GetInternal()
+        {
+            global::System.IntPtr cPtr = Interop.Clipboard.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("Clipboard.Instance called before Application created, or after Application terminated!");
+                // Do not throw exception until TCT test passed.
+            }
+
+            Clipboard ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as Clipboard;
+            if (ret != null)
+            {
+                NUILog.ErrorBacktrace("Clipboard.GetInternal() Should be called only one time!");
+                object dummyObect = new object();
+
+                HandleRef CPtr = new HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new Clipboard(cPtr, true);
+            }
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
+        }
 
         /// <summary>
         /// Request set the given data to the clipboard.

--- a/src/Tizen.NUI/src/public/Common/StyleManager.cs
+++ b/src/Tizen.NUI/src/public/Common/StyleManager.cs
@@ -33,7 +33,7 @@ namespace Tizen.NUI
     [Obsolete("Deprecated in API9, will be removed in API11. Use ThemeManager instead.")]
     public class StyleManager : BaseHandle
     {
-        private static readonly StyleManager instance = StyleManager.Get();
+        private static readonly StyleManager instance = StyleManager.GetInternal();
         private EventHandler<StyleChangedEventArgs> styleManagerStyleChangedEventHandler;
         private StyleChangedCallbackDelegate styleManagerStyleChangedCallbackDelegate;
 
@@ -98,14 +98,27 @@ namespace Tizen.NUI
         /// </summary>
         /// <returns>A handle to the StyleManager control.</returns>
         /// <since_tizen> 3 </since_tizen>
-        [Obsolete("Deprecated in API9, will be removed in API11. Use ThemeManager instead.")]
+        [Obsolete("Deprecated in API9, will be removed in API11. Use ThemeManager instead." +
+            "Do not use this, that will be deprecated. Use StyleManager.Instance instead.")]
         public static StyleManager Get()
         {
+            return StyleManager.Instance;
+        }
+
+        private static StyleManager GetInternal()
+        {
             global::System.IntPtr cPtr = Interop.StyleManager.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("StyleManager.Instance called before Application created, or after Application terminated!");
+                // Do not throw exception until TCT test passed.
+            }
 
             StyleManager ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as StyleManager;
             if (ret != null)
             {
+                NUILog.ErrorBacktrace("StyleManager.GetInternal() Should be called only one time!");
                 object dummyObect = new object();
 
                 HandleRef CPtr = new HandleRef(dummyObect, cPtr);
@@ -119,6 +132,19 @@ namespace Tizen.NUI
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Common/TypeRegistry.cs
+++ b/src/Tizen.NUI/src/public/Common/TypeRegistry.cs
@@ -26,6 +26,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class TypeRegistry : BaseHandle
     {
+        private static readonly TypeRegistry instance = TypeRegistry.GetInternal();
         internal TypeRegistry(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
         }
@@ -42,18 +43,43 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets the singleton of the TypeRegistry object.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static TypeRegistry Instance
+        {
+            get
+            {
+                return instance;
+            }
+        }
+
+        /// <summary>
         /// Gets Type Registry handle.
         /// </summary>
         /// <returns>TypeRegistry handle.</returns>
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [global::System.Obsolete("Do not use this, that will be deprecated. Use TypeRegistry.Instance instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static TypeRegistry Get()
         {
+            return TypeRegistry.Instance;
+        }
+
+        private static TypeRegistry GetInternal()
+        {
             global::System.IntPtr cPtr = Interop.TypeRegistry.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("TypeRegistry.Instance called before Application created, or after Application terminated!");
+            }
 
             TypeRegistry ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TypeRegistry;
             if (ret != null)
             {
+                NUILog.ErrorBacktrace("TypeRegistry.GetInternal() Should be called only one time!");
                 object dummyObect = new object();
 
                 global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
@@ -67,6 +93,19 @@ namespace Tizen.NUI
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Input/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/Input/FocusManager.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class FocusManager : BaseHandle
     {
-        private static readonly FocusManager instance = FocusManager.Get();
+        private static readonly FocusManager instance = FocusManager.GetInternal();
         private CustomAlgorithmInterfaceWrapper customAlgorithmInterfaceWrapper;
 
         private EventHandlerWithReturnType<object, PreFocusChangeEventArgs, View> preFocusChangeEventHandler;
@@ -602,9 +602,39 @@ namespace Tizen.NUI
             return ret;
         }
 
+        [global::System.Obsolete("Do not use this, that will be deprecated. Use TypeRegistry.Instance instead. " +
+            "Like: " +
+            "TypeRegistry visualFactory = TypeRegistry.Instance; " +
+            "TypeRegistry.CreateVisual(visualMap);")]
         internal static FocusManager Get()
         {
-            FocusManager ret = new FocusManager(Interop.FocusManager.Get(), true);
+            return FocusManager.Instance;
+        }
+
+        private static FocusManager GetInternal()
+        {
+            global::System.IntPtr cPtr = Interop.FocusManager.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("FocusManager.Instance called before Application created, or after Application terminated!");
+            }
+
+            FocusManager ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as FocusManager;
+            if (ret != null)
+            {
+                NUILog.ErrorBacktrace("FocusManager.GetInternal() Should be called only one time!");
+                object dummyObect = new object();
+
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new FocusManager(cPtr, true);
+            }
+
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
 #if !PROFILE_TV
@@ -612,6 +642,19 @@ namespace Tizen.NUI
             ret.FocusIndicator = ret.GetDefaultFocusIndicator();
 #endif
             return ret;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
         }
 
         internal void SetFocusGroupLoop(bool enabled)

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     /// <since_tizen> 5 </since_tizen>
     public class FontClient : BaseHandle
     {
-        private static readonly FontClient instance = FontClient.Get();
+        private static readonly FontClient instance = FontClient.GetInternal();
 
         internal FontClient(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -284,13 +284,28 @@ namespace Tizen.NUI
             return fontInfoList;
         }
 
+        [global::System.Obsolete("Do not use this, that will be deprecated. Use FontClient.Instance instead. " +
+            "Like: " +
+            "FontClient fontClient = FontClient.Instance; " +
+            "FontClient.GetSystemFonts();")]
         internal static FontClient Get()
         {
+            return FontClient.Instance;
+        }
+
+        private static FontClient GetInternal()
+        {
             global::System.IntPtr cPtr = Interop.FontClient.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("FontClient.Instance called before Application created, or after Application terminated!");
+            }
 
             FontClient ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as FontClient;
             if (ret != null)
             {
+                NUILog.ErrorBacktrace("FontClient.GetInternal() Should be called only one time!");
                 object dummyObect = new object();
 
                 global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
@@ -304,6 +319,19 @@ namespace Tizen.NUI
 
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
         }
 
         internal FontClient Assign(FontClient handle)

--- a/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
+++ b/src/Tizen.NUI/src/public/Utility/TTSPlayer.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class TTSPlayer : BaseHandle
     {
-        private static readonly TTSPlayer instance = TTSPlayer.Get();
+        private static readonly TTSPlayer[] instance = {TTSPlayer.GetInternal(TTSMode.Default), TTSPlayer.GetInternal(TTSMode.Notification), TTSPlayer.GetInternal(TTSMode.ScreenReader)};
         private StateChangedEventCallbackType stateChangedEventCallback;
 
         internal TTSPlayer(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
@@ -137,7 +137,7 @@ namespace Tizen.NUI
         {
             get
             {
-                return instance;
+                return instance[(int)TTSMode.Default];
             }
         }
 
@@ -149,11 +149,32 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public static TTSPlayer Get(TTSMode mode)
         {
-            global::System.IntPtr cPtr = Interop.TtsPlayer.Get((int)mode);
+            return instance[(int)mode];
+        }
+
+        /// <summary>
+        /// Gets the singleton of the TTS player for the default mode.
+        /// </summary>
+        /// <returns> A handle of the TTS player for the default mode.</returns>
+        /// <since_tizen> 3 </since_tizen>
+        public static TTSPlayer Get()
+        {
+            return TTSPlayer.Instance;
+        }
+
+        private static TTSPlayer GetInternal(TTSMode mode)
+        {
+            global::System.IntPtr cPtr = Interop.TtsPlayer.Get((int) mode);
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("TTSPlayer.Instance called before Application created, or after Application terminated!");
+            }
 
             TTSPlayer ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TTSPlayer;
             if (ret != null)
             {
+                NUILog.ErrorBacktrace("TTSPlayer.GetInternal() Should be called only one time!");
                 object dummyObect = new object();
 
                 HandleRef CPtr = new HandleRef(dummyObect, cPtr);
@@ -169,31 +190,17 @@ namespace Tizen.NUI
             return ret;
         }
 
-        /// <summary>
-        /// Gets the singleton of the TTS player for the default mode.
-        /// </summary>
-        /// <returns> A handle of the TTS player for the default mode.</returns>
-        /// <since_tizen> 3 </since_tizen>
-        public static TTSPlayer Get()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
         {
-            global::System.IntPtr cPtr = Interop.TtsPlayer.Get();
-
-            TTSPlayer ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as TTSPlayer;
-            if (ret != null)
+            if (disposing)
             {
-                object dummyObect = new object();
-
-                HandleRef CPtr = new HandleRef(dummyObect, cPtr);
-                Interop.BaseHandle.DeleteBaseHandle(CPtr);
-                CPtr = new HandleRef(null, global::System.IntPtr.Zero);
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
             }
             else
             {
-                ret = new TTSPlayer(cPtr, true);
+                base.Dispose(disposing);
             }
-
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Instance of the VisualFactory singleton.
         /// </summary>
-        private static VisualFactory instance;
+        private static readonly VisualFactory instance = VisualFactory.GetInternal();
 
         private VisualFactory(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -48,12 +48,6 @@ namespace Tizen.NUI
         {
             get
             {
-                if (!instance)
-                {
-                    instance = new VisualFactory(Interop.VisualFactory.Get(), true);
-                    if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                }
-
                 return instance;
             }
         }
@@ -70,6 +64,47 @@ namespace Tizen.NUI
         public static VisualFactory Get()
         {
             return VisualFactory.Instance;
+        }
+
+        private static VisualFactory GetInternal()
+        {
+            global::System.IntPtr cPtr = Interop.VisualFactory.Get();
+
+            if(cPtr == global::System.IntPtr.Zero)
+            {
+                NUILog.ErrorBacktrace("VisualFactory.Instance called before Application created, or after Application terminated!");
+            }
+
+            VisualFactory ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as VisualFactory;
+            if (ret != null)
+            {
+                NUILog.ErrorBacktrace("VisualFactory.GetInternal() Should be called only one time!");
+                object dummyObect = new object();
+
+                global::System.Runtime.InteropServices.HandleRef CPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObect, cPtr);
+                Interop.BaseHandle.DeleteBaseHandle(CPtr);
+                CPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            }
+            else
+            {
+                ret = new VisualFactory(cPtr, true);
+            }
+
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                NUILog.ErrorBacktrace("We should not manually dispose for singleton class!");
+            }
+            else
+            {
+                base.Dispose(disposing);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
There was 2 way to get sigletone class - `Get()` method and `Instance` proeprty.

After merge #5683 PR, some singletone class' `Get()` method register registry at that moment. If someone call `Instance` after `Get()` call, the singletone class become GC, due to unknown reason.

To avoid this cases, let we make `Get()` method also use `Instance` property internally, and deprecate that method.

For watch the trends after change the singletone pattern, let we just print error log if some NUI developer implement wrong way in future.
