### PR TITLE
[NUI] Fix svace issue for BorderWindow

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -289,14 +289,16 @@ namespace Tizen.NUI
                 if (hasBottomView) borderHeight += bottomView.SizeHeight;
 
                 // Sets the minimum / maximum size to be resized by RequestResizeToServer.
-                if (borderInterface.MinSize != null)
+                var minSize = borderInterface.MinSize;
+                if (null != minSize)
                 {
-                    using Size2D mimimumSize = new Size2D(borderInterface.MinSize.Width + (int)borderInterface.BorderLineThickness * 2, borderInterface.MinSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
+                    using Size2D mimimumSize = new Size2D(minSize.Width + (int)borderInterface.BorderLineThickness * 2, minSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMimimumSize(mimimumSize);
                 }
-                if (borderInterface.MaxSize != null)
+                var maxSize = borderInterface.MaxSize;
+                if (null != maxSize)
                 {
-                    using Size2D maximumSize = new Size2D(borderInterface.MaxSize.Width + (int)borderInterface.BorderLineThickness * 2, borderInterface.MaxSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
+                    using Size2D maximumSize = new Size2D(maxSize.Width + (int)borderInterface.BorderLineThickness * 2, maxSize.Height + (int)(borderHeight + borderInterface.BorderLineThickness * 2));
                     SetMaximumSize(maximumSize);
                 }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
1.  Fix svace issue for BorderWindow

* WID:49385020 [STATISTICAL] Value borderInterface.MinSize, which is result of method invocation with possible null return value, is dereferenced in member access expression borderInterface.MinSize.Width

* WID:49385028 [STATISTICAL] Value borderInterface.MinSize, which is result of method invocation with possible null return value, is dereferenced in member access expression borderInterface.MinSize.Height

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
