### PR TITLE
[NUI] Add SetTransitionEffectOption for ImageView's transition effect

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ImageView.cs
@@ -35,6 +35,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_TRANSITION_EFFECT_get")]
             public static extern int TransitionEffectGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_Property_TRANSITION_EFFECT_OPTION_get")]
+            public static extern int TransitionEffectOptionGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ImageView_New__SWIG_0")]
             public static extern global::System.IntPtr New();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -82,6 +82,8 @@ namespace Tizen.NUI.BaseComponents
                 TransitionEffectProperty = BindableProperty.Create(nameof(TransitionEffect), typeof(bool), typeof(ImageView), false, propertyChanged: SetInternalTransitionEffectProperty, defaultValueCreator: GetInternalTransitionEffectProperty);
 
                 ImageColorProperty = BindableProperty.Create(nameof(ImageColor), typeof(Color), typeof(ImageView), null, propertyChanged: SetInternalImageColorProperty, defaultValueCreator: GetInternalImageColorProperty);
+
+                TransitionEffectOptionProperty = BindableProperty.Create(nameof(TransitionEffectOption), typeof(Tizen.NUI.PropertyMap), typeof(ImageView), null, propertyChanged: SetInternalTransitionEffectOptionProperty, defaultValueCreator: GetInternalTransitionEffectOptionProperty);
             }
         }
 
@@ -161,6 +163,8 @@ namespace Tizen.NUI.BaseComponents
         private TriggerableSelector<Rectangle> borderSelector;
 
         private RelativeVector4 internalPixelArea;
+
+        internal PropertyMap transitionEffectPropertyMap;
 
         /// <summary>
         /// Creates an initialized ImageView.
@@ -1263,6 +1267,63 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// This method allows users to configure the blending of two images(previous and currnet) using alpha values.
+        /// </summary>
+        /// <param name="initialImageAlpha">The initial alpha value of the first image.</param>
+        /// <param name="destinationImageAlpha">The final alpha value of the second image.</param>
+        /// <param name="delay">The amount of time (in seconds) to wait before applying the blend.</param>
+        /// <param name="speed">The total time (in seconds) taken for the animation to finish</param>
+        /// <param name="alphaFunction">An optional built-in alpha function to apply during the blend. If not specified, defaults to no alpha function applied.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetTransitionEffectOption(object initialImageAlpha,object destinationImageAlpha, float delay, float speed, AlphaFunction.BuiltinFunctions? alphaFunction = null)
+        {
+            using (PropertyMap animator = new PropertyMap())
+            using (PropertyMap timePeriod = new PropertyMap())
+            using (PropertyValue initValue = PropertyValue.CreateFromObject(initialImageAlpha))
+            using (PropertyValue destValue = PropertyValue.CreateFromObject(destinationImageAlpha))
+            using (PropertyValue pvDelay = new PropertyValue(delay))
+            using (PropertyValue pvSpeed = new PropertyValue(speed))
+            using (PropertyValue pvProperty = new PropertyValue("opacity"))
+            using (PropertyValue pvAnimationType = new PropertyValue("BETWEEN"))
+            using (PropertyMap transition = new PropertyMap())
+            {
+                if (alphaFunction != null)
+                {
+                    using (PropertyValue pvAlpha = new PropertyValue(AlphaFunction.BuiltinToPropertyKey(alphaFunction)))
+                    {
+                        animator.Add("alphaFunction", pvAlpha);
+                    }
+                }
+
+                timePeriod.Add("duration", pvSpeed);
+                timePeriod.Add("delay", pvDelay);
+                using (PropertyValue pvTimePeriod = new PropertyValue(timePeriod))
+                {
+                    animator.Add("timePeriod", pvTimePeriod);
+                }
+
+                animator.Add("animationType", pvAnimationType);
+
+                using (PropertyValue pvAnimator = new PropertyValue(animator))
+                {
+                    transition.Add("animator", pvAnimator);
+                }
+                using(PropertyValue pvTarget = new PropertyValue("image"))
+                {
+                    transition.Add("target", pvTarget);
+                }
+
+                transition.Add("property", pvProperty);
+                transition.Add("initialValue", initValue);
+                transition.Add("targetValue", destValue);
+
+                SetProperty(ImageView.Property.TransitionEffectOption, new Tizen.NUI.PropertyValue(transition));
+                if (NDalicPINVOKE.SWIGPendingException.Pending)
+                    throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the desired image width.<br />
         /// If not specified, the actual image width is used.<br />
         /// For normal quad images only.<br />
@@ -1654,6 +1715,55 @@ namespace Tizen.NUI.BaseComponents
                     SetInternalTransitionEffectProperty(this, null, value);
                 }
                 NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether the image use TransitionEffect or not<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public PropertyMap TransitionEffectOption
+        {
+            get
+            {
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (PropertyMap)GetValue(TransitionEffectOptionProperty);
+                }
+                else
+                {
+                    return GetInternalTransitionEffectOptionProperty(this) as PropertyMap;
+                }
+            }
+            set
+            {
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(TransitionEffectOptionProperty, value);
+                }
+                else
+                {
+                    SetInternalTransitionEffectOptionProperty(this, null, value);
+                }
+                NotifyPropertyChanged();
+            }
+        }
+
+        private PropertyMap InternalTransitionEffectOption
+        {
+            get
+            {
+                PropertyMap retValue = new PropertyMap();
+                PropertyValue transitionEffect = GetProperty(ImageView.Property.TransitionEffectOption);
+                transitionEffect?.Get(retValue);
+                transitionEffect?.Dispose();
+                return retValue;
+            }
+            set
+            {
+                PropertyValue setValue = new Tizen.NUI.PropertyValue(value);
+                SetProperty(ImageView.Property.TransitionEffectOption, setValue);
+                setValue?.Dispose();
             }
         }
 
@@ -2307,6 +2417,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int PixelArea = Interop.ImageView.PixelAreaGet();
             internal static readonly int PlaceHolderUrl = Interop.ImageView.PlaceHolderImageGet();
             internal static readonly int TransitionEffect = Interop.ImageView.TransitionEffectGet();
+            internal static readonly int TransitionEffectOption = Interop.ImageView.TransitionEffectOptionGet();
 
             internal static void Preload()
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -668,5 +668,26 @@ namespace Tizen.NUI.BaseComponents
 
             return ret;
         }
+
+        /// <summary>
+        /// TransitionEffectOptionProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty TransitionEffectOptionProperty = null;
+
+        internal static void SetInternalTransitionEffectOptionProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
+            if (newValue != null)
+            {
+                instance.InternalTransitionEffectOption = (Tizen.NUI.PropertyMap)newValue;
+            }
+        }
+
+        internal static object GetInternalTransitionEffectOptionProperty(BindableObject bindable)
+        {
+            var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
+            return instance.InternalTransitionEffectOption;
+        }
     }
 }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PlaceHolderImageTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/PlaceHolderImageTest.cs
@@ -68,6 +68,7 @@ namespace Tizen.NUI.Samples
                 imageViews[i].ResourceUrl = url[i];
                 imageViews[i].PlaceHolderUrl = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "images/placeholder_image.png";
                 imageViews[i].TransitionEffect = true;
+                imageViews[i].SetTransitionEffectOption(0.0f, 1.0f, 0.0f, 3.0f, AlphaFunction.BuiltinFunctions.EaseInOut);
                 mainWin.Add(imageViews[i]);
             }
 


### PR DESCRIPTION
This method allows users to configure the blending of two images(previous and currnet) using alpha values. \
if only the transition effect is set to true, the default values are used. 
however, if options are configured through this API, the effect can be applied with the values desired by the user.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/310863/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/310864/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
