### PR TITLE
[NUI] Fix the crash in ubuntu-backend

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -690,9 +690,16 @@ namespace Tizen.NUI
             ProcessorController.Instance.Initialize();
             Tizen.Tracer.End();
 
+#if REMOVE_READONLY_FOR_BINDABLE_PROPERTY
+            if(NUIApplication.IsUsingXaml)
+            {
+                Tizen.NUI.BaseComponents.View.CreateBindableProperties();
+            }
+#endif
             Log.Info("NUI", "[NUI] OnApplicationInit: GetWindow");
             Tizen.Tracer.Begin("[NUI] OnApplicationInit: GetWindow");
             Window.Instance = GetWindow();
+
 #if !PROFILE_TV
             //tv profile never use default focus indicator, so this is not needed!
             _ = FocusManager.Instance;

--- a/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
@@ -393,12 +393,6 @@ namespace Tizen.NUI
 
             Log.Info("NUI", "NUICorebackend OnPreCreated Called");
 
-#if REMOVE_READONLY_FOR_BINDABLE_PROPERTY
-            if(NUIApplication.IsUsingXaml)
-            {
-                View.CreateBindableProperties();
-            }
-#endif
             Tizen.Tracer.Begin("[NUI] OnInitialized(): OnPreCreated event handler");
             var preCreateHandler = Handlers[EventType.PreCreated] as Action;
             preCreateHandler?.Invoke();


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix the crash in ubuntu-backend
- View's BindableProperty creation should be prior to use the properties of the View and View's derived class.
- checked the normal running in ubuntu-backend with tizen_8.0 and API11 code snapshot.

### API Changes ###
nothing