### PR TITLE
[NUI] Fix View to use control-accessible State::SENSITIVE

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibility.cs
@@ -539,7 +539,6 @@ namespace Tizen.NUI.BaseComponents
 
             states[AccessibilityState.Focused] = this.State == States.Focused;
             states[AccessibilityState.Enabled] = this.State != States.Disabled;
-            states[AccessibilityState.Sensitive] = this.Sensitive;
 
             return states;
         }


### PR DESCRIPTION
In dali-toolkit, control-accessible's State::SENSITIVE has been modified from Actor::Property::SENSITIVE to IsHittable() && GetTouchRequired().

Unlike control-accessible, NUI View's custom Accessibility state of Sensitive still refers Actor::Property::SENSITIVE.

So NUI View with ViewAccessibilityMode.Default's Accessibility state of Sensitive refers IsHittable() && GetTouchRequired().

In contrast, NUI View with ViewAccessibilityMode.Custom's Accessibility state of Sensitive refers Actor::Property::SENSITIVE.

To make them have same Sensitive value, NUI View's custom Accessibility state of Sensitive is modified to use the value from control-accessible.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
