### PR TITLE
[NUI] Remove build warning

### DIFF
--- a/src/Tizen.NUI/src/internal/Utility/ItemViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemViewBindableProperty.cs
@@ -26,8 +26,8 @@ namespace Tizen.NUI
         /// LayoutProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static BindableProperty LayoutProperty = null;
-        internal static void SetInternalLayoutProperty(BindableObject bindable, object oldValue, object newValue)
+        public static new BindableProperty LayoutProperty = null;
+        internal static new void SetInternalLayoutProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             if (newValue != null)
@@ -35,7 +35,7 @@ namespace Tizen.NUI
                 instance.InternalLayout = (Tizen.NUI.PropertyArray)newValue;
             }
         }
-        internal static object GetInternalLayoutProperty(BindableObject bindable)
+        internal static new object GetInternalLayoutProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.ItemView)bindable;
             return instance.InternalLayout;

--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageViewBindableProperty.cs
@@ -45,18 +45,22 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// ResourceUrlProperty
         /// </summary>
+        /// <remarks>
+        /// This property does not have same logic with LottieAnimationView.ResourceUrl.
+        /// Should use new keyword!
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #if REMOVE_READONLY_FOR_BINDABLE_PROPERTY
         public static new BindableProperty ResourceUrlProperty = null;
 #else
         public static readonly new BindableProperty ResourceUrlProperty = null;
 #endif
-        internal static void SetInternalResourceUrlProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static new void SetInternalResourceUrlProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             instance.InternalResourceUrl = (string)newValue;
         }
-        internal static object GetInternalResourceUrlProperty(BindableObject bindable)
+        internal static new object GetInternalResourceUrlProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             return instance.InternalResourceUrl;
@@ -88,13 +92,17 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// CurrentFrameProperty
         /// </summary>
+        /// <remarks>
+        /// This property does not have same logic with LottieAnimationView.CurrentFrame.
+        /// Should use new keyword!
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
 #if REMOVE_READONLY_FOR_BINDABLE_PROPERTY
         public static new BindableProperty CurrentFrameProperty = null;
 #else
         public static readonly new BindableProperty CurrentFrameProperty = null;
 #endif
-        internal static void SetInternalCurrentFrameProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static new void SetInternalCurrentFrameProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             if (newValue != null)
@@ -102,7 +110,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalCurrentFrame = (int)newValue;
             }
         }
-        internal static object GetInternalCurrentFrameProperty(BindableObject bindable)
+        internal static new object GetInternalCurrentFrameProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.AnimatedVectorImageView)bindable;
             return instance.InternalCurrentFrame;

--- a/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VectorGraphics/CanvasView.cs
@@ -93,9 +93,9 @@ namespace Tizen.NUI.BaseComponents.VectorGraphics
             {
                 ViewBoxProperty = BindableProperty.Create(nameof(ViewBox), typeof(Tizen.NUI.Size2D), typeof(Tizen.NUI.BaseComponents.VectorGraphics.CanvasView), null,
                   propertyChanged: SetInternalViewBoxProperty, defaultValueCreator: GetInternalViewBoxProperty);
-                SynchronousLoadingProperty = BindableProperty.Create(nameof(ViewBox), typeof(bool), typeof(Tizen.NUI.BaseComponents.VectorGraphics.CanvasView), true,
+                SynchronousLoadingProperty = BindableProperty.Create(nameof(SynchronousLoading), typeof(bool), typeof(Tizen.NUI.BaseComponents.VectorGraphics.CanvasView), true,
                   propertyChanged: SetInternalSynchronousLoadingProperty, defaultValueCreator: GetInternalSynchronousLoadingProperty);
-                RasterizationRequestManuallyProperty = BindableProperty.Create(nameof(ViewBox), typeof(bool), typeof(Tizen.NUI.BaseComponents.VectorGraphics.CanvasView), false,
+                RasterizationRequestManuallyProperty = BindableProperty.Create(nameof(RasterizationRequestManually), typeof(bool), typeof(Tizen.NUI.BaseComponents.VectorGraphics.CanvasView), false,
                   propertyChanged: SetInternalRasterizationRequestManuallyProperty, defaultValueCreator: GetInternalRasterizationRequestManuallyProperty);
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -210,14 +210,29 @@ namespace Tizen.NUI.BaseComponents
 
             protected override bool ReleaseHandle()
             {
-                DisposeQueue.Instance.Add(this);
+                if (!IsInvalid)
+                {
+                    DisposeQueue.Instance.Add(this);
+                }
                 return true;
             }
 
-            public void Dispose()
+            protected override void Dispose(bool disposing)
             {
-                Interop.View.DeleteControlHandleView(handle);
-                this.SetHandle(IntPtr.Zero);
+                if (IsInvalid)
+                {
+                    return;
+                }
+
+                if (disposing)
+                {
+                    Interop.View.DeleteControlHandleView(handle);
+                    this.SetHandle(IntPtr.Zero);
+                }
+                else
+                {
+                    DisposeQueue.Instance.Add(this);
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -51,7 +51,8 @@ namespace Tizen.NUI.BaseComponents
 
         internal BackgroundExtraDataUpdatedFlag backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
 
-        private bool backgroundExtraDataUpdateProcessAttachedFlag = false;
+        // TODO : Re-open this API when we resolve Animation issue.
+        // private bool backgroundExtraDataUpdateProcessAttachedFlag = false;
 
         internal virtual LayoutItem CreateDefaultLayout()
         {
@@ -1217,7 +1218,8 @@ namespace Tizen.NUI.BaseComponents
         private void UpdateBackgroundExtraData(object source, EventArgs e)
         {
             // Note : To allow event attachment during UpdateBackgroundExtraData, let we make flag as false before call UpdateBackgroundExtraData().
-            backgroundExtraDataUpdateProcessAttachedFlag = false;
+            // TODO : Re-open this API when we resolve Animation issue.
+            // backgroundExtraDataUpdateProcessAttachedFlag = false;
             UpdateBackgroundExtraData();
         }
 

--- a/src/Tizen.NUI/src/public/Common/WeakEvent.cs
+++ b/src/Tizen.NUI/src/public/Common/WeakEvent.cs
@@ -96,7 +96,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <remarks>
         /// The event handler count decreases when an event handler is removed
-        ///  with <see cref="Remove()"/> or after detecting that it is no longer valid.
+        ///  with <see cref="Remove(T)"/> or after detecting that it is no longer valid.
         /// </remarks>
         /// <since_tizen> 12 </since_tizen>
         protected virtual void OnCountDecreased()

--- a/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
+++ b/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI.Utility
 {
     /// <summary>
     /// Accumulating Velocity Tracker
-    /// </sumary>
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class AccumulatingVelocityTrackerStrategy : VelocityTrackerStrategy
     {
@@ -56,7 +56,7 @@ namespace Tizen.NUI.Utility
 
         /// <summary>
         /// Create an instance of AccumulatingVelocityTrackerStrategy.
-        /// </sumary>
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public AccumulatingVelocityTrackerStrategy(uint maximumTime) : base()
         {

--- a/src/Tizen.NUI/src/public/Utility/VelocityTracker.cs
+++ b/src/Tizen.NUI/src/public/Utility/VelocityTracker.cs
@@ -28,6 +28,7 @@ namespace Tizen.NUI.Utility
 {
     /// <summary>
     /// Calculates the velocity of touch movements over time.
+    /// </summary>
     /// <example>
     ///  private void OnPanGestureDetected(object source, PanGestureDetector.DetectedEventArgs e)
     ///  {
@@ -45,7 +46,6 @@ namespace Tizen.NUI.Utility
     ///      }
     ///  }
     /// </example>
-    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class VelocityTracker
     {

--- a/src/Tizen.NUI/src/public/Utility/VelocityTrackerStrategy.cs
+++ b/src/Tizen.NUI/src/public/Utility/VelocityTrackerStrategy.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI.Utility
 
     /// <summary>
     /// VelocityTrackerStrategy
-    /// </sumary>
+    /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class VelocityTrackerStrategy
     {

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CanvasViewSample.cs
@@ -35,6 +35,10 @@ namespace Tizen.NUI.Samples
                 PivotPoint = PivotPoint.Center,
                 PositionUsesPivotPoint = true,
             };
+            root.PropertyChanged += (object o, global::System.ComponentModel.PropertyChangedEventArgs e) =>
+            {
+                Tizen.Log.Error("NUI", $"root view Property Changed! {e.PropertyName}\n");
+            };
             window.Add(root);
 
             window.KeyEvent += WindowKeyEvent;
@@ -45,6 +49,10 @@ namespace Tizen.NUI.Samples
                 ParentOrigin = ParentOrigin.Center,
                 PivotPoint = PivotPoint.Center,
                 PositionUsesPivotPoint = true,
+            };
+            canvasView.PropertyChanged += (object o, global::System.ComponentModel.PropertyChangedEventArgs e) =>
+            {
+                Tizen.Log.Error("NUI", $"canvas view Property Changed! {e.PropertyName}\n");
             };
 
             RadialGradient roundedRectFillRadialGradient = new RadialGradient()


### PR DESCRIPTION
1. Remove XML parsing error
2. Let we use SafeHandle.Dispose(bool), instead of Dispose() API directly.
3. Add 'new' keyword what we re-define properties intention.
4. Remove unmatched property name with it's proeprty.