### PR TITLE
[NUI] Fix old value checking issue when IsUsingXaml = false

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -425,7 +425,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalAlphaMaskURL = (string)newValue;
             }
         }
-        
+
         internal static object GetInternalAlphaMaskURLProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -446,7 +446,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalCropToMask = (bool)newValue;
             }
         }
-        
+
         internal static object GetInternalCropToMaskProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -458,7 +458,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FittingModeProperty = null;
-        
+
         internal static void SetInternalFittingModeProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -467,7 +467,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalFittingMode = (Tizen.NUI.FittingModeType)newValue;
             }
         }
-        
+
         internal static object GetInternalFittingModeProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -488,7 +488,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalDesiredWidth = (int)newValue;
             }
         }
-        
+
         internal static object GetInternalDesiredWidthProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -509,7 +509,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalDesiredHeight = (int)newValue;
             }
         }
-        
+
         internal static object GetInternalDesiredHeightProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -530,7 +530,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalReleasePolicy = (Tizen.NUI.ReleasePolicyType)newValue;
             }
         }
-        
+
         internal static object GetInternalReleasePolicyProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -551,7 +551,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalWrapModeU = (Tizen.NUI.WrapModeType)newValue;
             }
         }
-        
+
         internal static object GetInternalWrapModeUProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -572,7 +572,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalWrapModeV = (Tizen.NUI.WrapModeType)newValue;
             }
         }
-        
+
         internal static object GetInternalWrapModeVProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -593,7 +593,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.adjustViewSize = (bool)newValue;
             }
         }
-        
+
         internal static object GetInternalAdjustViewSizeProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.ImageView)bindable;
@@ -658,7 +658,7 @@ namespace Tizen.NUI.BaseComponents
                 Interop.View.InternalUpdateVisualPropertyVector4(imageView.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.MixColor, Vector4.getCPtr((Color)newValue));
             }
         }
-        
+
         internal static object GetInternalImageColorProperty(BindableObject bindable)
         {
             var imageView = (ImageView)bindable;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -255,10 +255,13 @@ namespace Tizen.NUI.BaseComponents
 #endif
         internal static void SetInternalBackgroundImageProperty(BindableObject bindable, object oldValue, object newValue)
         {
-            if (String.Equals(oldValue, newValue))
+            if (NUIApplication.IsUsingXaml)
             {
-                NUILog.Debug($"oldValue={oldValue} newValue={newValue} are same. just return here");
-                return;
+                if (String.Equals(oldValue, newValue))
+                {
+                    NUILog.Debug($"oldValue={oldValue} newValue={newValue} are same. just return here");
+                    return;
+                }
             }
 
             var view = (View)bindable;
@@ -3161,7 +3164,7 @@ namespace Tizen.NUI.BaseComponents
 
                 ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(View), null,
                     propertyChanged: SetInternalColorProperty, defaultValueCreator: GetInternalColorProperty);
-                
+
                 ColorRedProperty = BindableProperty.Create(nameof(ColorRed), typeof(float), typeof(View), default(float),
                     propertyChanged: SetInternalColorRedProperty, defaultValueCreator: GetInternalColorRedProperty);
 
@@ -3428,7 +3431,7 @@ namespace Tizen.NUI.BaseComponents
 
                 AnchorPointProperty = BindableProperty.Create(nameof(AnchorPoint), typeof(Tizen.NUI.Position), typeof(View), null,
                     propertyChanged: SetInternalAnchorPointProperty, defaultValueCreator: GetInternalAnchorPointProperty);
-                
+
                 WidthSpecificationProperty = BindableProperty.Create(nameof(WidthSpecification), typeof(int), typeof(View), 0,
                     propertyChanged: SetInternalWidthSpecificationProperty, defaultValueCreator: GetInternalWidthSpecificationProperty);
 
@@ -3560,7 +3563,7 @@ namespace Tizen.NUI.BaseComponents
                 map.Add(Visual.Property.Type, imageType);
             }
 
-            if(backgroundExtraData != null)
+            if (backgroundExtraData != null)
             {
                 using var cornerRadiusValue = backgroundExtraData.CornerRadius == null ? new PropertyValue() : new PropertyValue(backgroundExtraData.CornerRadius);
                 using var cornerRadius = new PropertyValue(cornerRadiusValue);


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix old value checking issue when IsUsingXaml = false
- when IsUsingXaml is false, the OldValue is not updated so it should not be checked and not be used.

### API Changes ###
nothing