### PR TITLE
[NUI] Remove the legacy AccessibilityActivate code

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
@@ -184,18 +184,6 @@ namespace Tizen.NUI
         /// Do not use this, that will be deprecated.
         [Obsolete("Do not use this, that will be deprecated.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void AccessibilityActivate()
-        {
-            Interop.ViewImpl.AccessibilityActivate(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// <summary>
-        /// [Obsolete("Do not use this, that will be deprecated.")]
-        /// </summary>
-        /// Do not use this, that will be deprecated.
-        [Obsolete("Do not use this, that will be deprecated.")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public void KeyboardEnter()
         {
             Interop.ViewImpl.KeyboardEnter(SwigCPtr);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
@@ -85,9 +85,6 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsKeyboardFocusGroup(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_AccessibilityActivate")]
-            public static extern void AccessibilityActivate(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_KeyboardEnter")]
             public static extern void KeyboardEnter(global::System.Runtime.InteropServices.HandleRef jarg1);
 


### PR DESCRIPTION

### Description of Change ###
- `CSharp_Dali_ViewImpl_AccessibilityActivate` was removed in 2018 lol However, at that time, NUI codes couldn't be removed together (Not sure)

- The reason `ViewImpl_AccessibilityActivate` was removed is 

`Remove functions which using internal apis.
    Some binding functions use internal apis.
    It caused error when dlopen csharp binder.`

- User can use Activated event with `View.AccessibilityActivated`



### API Changes ###
- N/A