### PR TITLE
[NUI] Add SystemLocaleLanguageChangedManager class

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+extern alias TizenSystemSettings;
+using TizenSystemSettings.Tizen.System;
+
+using System;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// A static class which adds user handler to the SystemSettings.LocaleLanguageChanged event.
+    /// This class also adds user handler to the last of the SystemSettings.LocaleLanguageChanged event.
+    /// </summary>
+    internal static class SystemLocaleLanguageChangedManager
+    {
+        static SystemLocaleLanguageChangedManager()
+        {
+            SystemSettings.LocaleLanguageChanged += SystemLocaleLanguageChanged;
+        }
+
+        /// <summary>
+        /// The handler invoked last after all handlers added to the SystemSettings.LocaleLanguageChanged event are invoked.
+        /// </summary>
+        public static event EventHandler<LocaleLanguageChangedEventArgs> Finished;
+
+        /// <summary>
+        /// Adds the given handler to the SystemSettings.LocaleLanguageChanged event.
+        /// </summary>
+        /// <param name="handler">A handler to be added to the event</param>
+        public static void Add(EventHandler<LocaleLanguageChangedEventArgs> handler)
+        {
+            proxy.Add(handler);
+        }
+
+        /// <summary>
+        /// Removes the given handler from the SystemSettings.LocaleLanguageChanged event.
+        /// </summary>
+        /// <param name="handler">A handler to be added to the event</param>
+        public static void Remove(EventHandler<LocaleLanguageChangedEventArgs> handler)
+        {
+            proxy.Remove(handler);
+        }
+
+        private static void SystemLocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs args)
+        {
+            proxy.Invoke(sender, args);
+            Finished?.Invoke(sender, args);
+        }
+
+        private static WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>> proxy = new WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>>();
+    }
+}


### PR DESCRIPTION
SystemLocaleLanguageChangedManager is a static class which adds user handlers to the SystemSettings.LocaleLanguageChanged event.

It is similar to SystemLocaleLanguageChanged class but it is a static class and it also provides Finished event handler invoked last after all handlers added to the SystemSettings.LocaleLanguageChanged event are invoked.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
