### PR TITLE
Fix svace issue df240325-00447 240401

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -241,19 +241,22 @@ namespace Tizen.NUI.BaseComponents
                 if (textures != null)
                 {
                     int count = textures.Count;
-                    int intptrBytes = checked(Marshal.SizeOf(typeof(IntPtr)) * count);
-                    if (intptrBytes > 0)
+                    if (count > 0)
                     {
                         IntPtr[] texturesArray = new IntPtr[count];
                         for (int i = 0; i < count; i++)
                         {
                             texturesArray[i] = HandleRef.ToIntPtr(Texture.getCPtr(textures[i]));
                         }
-                        IntPtr unmanagedPointer = Marshal.AllocHGlobal(intptrBytes);
+                        IntPtr unmanagedPointer = Marshal.AllocHGlobal(checked(Marshal.SizeOf(typeof(IntPtr)) * texturesArray.Length));
                         try
                         {
                             Marshal.Copy(texturesArray, 0, unmanagedPointer, texturesArray.Length);
                             Interop.GLView.GlViewBindTextureResources(SwigCPtr, unmanagedPointer, texturesArray.Length);
+                        }
+                        catch(Exception e)
+                        {
+                            Tizen.Log.Error("NUI", "Exception in GlViewBindTextureResources : " + e.Message);
                         }
                         finally
                         {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Fix svace issue of buffer exceed size

WID:42154964 Writing texturesArray.Length elements of type System.IntPtr into buffer unmanagedPointer can exceed its size.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
