### PR TITLE
[Tizen.Multimedia.Util][NUI] Fix xmldoc structure errors

### DIFF
--- a/src/Tizen.Multimedia.Util/ImageUtil/ImageEncoder.cs
+++ b/src/Tizen.Multimedia.Util/ImageUtil/ImageEncoder.cs
@@ -99,7 +99,7 @@ namespace Tizen.Multimedia.Util
         /// Sets the color-space of the output image.
         /// </summary>
         /// <param name="colorSpace">The target color-space.</param>
-        /// <value>The default color space is <see cref="ColorSpace.Rgba8888"/>
+        /// <value>The default color space is <see cref="ColorSpace.Rgba8888"/>.</value>
         /// <exception cref="ArgumentException"><paramref name="colorSpace"/> is invalid.</exception>
         /// <exception cref="NotSupportedException"><paramref name="colorSpace"/> is not supported by the encoder.</exception>
         /// <seealso cref="ImageUtil.GetSupportedColorSpaces(ImageFormat)"/>

--- a/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
+++ b/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI.Utility
 {
     /// <summary>
     /// Accumulating Velocity Tracker
-    /// </sumary>
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class AccumulatingVelocityTrackerStrategy : VelocityTrackerStrategy
     {
@@ -56,7 +56,7 @@ namespace Tizen.NUI.Utility
 
         /// <summary>
         /// Create an instance of AccumulatingVelocityTrackerStrategy.
-        /// </sumary>
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AccumulatingVelocityTrackerStrategy(uint maximumTime) : base()
         {

--- a/src/Tizen.NUI/src/public/Utility/VelocityTrackerStrategy.cs
+++ b/src/Tizen.NUI/src/public/Utility/VelocityTrackerStrategy.cs
@@ -15,7 +15,6 @@
  *
  */
 
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Tizen.NUI.Utility
@@ -23,7 +22,7 @@ namespace Tizen.NUI.Utility
 
     /// <summary>
     /// VelocityTrackerStrategy
-    /// </sumary>
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class VelocityTrackerStrategy
     {

--- a/src/Tizen.Uix.Stt/Tizen.Uix.Stt/SttClient.cs
+++ b/src/Tizen.Uix.Stt/Tizen.Uix.Stt/SttClient.cs
@@ -125,12 +125,12 @@ namespace Tizen.Uix.Stt
         /// <summary>
         /// Out of Memory.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>.
+        /// <since_tizen> 3 </since_tizen>
         OutOfMemory,
         /// <summary>
         /// I/O error.
         /// </summary>
-        /// <since_tizen> 3 </since_tizen>.
+        /// <since_tizen> 3 </since_tizen>
         IoError,
         /// <summary>
         /// Invalid parameter.


### PR DESCRIPTION
### Description of Change ###
This PR fixes few XML structure errors in triple slash documentation comments - e.g. typos, missing tag.

### API Changes ###
No change in the API