### PR TITLE
[NUI] Add InheritedVisibilityChanged Event

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorSignal.cs
@@ -82,6 +82,12 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_VisibilityChangedSignal_Disconnect")]
             public static extern void VisibilityChangedDisconnect(HandleRef actor, HandleRef handler);
 
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InheritedVisibilityChangedSignal_Connect")]
+            public static extern void AggregatedVisibilityChangedConnect(HandleRef actor, HandleRef handler);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InheritedVisibilityChangedSignal_Disconnect")]
+            public static extern void AggregatedVisibilityChangedDisconnect(HandleRef actor, HandleRef handler);
+
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_LayoutDirectionChangedSignal_Connect")]
             public static extern void LayoutDirectionChangedConnect(HandleRef actor, HandleRef handler);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -43,11 +43,12 @@ namespace Tizen.NUI.BaseComponents
         private HoverEventCallbackType hoverEventCallback;
         private EventHandler<VisibilityChangedEventArgs> visibilityChangedEventHandler;
         private VisibilityChangedEventCallbackType visibilityChangedEventCallback;
+        private EventHandler<AggregatedVisibilityChangedEventArgs> aggregatedVisibilityChangedEventHandler;
+        private AggregatedVisibilityChangedEventCallbackType aggregatedVisibilityChangedEventCallback;
         private EventHandler keyInputFocusGainedEventHandler;
-
         private KeyInputFocusGainedCallbackType keyInputFocusGainedCallback;
-        private EventHandler keyInputFocusLostEventHandler;
 
+        private EventHandler keyInputFocusLostEventHandler;
         private KeyInputFocusLostCallbackType keyInputFocusLostCallback;
         private EventHandler onRelayoutEventHandler;
         private OnRelayoutEventCallbackType onRelayoutEventCallback;
@@ -64,30 +65,43 @@ namespace Tizen.NUI.BaseComponents
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OffWindowEventCallbackType(IntPtr control);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool WheelEventCallbackType(IntPtr view, IntPtr wheelEvent);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool KeyCallbackType(IntPtr control, IntPtr keyEvent);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool TouchDataCallbackType(IntPtr view, IntPtr touchData);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool HoverEventCallbackType(IntPtr view, IntPtr hoverEvent);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void VisibilityChangedEventCallbackType(IntPtr data, bool visibility, VisibilityChangeType type);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void AggregatedVisibilityChangedEventCallbackType(IntPtr data, bool visibility);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void ResourcesLoadedCallbackType(IntPtr control);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void _backgroundResourceLoadedCallbackType(IntPtr view);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void KeyInputFocusGainedCallbackType(IntPtr control);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void KeyInputFocusLostCallbackType(IntPtr control);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OnRelayoutEventCallbackType(IntPtr control);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OnWindowEventCallbackType(IntPtr control);
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void LayoutDirectionChangedEventCallbackType(IntPtr data, ViewLayoutDirectionType type);
 
@@ -477,6 +491,7 @@ namespace Tizen.NUI.BaseComponents
                 }
             }
         }
+
         /// <summary>
         /// An event for visibility change which can be used to subscribe or unsubscribe the event handler.<br />
         /// This event is sent when the visibility of this or a parent view is changed.<br />
@@ -514,6 +529,43 @@ namespace Tizen.NUI.BaseComponents
                     Interop.ActorSignal.VisibilityChangedDisconnect(SwigCPtr, visibilityChangedEventCallback.ToHandleRef(this));
                     NDalicPINVOKE.ThrowExceptionIfExists();
                     visibilityChangedEventCallback = null;
+                }
+            }
+        }
+        /// <summary>
+        /// An event for aggregated visibility change which can be used to subscribe or unsubscribe the event handler.<br />
+        /// This event is sent when visible property of this View, any of its parents (right up to the root layer) or Window changes.<br />
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This event is NOT sent if the view becomes transparent (or the reverse), it's ONLY linked with Show() and Hide() of View and Window.
+        /// For reference, a view is only shown if the view, its parents (up to the root view) and Window are also visible,
+        /// they are not transparent, and the view has a non-zero size.
+        /// So if its parent is not visible, the view is not shown.
+        /// </para>
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<AggregatedVisibilityChangedEventArgs> AggregatedVisibilityChanged
+        {
+            add
+            {
+                if (aggregatedVisibilityChangedEventHandler == null)
+                {
+                    aggregatedVisibilityChangedEventCallback = OnAggregatedVisibilityChanged;
+                    Interop.ActorSignal.AggregatedVisibilityChangedConnect(SwigCPtr, aggregatedVisibilityChangedEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                aggregatedVisibilityChangedEventHandler += value;
+            }
+
+            remove
+            {
+                aggregatedVisibilityChangedEventHandler -= value;
+                if (aggregatedVisibilityChangedEventHandler == null && aggregatedVisibilityChangedEventCallback != null)
+                {
+                    Interop.ActorSignal.AggregatedVisibilityChangedDisconnect(SwigCPtr, aggregatedVisibilityChangedEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    aggregatedVisibilityChangedEventCallback = null;
                 }
             }
         }
@@ -1021,6 +1073,18 @@ namespace Tizen.NUI.BaseComponents
             if (visibilityChangedEventHandler != null)
             {
                 visibilityChangedEventHandler(this, e);
+            }
+        }
+
+        // Callback for View aggregated visibility change signal
+        private void OnAggregatedVisibilityChanged(IntPtr data, bool visibility)
+        {
+            AggregatedVisibilityChangedEventArgs e = new AggregatedVisibilityChangedEventArgs();
+            e.Visibility = visibility;
+
+            if (aggregatedVisibilityChangedEventHandler != null)
+            {
+                aggregatedVisibilityChangedEventHandler(this, e);
             }
         }
 

--- a/src/Tizen.NUI/src/public/Common/AggregatedVisibilityChangedEventArgs.cs
+++ b/src/Tizen.NUI/src/public/Common/AggregatedVisibilityChangedEventArgs.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) 2024 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Event arguments of aggregated visibility changed.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AggregatedVisibilityChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Whether the view is now visible or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Visibility
+        {
+            get; set;
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -29,10 +29,18 @@ namespace Tizen.NUI
     {
         private Window window;
         private int layoutCount = 0;
+
         private EventHandler<VisibilityChangedEventArgs> visibilityChangedEventHandler;
         private VisibilityChangedEventCallbackType visibilityChangedEventCallback;
+
+        private EventHandler<AggregatedVisibilityChangedEventArgs> aggregatedVisibilityChangedEventHandler;
+        private AggregatedVisibilityChangedEventCallbackType aggregatedVisibilityChangedEventCallback;
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void VisibilityChangedEventCallbackType(IntPtr data, bool visibility, VisibilityChangeType type);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void AggregatedVisibilityChangedEventCallbackType(IntPtr data, bool visibility);
 
         /// <summary>
         /// Creates a Layer object.
@@ -67,6 +75,15 @@ namespace Tizen.NUI
                 Interop.ActorSignal.VisibilityChangedDisconnect(GetBaseHandleCPtrHandleRef, visibilityChangedEventCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExistsDebug();
                 visibilityChangedEventCallback = null;
+            }
+
+            if (aggregatedVisibilityChangedEventCallback != null)
+            {
+                NUILog.Debug($"[Dispose] aggregatedVisibilityChangedEventCallback");
+
+                Interop.ActorSignal.AggregatedVisibilityChangedDisconnect(GetBaseHandleCPtrHandleRef, aggregatedVisibilityChangedEventCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                aggregatedVisibilityChangedEventCallback = null;
             }
 
             LayoutCount = 0;
@@ -652,6 +669,35 @@ namespace Tizen.NUI
                 }
             }
         }
+        /// <summary>
+        /// An event for aggregated visibility change which can be used to subscribe or unsubscribe the event handler.<br />
+        /// This event is sent when visible property of this or any of its parents (right up to the root) and Window changes.<br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<AggregatedVisibilityChangedEventArgs> AggregatedVisibilityChanged
+        {
+            add
+            {
+                if (aggregatedVisibilityChangedEventHandler == null)
+                {
+                    aggregatedVisibilityChangedEventCallback = OnAggregatedVisibilityChanged;
+                    Interop.ActorSignal.AggregatedVisibilityChangedConnect(SwigCPtr, aggregatedVisibilityChangedEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                aggregatedVisibilityChangedEventHandler += value;
+            }
+
+            remove
+            {
+                aggregatedVisibilityChangedEventHandler -= value;
+                if (aggregatedVisibilityChangedEventHandler == null && aggregatedVisibilityChangedEventCallback != null)
+                {
+                    Interop.ActorSignal.AggregatedVisibilityChangedDisconnect(SwigCPtr, aggregatedVisibilityChangedEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    aggregatedVisibilityChangedEventCallback = null;
+                }
+            }
+        }
 
         /// <summary>
         /// Event arguments of visibility changed.
@@ -898,6 +944,18 @@ namespace Tizen.NUI
             if (visibilityChangedEventHandler != null)
             {
                 visibilityChangedEventHandler(this, e);
+            }
+        }
+
+        // Callback for Layer aggregated visibility change signal
+        private void OnAggregatedVisibilityChanged(IntPtr data, bool visibility)
+        {
+            AggregatedVisibilityChangedEventArgs e = new AggregatedVisibilityChangedEventArgs();
+            e.Visibility = visibility;
+
+            if (aggregatedVisibilityChangedEventHandler != null)
+            {
+                aggregatedVisibilityChangedEventHandler(this, e);
             }
         }
     }


### PR DESCRIPTION
### Description of Change ###

Add InheritedVisibilityChange Event to detect an Actor's actual visibility is changed or not.
The event is sent when visible property of this View, any of its parents (right up to the root layer), or Window changes.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
