### PR TITLE
Revert "[NUI] If the view had focus when it was unparented, the focusis cleared. (#4654)"

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1143,12 +1143,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal void RemoveChild(View child)
         {
-            // If the view had focus, it clears focus.
-            if (child == FocusManager.Instance.GetCurrentFocusView())
-            {
-                Tizen.Log.Debug("NUI", $"ClearFocus due to View id:({child.ID}) removed from scene\n");
-                FocusManager.Instance.ClearFocus();
-            }
             // Do actual child removal
             Interop.Actor.Remove(SwigCPtr, View.getCPtr(child));
             if (NDalicPINVOKE.SWIGPendingException.Pending)

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -348,12 +348,6 @@ namespace Tizen.NUI
                 Tizen.Log.Error("NUI", "You have deleted a view that is not a child of this layer.");
                 return;
             }
-            // If the view had focus, it clears focus.
-            if (child == FocusManager.Instance.GetCurrentFocusView())
-            {
-                FocusManager.Instance.ClearFocus();
-            }
-
             Interop.Actor.Remove(SwigCPtr, View.getCPtr(child));
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->

This reverts commit 09f52bc8bdea3e4e50b610c0b6bc18b54104feb4.

This operation is moved to the DALi.
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/314664/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/314958/


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
