### PR TITLE
[NUI] Fix SVACE issue of null in ViewStyle.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -565,14 +565,13 @@ namespace Tizen.NUI.BaseComponents
         public override void CopyFrom(BindableObject other)
         {
             var source = other as ViewStyle;
-
-            IncludeDefaultStyle = source.IncludeDefaultStyle;
-            SolidNull = source.SolidNull;
-
             if (source == null || source.DirtyProperties == null || source.DirtyProperties.Count == 0)
             {
                 return;
             }
+
+            IncludeDefaultStyle = source.IncludeDefaultStyle;
+            SolidNull = source.SolidNull;
 
             BindableProperty.GetBindablePropertysOfType(GetType(), out var thisBindableProperties);
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
WID:36371588 Value source, which was created by as-operator, so can be null, is dereferenced in member access expression source.IncludeDefaultStyle
WID:36385014 Value source, which was dereferenced in member access expression source.SolidNull, is compared with null

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
