### PR TITLE
[API10][NUI][AT-SPI] Fixed AlertDialog behaviour

### DIFF
--- a/src/Tizen.NUI.Components/Controls/AlertDialog.cs
+++ b/src/Tizen.NUI.Components/Controls/AlertDialog.cs
@@ -79,6 +79,9 @@ namespace Tizen.NUI.Components
                 return;
             }
 
+            AddedToWindow -= OnAddedToWindow;
+            RemovedFromWindow -= OnRemovedFromWindow;
+
             if (type == DisposeTypes.Explicit)
             {
                 if (titleContent != null)
@@ -461,7 +464,14 @@ namespace Tizen.NUI.Components
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override string AccessibilityGetDescription()
         {
-            return Message;
+            if (!String.IsNullOrEmpty(Title))
+            {
+                return Message;
+            }
+            else
+            {
+                return "";
+            }
         }
 
         /// <summary>
@@ -472,8 +482,18 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             AccessibilityRole = Role.Dialog;
+        }
+
+        private void OnAddedToWindow(object sender, EventArgs e)
+        {
             Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
         }
+
+        private void OnRemovedFromWindow(object sender, EventArgs e)
+        {
+            Hide();
+        }
+
 
         /// <summary>
         /// Informs AT-SPI bridge about the set of AT-SPI states associated with this object.
@@ -558,7 +578,9 @@ namespace Tizen.NUI.Components
                 linearLayout.CellPadding = new Size2D(alertDialogStyle.ItemSpacing.Width, alertDialogStyle.ItemSpacing.Height);
             }
 
-            this.Relayout += OnRelayout;
+            Relayout += OnRelayout;
+            AddedToWindow += OnAddedToWindow;
+            RemovedFromWindow += OnRemovedFromWindow;
 
             TitleContent = DefaultTitleContent;
 

--- a/src/Tizen.NUI.Components/Controls/Dialog.cs
+++ b/src/Tizen.NUI.Components/Controls/Dialog.cs
@@ -52,7 +52,9 @@ namespace Tizen.NUI.Components
         {
             Layout = new AbsoluteLayout();
 
-            this.Relayout += OnRelayout;
+            Relayout += OnRelayout;
+            AddedToWindow += OnAddedToWindow;
+            RemovedFromWindow += OnRemovedFromWindow;
         }
 
         /// <summary>
@@ -92,6 +94,9 @@ namespace Tizen.NUI.Components
             {
                 return;
             }
+
+            AddedToWindow -= OnAddedToWindow;
+            RemovedFromWindow -= OnRemovedFromWindow;
 
             if (type == DisposeTypes.Explicit)
             {
@@ -159,7 +164,16 @@ namespace Tizen.NUI.Components
         {
             base.OnInitialize();
             AccessibilityRole = Role.Dialog;
+        }
+
+        private void OnAddedToWindow(object sender, EventArgs e)
+        {
             Show(); // calls RegisterDefaultLabel(); Hide() will call UnregisterDefaultLabel()
+        }
+
+        private void OnRemovedFromWindow(object sender, EventArgs e)
+        {
+            Hide();
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Fixed AlertDialog's and Dialog's way of registering and unregistering default label

After this patch was added:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/308327/
The RegisterDefaultLabel() must be called after connecting the View to Window.
This pull request corrects this behaviour in AlertDialog component.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: none

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
