### PR TITLE
[NUI] Do not remove once event when ImageView is dispose

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
@@ -380,6 +380,11 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void UpdateImage()
         {
+            if (Disposed)
+            {
+                return;
+            }
+
             if (!imagePropertyUpdatedFlag) return;
 
             // Assume that we are using standard Image at first.

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1447,11 +1447,6 @@ namespace Tizen.NUI.BaseComponents
                 borderSelector?.Reset(this);
                 resourceUrlSelector?.Reset(this);
                 imagePropertyUpdatedFlag = false;
-                if (imagePropertyUpdateProcessAttachedFlag)
-                {
-                    ProcessorController.Instance.ProcessorOnceEvent -= UpdateImage;
-                    imagePropertyUpdateProcessAttachedFlag = false;
-                }
                 cachedImagePropertyMap?.Dispose();
                 cachedImagePropertyMap = null;
             }
@@ -1540,11 +1535,7 @@ namespace Tizen.NUI.BaseComponents
 
                 // Image visual is not exist anymore. We should ignore lazy UpdateImage
                 imagePropertyUpdatedFlag = false;
-                if (imagePropertyUpdateProcessAttachedFlag)
-                {
-                    ProcessorController.Instance.ProcessorOnceEvent -= UpdateImage;
-                    imagePropertyUpdateProcessAttachedFlag = false;
-                }
+
                 // Update resourceUrl as empty value
                 _resourceUrl = "";
                 cachedImagePropertyMap[ImageVisualProperty.URL] = emptyValue;
@@ -1670,6 +1661,11 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void UpdateImage()
         {
+            if (Disposed)
+            {
+                return;
+            }
+
             if (!imagePropertyUpdatedFlag) return;
 
             imagePropertyUpdatedFlag = false;

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -890,6 +890,11 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void UpdateImage()
         {
+            if (Disposed)
+            {
+                return;
+            }
+
             if (!imagePropertyUpdatedFlag) return;
 
             // Update currentStates properties to cachedImagePropertyMap

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -293,11 +293,6 @@ namespace Tizen.NUI.BaseComponents
 
                     // Background extra data is not valid anymore. We should ignore lazy UpdateBackgroundExtraData
                     view.backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
-                    if (view.backgroundExtraDataUpdateProcessAttachedFlag)
-                    {
-                        ProcessorController.Instance.ProcessorOnceEvent -= view.UpdateBackgroundExtraData;
-                        view.backgroundExtraDataUpdateProcessAttachedFlag = false;
-                    }
 
                     propertyValue.Dispose();
                     propertyValue = null;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1227,6 +1227,11 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         internal virtual void UpdateBackgroundExtraData()
         {
+            if (Disposed)
+            {
+                return;
+            }
+
             if (backgroundExtraData == null)
             {
                 return;
@@ -1457,11 +1462,6 @@ namespace Tizen.NUI.BaseComponents
             }
 
             backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
-            if (backgroundExtraDataUpdateProcessAttachedFlag)
-            {
-                ProcessorController.Instance.ProcessorOnceEvent -= UpdateBackgroundExtraData;
-                backgroundExtraDataUpdateProcessAttachedFlag = false;
-            }
 
             LayoutCount = 0;
 


### PR DESCRIPTION
Remove event from global static handler is heavy operation.

We can detach whether the view is disposed or not.
So just check disposed is more chip rather than remove event callback.
