### PR TITLE
[NUI][API11] Fix worker thread handle removal issue

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -210,9 +210,14 @@ namespace Tizen.NUI.BaseComponents
 
             protected override bool ReleaseHandle()
             {
+                DisposeQueue.Instance.Add(this);
+                return true;
+            }
+
+            public void Dispose()
+            {
                 Interop.View.DeleteControlHandleView(handle);
                 this.SetHandle(IntPtr.Zero);
-                return true;
             }
         }
 


### PR DESCRIPTION
Since `ControlHandle` could be deleted at GC thread, we should use DisposeQueue here.