### PR TITLE
[NUI] Add align API to InputMethodContext

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodContext.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodContext.cs
@@ -197,6 +197,10 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelPosition")]
             public static extern void SetInputPanelPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, uint jarg3);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelPositionAlign")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool SetInputPanelPositionAlign(global::System.Runtime.InteropServices.HandleRef inputMethodContext, int x, int y, int align);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_ActivatedSignal")]
             public static extern global::System.IntPtr ActivatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
@@ -377,6 +377,50 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Enumeration for align of the input panel.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum InputPanelAlign
+        {
+            /// <summary>
+            /// The top-left corner.
+            /// </summary>
+            TopLeft,
+            /// <summary>
+            /// The top-center position.
+            /// </summary>
+            TopCenter,
+            /// <summary>
+            /// The top-right corner.
+            /// </summary>
+            TopRight,
+            /// <summary>
+            /// The middle-left position.
+            /// </summary>
+            MiddleLeft,
+            /// <summary>
+            /// The middle-center position.
+            /// </summary>
+            MiddleCenter,
+            /// <summary>
+            /// The middle-right position.
+            /// </summary>
+            MiddleRight,
+            /// <summary>
+            /// The bottom-left corner.
+            /// </summary>
+            BottomLeft,
+            /// <summary>
+            /// The bottom-center position.
+            /// </summary>
+            BottomCenter,
+            /// <summary>
+            /// The bottom-right corner.
+            /// </summary>
+            BottomRight
+        }
+
+        /// <summary>
         /// Gets or sets whether the IM context allows to use the text prediction.
         /// </summary>
         /// <since_tizen> 8 </since_tizen>
@@ -679,6 +723,26 @@ namespace Tizen.NUI
         {
             Interop.InputMethodContext.SetInputPanelPosition(SwigCPtr, x, y);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Sets the alignment and its x,y coordinates of the input panel.<br/>
+        /// Regardless of the rotation degree, the x, y values of the top-left corner on the screen are based on 0, 0.<br/>
+        /// When the IME size is changed, its size will change according to the set alignment.
+        /// </summary>
+        /// <remarks>
+        /// This API can be used to set the alignment of a floating IME.
+        /// </remarks>
+        /// <param name="x">The x coordinate of the InputPanelAlign value.</param>
+        /// <param name="y">The y coordinate of the InputPanelAlign value.</param>
+        /// <param name="align">one of the InputPanelAlign values specifying the desired alignment.</param>
+        /// <returns>True on success, false otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool SetInputPanelPositionAlign(int x, int y, InputMethodContext.InputPanelAlign align)
+        {
+            bool ret = Interop.InputMethodContext.SetInputPanelPositionAlign(SwigCPtr, x, y, (int)align);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
         }
 
         /// <summary>


### PR DESCRIPTION
Added `SetInputPanelPositionAlign` method and `InputPanelAlign` enum to `InputMethodContext`.
This API can be used to set the alignment of a floating IME.

```
public bool SetInputPanelPositionAlign(int x, int y, InputMethodContext.InputPanelAlign align)
```

nui related:
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/312028/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/312029/

input method related:
https://quickbuild.tizen.org/build/509510