### PR TITLE
[NUI] Add ID value of Animation + Bind more API for RenderTask

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTask.cs
@@ -185,6 +185,7 @@ namespace Tizen.NUI
 
         public View GetSourceView()
         {
+            // TODO : Fix me, to avoid memory leak issue.
             View ret = new View(Interop.RenderTask.GetSourceActor(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
@@ -241,6 +242,7 @@ namespace Tizen.NUI
 
         public FrameBuffer GetFrameBuffer()
         {
+            // TODO : Fix me, to avoid memory leak issue.
             FrameBuffer ret = new FrameBuffer(Interop.RenderTask.GetFrameBuffer(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
@@ -268,6 +270,7 @@ namespace Tizen.NUI
 
         public View GetScreenToFrameBufferMappingView()
         {
+            // TODO : Fix me, to avoid memory leak issue.
             View ret = new View(Interop.RenderTask.GetScreenToFrameBufferMappingActor(SwigCPtr), true);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
@@ -366,6 +369,20 @@ namespace Tizen.NUI
             return ret;
         }
 
+        public void RenderUntil(View view)
+        {
+            Interop.RenderTask.RenderUntil(SwigCPtr, View.getCPtr(view));
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
+        public View GetStopperView()
+        {
+            // TODO : Fix me, to avoid memory leak issue.
+            View ret = new View(Interop.RenderTask.GetStopperView(SwigCPtr), true);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            return ret;
+        }
+
         public bool WorldToViewport(Vector3 position, out float viewportX, out float viewportY)
         {
             bool ret = Interop.RenderTask.WorldToViewport(SwigCPtr, Vector3.getCPtr(position), out viewportX, out viewportY);
@@ -460,6 +477,74 @@ namespace Tizen.NUI
                 PropertyValue setVal = new Tizen.NUI.PropertyValue(value);
                 SetProperty(RenderTask.Property.RequiresSync, setVal);
                 setVal?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Sets / gets the tag of render pass. It will be used when we want to change render pass without change shader.
+        /// Default is 0.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint RenderPassTag
+        {
+            get
+            {
+                uint ret = Interop.RenderTask.GetRenderPassTag(SwigCPtr);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return ret;
+            }
+            set
+            {
+                Interop.RenderTask.SetRenderPassTag(SwigCPtr, value);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
+        }
+
+        /// <summary>
+        /// Sets / gets the rendering order of render task.
+        /// </summary>
+        /// <remarks>
+        /// In the DALi, offscreen renderTasks are rendered earlier than onscreen renderTask.
+        ///  * In each category of OffScreen RenderTask and OnScreen RenderTask,
+        ///  * a RenderTask with a smaller orderIndex is rendered first.
+        ///  * The RenderTasks in RenderTaskList is always sorted as acending order of the OrderIndex.
+        ///  * The OrderIndex value is needed to be set between [-1000, 1000].
+        ///  * Default orderIndex is 0.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int OrderIndex
+        {
+            get
+            {
+                int ret = Interop.RenderTask.GetOrderIndex(SwigCPtr);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return ret;
+            }
+            set
+            {
+                Interop.RenderTask.SetOrderIndex(SwigCPtr, value);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
+        }
+
+        /// <summary>
+        /// Gets the render task's ID. 0 if render task is invalid.
+        /// Read-only
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint ID
+        {
+            get
+            {
+                uint ret = 0u;
+
+                if(!Disposed && !IsDisposeQueued)
+                {
+                    ret = Interop.RenderTask.GetRenderTaskId(SwigCPtr);
+                }
+
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return ret;
             }
         }
     }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Animation.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Animation.cs
@@ -115,6 +115,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetLoopingMode")]
             public static extern int GetLoopingMode(global::System.Runtime.InteropServices.HandleRef jarg1);
+            
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_GetAnimationId")]
+            public static extern uint GetAnimationId(global::System.Runtime.InteropServices.HandleRef nuiAnimation);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Animation_SetProgressNotification")]
             public static extern void SetProgressNotification(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RenderTask.cs
@@ -190,6 +190,27 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool ViewportToLocal(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3, float jarg4, out float jarg5, out float jarg6);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetRenderPassTag")]
+            public static extern void SetRenderPassTag(global::System.Runtime.InteropServices.HandleRef nuiRenderTask, uint renderPassTag);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRenderPassTag")]
+            public static extern uint GetRenderPassTag(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_SetOrderIndex")]
+            public static extern void SetOrderIndex(global::System.Runtime.InteropServices.HandleRef nuiRenderTask, int orderIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetOrderIndex")]
+            public static extern int GetOrderIndex(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetRenderTaskId")]
+            public static extern uint GetRenderTaskId(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_RenderUntil")]
+            public static extern void RenderUntil(global::System.Runtime.InteropServices.HandleRef nuiRenderTask, global::System.Runtime.InteropServices.HandleRef nuiStopperView);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_GetStopperActor")]
+            public static extern global::System.IntPtr GetStopperView(global::System.Runtime.InteropServices.HandleRef nuiRenderTask);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderTask_FinishedSignal")]
             public static extern global::System.IntPtr FinishedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -529,6 +529,19 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets the animation's ID. 0 if animation is invalid.
+        /// Read-only
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public uint ID
+        {
+            get
+            {
+                return GetId();
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the properties of the animation.
         /// </summary>
         //ToDo : will raise deprecated-ACR, [Obsolete("Deprecated in API9, will be removed in API11, Use PropertyList instead")]
@@ -1590,6 +1603,19 @@ namespace Tizen.NUI
         {
             Animation.States ret = (Animation.States)Interop.Animation.GetState(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal uint GetId()
+        {
+            uint ret = 0u;
+
+            if(!Disposed && !IsDisposeQueued)
+            {
+                ret = Interop.Animation.GetAnimationId(SwigCPtr);
+            }
+
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 


### PR DESCRIPTION
Let we bind the getter of Animation and RenderTask's ID integer.

Also, bind some more API that we added recently.

Required DALI patches :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/311349
