### PR TITLE
[API10][NUI][AT-SPI] Promote ReadingInfoTypes to Container 

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -84,12 +84,12 @@ namespace Tizen.NUI
             public static extern void DaliToolkitDevelControlClearAccessibilityRelations(HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_SetAccessibilityReadingInfoType2")]
-            public static extern void DaliToolkitDevelControlSetAccessibilityReadingInfoTypes(HandleRef arg1, int arg2);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetReadingInfoTypes")]
+            public static extern void DaliAccessibilitySetReadingInfoTypes(HandleRef arg1, int arg2);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_GetAccessibilityReadingInfoType2")]
-            public static extern int DaliToolkitDevelControlGetAccessibilityReadingInfoTypes(HandleRef arg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_GetReadingInfoTypes")]
+            public static extern int DaliAccessibilityGetReadingInfoTypes(HandleRef arg1);
 
             [EditorBrowsable(EditorBrowsableState.Never)]
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Toolkit_DevelControl_ClearAccessibilityHighlight")]

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
@@ -87,9 +87,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_HIGHLIGHTABLE_get")]
             public static extern int AccessibilityHighlightableGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_ACCESSIBILITY_ATTRIBUTES_get")]
-            public static extern int AccessibilityAttributesGet();
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_DISPATCH_KEY_EVENTS_get")]
             public static extern int DispatchKeyEventsGet();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -198,33 +198,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         ///////////////////////////////////////////////////////////////////
-        // ********************* ReadingInfoType *********************** //
-        ///////////////////////////////////////////////////////////////////
-
-        /// <summary>
-        /// Sets accessibility reading information.
-        /// </summary>
-        /// <param name="type">Reading information type</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetAccessibilityReadingInfoTypes(AccessibilityReadingInfoTypes type)
-        {
-            Interop.ControlDevel.DaliToolkitDevelControlSetAccessibilityReadingInfoTypes(SwigCPtr, (int)type);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// <summary>
-        /// Gets accessibility reading information.
-        /// </summary>
-        /// <returns>Reading information type</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public AccessibilityReadingInfoTypes GetAccessibilityReadingInfoTypes()
-        {
-            AccessibilityReadingInfoTypes result = (AccessibilityReadingInfoTypes)Interop.ControlDevel.DaliToolkitDevelControlGetAccessibilityReadingInfoTypes(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return result;
-        }
-
-        ///////////////////////////////////////////////////////////////////
         // ******************** Accessibility States ******************* //
         ///////////////////////////////////////////////////////////////////
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -261,7 +261,6 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int AccessibilityTranslationDomain = Interop.ViewProperty.AccessibilityTranslationDomainGet();
             internal static readonly int AccessibilityRole = Interop.ViewProperty.AccessibilityRoleGet();
             internal static readonly int AccessibilityHighlightable = Interop.ViewProperty.AccessibilityHighlightableGet();
-            internal static readonly int AccessibilityAttributes = Interop.ViewProperty.AccessibilityAttributesGet();
             internal static readonly int DispatchKeyEvents = Interop.ViewProperty.DispatchKeyEventsGet();
             internal static readonly int AccessibilityHidden = Interop.ViewProperty.AccessibilityHiddenGet();
             internal static readonly int AutomationId = Interop.ViewProperty.AutomationIdGet();

--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -272,6 +272,29 @@ namespace Tizen.NUI
         [Obsolete("This has been deprecated in API9 and will be removed in API11. Use ChildCount property instead.")]
         public abstract UInt32 GetChildCount();
 
+        /// <summary>
+        /// Sets accessibility reading information.
+        /// </summary>
+        /// <param name="type">Reading information type</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetAccessibilityReadingInfoTypes(AccessibilityReadingInfoTypes type)
+        {
+            Interop.ControlDevel.DaliAccessibilitySetReadingInfoTypes(SwigCPtr, (int)type);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Gets accessibility reading information.
+        /// </summary>
+        /// <returns>Reading information type</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public AccessibilityReadingInfoTypes GetAccessibilityReadingInfoTypes()
+        {
+            AccessibilityReadingInfoTypes result = (AccessibilityReadingInfoTypes)Interop.ControlDevel.DaliAccessibilityGetReadingInfoTypes(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return result;
+        }
+
         internal abstract View FindCurrentChildById(uint id);
 
         internal override void OnParentResourcesChanged(IEnumerable<KeyValuePair<string, object>> values)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

This way both View and Layer can use this API.

Note: This is an API10 port of https://github.com/Samsung/TizenFX/pull/6028.

### Dependencies
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/309098/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/309099/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/309102/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/widget-viewer-dali/+/309103/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/309100/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/309101/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
