### PR TITLE
[NUI] Fix manual TCT crash issue only on TV target

### DIFF
--- a/src/Tizen.NUI.Components/Controls/Control.cs
+++ b/src/Tizen.NUI.Components/Controls/Control.cs
@@ -164,12 +164,23 @@ namespace Tizen.NUI.Components
 
         private bool OnTouchPlayFeedback(object source, TouchEventArgs e)
         {
-            if (Feedback && e?.Touch.GetState(0) == PointStateType.Down)
+            try
             {
-                if (feedback != null && feedback.IsSupportedPattern(FeedbackType.Sound, "Tap"))
+                if (Feedback && e?.Touch.GetState(0) == PointStateType.Down)
                 {
-                    feedback.Play(FeedbackType.Sound, "Tap");
+                    if (feedback != null && feedback.IsSupportedPattern(FeedbackType.Sound, "Tap"))
+                    {
+                        feedback.Play(FeedbackType.Sound, "Tap");
+                    }
                 }
+            }
+            catch (NotSupportedException ex)
+            {
+                Log.Error("NUI", $"[ERROR] No support of Feedback: {ex}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                Log.Error("NUI", $"[ERROR] Fail to initialize Feedback: {ex}");
             }
             return false;
         }


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix manual TCT crash issue only on TV target
- fix the following exception on TV target
 `01-01 09:07:09.036+0900 W/Tizen.System.Feedback(P 9174, T 9174): Feedback.cs: IsSupportedPattern(429) > Failed to get supported information. err = -38404095`
`01-01 09:07:09.682+0900 E/DOTNET_LAUNCHER(P 9174, T 9708): log.cc: stdErrRedirect(57) > Unhandled exception. `
`01-01 09:07:10.232+0900 E/DOTNET_LAUNCHER(P 9174, T 9708): log.cc: stdErrRedirect(57) > System.InvalidOperationException: Failed to get supported information`
`01-01 09:07:10.232+0900 E/DOTNET_LAUNCHER(P 9174, T 9708): log.cc: stdErrRedirect(57) >    at Tizen.System.Feedback.IsSupportedPattern(FeedbackType type, String pattern) in /home/abuild/rpmbuild/BUILD/csapi-tizenfx-12.0.0.18257+nui22316/src/Tizen.System.Feedback/Feedback/Feedback.cs:line 442`
`01-01 09:07:10.232+0900 E/DOTNET_LAUNCHER(P 9174, T 9708): log.cc: stdErrRedirect(57) >    at Tizen.NUI.Components.Control.OnTouchPlayFeedback(Object source, TouchEventArgs e) in /home/abuild/rpmbuild/BUILD/csapi-tizenfx-12.0.0.18257+nui22316/src/Tizen.NUI.Components/Controls/Control.cs:line 169`
`01-01 09:07:10.232+0900 E/DOTNET_LAUNCHER(P 9174, T 9708): log.cc: stdErrRedirect(57) >    at Tizen.NUI.BaseComponents.View.OnTouch(IntPtr view, IntPtr touchData) in /home/abuild/rpmbuild/BUILD/csapi-tizenfx-12.0.0.18257+nui22316/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs:line 877`
`01-01 09:07:10.233+0900 E/DOTNET_LAUNCHER(P 9174, T 9708): log.cc: stdErrRedirect(57) > DotNET onSigabrt called on Tizen.ComponentBased.Manual.Tests`

### API Changes ###
nothing