### PR TITLE
[NUI.WindowSystem] Backport GetSourceMimetypes of KVMService to API11

### DIFF
--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.KVMService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.KVMService.cs
@@ -25,6 +25,12 @@ namespace Tizen.NUI.WindowSystem.Shell
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_kvm_service_receive_drag_data")]
             internal static extern int ReceiveDragData(IntPtr kvmService, string mimeType);
 
+            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_kvm_service_get_source_mimetypes")]
+            internal static extern int GetSourceMimetypes(
+                IntPtr kvmService,
+                out string[] mimeTypes,
+                out int count);
+
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_kvm_service_secondary_selection_set")]
             internal static extern int SetSecondarySelection(IntPtr kvmService);
 

--- a/src/Tizen.NUI.WindowSystem/src/public/KVMService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/KVMService.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Collections.Generic;
 
 namespace Tizen.NUI.WindowSystem.Shell
 {
@@ -206,6 +207,23 @@ namespace Tizen.NUI.WindowSystem.Shell
         {
             int res = Interop.KVMService.ReceiveDragData(_kvmService, mimeType);
             _tzsh.ErrorCodeThrow(res);
+        }
+
+        /// <summary>
+        /// Requests to receive the mimetype list of drag source.
+        /// </summary>
+        /// <returns>
+        /// The list of mimetype.
+        /// If there are no mimetype, returns null.
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        public List<string> GetSourceMimetypes()
+        {
+            int res = Interop.KVMService.GetSourceMimetypes(_kvmService, out string[] mimetypes, out int mimeTypeCount);
+            _tzsh.ErrorCodeThrow(res);
+
+            if (mimetypes == null) return null;
+            return new List<string>(mimetypes);
         }
 
         /// <summary>

--- a/test/NUIWindowKVMSample/NUIWindowKVMSample.cs
+++ b/test/NUIWindowKVMSample/NUIWindowKVMSample.cs
@@ -148,9 +148,17 @@ namespace NUIWindowKVMSample
         {
             Log.Debug("KVMSample", "Tizen KVM: Drag started");
 
+            List<string> mimeTypes;
+            mimeTypes = kvmService.GetSourceMimetypes();
+            if (mimeTypes == null)
+                Log.Debug("KVMSample", "Tizen KVM: There're no Source mimetypes");
+            else
+                Log.Debug("KVMSample", "Tizen KVM: Source mimetypes: " + string.Join(", ", mimeTypes));
+            string mimeType = mimeTypes[0];
+
             // Request the drag data to the Display server.
             // The drag data can get at DnD Listener (OnDnDEvent function)
-            kvmService.ReceiveDragData("text/plain");
+            kvmService.ReceiveDragData(mimeType);
         }
 
         private void OnDragEnded(object sender, EventArgs e)


### PR DESCRIPTION
## Description of Change ##
Backport GetSourceMimetypes of KVMService to API11

## API Changes ##
### Internal API Changes ###

Added:
 - List<string> GetSourceMimetypes(void)
   - method to get mimetype list that current drag source offered.
