### PR TITLE
[NUI] Calculate desired size internally

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -2106,43 +2106,6 @@ namespace Tizen.NUI.BaseComponents
             backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.ContentsCornerRadius;
             backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.ContentsBorderline;
 
-            // Do Fitting Buffer when desired dimension is set
-            // TODO : Couldn't we do this job in dali-engine side.
-            if (_desired_width != -1 && _desired_height != -1)
-            {
-                if (!string.IsNullOrEmpty(_resourceUrl))
-                {
-                    Size2D imageSize = ImageLoader.GetOriginalImageSize(_resourceUrl, true);
-                    if (imageSize.Height > 0 && imageSize.Width > 0 && _desired_width > 0 && _desired_height > 0)
-                    {
-                        int adjustedDesiredWidth, adjustedDesiredHeight;
-                        float aspectOfDesiredSize = (float)_desired_height / (float)_desired_width;
-                        float aspectOfImageSize = (float)imageSize.Height / (float)imageSize.Width;
-                        if (aspectOfImageSize > aspectOfDesiredSize)
-                        {
-                            adjustedDesiredWidth = _desired_width;
-                            adjustedDesiredHeight = imageSize.Height * _desired_width / imageSize.Width;
-                        }
-                        else
-                        {
-                            adjustedDesiredWidth = imageSize.Width * _desired_height / imageSize.Height;
-                            adjustedDesiredHeight = _desired_height;
-                        }
-
-                        PropertyValue returnWidth = new PropertyValue(adjustedDesiredWidth);
-                        cachedImagePropertyMap[ImageVisualProperty.DesiredWidth] = returnWidth;
-                        returnWidth?.Dispose();
-                        PropertyValue returnHeight = new PropertyValue(adjustedDesiredHeight);
-                        cachedImagePropertyMap[ImageVisualProperty.DesiredHeight] = returnHeight;
-                        returnHeight?.Dispose();
-                        PropertyValue scaleToFit = new PropertyValue((int)FittingModeType.ScaleToFill);
-                        cachedImagePropertyMap[ImageVisualProperty.FittingMode] = scaleToFit;
-                        scaleToFit?.Dispose();
-                    }
-                    imageSize?.Dispose();
-                }
-            }
-
             UpdateImageMap();
         }
 


### PR DESCRIPTION
The desired size of the image view will be calculated internally. Therefore, the NUI is no longer calculated the desired size for fitting mode.

related patches:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/307711/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/307712/

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
