### PR TITLE
[NUI.Gadget] Fix NUIGadgetResourceManager

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetResourceManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetResourceManager.cs
@@ -104,6 +104,11 @@ namespace Tizen.NUI
             try
             {
                 var resourceManager = GetResourceManager(cultureInfo.Name);
+                if (resourceManager == null)
+                {
+                    resourceManager = GetResourceManager(cultureInfo.TwoLetterISOLanguageName);
+                }
+
                 if (resourceManager != null)
                 {
                     result = resourceManager.GetString(name, cultureInfo);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
If getting the resource manager is failed, the NUIGadgeResourceManager tries to get the resource manager from the TwoLetterISOLanguageName of the CultureInfo.
