### PR TITLE
[NUI] Fix svace issue of buffer exceed size

### DIFF
--- a/src/Tizen.NUI.Wearable/src/public/Title.cs
+++ b/src/Tizen.NUI.Wearable/src/public/Title.cs
@@ -330,16 +330,20 @@ namespace Tizen.NUI.Components
 
             TexturedQuadVertex[] texturedQuadVertexData = new TexturedQuadVertex[4] { vertex1, vertex2, vertex3, vertex4 };
 
-            int length = Marshal.SizeOf(vertex1);
-            IntPtr pA = Marshal.AllocHGlobal(checked(length * 4));
+            int size = Marshal.SizeOf(vertex1);
+            IntPtr pA = Marshal.AllocHGlobal(checked(size * texturedQuadVertexData.Length));
 
             try
             {
-                for (int i = 0; i < 4; i++)
+                for (int i = 0; i < texturedQuadVertexData.Length; i++)
                 {
-                    Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * length, true);
+                    Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * size, true);
                 }
-                vertexData.SetData(pA, 4);
+                vertexData.SetData(pA, (uint)texturedQuadVertexData.Length);
+            }
+            catch(Exception e)
+            {
+                Tizen.Log.Error("NUI", "Exception in Title : " + e.Message);
             }
             finally
             {

--- a/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
@@ -312,17 +312,21 @@ namespace Tizen.NUI
 
             TexturedQuadVertex[] texturedQuadVertexData = new TexturedQuadVertex[4] { vertex1, vertex2, vertex3, vertex4 };
 
-            int length = Marshal.SizeOf(vertex1);
-            IntPtr pA = Marshal.AllocHGlobal(checked(length * 4));
+            int size = Marshal.SizeOf(vertex1);
+            IntPtr pA = Marshal.AllocHGlobal(checked(size * texturedQuadVertexData.Length));
 
             try
             {
-                for (int i = 0; i < 4; i++)
+                for (int i = 0; i < texturedQuadVertexData.Length; i++)
                 {
-                    Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * length, true);
+                    Marshal.StructureToPtr(texturedQuadVertexData[i], pA + i * size, true);
                 }
 
-                vertexBuffer.SetData(pA, 4);
+                vertexBuffer.SetData(pA, (uint)texturedQuadVertexData.Length);
+            }
+            catch(Exception e)
+            {
+                Tizen.Log.Error("NUI", "Exception in FrameBrokerBase : " + e.Message);
             }
             finally
             {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1. Fix svace issue of buffer exceed size.

WID:42154958 Writing 1 element of type Tizen.NUI.FrameBrokerBase.TexturedQuadVertex into buffer pA + i * length can exceed its size
WID:42154959 Writing 1 element of type Tizen.NUI.Components.Title.TexturedQuadVertex into buffer pA + i * length can exceed its size

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
