### PR TITLE
[NUI.Extension] Use rive-tizen so file

### DIFF
--- a/src/Tizen.NUI.Extension/Interop/Interop.RiveAnimationView.cs
+++ b/src/Tizen.NUI.Extension/Interop/Interop.RiveAnimationView.cs
@@ -21,40 +21,42 @@ namespace Tizen.NUI.Extension
     {
         internal static partial class RiveAnimationView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_New__SWIG_0")]
+            public const string Lib = "libdali2-csharp-binder-rive-animation.so";
+
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_New__SWIG_0")]
             public static extern global::System.IntPtr New(string url);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_EnableAnimation")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_EnableAnimation")]
             public static extern void EnableAnimation(global::System.Runtime.InteropServices.HandleRef handle, string animationName, bool on);
             
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetShapeFillColor")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetShapeFillColor")]
             public static extern void SetShapeFillColor(global::System.Runtime.InteropServices.HandleRef handle, string shapeFillName, global::System.Runtime.InteropServices.HandleRef color);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetShapeStrokeColor")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetShapeStrokeColor")]
             public static extern void SetShapeStrokeColor(global::System.Runtime.InteropServices.HandleRef handle, string shapeStrokeName, global::System.Runtime.InteropServices.HandleRef color);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodeOpacity")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodeOpacity")]
             public static extern void SetNodeOpacity(global::System.Runtime.InteropServices.HandleRef handle, string nodeOpacity, float opacity);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodeScale")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodeScale")]
             public static extern void SetNodeScale(global::System.Runtime.InteropServices.HandleRef handle, string nodeScale, global::System.Runtime.InteropServices.HandleRef scale);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodeRotation")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodeRotation")]
             public static extern void SetNodeRotation(global::System.Runtime.InteropServices.HandleRef handle, string nodeRotation, global::System.Runtime.InteropServices.HandleRef degree);
             
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodePosition")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetNodePosition")]
             public static extern void SetNodePosition(global::System.Runtime.InteropServices.HandleRef handle, string nodeName, global::System.Runtime.InteropServices.HandleRef position);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_PlayAnimation")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_PlayAnimation")]
             public static extern void Play(global::System.Runtime.InteropServices.HandleRef handle);
             
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_PauseAnimation")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_PauseAnimation")]
             public static extern void Pause(global::System.Runtime.InteropServices.HandleRef handle);
             
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_StopAnimation")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_StopAnimation")]
             public static extern void Stop(global::System.Runtime.InteropServices.HandleRef handle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetAnimationElapsedTime")]
+            [global::System.Runtime.InteropServices.DllImport(Lib, EntryPoint = "CSharp_Dali_RiveAnimationView_SetAnimationElapsedTime")]
             public static extern void SetAnimationElapsedTime(global::System.Runtime.InteropServices.HandleRef handle, string animationName, float elapsed);
         }
     }


### PR DESCRIPTION
Split rive-tizen binder from csharp-binder
Refer :
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/309648/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
