### PR TITLE
[NUI][API10] Cherry-pick Registry relative codes

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
+++ b/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
@@ -238,6 +238,22 @@ namespace Tizen.NUI
         {
             Tizen.Log.Error("NUI", $"{msg} (at line {lineNum} of {caller} in {file})\n");
         }
+
+        public static void ErrorBacktrace(string msg,
+            [CallerLineNumber] int lineNum = 0,
+            [CallerMemberName] string caller = null,
+            [CallerFilePath] string file = null
+        )
+        {
+            Tizen.Log.Error("NUI", $"[ERR]{msg} (at line {lineNum} of {caller} in {file})\n");
+            Tizen.Log.Error("NUI", $"[ERR] Back Trace =>");
+            global::System.Diagnostics.StackTrace st = new global::System.Diagnostics.StackTrace(true);
+            for (int i = 0; i < st.FrameCount; i++)
+            {
+                global::System.Diagnostics.StackFrame sf = st.GetFrame(i);
+                Tizen.Log.Error("NUI", " Method " + sf.GetMethod() + ":" + sf.GetFileName() + ":" + sf.GetFileLineNumber());
+            }
+        }
     }
 
 }

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -75,6 +75,32 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        internal BaseHandle(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister)
+        {
+            //to catch derived classes dali native exceptions
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            DebugFileLogging.Instance.WriteLog($"BaseHandle.contructor with cMemeryOwn:{cMemoryOwn} and cRegister:{cRegister} START");
+
+            registerMe = cRegister;
+            swigCMemOwn = cMemoryOwn;
+            swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            if (registerMe)
+            {
+                // Register this instance of BaseHandle in the registry.
+                if (!Registry.Register(this))
+                {
+                    registerMe = false;
+                }
+            }
+
+            disposeDebuggingCtor();
+            DebugFileLogging.Instance.WriteLog($" BaseHandle.contructor with cMemeryOwn and cRegister END");
+            DebugFileLogging.Instance.WriteLog($"=============================");
+        }
+
         internal BaseHandle(global::System.IntPtr cPtr, bool cMemoryOwn)
         {
             //to catch derived classes dali native exceptions
@@ -91,7 +117,10 @@ namespace Tizen.NUI
             if (registerMe)
             {
                 // Register this instance of BaseHandle in the registry.
-                Registry.Register(this);
+                if (!Registry.Register(this))
+                {
+                    registerMe = false;
+                }
             }
 
             disposeDebuggingCtor();
@@ -114,7 +143,10 @@ namespace Tizen.NUI
             if (registerMe)
             {
                 // Register this instance of BaseHandle in the registry.
-                Registry.Register(this);
+                if (!Registry.Register(this))
+                {
+                    registerMe = false;
+                }
             }
 
             disposeDebuggingCtor();
@@ -525,6 +557,15 @@ namespace Tizen.NUI
             PropertySet?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
+        internal void UnregisterFromRegistry()
+        {
+            if (registerMe)
+            {
+                Registry.Unregister(this);
+                registerMe = false;
+            }
+        }
+
         /// <summary>
         /// Dispose.
         /// </summary>
@@ -551,10 +592,7 @@ namespace Tizen.NUI
             //because the execution order of Finalizes is non-deterministic.
 
             //Unreference this instance from Registry.
-            if (registerMe)
-            {
-                Registry.Unregister(this);
-            }
+            UnregisterFromRegistry();
 
             disposeDebuggingDispose(type);
 
@@ -644,7 +682,7 @@ namespace Tizen.NUI
                     for (int i = 0; i < st.FrameCount; i++)
                     {
                         global::System.Diagnostics.StackFrame sf = st.GetFrame(i);
-                        Tizen.Log.Fatal("NUI", " Method " + sf.GetMethod());
+                        Tizen.Log.Fatal("NUI", " Method " + sf.GetMethod() + ":" + sf.GetFileName() + ":" + sf.GetFileLineNumber());
                     }
                     Tizen.Log.Fatal("NUI", "Error! just return here with null swigCPtr! this can cause unknown error or crash in next step");
 
@@ -692,7 +730,7 @@ namespace Tizen.NUI
                 for (int i = 0; i < st.FrameCount; i++)
                 {
                     global::System.Diagnostics.StackFrame sf = st.GetFrame(i);
-                    DebugFileLogging.Instance.WriteLog($"[{i}] {sf.GetMethod()}");
+                    DebugFileLogging.Instance.WriteLog($"[{i}] {sf.GetMethod()}:{sf.GetFileName()}:{sf.GetFileLineNumber()}");
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Utility/Timer.cs
+++ b/src/Tizen.NUI/src/public/Utility/Timer.cs
@@ -136,7 +136,7 @@ namespace Tizen.NUI
                 for (int i = 0; i < st.FrameCount; i++)
                 {
                     StackFrame sf = st.GetFrame(i);
-                    Tizen.Log.Error("NUI", " Method " + sf.GetMethod());
+                    Tizen.Log.Error("NUI", " Method " + sf.GetMethod() + ":" + sf.GetFileName() + ":" + sf.GetFileLineNumber());
                 }
             }
 
@@ -166,7 +166,7 @@ namespace Tizen.NUI
                 for (int i = 0; i < st.FrameCount; i++)
                 {
                     StackFrame sf = st.GetFrame(i);
-                    Tizen.Log.Error("NUI", " Method " + sf.GetMethod());
+                    Tizen.Log.Error("NUI", " Method " + sf.GetMethod() + ":" + sf.GetFileName() + ":" + sf.GetFileLineNumber());
                 }
             }
 
@@ -197,7 +197,7 @@ namespace Tizen.NUI
                 for (int i = 0; i < st.FrameCount; i++)
                 {
                     StackFrame sf = st.GetFrame(i);
-                    Tizen.Log.Error("NUI", " Method " + sf.GetMethod());
+                    Tizen.Log.Error("NUI", " Method " + sf.GetMethod() + ":" + sf.GetFileName() + ":" + sf.GetFileLineNumber());
                 }
             }
 


### PR DESCRIPTION
This is a combination of 6 commits.

- This is the 1st commit message:

[NUI] Let registry throw exception at error case

Let we throw exception if same object try to register.

Moreover, let we print more useful callstack if we got unmatched case.



- This is the commit message 2:

[NUI] Consider WeakReference resurrection at Registry.

Since NUI use DisposeQueue system instead of GC directly, the lifecycle of WeakReference may need to be alive more times.

If we make trackResurrection as false, WeakReference.Target become null when the item is in DisposeQueue.



- This is the commit message 3:

[NUI] Temperary revert exception throw at Registry.

Until resolve all kind of apps fix wrong behavior, let we just print error without exception.



- This is the commit message 4:

[NUI] Do not register when BaseHandle doesn't have body

If BaseHandle doesn't have body, the refCPtr value is IntPtr.Zero.

If than, the various cases have wrong registration in future.

To avoid this case, let we ignore to register to registry, and make BaseHandle.registerMe value as false.



- This is the commit message 5:

[NUI] Resolve the potential issue when DisposeQueued handle get

It is possible that DisposeQueued handle be used as input of GetManagedBaseHandleFromRefObject.

In this case, even if app hold that BaseHandle, it will be Disposed by DisposeQueue. If then the returned item become disposed, and it might breakdown app logics.



- This is the commit message 6:

[NUI] Unregister disposed / disposequeued BaseHandle and register again if need

It is possible that dispose queued basehandle try to get / register again due to some reason. Like, Native side object is alived but C# side has no reference.

We already to to detect that cases. But if BaseHandle added at DisposeQueue, we cannot avoid to call the Dispose(); after some event loops later, and then Unregister the handle.

To avoid some error cases, let we Unregister the basehandle synchronously and then re-register base on the new BaseHandle.
