### PR TITLE
[NUI] Clean BackgroundImage setter logic

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -4780,15 +4780,18 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
-                backgroundImageSynchronousLoading = value;
-
-                if (!string.IsNullOrEmpty(BackgroundImage))
+                if (backgroundImageSynchronousLoading != value)
                 {
-                    PropertyMap bgMap = this.Background;
-                    var temp = new PropertyValue(backgroundImageSynchronousLoading);
-                    bgMap[ImageVisualProperty.SynchronousLoading] = temp;
-                    temp.Dispose();
-                    Background = bgMap;
+                    backgroundImageSynchronousLoading = value;
+
+                    if (!string.IsNullOrEmpty(BackgroundImage))
+                    {
+                        PropertyMap bgMap = this.Background;
+                        var temp = new PropertyValue(backgroundImageSynchronousLoading);
+                        bgMap[ImageVisualProperty.SynchronousLoading] = temp;
+                        temp.Dispose();
+                        Background = bgMap;
+                    }
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -3521,65 +3521,54 @@ namespace Tizen.NUI.BaseComponents
                 value = value.Replace("*Resource*", resource);
             }
 
-            if (backgroundExtraData == null)
+            // Fast return for usual cases.
+            if (backgroundExtraData == null && !backgroundImageSynchronousLoading)
             {
-
                 Object.InternalSetPropertyString(SwigCPtr, View.Property.BACKGROUND, value);
-                BackgroundImageSynchronousLoading = backgroundImageSynchronousLoading;
                 return;
             }
 
-            var map = new PropertyMap();
-            var url = new PropertyValue(value);
-            var cornerRadiusValue = backgroundExtraData.CornerRadius == null ? new PropertyValue() : new PropertyValue(backgroundExtraData.CornerRadius);
-            var cornerRadius = new PropertyValue(cornerRadiusValue);
-            var cornerRadiusPolicy = new PropertyValue((int)(backgroundExtraData.CornerRadiusPolicy));
-            var borderlineWidth = new PropertyValue(backgroundExtraData.BorderlineWidth);
-            var borderlineColorValue = backgroundExtraData.BorderlineColor == null ? new PropertyValue(Color.Black) : new PropertyValue(backgroundExtraData.BorderlineColor);
-            var borderlineColor = new PropertyValue(borderlineColorValue);
-            var borderlineOffset = new PropertyValue(backgroundExtraData.BorderlineOffset);
-            var synchronousLoading = new PropertyValue(backgroundImageSynchronousLoading);
-            var npatchType = new PropertyValue((int)Visual.Type.NPatch);
-            var border = (backgroundExtraData.BackgroundImageBorder != null) ? new PropertyValue(backgroundExtraData.BackgroundImageBorder) : null;
-            var imageType = new PropertyValue((int)Visual.Type.Image);
+            using var map = new PropertyMap();
+            using var url = new PropertyValue(value);
+            using var synchronousLoading = new PropertyValue(backgroundImageSynchronousLoading);
 
             map.Add(ImageVisualProperty.URL, url)
-               .Add(Visual.Property.CornerRadius, cornerRadius)
-               .Add(Visual.Property.CornerRadiusPolicy, cornerRadiusPolicy)
-               .Add(Visual.Property.BorderlineWidth, borderlineWidth)
-               .Add(Visual.Property.BorderlineColor, borderlineColor)
-               .Add(Visual.Property.BorderlineOffset, borderlineOffset)
                .Add(ImageVisualProperty.SynchronousLoading, synchronousLoading);
 
-            if (backgroundExtraData.BackgroundImageBorder != null)
+            if ((backgroundExtraData?.BackgroundImageBorder) != null)
             {
+                using var npatchType = new PropertyValue((int)Visual.Type.NPatch);
+                using var border = new PropertyValue(backgroundExtraData.BackgroundImageBorder);
                 map.Add(Visual.Property.Type, npatchType)
                    .Add(NpatchImageVisualProperty.Border, border);
             }
             else
             {
+                using var imageType = new PropertyValue((int)Visual.Type.Image);
                 map.Add(Visual.Property.Type, imageType);
+            }
+
+            if(backgroundExtraData != null)
+            {
+                using var cornerRadiusValue = backgroundExtraData.CornerRadius == null ? new PropertyValue() : new PropertyValue(backgroundExtraData.CornerRadius);
+                using var cornerRadius = new PropertyValue(cornerRadiusValue);
+                using var cornerRadiusPolicy = new PropertyValue((int)(backgroundExtraData.CornerRadiusPolicy));
+                using var borderlineWidth = new PropertyValue(backgroundExtraData.BorderlineWidth);
+                using var borderlineColorValue = backgroundExtraData.BorderlineColor == null ? new PropertyValue(Color.Black) : new PropertyValue(backgroundExtraData.BorderlineColor);
+                using var borderlineColor = new PropertyValue(borderlineColorValue);
+                using var borderlineOffset = new PropertyValue(backgroundExtraData.BorderlineOffset);
+
+                map.Add(Visual.Property.CornerRadius, cornerRadius)
+                   .Add(Visual.Property.CornerRadiusPolicy, cornerRadiusPolicy)
+                   .Add(Visual.Property.BorderlineWidth, borderlineWidth)
+                   .Add(Visual.Property.BorderlineColor, borderlineColor)
+                   .Add(Visual.Property.BorderlineOffset, borderlineOffset);
             }
 
             backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.Background;
 
-            var mapValue = new PropertyValue(map);
+            using var mapValue = new PropertyValue(map);
             Object.SetProperty(SwigCPtr, Property.BACKGROUND, mapValue);
-
-            imageType?.Dispose();
-            border?.Dispose();
-            npatchType?.Dispose();
-            synchronousLoading?.Dispose();
-            borderlineOffset?.Dispose();
-            borderlineColor?.Dispose();
-            borderlineColorValue?.Dispose();
-            borderlineWidth?.Dispose();
-            cornerRadiusPolicy?.Dispose();
-            cornerRadius?.Dispose();
-            cornerRadiusValue?.Dispose();
-            url?.Dispose();
-            map?.Dispose();
-            mapValue?.Dispose();
         }
 
         private void SetBackgroundImageBorder(Rectangle value)


### PR DESCRIPTION
Usually we load image load asynchronously as default.

(The only one except case is lottie.
But most of cases we don't need to consider
set BackgroundImage as Lottie file.)

So, for usual cases, we don't need to apply the informations whether we need to load image synchronously or not.

But previous implementation set `BackgroundImageSynchronousLoading` forcibly.

It might required `BackgroundImage` getter, what we don't need to know.

And also, it doesn't skip this getter/setter logic when the value is same as previous.

To avoid this useless visual creation, let we consider for backgroundImageSynchronousLoading property works well and works faster for usual cases, who don't set this property.