### PR TITLE
[NUI][API11] Make ProcessController.Initialized check as static + Initialize at Instance getter

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -684,12 +684,6 @@ namespace Tizen.NUI
             DisposeQueue.Instance.Initialize();
             Tizen.Tracer.End();
 
-            Log.Info("NUI", "[NUI] OnApplicationInit: ProcessorController Initialize");
-            Tizen.Tracer.Begin("[NUI] OnApplicationInit: ProcessorController Initialize");
-            // Initialize ProcessorController Singleton class. This is also required to create ProcessorController on main thread.
-            ProcessorController.Instance.Initialize();
-            Tizen.Tracer.End();
-
             Log.Info("NUI", "[NUI] OnApplicationInit: GetWindow");
             Tizen.Tracer.Begin("[NUI] OnApplicationInit: GetWindow");
             Window.Instance = GetWindow();

--- a/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
+++ b/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
@@ -52,7 +52,7 @@ namespace Tizen.NUI
         {
             Tizen.Log.Debug("NUI", $"DisposeQueue is destroyed\n");
             initialized = false;
-            if (processorRegistered && ProcessorController.Instance.Initialized)
+            if (processorRegistered && ProcessorController.Initialized)
             {
                 processorRegistered = false;
                 ProcessorController.Instance.ProcessorOnceEvent -= TriggerProcessDisposables;
@@ -158,7 +158,7 @@ namespace Tizen.NUI
             if (incrementallyDisposedQueue.Count > 0)
             {
                 if (!incrementalDisposeSupported ||
-                    (!fullCollectRequested && !ProcessorController.Instance.Initialized))
+                    (!fullCollectRequested && !ProcessorController.Initialized))
                 {
                     // Full Dispose if IncrementalDisposeSupported is false, or ProcessorController is not initialized yet.
                     fullCollectRequested = true;
@@ -189,7 +189,7 @@ namespace Tizen.NUI
 
             if (incrementallyDisposedQueue.Count > 0)
             {
-                if (ProcessorController.Instance.Initialized && !processorRegistered)
+                if (ProcessorController.Initialized && !processorRegistered)
                 {
                     processorRegistered = true;
                     ProcessorController.Instance.ProcessorOnceEvent += TriggerProcessDisposables;

--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI
     internal sealed class ProcessorController : Disposable
     {
         private static ProcessorController instance = null;
-        private bool initialized = false;
+        private static bool initialized = false;
 
         private ProcessorController() : this(true)
         {
@@ -75,7 +75,7 @@ namespace Tizen.NUI
         public event EventHandler ProcessorEvent;
         public event EventHandler LayoutProcessorEvent;
 
-        public bool Initialized => initialized;
+        public static bool Initialized => initialized;
 
         public static ProcessorController Instance
         {
@@ -83,7 +83,11 @@ namespace Tizen.NUI
             {
                 if (instance == null)
                 {
-                    instance = new ProcessorController(false);
+                    // Create an instance of ProcessorController with Initialize.
+                    // Legacy note : We were call Initialize() at internal/Application/Application.cs OnApplicationInit().
+                    // Since DisposeQueue can use this class before Application initialized.
+                    // But now, we just make ProcessorController.Initialized state as static. So we don't need to call Initialize() at Application.cs.
+                    instance = new ProcessorController(true);
                 }
                 return instance;
             }
@@ -91,7 +95,7 @@ namespace Tizen.NUI
 
         public void Initialize()
         {
-            if (initialized == false)
+            if (initialized == false) // We only allow single instance ProcessorController
             {
                 initialized = true;
 
@@ -108,7 +112,7 @@ namespace Tizen.NUI
             }
         }
 
-        public void Process()
+        private void Process()
         {
             // Let us add once event into 1 index during 0 event invoke
             onceEventIndex = 1;
@@ -146,7 +150,7 @@ namespace Tizen.NUI
 
         /// <summary>
         /// Awake ProcessorController.
-        /// It will call ProcessController.processorCallback and ProcessController.processorPostCallback hardly.
+        /// It will call ProcessorController.processorCallback and ProcessorController.processorPostCallback hardly.
         /// </summary>
         /// <note>
         /// When event thread is not in idle state, This function will be ignored.


### PR DESCRIPTION
Let we don't get the instance of ProcessController at DisposeQueue.

Since DisposeQueue could be works at worker thread, or execute before NUIApplication initialized, we need to check whether ProcessController was initialized or not.