### PR TITLE
[NUI.Scene3D] Add CastShadow and ReceiveShadow for Model and ModelNode

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.Model.cs
@@ -96,6 +96,21 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_LoadFacialAnimation_2")]
             public static extern global::System.IntPtr LoadBlendShapeAnimationFromBuffer(global::System.Runtime.InteropServices.HandleRef model, string jsonBuffer, int jsonBufferLength);
             
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_CastShadow")]
+            public static extern void CastShadow(global::System.Runtime.InteropServices.HandleRef model, bool castShadow);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_IsShadowCasting")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsShadowCasting(global::System.Runtime.InteropServices.HandleRef model);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_ReceiveShadow")]
+            public static extern void ReceiveShadow(global::System.Runtime.InteropServices.HandleRef model, bool receiveShadow);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_IsShadowReceiving")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsShadowReceiving(global::System.Runtime.InteropServices.HandleRef model);
+
+            
             // Signals
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_Model_MeshHitSignal_Connect")]
             public static extern void MeshHitSignalConnect(global::System.Runtime.InteropServices.HandleRef model, global::System.Runtime.InteropServices.HandleRef handler);

--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.ModelNode.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.ModelNode.cs
@@ -75,7 +75,21 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_ModelNode_SetColliderMesh")]
             public static extern global::System.IntPtr SetColliderMesh(global::System.Runtime.InteropServices.HandleRef modelNode,
                 Vec3[] vPtr,
-                Vec3[] nPtr, int vLength, int[] iPtr, int iLength);            
+                Vec3[] nPtr, int vLength, int[] iPtr, int iLength);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_ModelNode_CastShadow")]
+            public static extern void CastShadow(global::System.Runtime.InteropServices.HandleRef model, bool castShadow);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_ModelNode_IsShadowCasting")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsShadowCasting(global::System.Runtime.InteropServices.HandleRef model);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_ModelNode_ReceiveShadow")]
+            public static extern void ReceiveShadow(global::System.Runtime.InteropServices.HandleRef model, bool receiveShadow);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_ModelNode_IsShadowReceiving")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsShadowReceiving(global::System.Runtime.InteropServices.HandleRef model);
         }
     }
 }

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/Model.cs
@@ -595,6 +595,64 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// Sets whether this Model casts shadow or not.
+        /// If it is true, this model is drawn on Shadow Map.
+        /// Note: This method affects all of the child ModelNode.
+        /// However, same property of each child ModelNode can be changed respectively and it not changes parent's property.
+        /// </summary>
+        /// <param name="castShadow">Whether this Model casts shadow or not.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void CastShadow(bool castShadow)
+        {
+            Interop.Model.CastShadow(SwigCPtr, castShadow);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Retrieves whether the Model casts shadow or not for Light.
+        /// Note: IBL does not cast any shadow.
+        /// </summary>
+        /// <returns>True if this model casts shadow.</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsShadowCasting()
+        {
+            var isShadowCasting = Interop.Model.IsShadowCasting(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return isShadowCasting;
+        }
+
+        /// <summary>
+        /// Sets whether this Model receives shadow or not.
+        /// If it is true, shadows are drawn on this model.
+        /// Note: This method affects all of the child ModelNode.
+        /// However, same property of each child ModelNode can be changed respectively and it not changes parent's property.
+        /// </summary>
+        /// <param name="receiveShadow">Whether this Model receives shadow or not.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ReceiveShadow(bool receiveShadow)
+        {
+            Interop.Model.ReceiveShadow(SwigCPtr, receiveShadow);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Retrieves whether the Model receives shadow or not for Light
+        /// If it is true, this model is drawn on Shadow Map.
+        /// </summary>
+        /// <returns>True if this model receives shadow.</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsShadowReceiving()
+        {
+            var isShadowReceiving = Interop.Model.IsShadowReceiving(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return isShadowReceiving;
+        }
+
+        /// <summary>
         /// Retrieves model root Actor.
         /// </summary>
         /// <returns>Root View of the model.</returns>

--- a/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelNode.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelComponents/ModelNode.cs
@@ -238,6 +238,64 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// Sets whether this Model casts shadow or not.
+        /// If it is true, this model is drawn on Shadow Map.
+        /// Note: This method affects all of the child ModelNode.
+        /// However, same property of each child ModelNode can be changed respectively and it not changes parent's property.
+        /// </summary>
+        /// <param name="castShadow">Whether this Model casts shadow or not.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void CastShadow(bool castShadow)
+        {
+            Interop.ModelNode.CastShadow(SwigCPtr, castShadow);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Retrieves whether the Model casts shadow or not for Light.
+        /// Note: IBL does not cast any shadow.
+        /// </summary>
+        /// <returns>True if this model casts shadow.</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsShadowCasting()
+        {
+            var isShadowCasting = Interop.ModelNode.IsShadowCasting(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return isShadowCasting;
+        }
+
+        /// <summary>
+        /// Sets whether this Model receives shadow or not.
+        /// If it is true, shadows are drawn on this model.
+        /// Note: This method affects all of the child ModelNode.
+        /// However, same property of each child ModelNode can be changed respectively and it not changes parent's property.
+        /// </summary>
+        /// <param name="receiveShadow">Whether this Model receives shadow or not.</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ReceiveShadow(bool receiveShadow)
+        {
+            Interop.ModelNode.ReceiveShadow(SwigCPtr, receiveShadow);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Retrieves whether the Model receives shadow or not for Light
+        /// If it is true, this model is drawn on Shadow Map.
+        /// </summary>
+        /// <returns>True if this model receives shadow.</returns>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsShadowReceiving()
+        {
+            var isShadowReceiving = Interop.ModelNode.IsShadowReceiving(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return isShadowReceiving;
+        }
+
+        /// <summary>
         /// Gets the number of ModelPrimitive objects in the ModelNode object.
         /// </summary>
         /// <returns>The number of ModelPrimitive objects in the ModelNode object.</returns>


### PR DESCRIPTION
 - CastShadow can be used to make an object cast shadow or not.
 - ReceiveShadow can be used to make an object be not drawn any shadow on its surface.
 - Model and ModelNode have the methods.
 - If Model's method is called, it is inherited to its current child ModelNode.
 - If ModelNode's method is called, it is only affects the ModelNode itself.
 - The ModelNode's property changes do not affect its parent Model's property.

dali-csharp-binder : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/307410/
dali-toolkit : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/307060/
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
