### PR TITLE
[API10][NUI][AT-SPI] Fixed AlertDialog behaviour

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -461,7 +461,14 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override string AccessibilityGetDescription()
         {
-            return Message;
+            if (!String.IsNullOrEmpty(Title))
+            {
+                return Message;
+            }
+            else
+            {
+                return "";
+            }
         }
 
         /// <summary>
@@ -472,7 +479,18 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             AccessibilityRole = Role.Dialog;
+        }
+
+        public override void OnSceneConnection(int depth)
+        {
+            base.OnSceneConnection(depth);
             Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
+        }
+
+        public override void OnSceneDisconnection()
+        {
+            base.OnSceneDisconnection();
+            Hide();
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Fixed behaviour of AlertDialog component in terms of registering/unregistering default label.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
