### PR TITLE
[NUI] Add IsUsingXaml

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
@@ -392,6 +392,12 @@ namespace Tizen.NUI
 
             Log.Info("NUI", "NUICorebackend OnPreCreated Called");
 
+            if (NUIApplication.IsUsingXaml)
+            {
+                Tizen.Log.Fatal("NT", $"NUICoreBackend.OnInitialized() XAML ON, IsUsingXaml={NUIApplication.IsUsingXaml}");
+            }
+
+
             Tizen.Tracer.Begin("[NUI] OnInitialized(): OnPreCreated event handler");
             var preCreateHandler = Handlers[EventType.PreCreated] as Action;
             preCreateHandler?.Invoke();

--- a/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
@@ -390,13 +390,7 @@ namespace Tizen.NUI
         {
             Tizen.Tracer.Begin("[NUI] OnInitialized()");
 
-            Log.Info("NUI", "NUICorebackend OnPreCreated Called");
-
-            if (NUIApplication.IsUsingXaml)
-            {
-                Tizen.Log.Fatal("NT", $"NUICoreBackend.OnInitialized() XAML ON, IsUsingXaml={NUIApplication.IsUsingXaml}");
-            }
-
+            Log.Info("NUI", $"NUICorebackend OnPreCreated Called IsUsingXaml={NUIApplication.IsUsingXaml}");
 
             Tizen.Tracer.Begin("[NUI] OnInitialized(): OnPreCreated event handler");
             var preCreateHandler = Handlers[EventType.PreCreated] as Action;

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -23,6 +23,7 @@ using System.Reflection;
 using Tizen.Applications;
 using Tizen.Applications.CoreBackend;
 using Tizen.NUI.Xaml;
+using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
 {
@@ -63,6 +64,7 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication() : base(new NUICoreBackend())
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #1");
         }
 
         /// <summary>
@@ -76,6 +78,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Size2D windowSize, Position2D windowPosition) : base(new NUICoreBackend("", NUIApplication.WindowMode.Opaque, windowSize, windowPosition))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #2");
         }
 
         /// <summary>
@@ -86,6 +89,7 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet) : base(new NUICoreBackend(styleSheet))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #3 IsUsingXaml={IsUsingXaml}");
         }
 
         /// <summary>
@@ -100,6 +104,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, Size2D windowSize, Position2D windowPosition) : base(new NUICoreBackend(styleSheet, WindowMode.Opaque, windowSize, windowPosition))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #4");
         }
 
         /// <summary>
@@ -111,6 +116,8 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet, WindowMode windowMode) : base(new NUICoreBackend(styleSheet, windowMode))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #5");
+            Tizen.Log.Fatal("NT", $"IsUsingXaml={IsUsingXaml}");
         }
 
         /// <summary>
@@ -126,6 +133,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, WindowMode windowMode, Size2D windowSize, Position2D windowPosition) : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #6");
         }
 
         /// <summary>
@@ -141,6 +149,8 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Graphics.BackendType backend, WindowMode windowMode = WindowMode.Opaque, Size2D windowSize = null, Position2D windowPosition = null, string styleSheet = "") : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #7");
+
             //windowMode and styleSheet will be added later. currently it's not working as expected.
             Graphics.Backend = backend;
             Tizen.Log.Error("NUI", "Plaese DO NOT set graphical backend type with this constructor! This will give no effect!");
@@ -154,6 +164,8 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(ThemeOptions option) : base(new NUICoreBackend())
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #8");
+
             ApplyThemeOption(option);
         }
 
@@ -167,6 +179,8 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Size2D windowSize, Position2D windowPosition, ThemeOptions option) : base(new NUICoreBackend("", NUIApplication.WindowMode.Opaque, windowSize, windowPosition))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #9");
+
             ApplyThemeOption(option);
         }
 
@@ -181,6 +195,8 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet, WindowMode windowMode, WindowType type) : base(new NUICoreBackend(styleSheet, windowMode, type))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #10");
+
             ExternalThemeManager.Initialize();
         }
 
@@ -196,6 +212,8 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet, Size2D windowSize, Position2D windowPosition, IBorderInterface borderInterface, WindowMode windowMode = WindowMode.Opaque) : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #11");
+
             EnableBorder(borderInterface);
         }
 
@@ -208,6 +226,8 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(ThemeOptions option, IBorderInterface borderInterface) : base(new NUICoreBackend())
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #12");
+
             EnableBorder(borderInterface);
             ApplyThemeOption(option);
         }
@@ -223,6 +243,8 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Size2D windowSize, Position2D windowPosition, ThemeOptions option, IBorderInterface borderInterface) : base(new NUICoreBackend("", NUIApplication.WindowMode.Opaque, windowSize, windowPosition))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #13");
+
             EnableBorder(borderInterface);
             ApplyThemeOption(option);
         }
@@ -247,6 +269,8 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, WindowMode windowMode, CoreTask task) : base(new NUICoreBackend(styleSheet, windowMode), task)
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #14");
+
         }
 
         /// <summary>
@@ -261,6 +285,8 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, WindowMode windowMode, Size2D windowSize, Position2D windowPosition, CoreTask task) : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition), task)
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #15");
+
         }
 
         /// <summary>
@@ -272,6 +298,8 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(ThemeOptions option, WindowData windowData) : base(new NUICoreBackend(windowData))
         {
+            Tizen.Log.Fatal("NT", $"NUIApplication constructor #16");
+
             if (windowData.BorderInterface != null)
             {
                 EnableBorder(windowData.BorderInterface);
@@ -645,6 +673,9 @@ namespace Tizen.NUI
             var disposalbeQueue = DisposeQueue.Instance;
             var registry = Registry.Instance;
 
+            // no need to be enable XAML when preload
+            NUIApplication.IsUsingXaml = false;
+
             // Initialize some BaseComponent static variables now
             BaseComponents.View.Preload();
             BaseComponents.ImageView.Preload();
@@ -660,15 +691,15 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Set to true if BindableProperty is not used. 
-        /// This must be called immediately after the NUIApplication constructor is called.
-        /// The default value is false.        
+        /// Set to true if XAML is used. 
+        /// This must be called before or immediately after the NUIApplication constructor is called.
+        /// The default value is true.
         /// </summary>
         /// <remarks>
-        /// This must be called immediately after the NUIApplication constructor is called.
+        /// This must be called before or immediately after the NUIApplication constructor is called.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        static public bool DisableBindableProperty { get; set; } = false;
+        static public bool IsUsingXaml { get; set; } = true;
 
         /// <summary>
         /// Check if it is loaded as dotnet-loader-nui.

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -64,7 +64,6 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication() : base(new NUICoreBackend())
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #1");
         }
 
         /// <summary>
@@ -78,7 +77,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Size2D windowSize, Position2D windowPosition) : base(new NUICoreBackend("", NUIApplication.WindowMode.Opaque, windowSize, windowPosition))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #2");
         }
 
         /// <summary>
@@ -89,7 +87,6 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet) : base(new NUICoreBackend(styleSheet))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #3 IsUsingXaml={IsUsingXaml}");
         }
 
         /// <summary>
@@ -104,7 +101,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, Size2D windowSize, Position2D windowPosition) : base(new NUICoreBackend(styleSheet, WindowMode.Opaque, windowSize, windowPosition))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #4");
         }
 
         /// <summary>
@@ -116,8 +112,6 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet, WindowMode windowMode) : base(new NUICoreBackend(styleSheet, windowMode))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #5");
-            Tizen.Log.Fatal("NT", $"IsUsingXaml={IsUsingXaml}");
         }
 
         /// <summary>
@@ -133,7 +127,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, WindowMode windowMode, Size2D windowSize, Position2D windowPosition) : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #6");
         }
 
         /// <summary>
@@ -149,8 +142,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Graphics.BackendType backend, WindowMode windowMode = WindowMode.Opaque, Size2D windowSize = null, Position2D windowPosition = null, string styleSheet = "") : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #7");
-
             //windowMode and styleSheet will be added later. currently it's not working as expected.
             Graphics.Backend = backend;
             Tizen.Log.Error("NUI", "Plaese DO NOT set graphical backend type with this constructor! This will give no effect!");
@@ -164,8 +155,6 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(ThemeOptions option) : base(new NUICoreBackend())
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #8");
-
             ApplyThemeOption(option);
         }
 
@@ -179,8 +168,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Size2D windowSize, Position2D windowPosition, ThemeOptions option) : base(new NUICoreBackend("", NUIApplication.WindowMode.Opaque, windowSize, windowPosition))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #9");
-
             ApplyThemeOption(option);
         }
 
@@ -195,8 +182,6 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet, WindowMode windowMode, WindowType type) : base(new NUICoreBackend(styleSheet, windowMode, type))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #10");
-
             ExternalThemeManager.Initialize();
         }
 
@@ -212,8 +197,6 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(string styleSheet, Size2D windowSize, Position2D windowPosition, IBorderInterface borderInterface, WindowMode windowMode = WindowMode.Opaque) : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #11");
-
             EnableBorder(borderInterface);
         }
 
@@ -226,8 +209,6 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA2000: Dispose objects before losing scope", Justification = "NUICoreBackend is disposed in the base class when the application is terminated")]
         public NUIApplication(ThemeOptions option, IBorderInterface borderInterface) : base(new NUICoreBackend())
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #12");
-
             EnableBorder(borderInterface);
             ApplyThemeOption(option);
         }
@@ -243,8 +224,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(Size2D windowSize, Position2D windowPosition, ThemeOptions option, IBorderInterface borderInterface) : base(new NUICoreBackend("", NUIApplication.WindowMode.Opaque, windowSize, windowPosition))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #13");
-
             EnableBorder(borderInterface);
             ApplyThemeOption(option);
         }
@@ -269,8 +248,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, WindowMode windowMode, CoreTask task) : base(new NUICoreBackend(styleSheet, windowMode), task)
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #14");
-
         }
 
         /// <summary>
@@ -285,8 +262,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(string styleSheet, WindowMode windowMode, Size2D windowSize, Position2D windowPosition, CoreTask task) : base(new NUICoreBackend(styleSheet, windowMode, windowSize, windowPosition), task)
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #15");
-
         }
 
         /// <summary>
@@ -298,8 +273,6 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public NUIApplication(ThemeOptions option, WindowData windowData) : base(new NUICoreBackend(windowData))
         {
-            Tizen.Log.Fatal("NT", $"NUIApplication constructor #16");
-
             if (windowData.BorderInterface != null)
             {
                 EnableBorder(windowData.BorderInterface);
@@ -672,9 +645,6 @@ namespace Tizen.NUI
             // Initialize some static utility
             var disposalbeQueue = DisposeQueue.Instance;
             var registry = Registry.Instance;
-
-            // no need to be enable XAML when preload
-            NUIApplication.IsUsingXaml = false;
 
             // Initialize some BaseComponent static variables now
             BaseComponents.View.Preload();

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -89,8 +89,11 @@ namespace Tizen.NUI.BaseComponents
 
         static View()
         {
-            if (NUIApplication.DisableBindableProperty == false)
+            Tizen.Log.Fatal("NT", $"static View construct IsUsingXaml={NUIApplication.IsUsingXaml}");
+            if (NUIApplication.IsUsingXaml)
             {
+                CreateBindableProperties();
+
                 RegisterPropertyGroup(PositionProperty, positionPropertyGroup);
                 RegisterPropertyGroup(Position2DProperty, positionPropertyGroup);
                 RegisterPropertyGroup(PositionXProperty, positionPropertyGroup);
@@ -114,10 +117,13 @@ namespace Tizen.NUI.BaseComponents
         {
             Container.Preload();
 
-            // Do nothing. Just call for load static values.
-            var temporalPositionPropertyGroup = positionPropertyGroup;
-            var temporalSizePropertyGroup = sizePropertyGroup;
-            var temporalScalePropertyGroup = scalePropertyGroup;
+            if (NUIApplication.IsUsingXaml)
+            {
+                // Do nothing. Just call for load static values.
+                var temporalPositionPropertyGroup = positionPropertyGroup;
+                var temporalSizePropertyGroup = sizePropertyGroup;
+                var temporalScalePropertyGroup = scalePropertyGroup;
+            }
         }
 
         /// <summary>
@@ -526,24 +532,24 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                if (NUIApplication.DisableBindableProperty)
+                if (NUIApplication.IsUsingXaml)
                 {
-                    return (Color)GetInternalBackgroundColorProperty(this);
+                    return (Color)GetValue(BackgroundColorProperty);
                 }
                 else
                 {
-                    return (Color)GetValue(BackgroundColorProperty);
+                    return (Color)GetInternalBackgroundColorProperty(this);
                 }
             }
             set
             {
-                if (NUIApplication.DisableBindableProperty)
+                if (NUIApplication.IsUsingXaml)
                 {
-                    SetInternalBackgroundColorProperty(this, null, value);
+                    SetValue(BackgroundColorProperty, value);
                 }
                 else
                 {
-                    SetValue(BackgroundColorProperty, value);
+                    SetInternalBackgroundColorProperty(this, null, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -994,11 +1000,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Vector2)GetValue(CellIndexProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Vector2)GetValue(CellIndexProperty);
+                }
+                else
+                {
+                    return (Vector2)GetInternalCellIndexProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(CellIndexProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(CellIndexProperty, value);
+                }
+                else
+                {
+                    SetInternalCellIndexProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -1301,9 +1325,9 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                if (NUIApplication.DisableBindableProperty)
+                if (NUIApplication.IsUsingXaml)
                 {
-                    var temp = (Size2D)GetInternalSize2DProperty(this);
+                    var temp = (Size2D)GetValue(Size2DProperty);
                     if (this.Layout == null)
                     {
                         if (temp.Width < 0) { temp.Width = 0; }
@@ -1313,7 +1337,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    var temp = (Size2D)GetValue(Size2DProperty);
+                    var temp = (Size2D)GetInternalSize2DProperty(this);
                     if (this.Layout == null)
                     {
                         if (temp.Width < 0) { temp.Width = 0; }
@@ -1324,13 +1348,13 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                if (NUIApplication.DisableBindableProperty)
+                if (NUIApplication.IsUsingXaml)
                 {
-                    SetInternalSize2DProperty(this, null, value);
+                    SetValue(Size2DProperty, value);
                 }
                 else
                 {
-                    SetValue(Size2DProperty, value);
+                    SetInternalSize2DProperty(this, null, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1404,24 +1428,26 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                if (NUIApplication.DisableBindableProperty)
+                if (NUIApplication.IsUsingXaml)
                 {
-                    return (Position2D)GetInternalPosition2DProperty(this);
+                    return (Position2D)GetValue(Position2DProperty);
                 }
                 else
                 {
-                    return (Position2D)GetValue(Position2DProperty);
+                    return (Position2D)GetInternalPosition2DProperty(this);
+
                 }
             }
             set
             {
-                if (NUIApplication.DisableBindableProperty)
+                if (NUIApplication.IsUsingXaml)
                 {
-                    SetInternalPosition2DProperty(this, null, value);
+                    SetValue(Position2DProperty, value);
                 }
                 else
                 {
-                    SetValue(Position2DProperty, value);
+                    SetInternalPosition2DProperty(this, null, value);
+
                 }
                 NotifyPropertyChanged();
             }
@@ -1615,12 +1641,27 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                Position tmp = (Position)GetValue(ParentOriginProperty);
-                return new Position(OnParentOriginChanged, tmp.X, tmp.Y, tmp.Z);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    var tmp = (Position)GetValue(ParentOriginProperty);
+                    return new Position(OnParentOriginChanged, tmp.X, tmp.Y, tmp.Z);
+                }
+                else
+                {
+                    var tmp = (Position)GetInternalParentOriginProperty(this);
+                    return new Position(OnParentOriginChanged, tmp.X, tmp.Y, tmp.Z);
+                }
             }
             set
             {
-                SetValue(ParentOriginProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ParentOriginProperty, value);
+                }
+                else
+                {
+                    SetInternalParentOriginProperty(this, null, value);
+                }
                 NotifyPropertyChanged();
             }
         }
@@ -1652,11 +1693,28 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Position)GetValue(PivotPointProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Position)GetValue(PivotPointProperty);
+                }
+                else
+                {
+                    return (Position)GetInternalPivotPointProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(PivotPointProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(PivotPointProperty, value);
+                }
+                else
+                {
+                    SetInternalPivotPointProperty(this, null, value);
+                }
+
                 NotifyPropertyChanged();
             }
         }
@@ -1677,11 +1735,28 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(SizeWidthProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(SizeWidthProperty);
+                }
+                else
+                {
+                    return (float)GetInternalSizeWidthProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(SizeWidthProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(SizeWidthProperty, value);
+                }
+                else
+                {
+                    SetInternalSizeWidthProperty(this, null, value);
+                }
+
                 NotifyPropertyChanged();
             }
         }
@@ -1702,11 +1777,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(SizeHeightProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(SizeHeightProperty);
+                }
+                else
+                {
+                    return (float)GetInternalSizeHeightProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(SizeHeightProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(SizeHeightProperty, value);
+                }
+                else
+                {
+                    SetInternalSizeHeightProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -1741,11 +1834,25 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Position)GetValue(PositionProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Position)GetValue(PositionProperty);
+                }
+                else
+                {
+                    return (Position2D)GetInternalPositionProperty(this);
+                }
             }
             set
             {
-                SetValue(PositionProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(PositionProperty, value);
+                }
+                else
+                {
+                    SetInternalPositionProperty(this, null, value);
+                }
                 NotifyPropertyChanged();
             }
         }
@@ -1766,11 +1873,25 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(PositionXProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(PositionXProperty);
+                }
+                else
+                {
+                    return (float)GetInternalPositionXProperty(this);
+                }
             }
             set
             {
-                SetValue(PositionXProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(PositionXProperty, value);
+                }
+                else
+                {
+                    SetInternalPositionXProperty(this, null, value);
+                }
                 NotifyPropertyChanged();
             }
         }
@@ -1791,11 +1912,25 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(PositionYProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(PositionYProperty);
+                }
+                else
+                {
+                    return (float)GetInternalPositionYProperty(this);
+                }
             }
             set
             {
-                SetValue(PositionYProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(PositionYProperty, value);
+                }
+                else
+                {
+                    SetInternalPositionYProperty(this, null, value);
+                }
                 NotifyPropertyChanged();
             }
         }
@@ -1816,11 +1951,28 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(PositionZProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(PositionZProperty);
+                }
+                else
+                {
+                    return (float)GetInternalPositionZProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(PositionZProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(PositionZProperty, value);
+                }
+                else
+                {
+                    SetInternalPositionZProperty(this, null, value);
+                }
+
                 NotifyPropertyChanged();
             }
         }
@@ -1910,11 +2062,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Vector3)GetValue(ScaleProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Vector3)GetValue(ScaleProperty);
+                }
+                else
+                {
+                    return (Vector3)GetInternalScaleProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ScaleProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ScaleProperty, value);
+                }
+                else
+                {
+                    SetInternalScaleProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -1935,11 +2105,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(ScaleXProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(ScaleXProperty);
+                }
+                else
+                {
+                    return (float)GetInternalScaleXProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ScaleXProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ScaleXProperty, value);
+                }
+                else
+                {
+                    SetInternalScaleXProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -1960,11 +2148,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(ScaleYProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(ScaleYProperty);
+                }
+                else
+                {
+                    return (float)GetInternalScaleYProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ScaleYProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ScaleYProperty, value);
+                }
+                else
+                {
+                    SetInternalScaleYProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -1985,11 +2191,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(ScaleZProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(ScaleZProperty);
+                }
+                else
+                {
+                    return (float)GetInternalScaleZProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ScaleZProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ScaleZProperty, value);
+                }
+                else
+                {
+                    SetInternalScaleZProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -2050,11 +2274,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (string)GetValue(NameProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (string)GetValue(NameProperty);
+                }
+                else
+                {
+                    return (string)GetInternalNameProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(NameProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(NameProperty, value);
+                }
+                else
+                {
+                    SetInternalNameProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -2218,11 +2460,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Vector3)GetValue(SizeModeFactorProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Vector3)GetValue(SizeModeFactorProperty);
+                }
+                else
+                {
+                    return (Vector3)GetInternalSizeModeFactorProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(SizeModeFactorProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(SizeModeFactorProperty, value);
+                }
+                else
+                {
+                    SetInternalSizeModeFactorProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -2335,11 +2595,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Extents)GetValue(PaddingProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Extents)GetValue(PaddingProperty);
+                }
+                else
+                {
+                    return (Extents)GetInternalPaddingProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(PaddingProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(PaddingProperty, value);
+                }
+                else
+                {
+                    SetInternalPaddingProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -2367,7 +2645,15 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Size2D)GetValue(MinimumSizeProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Size2D)GetValue(MinimumSizeProperty);
+                }
+                else
+                {
+                    return (Size2D)GetInternalMinimumSizeProperty(this);
+                }
+
             }
             set
             {
@@ -2383,7 +2669,15 @@ namespace Tizen.NUI.BaseComponents
                     layout.MinimumHeight = new Tizen.NUI.LayoutLength(value.Height);
                     layout.RequestLayout();
                 }
-                SetValue(MinimumSizeProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(MinimumSizeProperty, value);
+                }
+                else
+                {
+                    SetInternalMinimumSizeProperty(this, null, value);
+                }
+
                 NotifyPropertyChanged();
             }
         }
@@ -2407,7 +2701,14 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Size2D)GetValue(MaximumSizeProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Size2D)GetValue(MaximumSizeProperty);
+                }
+                else
+                {
+                    return (Size2D)GetInternalMaximumSizeProperty(this);
+                }
             }
             set
             {
@@ -2417,7 +2718,16 @@ namespace Tizen.NUI.BaseComponents
                 {
                     layout.RequestLayout();
                 }
-                SetValue(MaximumSizeProperty, value);
+
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(MaximumSizeProperty, value);
+                }
+                else
+                {
+                    SetInternalMaximumSizeProperty(this, null, value);
+                }
+
                 NotifyPropertyChanged();
             }
         }
@@ -2487,11 +2797,28 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return GetValue(AnchorPointProperty) as Position;
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Position)GetValue(AnchorPointProperty);
+                }
+                else
+                {
+                    return (Position)GetInternalAnchorPointProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(AnchorPointProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(AnchorPointProperty, value);
+                }
+                else
+                {
+                    SetInternalAnchorPointProperty(this, null, value);
+                }
+
             }
         }
 
@@ -2539,11 +2866,25 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Size)GetValue(SizeProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Size)GetValue(SizeProperty);
+                }
+                else
+                {
+                    return (Size)GetInternalSizeProperty(this);
+                }
             }
             set
             {
-                SetValue(SizeProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(SizeProperty, value);
+                }
+                else
+                {
+                    SetInternalSizeProperty(this, null, value);
+                }
                 NotifyPropertyChanged();
             }
         }
@@ -2643,11 +2984,27 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Extents)GetValue(MarginProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Extents)GetValue(MarginProperty);
+                }
+                else
+                {
+                    return (Extents)GetInternalMarginProperty(this);
+                }
+
             }
             set
             {
-                SetValue(MarginProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(MarginProperty, value);
+                }
+                else
+                {
+                    SetInternalMarginProperty(this, null, value);
+                }
+
                 NotifyPropertyChanged();
             }
         }
@@ -2892,11 +3249,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Color)GetValue(ColorProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (Color)GetValue(ColorProperty);
+                }
+                else
+                {
+                    return (Color)GetInternalColorProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ColorProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ColorProperty, value);
+                }
+                else
+                {
+                    SetInternalColorProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -2914,11 +3289,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(ColorRedProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(ColorRedProperty);
+                }
+                else
+                {
+                    return (float)GetInternalColorRedProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ColorRedProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ColorRedProperty, value);
+                }
+                else
+                {
+                    SetInternalColorRedProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -2936,11 +3329,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(ColorGreenProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(ColorGreenProperty);
+                }
+                else
+                {
+                    return (float)GetInternalColorGreenProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ColorGreenProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ColorGreenProperty, value);
+                }
+                else
+                {
+                    SetInternalColorGreenProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }
@@ -2958,11 +3369,29 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (float)GetValue(ColorBlueProperty);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (float)GetValue(ColorBlueProperty);
+                }
+                else
+                {
+                    return (float)GetInternalColorBlueProperty(this);
+                }
+
+
             }
             set
             {
-                SetValue(ColorBlueProperty, value);
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(ColorBlueProperty, value);
+                }
+                else
+                {
+                    SetInternalColorBlueProperty(this, null, value);
+                }
+
+
                 NotifyPropertyChanged();
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -89,10 +89,95 @@ namespace Tizen.NUI.BaseComponents
 
         static View()
         {
-            Tizen.Log.Fatal("NT", $"static View construct IsUsingXaml={NUIApplication.IsUsingXaml}");
             if (NUIApplication.IsUsingXaml)
             {
+#if REMOVE_READONLY
                 CreateBindableProperties();
+#else
+                BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(View), null,
+                    propertyChanged: SetInternalBackgroundColorProperty, defaultValueCreator: GetInternalBackgroundColorProperty);
+
+                ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(View), null,
+                    propertyChanged: SetInternalColorProperty, defaultValueCreator: GetInternalColorProperty);
+
+                ColorRedProperty = BindableProperty.Create(nameof(ColorRed), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalColorRedProperty, defaultValueCreator: GetInternalColorRedProperty);
+
+                ColorGreenProperty = BindableProperty.Create(nameof(ColorGreen), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalColorGreenProperty, defaultValueCreator: GetInternalColorGreenProperty);
+
+                ColorBlueProperty = BindableProperty.Create(nameof(ColorBlue), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalColorBlueProperty, defaultValueCreator: GetInternalColorBlueProperty);
+
+                CellIndexProperty = BindableProperty.Create(nameof(CellIndex), typeof(Vector2), typeof(View), null,
+                    propertyChanged: SetInternalCellIndexProperty, defaultValueCreator: GetInternalCellIndexProperty);
+
+                Size2DProperty = BindableProperty.Create(nameof(Size2D), typeof(Size2D), typeof(View), null,
+                    propertyChanged: SetInternalSize2DProperty, defaultValueCreator: GetInternalSize2DProperty);
+
+                Position2DProperty = BindableProperty.Create(nameof(Position2D), typeof(Position2D), typeof(View), null,
+                    propertyChanged: SetInternalPosition2DProperty, defaultValueCreator: GetInternalPosition2DProperty);
+
+                ParentOriginProperty = BindableProperty.Create(nameof(ParentOrigin), typeof(Position), typeof(View), null,
+                    propertyChanged: SetInternalParentOriginProperty, defaultValueCreator: GetInternalParentOriginProperty);
+
+                PivotPointProperty = BindableProperty.Create(nameof(PivotPoint), typeof(Position), typeof(View), null,
+                    propertyChanged: SetInternalPivotPointProperty, defaultValueCreator: GetInternalPivotPointProperty);
+
+                SizeWidthProperty = BindableProperty.Create(nameof(SizeWidth), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalSizeWidthProperty, defaultValueCreator: GetInternalSizeWidthProperty);
+
+                SizeHeightProperty = BindableProperty.Create(nameof(SizeHeight), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalSizeHeightProperty, defaultValueCreator: GetInternalSizeHeightProperty);
+
+                PositionProperty = BindableProperty.Create(nameof(Position), typeof(Position), typeof(View), null,
+                    propertyChanged: SetInternalPositionProperty, defaultValueCreator: GetInternalPositionProperty);
+
+                PositionXProperty = BindableProperty.Create(nameof(PositionX), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalPositionXProperty, defaultValueCreator: GetInternalPositionXProperty);
+
+                PositionYProperty = BindableProperty.Create(nameof(PositionY), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalPositionYProperty, defaultValueCreator: GetInternalPositionYProperty);
+
+                PositionZProperty = BindableProperty.Create(nameof(PositionZ), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalPositionZProperty, defaultValueCreator: GetInternalPositionZProperty);
+
+                ScaleProperty = BindableProperty.Create(nameof(Scale), typeof(Vector3), typeof(View), null,
+                    propertyChanged: SetInternalScaleProperty, defaultValueCreator: GetInternalScaleProperty);
+
+                ScaleXProperty = BindableProperty.Create(nameof(ScaleX), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalScaleXProperty, defaultValueCreator: GetInternalScaleXProperty);
+
+                ScaleYProperty = BindableProperty.Create(nameof(ScaleY), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalScaleYProperty, defaultValueCreator: GetInternalScaleYProperty);
+
+                ScaleZProperty = BindableProperty.Create(nameof(ScaleZ), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalScaleZProperty, defaultValueCreator: GetInternalScaleZProperty);
+
+                NameProperty = BindableProperty.Create(nameof(Name), typeof(string), typeof(View), string.Empty,
+                    propertyChanged: SetInternalNameProperty, defaultValueCreator: GetInternalNameProperty);
+
+                SizeModeFactorProperty = BindableProperty.Create(nameof(SizeModeFactor), typeof(Vector3), typeof(View), null,
+                    propertyChanged: SetInternalSizeModeFactorProperty, defaultValueCreator: GetInternalSizeModeFactorProperty);
+
+                PaddingProperty = BindableProperty.Create(nameof(Padding), typeof(Extents), typeof(View), null,
+                    propertyChanged: SetInternalPaddingProperty, defaultValueCreator: GetInternalPaddingProperty);
+
+                SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(View), null,
+                    propertyChanged: SetInternalSizeProperty, defaultValueCreator: GetInternalSizeProperty);
+
+                MinimumSizeProperty = BindableProperty.Create(nameof(MinimumSize), typeof(Size2D), typeof(View), null,
+                    propertyChanged: SetInternalMinimumSizeProperty, defaultValueCreator: GetInternalMinimumSizeProperty);
+
+                MaximumSizeProperty = BindableProperty.Create(nameof(MaximumSize), typeof(Size2D), typeof(View), null,
+                    propertyChanged: SetInternalMaximumSizeProperty, defaultValueCreator: GetInternalMaximumSizeProperty);
+
+                MarginProperty = BindableProperty.Create(nameof(Margin), typeof(Extents), typeof(View), null,
+                    propertyChanged: SetInternalMarginProperty, defaultValueCreator: GetInternalMarginProperty);
+
+                AnchorPointProperty = BindableProperty.Create(nameof(AnchorPoint), typeof(Tizen.NUI.Position), typeof(View), null,
+                    propertyChanged: SetInternalAnchorPointProperty, defaultValueCreator: GetInternalAnchorPointProperty);
+#endif
 
                 RegisterPropertyGroup(PositionProperty, positionPropertyGroup);
                 RegisterPropertyGroup(Position2DProperty, positionPropertyGroup);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -82,15 +82,12 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.KeyInputFocus);
         }));
 
+        // BackgroundColorProperty
         internal static void SetInternalBackgroundColorProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
 
-            if (!NUIApplication.IsUsingXaml)
-            {
-                view.SetBackgroundColor((Color)newValue);
-            }
-            else
+            if (NUIApplication.IsUsingXaml)
             {
                 view.themeData?.selectorData?.ClearBackground(view);
 
@@ -103,6 +100,11 @@ namespace Tizen.NUI.BaseComponents
                 {
                     view.SetBackgroundColor((Color)newValue);
                 }
+
+            }
+            else
+            {
+                view.SetBackgroundColor((Color)newValue);
             }
         }
 
@@ -128,6 +130,7 @@ namespace Tizen.NUI.BaseComponents
         /// BackgroundColorProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         public static BindableProperty BackgroundColorProperty = null;
 
         internal static BindableProperty GetBackgroundColorProperty()
@@ -139,8 +142,11 @@ namespace Tizen.NUI.BaseComponents
             }
             return BackgroundColorProperty;
         }
+#else
+        public static readonly BindableProperty BackgroundColorProperty = null;
+#endif
 
-
+        // ColorProperty
         internal static void SetInternalColorProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -156,7 +162,6 @@ namespace Tizen.NUI.BaseComponents
             {
                 view.SetColor((Color)newValue);
             }
-
         }
 
         internal static object GetInternalColorProperty(BindableObject bindable)
@@ -169,8 +174,14 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector4(view.SwigCPtr, View.Property.COLOR, view.internalColor.SwigCPtr);
             return view.internalColor;
-
         }
+
+        /// <summary>
+        /// ColorProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
+        public static BindableProperty ColorProperty = null;
 
         internal static BindableProperty GetColorProperty()
         {
@@ -181,26 +192,29 @@ namespace Tizen.NUI.BaseComponents
             }
             return ColorProperty;
         }
+#else
+        public static readonly BindableProperty ColorProperty = null;
+#endif
 
-        /// <summary>
-        /// ColorProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static BindableProperty ColorProperty = null;
-
+        // ColorRedProperty
         internal static void SetInternalColorRedProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             view.SetColorRed((float?)newValue);
-
         }
 
         internal static object GetInternalColorRedProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorRed);
-
         }
+
+        /// <summary>
+        /// ColorRedProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
+        public static BindableProperty ColorRedProperty = null;
 
         internal static BindableProperty GetColorRedProperty()
         {
@@ -211,14 +225,11 @@ namespace Tizen.NUI.BaseComponents
             }
             return ColorRedProperty;
         }
+#else
+        public static readonly BindableProperty ColorRedProperty = null;
+#endif
 
-        /// <summary>
-        /// ColorRedProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static BindableProperty ColorRedProperty = null;
-
-
+        // ColorGreenProperty
         internal static void SetInternalColorGreenProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -233,6 +244,13 @@ namespace Tizen.NUI.BaseComponents
 
         }
 
+        /// <summary>
+        /// ColorGreenProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
+        public static BindableProperty ColorGreenProperty = null;
+
         internal static BindableProperty GetColorGreenProperty()
         {
             if (ColorGreenProperty == null)
@@ -242,17 +260,11 @@ namespace Tizen.NUI.BaseComponents
             }
             return ColorGreenProperty;
         }
+#else
+        public static readonly BindableProperty ColorGreenProperty = null;
+#endif
 
-
-        /// <summary>
-        /// ColorGreenProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static BindableProperty ColorGreenProperty = null;
-
-
-
-
+        // ColorBlueProperty
         internal static void SetInternalColorBlueProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -267,6 +279,13 @@ namespace Tizen.NUI.BaseComponents
 
         }
 
+        /// <summary>
+        /// ColorBlueProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
+        public static BindableProperty ColorBlueProperty = null;
+
         internal static BindableProperty GetColorBlueProperty()
         {
             if (ColorBlueProperty == null)
@@ -276,13 +295,9 @@ namespace Tizen.NUI.BaseComponents
             }
             return ColorBlueProperty;
         }
-
-
-        /// <summary>
-        /// ColorBlueProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static BindableProperty ColorBlueProperty = null;
+#else
+        public static readonly BindableProperty ColorBlueProperty = null;
+#endif
 
         /// <summary> BackgroundImageProperty </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -517,7 +532,7 @@ namespace Tizen.NUI.BaseComponents
             return temp;
         }));
 
-
+        // CellIndexProperty
         internal static void SetInternalCellIndexProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -540,6 +555,11 @@ namespace Tizen.NUI.BaseComponents
 
         }
 
+        /// <summary>
+        /// CellIndexProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetCellIndexProperty()
         {
             if (CellIndexProperty == null)
@@ -550,11 +570,10 @@ namespace Tizen.NUI.BaseComponents
             return CellIndexProperty;
         }
 
-        /// <summary>
-        /// CellIndexProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty CellIndexProperty = null;
+#else
+        public static readonly BindableProperty CellIndexProperty = null;
+#endif
 
         /// <summary>
         /// RowSpanProperty
@@ -805,6 +824,7 @@ namespace Tizen.NUI.BaseComponents
             return view.IsFocusableInTouch();
         });
 
+        //Size2DProperty
         internal static void SetInternalSize2DProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -856,8 +876,7 @@ namespace Tizen.NUI.BaseComponents
         /// Size2DProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static BindableProperty Size2DProperty = null;
-
+#if REMOVE_READONLY
         internal static BindableProperty GetSize2DProperty()
         {
             if (Size2DProperty == null)
@@ -867,6 +886,11 @@ namespace Tizen.NUI.BaseComponents
             }
             return Size2DProperty;
         }
+
+        public static BindableProperty Size2DProperty = null;
+#else
+        public static readonly BindableProperty Size2DProperty = null;
+#endif
 
         /// <summary>
         /// OpacityProperty
@@ -894,6 +918,7 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.OPACITY);
         }));
 
+        // Position2DProperty
         internal static void SetInternalPosition2DProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -918,8 +943,7 @@ namespace Tizen.NUI.BaseComponents
         /// Position2DProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static BindableProperty Position2DProperty = null;
-
+#if REMOVE_READONLY
         internal static BindableProperty GetPosition2DProperty()
         {
             if (Position2DProperty == null)
@@ -929,6 +953,11 @@ namespace Tizen.NUI.BaseComponents
             }
             return Position2DProperty;
         }
+
+        public static BindableProperty Position2DProperty = null;
+#else
+        public static readonly BindableProperty Position2DProperty = null;
+#endif
 
         /// <summary>
         /// PositionUsesPivotPointProperty
@@ -997,7 +1026,7 @@ namespace Tizen.NUI.BaseComponents
             return 0;
         });
 
-
+        // ParentOriginProperty
         internal static void SetInternalParentOriginProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1005,7 +1034,6 @@ namespace Tizen.NUI.BaseComponents
             {
                 Object.InternalSetPropertyVector3(view.SwigCPtr, View.Property.ParentOrigin, ((Position)newValue).SwigCPtr);
             }
-
         }
 
         internal static object GetInternalParentOriginProperty(BindableObject bindable)
@@ -1014,9 +1042,13 @@ namespace Tizen.NUI.BaseComponents
             Position temp = new Position(0.0f, 0.0f, 0.0f);
             Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.ParentOrigin, temp.SwigCPtr);
             return temp;
-
         }
 
+        /// <summary>
+        /// ParentOriginProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetParentOriginProperty()
         {
             if (ParentOriginProperty == null)
@@ -1027,12 +1059,12 @@ namespace Tizen.NUI.BaseComponents
             return ParentOriginProperty;
         }
 
-        /// <summary>
-        /// ParentOriginProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty ParentOriginProperty = null;
+#else
+        public static readonly BindableProperty ParentOriginProperty = null;
+#endif
 
+        // PivotPointProperty
         internal static void SetInternalPivotPointProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1040,7 +1072,6 @@ namespace Tizen.NUI.BaseComponents
             {
                 view.SetAnchorPoint((Position)newValue);
             }
-
         }
 
         internal static object GetInternalPivotPointProperty(BindableObject bindable)
@@ -1052,9 +1083,13 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.AnchorPoint, view.internalPivotPoint.SwigCPtr);
             return view.internalPivotPoint;
-
         }
 
+        /// <summary>
+        /// PivotPointProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetPivotPointProperty()
         {
             if (PivotPointProperty == null)
@@ -1065,12 +1100,12 @@ namespace Tizen.NUI.BaseComponents
             return PivotPointProperty;
         }
 
-        /// <summary>
-        /// PivotPointProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty PivotPointProperty = null;
-
+#else
+        public static readonly BindableProperty PivotPointProperty = null;
+#endif
+        
+        // SizeWidthProperty
         internal static void SetInternalSizeWidthProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1101,6 +1136,11 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.SizeWidth);
         }
 
+        /// <summary>
+        /// SizeWidthProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetSizeWidthProperty()
         {
             if (SizeWidthProperty == null)
@@ -1111,12 +1151,12 @@ namespace Tizen.NUI.BaseComponents
             return SizeWidthProperty;
         }
 
-        /// <summary>
-        /// SizeWidthProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty SizeWidthProperty = null;
+#else
+        public static readonly BindableProperty SizeWidthProperty = null;
+#endif        
 
+        // SizeHeightProperty
         internal static void SetInternalSizeHeightProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1139,16 +1179,19 @@ namespace Tizen.NUI.BaseComponents
 
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.SizeHeight, height);
             }
-
         }
 
         internal static object GetInternalSizeHeightProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.SizeHeight);
-
         }
 
+        /// <summary>
+        /// SizeHeightProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetSizeHeightProperty()
         {
             if (SizeHeightProperty == null)
@@ -1159,13 +1202,12 @@ namespace Tizen.NUI.BaseComponents
             return SizeHeightProperty;
         }
 
-        /// <summary>
-        /// SizeHeightProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty SizeHeightProperty = null;
+#else
+        public static readonly BindableProperty SizeHeightProperty = null;
+#endif
 
-
+        // PositionProperty
         internal static void SetInternalPositionProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1186,6 +1228,11 @@ namespace Tizen.NUI.BaseComponents
             return view.internalPosition;
         }
 
+        /// <summary>
+        /// PositionProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetPositionProperty()
         {
             if (PositionProperty == null)
@@ -1196,12 +1243,12 @@ namespace Tizen.NUI.BaseComponents
             return PositionProperty;
         }
 
-        /// <summary>
-        /// PositionProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty PositionProperty = null;
-
+#else
+        public static readonly BindableProperty PositionProperty = null;
+#endif
+        
+        // PositionXProperty
         internal static void SetInternalPositionXProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1209,7 +1256,6 @@ namespace Tizen.NUI.BaseComponents
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.PositionX, (float)newValue);
             }
-
         }
 
         internal static object GetInternalPositionXProperty(BindableObject bindable)
@@ -1218,6 +1264,11 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionX);
         }
 
+        /// <summary>
+        /// PositionXProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetPositionXProperty()
         {
             if (PositionXProperty == null)
@@ -1228,12 +1279,12 @@ namespace Tizen.NUI.BaseComponents
             return PositionXProperty;
         }
 
-        /// <summary>
-        /// PositionXProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty PositionXProperty = null;
+#else
+        public static readonly BindableProperty PositionXProperty = null;
+#endif
 
+        // PositionYProperty
         internal static void SetInternalPositionYProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1249,6 +1300,11 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionY);
         }
 
+        /// <summary>
+        /// PositionYProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetPositionYProperty()
         {
             if (PositionYProperty == null)
@@ -1259,12 +1315,10 @@ namespace Tizen.NUI.BaseComponents
             return PositionYProperty;
         }
 
-        /// <summary>
-        /// PositionYProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty PositionYProperty = null;
-
+#else
+        public static readonly BindableProperty PositionYProperty = null;
+#endif
         internal static void SetInternalPositionZProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1275,13 +1329,18 @@ namespace Tizen.NUI.BaseComponents
 
         }
 
+        // PositionZProperty
         internal static object GetInternalPositionZProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionZ);
-
         }
 
+        /// <summary>
+        /// PositionZProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetPositionZProperty()
         {
             if (PositionZProperty == null)
@@ -1292,12 +1351,10 @@ namespace Tizen.NUI.BaseComponents
             return PositionZProperty;
         }
 
-        /// <summary>
-        /// PositionZProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty PositionZProperty = null;
-
+#else
+        public static readonly BindableProperty PositionZProperty = null;
+#endif
         /// <summary>
         /// OrientationProperty
         /// </summary>
@@ -1328,6 +1385,7 @@ namespace Tizen.NUI.BaseComponents
 
         }
 
+        // ScaleProperty
         internal static object GetInternalScaleProperty(BindableObject bindable)
         {
             var view = (View)bindable;
@@ -1337,9 +1395,13 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SCALE, view.internalScale.SwigCPtr);
             return view.internalScale;
-
         }
 
+        /// <summary>
+        /// ScaleProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetScaleProperty()
         {
             if (ScaleProperty == null)
@@ -1350,14 +1412,12 @@ namespace Tizen.NUI.BaseComponents
             return ScaleProperty;
         }
 
-
-        /// <summary>
-        /// ScaleProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty ScaleProperty = null;
+#else
+        public static readonly BindableProperty ScaleProperty = null;
+#endif
 
-
+        // ScaleXProperty
         internal static void SetInternalScaleXProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1365,16 +1425,19 @@ namespace Tizen.NUI.BaseComponents
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.ScaleX, (float)newValue);
             }
-
         }
 
         internal static object GetInternalScaleXProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleX);
-
         }
 
+        /// <summary>
+        /// ScaleXProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetScaleXProperty()
         {
             if (ScaleXProperty == null)
@@ -1385,12 +1448,12 @@ namespace Tizen.NUI.BaseComponents
             return ScaleXProperty;
         }
 
-        /// <summary>
-        /// ScaleXProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty ScaleXProperty = null;
+#else
+        public static readonly BindableProperty ScaleXProperty = null;
+#endif
 
+        // ScaleYProperty
         internal static void SetInternalScaleYProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1398,16 +1461,19 @@ namespace Tizen.NUI.BaseComponents
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.ScaleY, (float)newValue);
             }
-
         }
 
         internal static object GetInternalScaleYProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleY);
-
         }
 
+        /// <summary>
+        /// ScaleYProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetScaleYProperty()
         {
             if (ScaleYProperty == null)
@@ -1418,13 +1484,12 @@ namespace Tizen.NUI.BaseComponents
             return ScaleYProperty;
         }
 
-        /// <summary>
-        /// ScaleYProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty ScaleYProperty = null;
+#else
+        public static readonly BindableProperty ScaleYProperty = null;
+#endif
 
-
+        // ScaleZProperty
         internal static void SetInternalScaleZProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1432,16 +1497,19 @@ namespace Tizen.NUI.BaseComponents
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.ScaleZ, (float)newValue);
             }
-
         }
 
         internal static object GetInternalScaleZProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleZ);
-
         }
 
+        /// <summary>
+        /// ScaleZProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetScaleZProperty()
         {
             if (ScaleZProperty == null)
@@ -1452,12 +1520,12 @@ namespace Tizen.NUI.BaseComponents
             return ScaleZProperty;
         }
 
-        /// <summary>
-        /// ScaleZProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty ScaleZProperty = null;
-
+#else
+        public static readonly BindableProperty ScaleZProperty = null;
+#endif
+        
+        // NameProperty
         internal static void SetInternalNameProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1466,16 +1534,19 @@ namespace Tizen.NUI.BaseComponents
                 view.internalName = (string)newValue;
                 Object.InternalSetPropertyString(view.SwigCPtr, View.Property.NAME, (string)newValue);
             }
-
         }
 
         internal static object GetInternalNameProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return view.internalName;
-
         }
 
+        /// <summary>
+        /// NameProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetNameProperty()
         {
             if (NameProperty == null)
@@ -1486,12 +1557,10 @@ namespace Tizen.NUI.BaseComponents
             return NameProperty;
         }
 
-        /// <summary>
-        /// NameProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty NameProperty = null;
-
+#else
+        public static readonly BindableProperty NameProperty = null;
+#endif
         /// <summary>
         /// SensitiveProperty
         /// </summary>
@@ -1629,6 +1698,7 @@ namespace Tizen.NUI.BaseComponents
 
         }
 
+        // SizeModeFactorProperty
         internal static object GetInternalSizeModeFactorProperty(BindableObject bindable)
         {
             var view = (View)bindable;
@@ -1638,9 +1708,13 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SizeModeFactor, view.internalSizeModeFactor.SwigCPtr);
             return view.internalSizeModeFactor;
-
         }
 
+        /// <summary>
+        /// SizeModeFactorProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetSizeModeFactorProperty()
         {
             if (SizeModeFactorProperty == null)
@@ -1651,12 +1725,10 @@ namespace Tizen.NUI.BaseComponents
             return SizeModeFactorProperty;
         }
 
-        /// <summary>
-        /// SizeModeFactorProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty SizeModeFactorProperty = null;
-
+#else
+        public static readonly BindableProperty SizeModeFactorProperty = null;
+#endif
         /// <summary>
         /// WidthResizePolicyProperty
         /// </summary>
@@ -1837,6 +1909,7 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.HeightForWidth);
         }));
 
+        // PaddingProperty
         internal static void SetInternalPaddingProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1860,7 +1933,6 @@ namespace Tizen.NUI.BaseComponents
                     tmp?.Dispose();
                 }
             }
-
         }
 
         internal static object GetInternalPaddingProperty(BindableObject bindable)
@@ -1890,9 +1962,13 @@ namespace Tizen.NUI.BaseComponents
             }
 
             return view.internalPadding;
-
         }
 
+        /// <summary>
+        /// PaddingProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetPaddingProperty()
         {
             if (PaddingProperty == null)
@@ -1903,12 +1979,12 @@ namespace Tizen.NUI.BaseComponents
             return PaddingProperty;
         }
 
-        /// <summary>
-        /// PaddingProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty PaddingProperty = null;
+#else
+        public static readonly BindableProperty PaddingProperty = null;
+#endif
 
+        // SizeProperty
         internal static void SetInternalSizeProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1964,6 +2040,11 @@ namespace Tizen.NUI.BaseComponents
             return view.internalSize;
         }
 
+        /// <summary>
+        /// SizeProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetSizeProperty()
         {
             if (SizeProperty == null)
@@ -1974,13 +2055,12 @@ namespace Tizen.NUI.BaseComponents
             return SizeProperty;
         }
 
-        /// <summary>
-        /// SizeProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty SizeProperty = null;
+#else
+        public static readonly BindableProperty SizeProperty = null;
+#endif
 
-
+        // MinimumSizeProperty
         internal static void SetInternalMinimumSizeProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -1989,7 +2069,6 @@ namespace Tizen.NUI.BaseComponents
 
                 Object.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, ((Size2D)newValue).SwigCPtr);
             }
-
         }
 
         internal static object GetInternalMinimumSizeProperty(BindableObject bindable)
@@ -2002,9 +2081,13 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, view.internalMinimumSize.SwigCPtr);
             return view.internalMinimumSize;
-
         }
 
+        /// <summary>
+        /// MinimumSizeProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetMinimumSizeProperty()
         {
             if (MinimumSizeProperty == null)
@@ -2015,12 +2098,12 @@ namespace Tizen.NUI.BaseComponents
             return MinimumSizeProperty;
         }
 
-        /// <summary>
-        /// MinimumSizeProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty MinimumSizeProperty = null;
+#else
+        public static readonly BindableProperty MinimumSizeProperty = null;
+#endif
 
+        // MaximumSizeProperty
         internal static void SetInternalMaximumSizeProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -2029,7 +2112,6 @@ namespace Tizen.NUI.BaseComponents
 
                 Object.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, ((Size2D)newValue).SwigCPtr);
             }
-
         }
 
         internal static object GetInternalMaximumSizeProperty(BindableObject bindable)
@@ -2042,9 +2124,13 @@ namespace Tizen.NUI.BaseComponents
             }
             Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, view.internalMaximumSize.SwigCPtr);
             return view.internalMaximumSize;
-
         }
 
+        /// <summary>
+        /// MaximumSizeProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetMaximumSizeProperty()
         {
             if (MaximumSizeProperty == null)
@@ -2055,11 +2141,10 @@ namespace Tizen.NUI.BaseComponents
             return MaximumSizeProperty;
         }
 
-        /// <summary>
-        /// MaximumSizeProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty MaximumSizeProperty = null;
+#else
+        public static readonly BindableProperty MaximumSizeProperty = null;
+#endif
 
         /// <summary>
         /// InheritPositionProperty
@@ -2140,6 +2225,7 @@ namespace Tizen.NUI.BaseComponents
             return (ViewLayoutDirectionType)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.LayoutDirection);
         }));
 
+        // MarginProperty
         internal static void SetInternalMarginProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
@@ -2163,7 +2249,6 @@ namespace Tizen.NUI.BaseComponents
                     tmp?.Dispose();
                 }
             }
-
         }
 
         internal static object GetInternalMarginProperty(BindableObject bindable)
@@ -2194,9 +2279,13 @@ namespace Tizen.NUI.BaseComponents
             }
 
             return view.internalMargin;
-
         }
 
+        /// <summary>
+        /// MarginProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetMarginProperty()
         {
             if (MarginProperty == null)
@@ -2207,11 +2296,10 @@ namespace Tizen.NUI.BaseComponents
             return MarginProperty;
         }
 
-        /// <summary>
-        /// MarginProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty MarginProperty = null;
+#else
+        public static readonly BindableProperty MarginProperty = null;
+#endif
 
         /// <summary>
         /// UpdateAreaHintProperty
@@ -2660,6 +2748,7 @@ namespace Tizen.NUI.BaseComponents
             return instance.InternalPositionUsesAnchorPoint;
         });
 
+        // AnchorPointProperty
         internal static void SetInternalAnchorPointProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
@@ -2667,16 +2756,19 @@ namespace Tizen.NUI.BaseComponents
             {
                 instance.InternalAnchorPoint = (Tizen.NUI.Position)newValue;
             }
-
         }
 
         internal static object GetInternalAnchorPointProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalAnchorPoint;
-
         }
 
+        /// <summary>
+        /// AnchorPointProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if REMOVE_READONLY
         internal static BindableProperty GetAnchorPointProperty()
         {
             if (AnchorPointProperty == null)
@@ -2687,11 +2779,10 @@ namespace Tizen.NUI.BaseComponents
             return AnchorPointProperty;
         }
 
-        /// <summary>
-        /// AnchorPointProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public static BindableProperty AnchorPointProperty = null;
+#else
+        public static readonly BindableProperty AnchorPointProperty = null;
+#endif
 
         /// <summary>
         /// WidthSpecificationProperty
@@ -3010,11 +3101,9 @@ namespace Tizen.NUI.BaseComponents
             return new Size2D((int)userSizeWidth, (int)userSizeHeight);
         }
 
-
+#if REMOVE_READONLY
         internal static void CreateBindableProperties()
         {
-            Tizen.Log.Fatal("NT", $"CreateBindableProperties() START  IsUsingXaml={NUIApplication.IsUsingXaml}");
-
             _ = GetBackgroundColorProperty();
             _ = GetColorProperty();
             _ = GetColorRedProperty();
@@ -3043,8 +3132,8 @@ namespace Tizen.NUI.BaseComponents
             _ = GetMaximumSizeProperty();
             _ = GetMarginProperty();
             _ = GetAnchorPointProperty();
-            Tizen.Log.Fatal("NT", $"CreateBindableProperties() END");
         }
+#endif
 
         private void SetBackgroundImage(string value)
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -86,7 +86,7 @@ namespace Tizen.NUI.BaseComponents
         {
             var view = (View)bindable;
 
-            if (NUIApplication.DisableBindableProperty)
+            if (!NUIApplication.IsUsingXaml)
             {
                 view.SetBackgroundColor((Color)newValue);
             }
@@ -128,98 +128,161 @@ namespace Tizen.NUI.BaseComponents
         /// BackgroundColorProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(View), null,
-            propertyChanged: SetInternalBackgroundColorProperty,
-            defaultValueCreator: GetInternalBackgroundColorProperty
-        );
+        public static BindableProperty BackgroundColorProperty = null;
+
+        internal static BindableProperty GetBackgroundColorProperty()
+        {
+            if (BackgroundColorProperty == null)
+            {
+                BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(View), null,
+                    propertyChanged: SetInternalBackgroundColorProperty, defaultValueCreator: GetInternalBackgroundColorProperty);
+            }
+            return BackgroundColorProperty;
+        }
+
+
+        internal static void SetInternalColorProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+
+            view.themeData?.selectorData?.Color?.Reset(view);
+
+            if (newValue is Selector<Color> selector)
+            {
+                if (selector.HasAll()) view.SetColor(selector.All);
+                else view.EnsureSelectorData().Color = new TriggerableSelector<Color>(view, selector, view.SetColor, true);
+            }
+            else
+            {
+                view.SetColor((Color)newValue);
+            }
+
+        }
+
+        internal static object GetInternalColorProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+
+            if (view.internalColor == null)
+            {
+                view.internalColor = new Color(view.OnColorChanged, 0, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector4(view.SwigCPtr, View.Property.COLOR, view.internalColor.SwigCPtr);
+            return view.internalColor;
+
+        }
+
+        internal static BindableProperty GetColorProperty()
+        {
+            if (ColorProperty == null)
+            {
+                ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(View), null,
+                    propertyChanged: SetInternalColorProperty, defaultValueCreator: GetInternalColorProperty);
+            }
+            return ColorProperty;
+        }
 
         /// <summary>
         /// ColorProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
+        public static BindableProperty ColorProperty = null;
+
+        internal static void SetInternalColorRedProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            view.SetColorRed((float?)newValue);
+
+        }
+
+        internal static object GetInternalColorRedProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorRed);
+
+        }
+
+        internal static BindableProperty GetColorRedProperty()
+        {
+            if (ColorRedProperty == null)
             {
-                var view = (View)bindable;
-
-                view.themeData?.selectorData?.Color?.Reset(view);
-
-                if (newValue is Selector<Color> selector)
-                {
-                    if (selector.HasAll()) view.SetColor(selector.All);
-                    else view.EnsureSelectorData().Color = new TriggerableSelector<Color>(view, selector, view.SetColor, true);
-                }
-                else
-                {
-                    view.SetColor((Color)newValue);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-
-                if (view.internalColor == null)
-                {
-                    view.internalColor = new Color(view.OnColorChanged, 0, 0, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector4(view.SwigCPtr, View.Property.COLOR, view.internalColor.SwigCPtr);
-                return view.internalColor;
+                ColorRedProperty = BindableProperty.Create(nameof(ColorRed), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalColorRedProperty, defaultValueCreator: GetInternalColorRedProperty);
             }
-        );
+            return ColorRedProperty;
+        }
 
         /// <summary>
         /// ColorRedProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ColorRedProperty = BindableProperty.Create(nameof(ColorRed), typeof(float), typeof(View), default(float),
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                view.SetColorRed((float?)newValue);
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
+        public static BindableProperty ColorRedProperty = null;
 
-                return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorRed);
+
+        internal static void SetInternalColorGreenProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            view.SetColorGreen((float?)newValue);
+
+        }
+
+        internal static object GetInternalColorGreenProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorGreen);
+
+        }
+
+        internal static BindableProperty GetColorGreenProperty()
+        {
+            if (ColorGreenProperty == null)
+            {
+                ColorGreenProperty = BindableProperty.Create(nameof(ColorGreen), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalColorGreenProperty, defaultValueCreator: GetInternalColorGreenProperty);
             }
-        );
+            return ColorGreenProperty;
+        }
+
 
         /// <summary>
         /// ColorGreenProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ColorGreenProperty = BindableProperty.Create(nameof(ColorGreen), typeof(float), typeof(View), default(float),
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                view.SetColorGreen((float?)newValue);
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
+        public static BindableProperty ColorGreenProperty = null;
 
-                return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorGreen);
+
+
+
+        internal static void SetInternalColorBlueProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            view.SetColorBlue((float?)newValue);
+
+        }
+
+        internal static object GetInternalColorBlueProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorBlue);
+
+        }
+
+        internal static BindableProperty GetColorBlueProperty()
+        {
+            if (ColorBlueProperty == null)
+            {
+                ColorBlueProperty = BindableProperty.Create(nameof(ColorBlue), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalColorBlueProperty, defaultValueCreator: GetInternalColorBlueProperty);
             }
-        );
+            return ColorBlueProperty;
+        }
+
 
         /// <summary>
         /// ColorBlueProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ColorBlueProperty = BindableProperty.Create(nameof(ColorBlue), typeof(float), typeof(View), default(float),
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                view.SetColorBlue((float?)newValue);
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-
-                return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ColorBlue);
-            }
-        );
+        public static BindableProperty ColorBlueProperty = null;
 
         /// <summary> BackgroundImageProperty </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -454,30 +517,44 @@ namespace Tizen.NUI.BaseComponents
             return temp;
         }));
 
+
+        internal static void SetInternalCellIndexProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                Object.InternalSetPropertyVector2(view.SwigCPtr, TableView.ChildProperty.CellIndex, ((Vector2)newValue).SwigCPtr);
+            }
+
+        }
+
+        internal static object GetInternalCellIndexProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            if (view.internalCellIndex == null)
+            {
+                view.internalCellIndex = new Vector2(view.OnCellIndexChanged, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector2(view.SwigCPtr, TableView.ChildProperty.CellIndex, view.internalCellIndex.SwigCPtr);
+            return view.internalCellIndex;
+
+        }
+
+        internal static BindableProperty GetCellIndexProperty()
+        {
+            if (CellIndexProperty == null)
+            {
+                CellIndexProperty = BindableProperty.Create(nameof(CellIndex), typeof(Vector2), typeof(View), null,
+                    propertyChanged: SetInternalCellIndexProperty, defaultValueCreator: GetInternalCellIndexProperty);
+            }
+            return CellIndexProperty;
+        }
+
         /// <summary>
         /// CellIndexProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty CellIndexProperty = BindableProperty.Create(nameof(CellIndex), typeof(Vector2), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    Object.InternalSetPropertyVector2(view.SwigCPtr, TableView.ChildProperty.CellIndex, ((Vector2)newValue).SwigCPtr);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                if (view.internalCellIndex == null)
-                {
-                    view.internalCellIndex = new Vector2(view.OnCellIndexChanged, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector2(view.SwigCPtr, TableView.ChildProperty.CellIndex, view.internalCellIndex.SwigCPtr);
-                return view.internalCellIndex;
-            }
-        );
+        public static BindableProperty CellIndexProperty = null;
 
         /// <summary>
         /// RowSpanProperty
@@ -779,10 +856,17 @@ namespace Tizen.NUI.BaseComponents
         /// Size2DProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty Size2DProperty = BindableProperty.Create(nameof(Size2D), typeof(Size2D), typeof(View), null,
-            propertyChanged: SetInternalSize2DProperty,
-            defaultValueCreator: GetInternalSize2DProperty
-        );
+        public static BindableProperty Size2DProperty = null;
+
+        internal static BindableProperty GetSize2DProperty()
+        {
+            if (Size2DProperty == null)
+            {
+                Size2DProperty = BindableProperty.Create(nameof(Size2D), typeof(Size2D), typeof(View), null,
+                    propertyChanged: SetInternalSize2DProperty, defaultValueCreator: GetInternalSize2DProperty);
+            }
+            return Size2DProperty;
+        }
 
         /// <summary>
         /// OpacityProperty
@@ -834,10 +918,17 @@ namespace Tizen.NUI.BaseComponents
         /// Position2DProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty Position2DProperty = BindableProperty.Create(nameof(Position2D), typeof(Position2D), typeof(View), null,
-            propertyChanged: SetInternalPosition2DProperty,
-            defaultValueCreator: GetInternalPosition2DProperty
-        );
+        public static BindableProperty Position2DProperty = null;
+
+        internal static BindableProperty GetPosition2DProperty()
+        {
+            if (Position2DProperty == null)
+            {
+                Position2DProperty = BindableProperty.Create(nameof(Position2D), typeof(Position2D), typeof(View), null,
+                    propertyChanged: SetInternalPosition2DProperty, defaultValueCreator: GetInternalPosition2DProperty);
+            }
+            return Position2DProperty;
+        }
 
         /// <summary>
         /// PositionUsesPivotPointProperty
@@ -906,57 +997,81 @@ namespace Tizen.NUI.BaseComponents
             return 0;
         });
 
-        /// <summary>
-        /// ParentOriginProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ParentOriginProperty = BindableProperty.Create(nameof(ParentOrigin), typeof(Position), typeof(View), null, propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+
+        internal static void SetInternalParentOriginProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
             {
                 Object.InternalSetPropertyVector3(view.SwigCPtr, View.Property.ParentOrigin, ((Position)newValue).SwigCPtr);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+
+        }
+
+        internal static object GetInternalParentOriginProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             Position temp = new Position(0.0f, 0.0f, 0.0f);
             Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.ParentOrigin, temp.SwigCPtr);
             return temp;
-        })
-        );
+
+        }
+
+        internal static BindableProperty GetParentOriginProperty()
+        {
+            if (ParentOriginProperty == null)
+            {
+                ParentOriginProperty = BindableProperty.Create(nameof(ParentOrigin), typeof(Position), typeof(View), null,
+                    propertyChanged: SetInternalParentOriginProperty, defaultValueCreator: GetInternalParentOriginProperty);
+            }
+            return ParentOriginProperty;
+        }
+
+        /// <summary>
+        /// ParentOriginProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static BindableProperty ParentOriginProperty = null;
+
+        internal static void SetInternalPivotPointProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                view.SetAnchorPoint((Position)newValue);
+            }
+
+        }
+
+        internal static object GetInternalPivotPointProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            if (view.internalPivotPoint == null)
+            {
+                view.internalPivotPoint = new Position(view.OnPivotPointChanged, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.AnchorPoint, view.internalPivotPoint.SwigCPtr);
+            return view.internalPivotPoint;
+
+        }
+
+        internal static BindableProperty GetPivotPointProperty()
+        {
+            if (PivotPointProperty == null)
+            {
+                PivotPointProperty = BindableProperty.Create(nameof(PivotPoint), typeof(Position), typeof(View), null,
+                    propertyChanged: SetInternalPivotPointProperty, defaultValueCreator: GetInternalPivotPointProperty);
+            }
+            return PivotPointProperty;
+        }
 
         /// <summary>
         /// PivotPointProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PivotPointProperty = BindableProperty.Create(nameof(PivotPoint), typeof(Position), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    view.SetAnchorPoint((Position)newValue);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                if (view.internalPivotPoint == null)
-                {
-                    view.internalPivotPoint = new Position(view.OnPivotPointChanged, 0, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.AnchorPoint, view.internalPivotPoint.SwigCPtr);
-                return view.internalPivotPoint;
-            }
-        );
+        public static BindableProperty PivotPointProperty = null;
 
-        /// <summary>
-        /// SizeWidthProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SizeWidthProperty = BindableProperty.Create(nameof(SizeWidth), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        internal static void SetInternalSizeWidthProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
@@ -978,18 +1093,31 @@ namespace Tizen.NUI.BaseComponents
 
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.SizeWidth, width);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        }
+
+        internal static object GetInternalSizeWidthProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.SizeWidth);
-        }));
+        }
+
+        internal static BindableProperty GetSizeWidthProperty()
+        {
+            if (SizeWidthProperty == null)
+            {
+                SizeWidthProperty = BindableProperty.Create(nameof(SizeWidth), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalSizeWidthProperty, defaultValueCreator: GetInternalSizeWidthProperty);
+            }
+            return SizeWidthProperty;
+        }
 
         /// <summary>
-        /// SizeHeightProperty
+        /// SizeWidthProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SizeHeightProperty = BindableProperty.Create(nameof(SizeHeight), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static BindableProperty SizeWidthProperty = null;
+
+        internal static void SetInternalSizeHeightProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
@@ -1011,91 +1139,164 @@ namespace Tizen.NUI.BaseComponents
 
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.SizeHeight, height);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+
+        }
+
+        internal static object GetInternalSizeHeightProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.SizeHeight);
-        }));
+
+        }
+
+        internal static BindableProperty GetSizeHeightProperty()
+        {
+            if (SizeHeightProperty == null)
+            {
+                SizeHeightProperty = BindableProperty.Create(nameof(SizeHeight), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalSizeHeightProperty, defaultValueCreator: GetInternalSizeHeightProperty);
+            }
+            return SizeHeightProperty;
+        }
+
+        /// <summary>
+        /// SizeHeightProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static BindableProperty SizeHeightProperty = null;
+
+
+        internal static void SetInternalPositionProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                Object.InternalSetPropertyVector3(view.SwigCPtr, View.Property.POSITION, ((Position)newValue).SwigCPtr);
+            }
+        }
+
+        internal static object GetInternalPositionProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            if (view.internalPosition == null)
+            {
+                view.internalPosition = new Position(view.OnPositionChanged, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.POSITION, view.internalPosition.SwigCPtr);
+            return view.internalPosition;
+        }
+
+        internal static BindableProperty GetPositionProperty()
+        {
+            if (PositionProperty == null)
+            {
+                PositionProperty = BindableProperty.Create(nameof(Position), typeof(Position), typeof(View), null,
+                    propertyChanged: SetInternalPositionProperty, defaultValueCreator: GetInternalPositionProperty);
+            }
+            return PositionProperty;
+        }
 
         /// <summary>
         /// PositionProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PositionProperty = BindableProperty.Create(nameof(Position), typeof(Position), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    Object.InternalSetPropertyVector3(view.SwigCPtr, View.Property.POSITION, ((Position)newValue).SwigCPtr);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                if (view.internalPosition == null)
-                {
-                    view.internalPosition = new Position(view.OnPositionChanged, 0, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.POSITION, view.internalPosition.SwigCPtr);
-                return view.internalPosition;
-            }
-        );
+        public static BindableProperty PositionProperty = null;
 
-        /// <summary>
-        /// PositionXProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PositionXProperty = BindableProperty.Create(nameof(PositionX), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        internal static void SetInternalPositionXProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.PositionX, (float)newValue);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+
+        }
+
+        internal static object GetInternalPositionXProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionX);
-        }));
+        }
+
+        internal static BindableProperty GetPositionXProperty()
+        {
+            if (PositionXProperty == null)
+            {
+                PositionXProperty = BindableProperty.Create(nameof(PositionX), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalPositionXProperty, defaultValueCreator: GetInternalPositionXProperty);
+            }
+            return PositionXProperty;
+        }
 
         /// <summary>
-        /// PositionYProperty
+        /// PositionXProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PositionYProperty = BindableProperty.Create(nameof(PositionY), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static BindableProperty PositionXProperty = null;
+
+        internal static void SetInternalPositionYProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.PositionY, (float)newValue);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+        }
+
+        internal static object GetInternalPositionYProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionY);
-        }));
+        }
+
+        internal static BindableProperty GetPositionYProperty()
+        {
+            if (PositionYProperty == null)
+            {
+                PositionYProperty = BindableProperty.Create(nameof(PositionY), typeof(float), typeof(View), default(float),
+                propertyChanged: SetInternalPositionYProperty, defaultValueCreator: GetInternalPositionYProperty);
+            }
+            return PositionYProperty;
+        }
 
         /// <summary>
-        /// PositionZProperty
+        /// PositionYProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PositionZProperty = BindableProperty.Create(nameof(PositionZ), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static BindableProperty PositionYProperty = null;
+
+        internal static void SetInternalPositionZProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.PositionZ, (float)newValue);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+
+        }
+
+        internal static object GetInternalPositionZProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.PositionZ);
-        }));
+
+        }
+
+        internal static BindableProperty GetPositionZProperty()
+        {
+            if (PositionZProperty == null)
+            {
+                PositionZProperty = BindableProperty.Create(nameof(PositionZ), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalPositionZProperty, defaultValueCreator: GetInternalPositionZProperty);
+            }
+            return PositionZProperty;
+        }
+
+        /// <summary>
+        /// PositionZProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static BindableProperty PositionZProperty = null;
 
         /// <summary>
         /// OrientationProperty
@@ -1117,105 +1318,179 @@ namespace Tizen.NUI.BaseComponents
             return temp;
         }));
 
+        internal static void SetInternalScaleProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                view.SetScale((Vector3)newValue);
+            }
+
+        }
+
+        internal static object GetInternalScaleProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            if (view.internalScale == null)
+            {
+                view.internalScale = new Vector3(view.OnScaleChanged, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SCALE, view.internalScale.SwigCPtr);
+            return view.internalScale;
+
+        }
+
+        internal static BindableProperty GetScaleProperty()
+        {
+            if (ScaleProperty == null)
+            {
+                ScaleProperty = BindableProperty.Create(nameof(Scale), typeof(Vector3), typeof(View), null,
+                    propertyChanged: SetInternalScaleProperty, defaultValueCreator: GetInternalScaleProperty);
+            }
+            return ScaleProperty;
+        }
+
+
         /// <summary>
         /// ScaleProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScaleProperty = BindableProperty.Create(nameof(Scale), typeof(Vector3), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    view.SetScale((Vector3)newValue);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                if (view.internalScale == null)
-                {
-                    view.internalScale = new Vector3(view.OnScaleChanged, 0, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SCALE, view.internalScale.SwigCPtr);
-                return view.internalScale;
-            }
-        );
+        public static BindableProperty ScaleProperty = null;
 
-        /// <summary>
-        /// ScaleXProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScaleXProperty = BindableProperty.Create(nameof(ScaleX), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+
+        internal static void SetInternalScaleXProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.ScaleX, (float)newValue);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+
+        }
+
+        internal static object GetInternalScaleXProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleX);
-        }));
+
+        }
+
+        internal static BindableProperty GetScaleXProperty()
+        {
+            if (ScaleXProperty == null)
+            {
+                ScaleXProperty = BindableProperty.Create(nameof(ScaleX), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalScaleXProperty, defaultValueCreator: GetInternalScaleXProperty);
+            }
+            return ScaleXProperty;
+        }
 
         /// <summary>
-        /// ScaleYProperty
+        /// ScaleXProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScaleYProperty = BindableProperty.Create(nameof(ScaleY), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static BindableProperty ScaleXProperty = null;
+
+        internal static void SetInternalScaleYProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.ScaleY, (float)newValue);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+
+        }
+
+        internal static object GetInternalScaleYProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleY);
-        }));
+
+        }
+
+        internal static BindableProperty GetScaleYProperty()
+        {
+            if (ScaleYProperty == null)
+            {
+                ScaleYProperty = BindableProperty.Create(nameof(ScaleY), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalScaleYProperty, defaultValueCreator: GetInternalScaleYProperty);
+            }
+            return ScaleYProperty;
+        }
 
         /// <summary>
-        /// ScaleZProperty
+        /// ScaleYProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty ScaleZProperty = BindableProperty.Create(nameof(ScaleZ), typeof(float), typeof(View), default(float), propertyChanged: (BindableProperty.BindingPropertyChangedDelegate)((bindable, oldValue, newValue) =>
+        public static BindableProperty ScaleYProperty = null;
+
+
+        internal static void SetInternalScaleZProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var view = (View)bindable;
             if (newValue != null)
             {
                 Object.InternalSetPropertyFloat(view.SwigCPtr, View.Property.ScaleZ, (float)newValue);
             }
-        }),
-        defaultValueCreator: (BindableProperty.CreateDefaultValueDelegate)((bindable) =>
+
+        }
+
+        internal static object GetInternalScaleZProperty(BindableObject bindable)
         {
             var view = (View)bindable;
             return Object.InternalGetPropertyFloat(view.SwigCPtr, View.Property.ScaleZ);
-        }));
+
+        }
+
+        internal static BindableProperty GetScaleZProperty()
+        {
+            if (ScaleZProperty == null)
+            {
+                ScaleZProperty = BindableProperty.Create(nameof(ScaleZ), typeof(float), typeof(View), default(float),
+                    propertyChanged: SetInternalScaleZProperty, defaultValueCreator: GetInternalScaleZProperty);
+            }
+            return ScaleZProperty;
+        }
+
+        /// <summary>
+        /// ScaleZProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static BindableProperty ScaleZProperty = null;
+
+        internal static void SetInternalNameProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                view.internalName = (string)newValue;
+                Object.InternalSetPropertyString(view.SwigCPtr, View.Property.NAME, (string)newValue);
+            }
+
+        }
+
+        internal static object GetInternalNameProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            return view.internalName;
+
+        }
+
+        internal static BindableProperty GetNameProperty()
+        {
+            if (NameProperty == null)
+            {
+                NameProperty = BindableProperty.Create(nameof(Name), typeof(string), typeof(View), string.Empty,
+                    propertyChanged: SetInternalNameProperty, defaultValueCreator: GetInternalNameProperty);
+            }
+            return NameProperty;
+        }
 
         /// <summary>
         /// NameProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty NameProperty = BindableProperty.Create(nameof(Name), typeof(string), typeof(View), string.Empty,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    view.internalName = (string)newValue;
-                    Object.InternalSetPropertyString(view.SwigCPtr, View.Property.NAME, (string)newValue);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                return view.internalName;
-            }
-        );
+        public static BindableProperty NameProperty = null;
 
         /// <summary>
         /// SensitiveProperty
@@ -1344,30 +1619,43 @@ namespace Tizen.NUI.BaseComponents
             return (DrawModeType)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.DrawMode);
         }));
 
+        internal static void SetInternalSizeModeFactorProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                Object.InternalSetPropertyVector3(view.SwigCPtr, View.Property.SizeModeFactor, ((Vector3)newValue).SwigCPtr);
+            }
+
+        }
+
+        internal static object GetInternalSizeModeFactorProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            if (view.internalSizeModeFactor == null)
+            {
+                view.internalSizeModeFactor = new Vector3(view.OnSizeModeFactorChanged, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SizeModeFactor, view.internalSizeModeFactor.SwigCPtr);
+            return view.internalSizeModeFactor;
+
+        }
+
+        internal static BindableProperty GetSizeModeFactorProperty()
+        {
+            if (SizeModeFactorProperty == null)
+            {
+                SizeModeFactorProperty = BindableProperty.Create(nameof(SizeModeFactor), typeof(Vector3), typeof(View), null,
+                    propertyChanged: SetInternalSizeModeFactorProperty, defaultValueCreator: GetInternalSizeModeFactorProperty);
+            }
+            return SizeModeFactorProperty;
+        }
+
         /// <summary>
         /// SizeModeFactorProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SizeModeFactorProperty = BindableProperty.Create(nameof(SizeModeFactor), typeof(Vector3), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    Object.InternalSetPropertyVector3(view.SwigCPtr, View.Property.SizeModeFactor, ((Vector3)newValue).SwigCPtr);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                if (view.internalSizeModeFactor == null)
-                {
-                    view.internalSizeModeFactor = new Vector3(view.OnSizeModeFactorChanged, 0, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SizeModeFactor, view.internalSizeModeFactor.SwigCPtr);
-                return view.internalSizeModeFactor;
-            }
-        );
+        public static BindableProperty SizeModeFactorProperty = null;
 
         /// <summary>
         /// WidthResizePolicyProperty
@@ -1549,178 +1837,229 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyBool(view.SwigCPtr, View.Property.HeightForWidth);
         }));
 
+        internal static void SetInternalPaddingProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                if (view.Layout != null)
+                {
+                    view.Layout.Padding = new Extents((Extents)newValue);
+                    if ((view.Padding.Start != 0) || (view.Padding.End != 0) || (view.Padding.Top != 0) || (view.Padding.Bottom != 0))
+                    {
+                        var tmp = new PropertyValue(new Extents(0, 0, 0, 0));
+                        Object.SetProperty(view.SwigCPtr, Property.PADDING, tmp);
+                        tmp?.Dispose();
+                    }
+                    view.Layout.RequestLayout();
+                }
+                else
+                {
+                    var tmp = new PropertyValue((Extents)newValue);
+                    Object.SetProperty(view.SwigCPtr, Property.PADDING, tmp);
+                    tmp?.Dispose();
+                }
+            }
+
+        }
+
+        internal static object GetInternalPaddingProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            if ((view.internalPadding == null) || (view.Layout != null))
+            {
+                ushort start = 0, end = 0, top = 0, bottom = 0;
+                if (view.Layout != null)
+                {
+                    if (view.Layout.Padding != null)
+                    {
+                        start = view.Layout.Padding.Start;
+                        end = view.Layout.Padding.End;
+                        top = view.Layout.Padding.Top;
+                        bottom = view.Layout.Padding.Bottom;
+                    }
+                }
+                view.internalPadding = new Extents(view.OnPaddingChanged, start, end, top, bottom);
+            }
+
+            if (view.Layout == null)
+            {
+                var tmp = Object.GetProperty(view.SwigCPtr, Property.PADDING);
+                tmp?.Get(view.internalPadding);
+                tmp?.Dispose();
+            }
+
+            return view.internalPadding;
+
+        }
+
+        internal static BindableProperty GetPaddingProperty()
+        {
+            if (PaddingProperty == null)
+            {
+                PaddingProperty = BindableProperty.Create(nameof(Padding), typeof(Extents), typeof(View), null,
+                    propertyChanged: SetInternalPaddingProperty, defaultValueCreator: GetInternalPaddingProperty);
+            }
+            return PaddingProperty;
+        }
+
         /// <summary>
         /// PaddingProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty PaddingProperty = BindableProperty.Create(nameof(Padding), typeof(Extents), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
+        public static BindableProperty PaddingProperty = null;
+
+        internal static void SetInternalSizeProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
             {
-                var view = (View)bindable;
-                if (newValue != null)
+                // Size property setter is only used by user.
+                // Framework code uses SetSize() instead of Size property setter.
+                // Size set by user is returned by GetUserSize2D() for SuggestedMinimumWidth/Height.
+                // SuggestedMinimumWidth/Height is used by Layout calculation.
+                float width = ((Size)newValue).Width;
+                float height = ((Size)newValue).Height;
+                float depth = ((Size)newValue).Depth;
+
+                view.userSizeWidth = width;
+                view.userSizeHeight = height;
+
+                // Set Specification so when layouts measure this View it matches the value set here.
+                // All Views are currently Layouts.
+                int widthPolicy = (int)System.Math.Ceiling(width);
+                int heightPolicy = (int)System.Math.Ceiling(height);
+
+                bool relayoutRequired = false;
+                // To avoid duplicated size setup, change internal policy directly.
+                if (view.widthPolicy != widthPolicy)
                 {
-                    if (view.Layout != null)
-                    {
-                        view.Layout.Padding = new Extents((Extents)newValue);
-                        if ((view.Padding.Start != 0) || (view.Padding.End != 0) || (view.Padding.Top != 0) || (view.Padding.Bottom != 0))
-                        {
-                            var tmp = new PropertyValue(new Extents(0, 0, 0, 0));
-                            Object.SetProperty(view.SwigCPtr, Property.PADDING, tmp);
-                            tmp?.Dispose();
-                        }
-                        view.Layout.RequestLayout();
-                    }
-                    else
-                    {
-                        var tmp = new PropertyValue((Extents)newValue);
-                        Object.SetProperty(view.SwigCPtr, Property.PADDING, tmp);
-                        tmp?.Dispose();
-                    }
+                    view.widthPolicy = widthPolicy;
+                    relayoutRequired = true;
                 }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                if ((view.internalPadding == null) || (view.Layout != null))
+                if (view.heightPolicy != heightPolicy)
                 {
-                    ushort start = 0, end = 0, top = 0, bottom = 0;
-                    if (view.Layout != null)
-                    {
-                        if (view.Layout.Padding != null)
-                        {
-                            start = view.Layout.Padding.Start;
-                            end = view.Layout.Padding.End;
-                            top = view.Layout.Padding.Top;
-                            bottom = view.Layout.Padding.Bottom;
-                        }
-                    }
-                    view.internalPadding = new Extents(view.OnPaddingChanged, start, end, top, bottom);
+                    view.heightPolicy = heightPolicy;
+                    relayoutRequired = true;
+                }
+                if (relayoutRequired)
+                {
+                    view.layout?.RequestLayout();
                 }
 
-                if (view.Layout == null)
-                {
-                    var tmp = Object.GetProperty(view.SwigCPtr, Property.PADDING);
-                    tmp?.Get(view.internalPadding);
-                    tmp?.Dispose();
-                }
-
-                return view.internalPadding;
+                view.SetSize(width, height, depth);
             }
-        );
+        }
+
+        internal static object GetInternalSizeProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+
+            if (view.internalSize == null)
+            {
+                view.internalSize = new Size(view.OnSizeChanged, 0, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize.SwigCPtr);
+
+            return view.internalSize;
+        }
+
+        internal static BindableProperty GetSizeProperty()
+        {
+            if (SizeProperty == null)
+            {
+                SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(View), null,
+                    propertyChanged: SetInternalSizeProperty, defaultValueCreator: GetInternalSizeProperty);
+            }
+            return SizeProperty;
+        }
 
         /// <summary>
         /// SizeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(Size), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
+        public static BindableProperty SizeProperty = null;
+
+
+        internal static void SetInternalMinimumSizeProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
             {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    // Size property setter is only used by user.
-                    // Framework code uses SetSize() instead of Size property setter.
-                    // Size set by user is returned by GetUserSize2D() for SuggestedMinimumWidth/Height.
-                    // SuggestedMinimumWidth/Height is used by Layout calculation.
-                    float width = ((Size)newValue).Width;
-                    float height = ((Size)newValue).Height;
-                    float depth = ((Size)newValue).Depth;
 
-                    view.userSizeWidth = width;
-                    view.userSizeHeight = height;
-
-                    // Set Specification so when layouts measure this View it matches the value set here.
-                    // All Views are currently Layouts.
-                    int widthPolicy = (int)System.Math.Ceiling(width);
-                    int heightPolicy = (int)System.Math.Ceiling(height);
-
-                    bool relayoutRequired = false;
-                    // To avoid duplicated size setup, change internal policy directly.
-                    if (view.widthPolicy != widthPolicy)
-                    {
-                        view.widthPolicy = widthPolicy;
-                        relayoutRequired = true;
-                    }
-                    if (view.heightPolicy != heightPolicy)
-                    {
-                        view.heightPolicy = heightPolicy;
-                        relayoutRequired = true;
-                    }
-                    if (relayoutRequired)
-                    {
-                        view.layout?.RequestLayout();
-                    }
-
-                    view.SetSize(width, height, depth);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-
-                if (view.internalSize == null)
-                {
-                    view.internalSize = new Size(view.OnSizeChanged, 0, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector3(view.SwigCPtr, View.Property.SIZE, view.internalSize.SwigCPtr);
-
-                return view.internalSize;
+                Object.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, ((Size2D)newValue).SwigCPtr);
             }
-        );
+
+        }
+
+        internal static object GetInternalMinimumSizeProperty(BindableObject bindable)
+        {
+
+            var view = (View)bindable;
+            if (view.internalMinimumSize == null)
+            {
+                view.internalMinimumSize = new Size2D(view.OnMinimumSizeChanged, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, view.internalMinimumSize.SwigCPtr);
+            return view.internalMinimumSize;
+
+        }
+
+        internal static BindableProperty GetMinimumSizeProperty()
+        {
+            if (MinimumSizeProperty == null)
+            {
+                MinimumSizeProperty = BindableProperty.Create(nameof(MinimumSize), typeof(Size2D), typeof(View), null,
+                    propertyChanged: SetInternalMinimumSizeProperty, defaultValueCreator: GetInternalMinimumSizeProperty);
+            }
+            return MinimumSizeProperty;
+        }
 
         /// <summary>
         /// MinimumSizeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MinimumSizeProperty = BindableProperty.Create(nameof(MinimumSize), typeof(Size2D), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
+        public static BindableProperty MinimumSizeProperty = null;
 
-                    Object.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, ((Size2D)newValue).SwigCPtr);
-                }
-            },
-            defaultValueCreator: (bindable) =>
+        internal static void SetInternalMaximumSizeProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
             {
 
-                var view = (View)bindable;
-                if (view.internalMinimumSize == null)
-                {
-                    view.internalMinimumSize = new Size2D(view.OnMinimumSizeChanged, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MinimumSize, view.internalMinimumSize.SwigCPtr);
-                return view.internalMinimumSize;
+                Object.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, ((Size2D)newValue).SwigCPtr);
             }
-        );
+
+        }
+
+        internal static object GetInternalMaximumSizeProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+
+            if (view.internalMaximumSize == null)
+            {
+                view.internalMaximumSize = new Size2D(view.OnMaximumSizeChanged, 0, 0);
+            }
+            Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, view.internalMaximumSize.SwigCPtr);
+            return view.internalMaximumSize;
+
+        }
+
+        internal static BindableProperty GetMaximumSizeProperty()
+        {
+            if (MaximumSizeProperty == null)
+            {
+                MaximumSizeProperty = BindableProperty.Create(nameof(MaximumSize), typeof(Size2D), typeof(View), null,
+                    propertyChanged: SetInternalMaximumSizeProperty, defaultValueCreator: GetInternalMaximumSizeProperty);
+            }
+            return MaximumSizeProperty;
+        }
 
         /// <summary>
         /// MaximumSizeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MaximumSizeProperty = BindableProperty.Create(nameof(MaximumSize), typeof(Size2D), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-
-                    Object.InternalSetPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, ((Size2D)newValue).SwigCPtr);
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-
-                if (view.internalMaximumSize == null)
-                {
-                    view.internalMaximumSize = new Size2D(view.OnMaximumSizeChanged, 0, 0);
-                }
-                Object.InternalRetrievingPropertyVector2(view.SwigCPtr, View.Property.MaximumSize, view.internalMaximumSize.SwigCPtr);
-                return view.internalMaximumSize;
-            }
-        );
+        public static BindableProperty MaximumSizeProperty = null;
 
         /// <summary>
         /// InheritPositionProperty
@@ -1801,65 +2140,78 @@ namespace Tizen.NUI.BaseComponents
             return (ViewLayoutDirectionType)Object.InternalGetPropertyInt(view.SwigCPtr, View.Property.LayoutDirection);
         }));
 
+        internal static void SetInternalMarginProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var view = (View)bindable;
+            if (newValue != null)
+            {
+                if (view.Layout != null)
+                {
+                    view.Layout.Margin = new Extents((Extents)newValue);
+                    if ((view.Margin.Start != 0) || (view.Margin.End != 0) || (view.Margin.Top != 0) || (view.Margin.Bottom != 0))
+                    {
+                        var tmp = new PropertyValue(new Extents(0, 0, 0, 0));
+                        Object.SetProperty(view.SwigCPtr, Property.MARGIN, tmp);
+                        tmp?.Dispose();
+                    }
+                    view.Layout.RequestLayout();
+                }
+                else
+                {
+                    var tmp = new PropertyValue((Extents)newValue);
+                    Object.SetProperty(view.SwigCPtr, Property.MARGIN, tmp);
+                    tmp?.Dispose();
+                }
+            }
+
+        }
+
+        internal static object GetInternalMarginProperty(BindableObject bindable)
+        {
+            var view = (View)bindable;
+            if ((view.internalMargin == null) || (view.Layout != null))
+            {
+                ushort start = 0, end = 0, top = 0, bottom = 0;
+                if (view.Layout != null)
+                {
+                    if (view.Layout.Margin != null)
+                    {
+                        start = view.Layout.Margin.Start;
+                        end = view.Layout.Margin.End;
+                        top = view.Layout.Margin.Top;
+                        bottom = view.Layout.Margin.Bottom;
+                    }
+                }
+                view.internalMargin = new Extents(view.OnMarginChanged, start, end, top, bottom);
+            }
+
+            if (view.Layout == null)
+            {
+
+                var tmp = Object.GetProperty(view.SwigCPtr, Property.MARGIN);
+                tmp?.Get(view.internalMargin);
+                tmp?.Dispose();
+            }
+
+            return view.internalMargin;
+
+        }
+
+        internal static BindableProperty GetMarginProperty()
+        {
+            if (MarginProperty == null)
+            {
+                MarginProperty = BindableProperty.Create(nameof(Margin), typeof(Extents), typeof(View), null,
+                    propertyChanged: SetInternalMarginProperty, defaultValueCreator: GetInternalMarginProperty);
+            }
+            return MarginProperty;
+        }
+
         /// <summary>
         /// MarginProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty MarginProperty = BindableProperty.Create(nameof(Margin), typeof(Extents), typeof(View), null,
-            propertyChanged: (bindable, oldValue, newValue) =>
-            {
-                var view = (View)bindable;
-                if (newValue != null)
-                {
-                    if (view.Layout != null)
-                    {
-                        view.Layout.Margin = new Extents((Extents)newValue);
-                        if ((view.Margin.Start != 0) || (view.Margin.End != 0) || (view.Margin.Top != 0) || (view.Margin.Bottom != 0))
-                        {
-                            var tmp = new PropertyValue(new Extents(0, 0, 0, 0));
-                            Object.SetProperty(view.SwigCPtr, Property.MARGIN, tmp);
-                            tmp?.Dispose();
-                        }
-                        view.Layout.RequestLayout();
-                    }
-                    else
-                    {
-                        var tmp = new PropertyValue((Extents)newValue);
-                        Object.SetProperty(view.SwigCPtr, Property.MARGIN, tmp);
-                        tmp?.Dispose();
-                    }
-                }
-            },
-            defaultValueCreator: (bindable) =>
-            {
-                var view = (View)bindable;
-                if ((view.internalMargin == null) || (view.Layout != null))
-                {
-                    ushort start = 0, end = 0, top = 0, bottom = 0;
-                    if (view.Layout != null)
-                    {
-                        if (view.Layout.Margin != null)
-                        {
-                            start = view.Layout.Margin.Start;
-                            end = view.Layout.Margin.End;
-                            top = view.Layout.Margin.Top;
-                            bottom = view.Layout.Margin.Bottom;
-                        }
-                    }
-                    view.internalMargin = new Extents(view.OnMarginChanged, start, end, top, bottom);
-                }
-
-                if (view.Layout == null)
-                {
-
-                    var tmp = Object.GetProperty(view.SwigCPtr, Property.MARGIN);
-                    tmp?.Get(view.internalMargin);
-                    tmp?.Dispose();
-                }
-
-                return view.internalMargin;
-            }
-        );
+        public static BindableProperty MarginProperty = null;
 
         /// <summary>
         /// UpdateAreaHintProperty
@@ -2308,23 +2660,38 @@ namespace Tizen.NUI.BaseComponents
             return instance.InternalPositionUsesAnchorPoint;
         });
 
-        /// <summary>
-        /// AnchorPointProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty AnchorPointProperty = BindableProperty.Create(nameof(AnchorPoint), typeof(Tizen.NUI.Position), typeof(View), null, propertyChanged: (bindable, oldValue, newValue) =>
+        internal static void SetInternalAnchorPointProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             if (newValue != null)
             {
                 instance.InternalAnchorPoint = (Tizen.NUI.Position)newValue;
             }
-        },
-        defaultValueCreator: (bindable) =>
+
+        }
+
+        internal static object GetInternalAnchorPointProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.View)bindable;
             return instance.InternalAnchorPoint;
-        });
+
+        }
+
+        internal static BindableProperty GetAnchorPointProperty()
+        {
+            if (AnchorPointProperty == null)
+            {
+                AnchorPointProperty = BindableProperty.Create(nameof(AnchorPoint), typeof(Tizen.NUI.Position), typeof(View), null,
+                    propertyChanged: SetInternalAnchorPointProperty, defaultValueCreator: GetInternalAnchorPointProperty);
+            }
+            return AnchorPointProperty;
+        }
+
+        /// <summary>
+        /// AnchorPointProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static BindableProperty AnchorPointProperty = null;
 
         /// <summary>
         /// WidthSpecificationProperty
@@ -2641,6 +3008,42 @@ namespace Tizen.NUI.BaseComponents
         internal Size2D GetUserSize2D()
         {
             return new Size2D((int)userSizeWidth, (int)userSizeHeight);
+        }
+
+
+        internal static void CreateBindableProperties()
+        {
+            Tizen.Log.Fatal("NT", $"CreateBindableProperties() START  IsUsingXaml={NUIApplication.IsUsingXaml}");
+
+            _ = GetBackgroundColorProperty();
+            _ = GetColorProperty();
+            _ = GetColorRedProperty();
+            _ = GetColorGreenProperty();
+            _ = GetColorBlueProperty();
+            _ = GetCellIndexProperty();
+            _ = GetSize2DProperty();
+            _ = GetPosition2DProperty();
+            _ = GetParentOriginProperty();
+            _ = GetPivotPointProperty();
+            _ = GetSizeWidthProperty();
+            _ = GetSizeHeightProperty();
+            _ = GetPositionProperty();
+            _ = GetPositionXProperty();
+            _ = GetPositionYProperty();
+            _ = GetPositionZProperty();
+            _ = GetScaleProperty();
+            _ = GetScaleXProperty();
+            _ = GetScaleYProperty();
+            _ = GetScaleZProperty();
+            _ = GetNameProperty();
+            _ = GetSizeModeFactorProperty();
+            _ = GetPaddingProperty();
+            _ = GetSizeProperty();
+            _ = GetMinimumSizeProperty();
+            _ = GetMaximumSizeProperty();
+            _ = GetMarginProperty();
+            _ = GetAnchorPointProperty();
+            Tizen.Log.Fatal("NT", $"CreateBindableProperties() END");
         }
 
         private void SetBackgroundImage(string value)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliDemo.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DaliDemo/DaliDemo.cs
@@ -12,7 +12,6 @@ namespace Tizen.NUI.Samples
     {
         public DaliDemo(string styleSheet) : base(styleSheet)
         {
-            //DisableBindableProperty = true;
         }
 
         private IExample curExample = null;

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/IsUsingXamlTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/IsUsingXamlTest.cs
@@ -5,7 +5,7 @@ using Tizen.NUI.BaseComponents;
 namespace Tizen.NUI.Samples
 {
     using tlog = Tizen.Log;
-    public class DisableBindablePropertyTest : IExample
+    public class IsUsingXamlTest : IExample
     {
         private const int NUMBER_OF_VIEW = 300;
         private const int MIN_SIZE = 100;


### PR DESCRIPTION
### Description of Change ###
[NUI] Add IsUsingXaml
- try to make NUI App's performance in memory and launching speed by separating property usage at runtime.
- tested in PontusM target.
- REMOVE_READONLY macro is for removing `readonly` keyword for BindableProperty instance creation. 
  this is for testing how it can enhance the performance even if changing the interface. (Xaml APP need change codes)
- only changing the View's properties and even they are not whole, but only some.
- further code work will be done step by step.

### API Changes ###
nothing