### PR TITLE
[NUI] Fix LottieAnimationView not to reference disposed delegate

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1190,7 +1190,7 @@ namespace Tizen.NUI.BaseComponents
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void RootCallbackType(int id, int returnType, uint frameNumber, ref float val1, ref float val2, ref float val3);
 
-        internal RootCallbackType rootCallback = RootCallback;
+        static internal RootCallbackType rootCallback = RootCallback;
 
         static internal void RootCallback(int id, int returnType, uint frameNumber, ref float val1, ref float val2, ref float val3)
         {
@@ -1201,9 +1201,9 @@ namespace Tizen.NUI.BaseComponents
 
             if (weakReferencesOfLottie.TryGetValue(id, out current))
             {
-                if (current.TryGetTarget(out currentView))
+                if (current.TryGetTarget(out currentView) && (currentView != null) && !currentView.Disposed && !currentView.IsDisposeQueued)
                 {
-                    if (currentView != null && currentView.InternalSavedDynamicPropertyCallbacks != null &&
+                    if (currentView.InternalSavedDynamicPropertyCallbacks != null &&
                         currentView.InternalSavedDynamicPropertyCallbacks.TryGetValue(id, out currentCallback))
                     {
                         ret = currentCallback?.Invoke(returnType, frameNumber);
@@ -1237,7 +1237,6 @@ namespace Tizen.NUI.BaseComponents
                         val2 = tmpVector3.Y;
                         val3 = tmpVector3.Z;
                     }
-                    tmpVector3.Dispose();
                     break;
 
                 case (int)(VectorProperty.TransformAnchor):
@@ -1249,7 +1248,6 @@ namespace Tizen.NUI.BaseComponents
                         val1 = tmpVector2.X;
                         val2 = tmpVector2.Y;
                     }
-                    tmpVector2.Dispose();
                     break;
 
                 case (int)(VectorProperty.FillOpacity):


### PR DESCRIPTION
Delegate rootCallback of LottieAnimationView is called by multi threads for lottie dynamic properties.

This causes the following issues.
- Delegate rootCallback of disposed LottieAnimationView can be referenced.
- Local variables in RootCallback is disposed by multi threads.

To resolve the above issues, the followings are done.
- Delegate rootCallback of LottieAnimationView is changed to be static.
- Local variables in RootCallback is not disposed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
