### PR TITLE
[Tizen.System.Storage] Register eventhandler if it is already existed

### DIFF
--- a/src/Tizen.System.Storage/Storage/Storage.cs
+++ b/src/Tizen.System.Storage/Storage/Storage.cs
@@ -59,7 +59,10 @@ namespace Tizen.System
             };
         }
 
-        internal Storage(int storageID, Interop.Storage.StorageArea storageType, Interop.Storage.StorageState storagestate, string rootDirectory, Interop.Storage.StorageDevice devicetype, string fstype, string fsuuid, bool primary, int flags)
+        internal Storage(int storageID, Interop.Storage.StorageArea storageType,
+			Interop.Storage.StorageState storagestate, string rootDirectory,
+			Interop.Storage.StorageDevice devicetype, string fstype,
+			string fsuuid, bool primary, int flags, EventHandler eventhandler = null)
         {
             Id = storageID;
             _storagetype = storageType;
@@ -71,6 +74,9 @@ namespace Tizen.System
             _primary = primary;
             _flags = flags;
             information_set = true;
+            s_stateChangedEventHandler = eventhandler;
+            if (s_stateChangedEventHandler == null)
+                Log.Warn(LogTag, string.Format("Can't register event handler"));
 
             Interop.Storage.ErrorCode err = Interop.Storage.StorageGetTotalSpace(Id, out _totalSpace);
             if (err != Interop.Storage.ErrorCode.None)

--- a/src/Tizen.System.Storage/Storage/StorageManager.cs
+++ b/src/Tizen.System.Storage/Storage/StorageManager.cs
@@ -55,12 +55,15 @@ namespace Tizen.System
         private static EventHandler s_ExtendedInternalStorageChangedEventHandler;
         private static Interop.Storage.StorageChangedCallback s_ChangedEventCallback = (int id, Interop.Storage.StorageDevice devicetype, Interop.Storage.StorageState state, string fstype, string fsuuid, string rootDirectory, bool primary, int flags, IntPtr userData) =>
         {
-            Storage storage = new Storage(id, Interop.Storage.StorageArea.External, state, rootDirectory, devicetype, fstype, fsuuid, primary, flags);
-
+            EventHandler eventhandler = null;
             if (devicetype == Interop.Storage.StorageDevice.ExtendedInternalStorage)
-                s_ExtendedInternalStorageChangedEventHandler?.Invoke(storage, EventArgs.Empty);
+                eventhandler = s_ExtendedInternalStorageChangedEventHandler;
             else
-                s_ExternalStorageChangedEventHandler?.Invoke(storage, EventArgs.Empty);
+                eventhandler = s_ExternalStorageChangedEventHandler;
+
+            Storage storage = new Storage(id, Interop.Storage.StorageArea.External,
+			    state, rootDirectory, devicetype, fstype, fsuuid, primary, flags, eventhandler);
+            eventhandler?.Invoke(storage, EventArgs.Empty);
         };
 
         private static void RegisterChangedEvent(StorageArea type)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

In the previous implementation, no event handler was registered within class Storage when it was registered by storage type.
As a result of that, when the USB (or SD card) was removed, it attempted to obtain the state from outside and provided incorrect information to the application because there is no storage already removed.
It registers event handler within class Storage when event handler was registered by storage type.
