### PR TITLE
[NUI] Make Capture return ImageUrl

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Capture.cs
@@ -65,6 +65,9 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_Signal_Get")]
             public static extern IntPtr Get(HandleRef jarg1);
 
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetImageUrl")]
+            public static extern IntPtr GetImageUrl(HandleRef capture);
+
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Capture_GetNativeImageSource")]
             public static extern IntPtr GetNativeImageSourcePtr(HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/Utility/Capture.cs
+++ b/src/Tizen.NUI/src/public/Utility/Capture.cs
@@ -324,6 +324,27 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets ImageUrl that is saved captured image.
+        /// </summary>
+        /// <returns>ImageUrl that is saved captured image.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ImageUrl GetImageUrl()
+        {
+            IntPtr cPtr = Interop.Capture.GetImageUrl(SwigCPtr);
+            ImageUrl ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as ImageUrl;
+            if (ret != null)
+            {
+                Interop.BaseHandle.DeleteBaseHandle(new HandleRef(this, cPtr));
+            }
+            else
+            {
+                ret = new ImageUrl(cPtr, true);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            return ret;
+        }
+
+        /// <summary>
         /// Get NativeImageSource that is saved captured image.
         /// </summary>
         /// <returns>NativeImageSource that is saved captured image.</returns>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CaptureTest.cs
@@ -58,13 +58,9 @@ namespace Tizen.NUI.Samples
             if (sender is Capture)
             {
                 log.Debug(tag, $"sender is Capture \n");
-                PixelBuffer pixelBuffer = capture.GetCapturedBuffer();
-                PixelData pixelData = PixelBuffer.Convert(pixelBuffer);
-                //var imageUrl = pixelData.GenerateUrl();//capture.GetNativeImageSource().Url;
-                //capturedImage = new ImageView(imageUrl.ToString());
-                var url = pixelData.GenerateUrl();
-                capturedImage = new ImageView(url.ToString());
-                log.Debug(tag, $"url={url} \n");
+                ImageUrl imageUrl = capture.GetImageUrl();
+                capturedImage = new ImageView(imageUrl.ToString());
+                log.Debug(tag, $"url={imageUrl.ToString()} \n");
 
                 capturedImage.Size = new Size(510, 510);
                 capturedImage.Position = new Position(10, 10);
@@ -81,7 +77,7 @@ namespace Tizen.NUI.Samples
                 {
                     done = true;
                     capture = new Capture();
-                    capture.Start(root, new Size(510, 510), @"/opt/usr/nui_captured.jpg");
+                    capture.Start(root, new Size(510, 510), "");
                     capture.Finished += onCaptureFinished;
                     log.Debug(tag, $"capture done \n");
                 }


### PR DESCRIPTION
### Description of Change ###
This PR is to make Capture return ImageUrl.
The GetImageUrl API can be used to get ImageUrl of the captured image.
This API can be used as a replacement for the GetNativeImageSource,
when the app only want to draw the captured buffer by using imageView.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
