### PR TITLE
[NUI] Add RelativeMotionGrab and RelativeMotionUnGrab

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -384,6 +384,14 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_IsAlwaysOnTop")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsAlwaysOnTop(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RelativeMotionGrab")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool RelativeMotionGrab(global::System.Runtime.InteropServices.HandleRef window, uint boundary);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_RelativeMotionUnGrab")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool RelativeMotionUnGrab(global::System.Runtime.InteropServices.HandleRef window);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -417,6 +417,44 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// The Pointer edge boundary for grab.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum PointerBoundary
+        {
+            /// <summary>
+            /// Default value
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            None = 0,
+
+            /// <summary>
+            /// Top
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Top = 1,
+
+            /// <summary>
+            /// Right
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Right = 2,
+
+            /// <summary>
+            /// Bottom
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Bottom = 3,
+
+            /// <summary>
+            /// Left
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Left = 4,
+
+        }
+
+        /// <summary>
         /// The stage instance property (read-only).<br />
         /// Gets the current window.<br />
         /// </summary>
@@ -2547,6 +2585,30 @@ namespace Tizen.NUI
                 Interop.Window.SetAlwaysOnTop(SwigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
+        }
+
+        /// <summary>
+        /// Requests relative motion grab
+        /// </summary>
+        /// <returns>True if RelativeMotionGrab succeeds.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool RelativeMotionGrab(PointerBoundary boundary)
+        {
+            bool ret = Interop.Window.RelativeMotionGrab(SwigCPtr, (uint)boundary);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Requests relative motion ungrab
+        /// </summary>
+        /// <returns>True if RelativeMotionGrab succeeds.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool RelativeMotionUnGrab()
+        {
+            bool ret = Interop.Window.RelativeMotionUnGrab(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
         }
 
         IntPtr IWindowProvider.WindowHandle => GetNativeWindowHandler();


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
Add RelativeMotionGrab and RelativeMotionUnGrab

**[요청사항]**

1. MCF의 Gesture Connection을 지원하기 위해 (참고: https://confluence.sec.samsung.net/pages/viewpage.action?pageId=741952374)
아래와 같이 ecore_wl2 API를 추가하였습니다. NUI API로 지원 부탁드려도 될까요?
```
EAPI Eina_Bool ecore_wl2_window_relative_motion_grab(Ecore_Wl2_Window *win);
EAPI Eina_Bool ecore_wl2_window_relative_motion_ungrab(Ecore_Wl2_Window *win);
```

2. MC App의 요청사항으로 grab하고자 하는 edge를 argument로 추가하였습니다. 
NUI API로 지원 부탁드립니다.  
```
boundary enum: ECORE_WL2_POINTER_BOUNDARY_TOP/RIGHT/BOTTOM/LEFT
EAPI Eina_Bool ecore_wl2_window_relative_motion_grab(Ecore_Wl2_Window *win, Ecore_Wl2_Pointer_Boundary boundary);
EAPI Eina_Bool ecore_wl2_window_relative_motion_ungrab(Ecore_Wl2_Window *win);
```

**[구현내용]**
추가된 ecore api를 window에서 호출할 수 있도록 바인딩 합니다. 

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/314828/ 
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/314829/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
