### PR TITLE
[NoACR][MachineLearning.Inference] Fix bug using wrong handle

### DIFF
--- a/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/TensorsData.cs
+++ b/src/Tizen.MachineLearning.Inference/Tizen.MachineLearning.Inference/TensorsData.cs
@@ -50,7 +50,7 @@ namespace Tizen.MachineLearning.Inference
 
             /* Set count */
             int count = 0;
-            ret = Interop.Util.GetTensorsCount(_handle, out count);
+            ret = Interop.Util.GetTensorsCount(_tensorsInfo.GetTensorsInfoHandle(), out count);
             NNStreamer.CheckException(ret, "unable to get the count of TensorsData");
 
             _dataList = new ArrayList(count);


### PR DESCRIPTION
### Description of Change ###
This patch fixes the bug which use wrong handle.
GetTensorsCount should use TensorsInfo handle instead of TensorsData handle.

See also : #5800