### PR TITLE
[NUI] Unified EventHandler connect-disconnect code style (Phase 1)

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -660,18 +660,25 @@ namespace Tizen.NUI
                     initSignal = this.InitSignal();
                     initSignal?.Connect(applicationInitEventCallbackDelegate);
                 }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.Initialized] Only one listener is allowed\n");
+                }
             }
 
             remove
             {
                 if (applicationInitEventHandler != null)
                 {
-                    initSignal?.Disconnect(applicationInitEventCallbackDelegate);
-                    initSignal?.Dispose();
-                    initSignal = null;
+                    applicationInitEventHandler -= value;
+                    if (applicationInitEventHandler == null)
+                    {
+                        initSignal?.Disconnect(applicationInitEventCallbackDelegate);
+                        initSignal?.Dispose();
+                        initSignal = null;
+                        applicationInitEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationInitEventHandler -= value;
             }
         }
 
@@ -724,10 +731,13 @@ namespace Tizen.NUI
                 if (applicationTerminateEventHandler == null)
                 {
                     applicationTerminateEventHandler += value;
-
                     applicationTerminateEventCallbackDelegate = new NUIApplicationTerminateEventCallbackDelegate(OnNUIApplicationTerminate);
                     terminateSignal = this.TerminateSignal();
                     terminateSignal?.Connect(applicationTerminateEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.Terminating] Only one listener is allowed\n");
                 }
             }
 
@@ -735,12 +745,15 @@ namespace Tizen.NUI
             {
                 if (applicationTerminateEventHandler != null)
                 {
-                    terminateSignal?.Disconnect(applicationTerminateEventCallbackDelegate);
-                    terminateSignal?.Dispose();
-                    terminateSignal = null;
+                    applicationTerminateEventHandler -= value;
+                    if (applicationTerminateEventHandler == null)
+                    {
+                        terminateSignal?.Disconnect(applicationTerminateEventCallbackDelegate);
+                        terminateSignal?.Dispose();
+                        terminateSignal = null;
+                        applicationTerminateEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTerminateEventHandler -= value;
             }
         }
 
@@ -774,10 +787,13 @@ namespace Tizen.NUI
                 if (applicationPauseEventHandler == null)
                 {
                     applicationPauseEventHandler += value;
-
                     applicationPauseEventCallbackDelegate = new NUIApplicationPauseEventCallbackDelegate(OnNUIApplicationPause);
                     pauseSignal = this.PauseSignal();
                     pauseSignal?.Connect(applicationPauseEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.Paused] Only one listener is allowed\n");
                 }
             }
 
@@ -785,12 +801,15 @@ namespace Tizen.NUI
             {
                 if (applicationPauseEventHandler != null)
                 {
-                    pauseSignal?.Disconnect(applicationPauseEventCallbackDelegate);
-                    pauseSignal?.Dispose();
-                    pauseSignal = null;
+                    applicationPauseEventHandler -= value;
+                    if (applicationTerminateEventHandler == null)
+                    {
+                        pauseSignal?.Disconnect(applicationPauseEventCallbackDelegate);
+                        pauseSignal?.Dispose();
+                        pauseSignal = null;
+                        applicationPauseEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationPauseEventHandler -= value;
             }
         }
 
@@ -815,10 +834,13 @@ namespace Tizen.NUI
                 if (applicationResumeEventHandler == null)
                 {
                     applicationResumeEventHandler += value;
-
                     applicationResumeEventCallbackDelegate = new NUIApplicationResumeEventCallbackDelegate(OnNUIApplicationResume);
                     resumeSignal = this.ResumeSignal();
                     resumeSignal?.Connect(applicationResumeEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.Resumed] Only one listener is allowed\n");
                 }
             }
 
@@ -826,12 +848,15 @@ namespace Tizen.NUI
             {
                 if (applicationResumeEventHandler != null)
                 {
-                    resumeSignal?.Disconnect(applicationResumeEventCallbackDelegate);
-                    resumeSignal?.Dispose();
-                    resumeSignal = null;
+                    applicationResumeEventHandler -= value;
+                    if (applicationResumeEventHandler == null)
+                    {
+                        resumeSignal?.Disconnect(applicationResumeEventCallbackDelegate);
+                        resumeSignal?.Dispose();
+                        resumeSignal = null;
+                        applicationResumeEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationResumeEventHandler -= value;
             }
         }
 
@@ -856,10 +881,13 @@ namespace Tizen.NUI
                 if (applicationResetEventHandler == null)
                 {
                     applicationResetEventHandler += value;
-
                     applicationResetEventCallbackDelegate = new NUIApplicationResetEventCallbackDelegate(OnNUIApplicationReset);
                     resetSignal = this.ResetSignal();
                     resetSignal?.Connect(applicationResetEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.Reset] Only one listener is allowed\n");
                 }
             }
 
@@ -867,12 +895,15 @@ namespace Tizen.NUI
             {
                 if (applicationResetEventHandler != null)
                 {
-                    resetSignal?.Disconnect(applicationResetEventCallbackDelegate);
-                    resetSignal?.Dispose();
-                    resetSignal = null;
+                    applicationResetEventHandler -= value;
+                    if (applicationResetEventHandler == null)
+                    {
+                        resetSignal?.Disconnect(applicationResetEventCallbackDelegate);
+                        resetSignal?.Dispose();
+                        resetSignal = null;
+                        applicationResetEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationResetEventHandler -= value;
             }
         }
 
@@ -897,10 +928,13 @@ namespace Tizen.NUI
                 if (applicationLanguageChangedEventHandler == null)
                 {
                     applicationLanguageChangedEventHandler += value;
-
                     applicationLanguageChangedEventCallbackDelegate = new NUIApplicationLanguageChangedEventCallbackDelegate(OnNUIApplicationLanguageChanged);
                     languageChangedSignal = this.LanguageChangedSignal();
                     languageChangedSignal?.Connect(applicationLanguageChangedEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.LanguageChanged] Only one listener is allowed\n");
                 }
             }
 
@@ -908,12 +942,15 @@ namespace Tizen.NUI
             {
                 if (applicationLanguageChangedEventHandler != null)
                 {
-                    languageChangedSignal?.Disconnect(applicationLanguageChangedEventCallbackDelegate);
-                    languageChangedSignal?.Dispose();
-                    languageChangedSignal = null;
+                    applicationLanguageChangedEventHandler -= value;
+                    if (applicationLanguageChangedEventHandler == null)
+                    {
+                        languageChangedSignal?.Disconnect(applicationLanguageChangedEventCallbackDelegate);
+                        languageChangedSignal?.Dispose();
+                        languageChangedSignal = null;
+                        applicationLanguageChangedEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationLanguageChangedEventHandler -= value;
             }
         }
 
@@ -938,10 +975,13 @@ namespace Tizen.NUI
                 if (applicationRegionChangedEventHandler == null)
                 {
                     applicationRegionChangedEventHandler += value;
-
                     applicationRegionChangedEventCallbackDelegate = new NUIApplicationRegionChangedEventCallbackDelegate(OnNUIApplicationRegionChanged);
                     regionChangedSignal = this.RegionChangedSignal();
                     regionChangedSignal?.Connect(applicationRegionChangedEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.RegionChanged] Only one listener is allowed\n");
                 }
             }
 
@@ -949,12 +989,15 @@ namespace Tizen.NUI
             {
                 if (applicationRegionChangedEventHandler != null)
                 {
-                    regionChangedSignal?.Disconnect(applicationRegionChangedEventCallbackDelegate);
-                    regionChangedSignal?.Dispose();
-                    regionChangedSignal = null;
+                    applicationRegionChangedEventHandler -= value;
+                    if (applicationRegionChangedEventHandler == null)
+                    {
+                        regionChangedSignal?.Disconnect(applicationRegionChangedEventCallbackDelegate);
+                        regionChangedSignal?.Dispose();
+                        regionChangedSignal = null;
+                        applicationRegionChangedEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationRegionChangedEventHandler -= value;
             }
         }
 
@@ -979,10 +1022,13 @@ namespace Tizen.NUI
                 if (applicationBatteryLowEventHandler == null)
                 {
                     applicationBatteryLowEventHandler += value;
-
                     applicationBatteryLowEventCallbackDelegate = new NUIApplicationBatteryLowEventCallbackDelegate(OnNUIApplicationBatteryLow);
                     batteryLowSignal = this.BatteryLowSignal();
                     batteryLowSignal?.Connect(applicationBatteryLowEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.BatteryLow] Only one listener is allowed\n");
                 }
             }
 
@@ -990,12 +1036,15 @@ namespace Tizen.NUI
             {
                 if (applicationBatteryLowEventHandler != null)
                 {
-                    batteryLowSignal?.Disconnect(applicationBatteryLowEventCallbackDelegate);
-                    batteryLowSignal?.Dispose();
-                    batteryLowSignal = null;
+                    applicationBatteryLowEventHandler -= value;
+                    if (applicationBatteryLowEventHandler == null)
+                    {
+                        batteryLowSignal?.Disconnect(applicationBatteryLowEventCallbackDelegate);
+                        batteryLowSignal?.Dispose();
+                        batteryLowSignal = null;
+                        applicationBatteryLowEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationBatteryLowEventHandler -= value;
             }
         }
 
@@ -1019,10 +1068,13 @@ namespace Tizen.NUI
                 if (applicationMemoryLowEventHandler == null)
                 {
                     applicationMemoryLowEventHandler += value;
-
                     applicationMemoryLowEventCallbackDelegate = new NUIApplicationMemoryLowEventCallbackDelegate(OnNUIApplicationMemoryLow);
                     memoryLowSignal = this.MemoryLowSignal();
                     memoryLowSignal?.Connect(applicationMemoryLowEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.MemoryLow] Only one listener is allowed\n");
                 }
             }
 
@@ -1030,12 +1082,15 @@ namespace Tizen.NUI
             {
                 if (applicationMemoryLowEventHandler != null)
                 {
-                    memoryLowSignal?.Disconnect(applicationMemoryLowEventCallbackDelegate);
-                    memoryLowSignal?.Dispose();
-                    memoryLowSignal = null;
+                    applicationMemoryLowEventHandler -= value;
+                    if (applicationMemoryLowEventHandler == null)
+                    {
+                        memoryLowSignal?.Disconnect(applicationMemoryLowEventCallbackDelegate);
+                        memoryLowSignal?.Dispose();
+                        memoryLowSignal = null;
+                        applicationMemoryLowEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationMemoryLowEventHandler -= value;
             }
         }
 
@@ -1059,10 +1114,13 @@ namespace Tizen.NUI
                 if (applicationDeviceOrientationChangedEventHandler == null)
                 {
                     applicationDeviceOrientationChangedEventHandler += value;
-
                     applicationDeviceOrientationChangedEventCallback = new NUIApplicationDeviceOrientationChangedEventCallback(OnNUIApplicationDeviceOrientationChanged);
                     deviceOrientationChangedSignal = this.DeviceOrientationChangedSignal();
                     deviceOrientationChangedSignal?.Connect(applicationDeviceOrientationChangedEventCallback);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.DeviceOrientationChanged] Only one listener is allowed\n");
                 }
             }
 
@@ -1070,12 +1128,15 @@ namespace Tizen.NUI
             {
                 if (applicationDeviceOrientationChangedEventHandler != null)
                 {
-                    deviceOrientationChangedSignal?.Disconnect(applicationDeviceOrientationChangedEventCallback);
-                    deviceOrientationChangedSignal?.Dispose();
-                    deviceOrientationChangedSignal = null;
+                    applicationDeviceOrientationChangedEventHandler -= value;
+                    if (applicationDeviceOrientationChangedEventHandler == null)
+                    {
+                        deviceOrientationChangedSignal?.Disconnect(applicationDeviceOrientationChangedEventCallback);
+                        deviceOrientationChangedSignal?.Dispose();
+                        deviceOrientationChangedSignal = null;
+                        applicationDeviceOrientationChangedEventCallback = null;
+                    }
                 }
-
-                applicationDeviceOrientationChangedEventHandler -= value;
             }
         }
 
@@ -1098,10 +1159,13 @@ namespace Tizen.NUI
                 if (applicationAppControlEventHandler == null)
                 {
                     applicationAppControlEventHandler += value;
-
                     applicationAppControlEventCallbackDelegate = new NUIApplicationAppControlEventCallbackDelegate(OnNUIApplicationAppControl);
                     appControlSignal = this.AppControlSignal();
                     appControlSignal?.Connect(applicationAppControlEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.AppControl] Only one listener is allowed\n");
                 }
             }
 
@@ -1109,12 +1173,15 @@ namespace Tizen.NUI
             {
                 if (applicationAppControlEventHandler != null)
                 {
-                    appControlSignal?.Disconnect(applicationAppControlEventCallbackDelegate);
-                    appControlSignal?.Dispose();
-                    appControlSignal = null;
+                    applicationAppControlEventHandler -= value;
+                    if (applicationAppControlEventHandler == null)
+                    {
+                        appControlSignal?.Disconnect(applicationAppControlEventCallbackDelegate);
+                        appControlSignal?.Dispose();
+                        appControlSignal = null;
+                        applicationAppControlEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationAppControlEventHandler -= value;
             }
         }
 
@@ -1141,11 +1208,14 @@ namespace Tizen.NUI
                 // Restricted to only one listener
                 if (applicationTaskInitEventHandler == null)
                 {
-                    Tizen.Log.Fatal("NUI", "TaskInitialized Property adding");
                     applicationTaskInitEventHandler += value;
                     applicationTaskInitEventCallbackDelegate = new NUIApplicationInitEventCallbackDelegate(OnApplicationTaskInit);
                     taskInitSignal = this.TaskInitSignal();
                     taskInitSignal?.Connect(applicationTaskInitEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskInitialized] Only one listener is allowed\n");
                 }
             }
 
@@ -1153,12 +1223,15 @@ namespace Tizen.NUI
             {
                 if (applicationTaskInitEventHandler != null)
                 {
-                    taskInitSignal?.Disconnect(applicationTaskInitEventCallbackDelegate);
-                    taskInitSignal?.Dispose();
-                    taskInitSignal = null;
+                    applicationTaskInitEventHandler -= value;
+                    if (applicationTaskInitEventHandler == null)
+                    {
+                        taskInitSignal?.Disconnect(applicationTaskInitEventCallbackDelegate);
+                        taskInitSignal?.Dispose();
+                        taskInitSignal = null;
+                        applicationTaskInitEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTaskInitEventHandler -= value;
             }
         }
 
@@ -1185,10 +1258,13 @@ namespace Tizen.NUI
                 if (applicationTaskTerminateEventHandler == null)
                 {
                     applicationTaskTerminateEventHandler += value;
-
                     applicationTaskTerminateEventCallbackDelegate = new NUIApplicationTerminateEventCallbackDelegate(OnNUIApplicationTaskTerminate);
                     taskTerminateSignal = this.TaskTerminateSignal();
                     taskTerminateSignal?.Connect(applicationTaskTerminateEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskTerminating] Only one listener is allowed\n");
                 }
             }
 
@@ -1196,12 +1272,15 @@ namespace Tizen.NUI
             {
                 if (applicationTaskTerminateEventHandler != null)
                 {
-                    taskTerminateSignal?.Disconnect(applicationTaskTerminateEventCallbackDelegate);
-                    taskTerminateSignal?.Dispose();
-                    taskTerminateSignal = null;
+                    applicationTaskTerminateEventHandler -= value;
+                    if (applicationTaskTerminateEventHandler == null)
+                    {
+                        taskTerminateSignal?.Disconnect(applicationTaskTerminateEventCallbackDelegate);
+                        taskTerminateSignal?.Dispose();
+                        taskTerminateSignal = null;
+                        applicationTaskTerminateEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTaskTerminateEventHandler -= value;
             }
         }
 
@@ -1227,10 +1306,13 @@ namespace Tizen.NUI
                 if (applicationTaskLanguageChangedEventHandler == null)
                 {
                     applicationTaskLanguageChangedEventHandler += value;
-
                     applicationTaskLanguageChangedEventCallbackDelegate = new NUIApplicationLanguageChangedEventCallbackDelegate(OnNUIApplicationTaskLanguageChanged);
                     taskLanguageChangedSignal = this.TaskLanguageChangedSignal();
                     taskLanguageChangedSignal?.Connect(applicationTaskLanguageChangedEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskLanguageChanged] Only one listener is allowed\n");
                 }
             }
 
@@ -1238,12 +1320,15 @@ namespace Tizen.NUI
             {
                 if (applicationTaskLanguageChangedEventHandler != null)
                 {
-                    taskLanguageChangedSignal?.Disconnect(applicationTaskLanguageChangedEventCallbackDelegate);
-                    taskLanguageChangedSignal?.Dispose();
-                    taskLanguageChangedSignal = null;
+                    applicationTaskLanguageChangedEventHandler -= value;
+                    if (applicationTaskLanguageChangedEventHandler == null)
+                    {
+                        taskLanguageChangedSignal?.Disconnect(applicationTaskLanguageChangedEventCallbackDelegate);
+                        taskLanguageChangedSignal?.Dispose();
+                        taskLanguageChangedSignal = null;
+                        applicationTaskLanguageChangedEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTaskLanguageChangedEventHandler -= value;
             }
         }
 
@@ -1269,10 +1354,13 @@ namespace Tizen.NUI
                 if (applicationTaskRegionChangedEventHandler == null)
                 {
                     applicationTaskRegionChangedEventHandler += value;
-
                     applicationTaskRegionChangedEventCallbackDelegate = new NUIApplicationRegionChangedEventCallbackDelegate(OnNUIApplicationTaskRegionChanged);
                     taskRegionChangedSignal = this.TaskRegionChangedSignal();
                     taskRegionChangedSignal?.Connect(applicationTaskRegionChangedEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskRegionChanged] Only one listener is allowed\n");
                 }
             }
 
@@ -1280,12 +1368,15 @@ namespace Tizen.NUI
             {
                 if (applicationTaskRegionChangedEventHandler != null)
                 {
-                    taskRegionChangedSignal?.Disconnect(applicationTaskRegionChangedEventCallbackDelegate);
-                    taskRegionChangedSignal?.Dispose();
-                    taskRegionChangedSignal = null;
+                    applicationTaskRegionChangedEventHandler -= value;
+                    if (applicationTaskRegionChangedEventHandler == null)
+                    {
+                        taskRegionChangedSignal?.Disconnect(applicationTaskRegionChangedEventCallbackDelegate);
+                        taskRegionChangedSignal?.Dispose();
+                        taskRegionChangedSignal = null;
+                        applicationTaskRegionChangedEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTaskRegionChangedEventHandler -= value;
             }
         }
 
@@ -1311,10 +1402,13 @@ namespace Tizen.NUI
                 if (applicationTaskBatteryLowEventHandler == null)
                 {
                     applicationTaskBatteryLowEventHandler += value;
-
                     applicationTaskBatteryLowEventCallbackDelegate = new NUIApplicationBatteryLowEventCallbackDelegate(OnNUIApplicationTaskBatteryLow);
                     taskBatteryLowSignal = this.TaskBatteryLowSignal();
                     taskBatteryLowSignal?.Connect(applicationTaskBatteryLowEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskBatteryLow] Only one listener is allowed\n");
                 }
             }
 
@@ -1322,12 +1416,15 @@ namespace Tizen.NUI
             {
                 if (applicationTaskBatteryLowEventHandler != null)
                 {
-                    taskBatteryLowSignal?.Disconnect(applicationTaskBatteryLowEventCallbackDelegate);
-                    taskBatteryLowSignal?.Dispose();
-                    taskBatteryLowSignal = null;
+                    applicationTaskBatteryLowEventHandler -= value;
+                    if (applicationTaskBatteryLowEventHandler == null)
+                    {
+                        taskBatteryLowSignal?.Disconnect(applicationTaskBatteryLowEventCallbackDelegate);
+                        taskBatteryLowSignal?.Dispose();
+                        taskBatteryLowSignal = null;
+                        applicationTaskBatteryLowEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTaskBatteryLowEventHandler -= value;
             }
         }
 
@@ -1352,10 +1449,13 @@ namespace Tizen.NUI
                 if (applicationTaskMemoryLowEventHandler == null)
                 {
                     applicationTaskMemoryLowEventHandler += value;
-
                     applicationTaskMemoryLowEventCallbackDelegate = new NUIApplicationMemoryLowEventCallbackDelegate(OnNUIApplicationTaskMemoryLow);
                     taskMemoryLowSignal = this.TaskMemoryLowSignal();
                     taskMemoryLowSignal?.Connect(applicationTaskMemoryLowEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskMemoryLow] Only one listener is allowed\n");
                 }
             }
 
@@ -1363,12 +1463,15 @@ namespace Tizen.NUI
             {
                 if (applicationTaskMemoryLowEventHandler != null)
                 {
-                    taskMemoryLowSignal?.Disconnect(applicationTaskMemoryLowEventCallbackDelegate);
-                    taskMemoryLowSignal?.Dispose();
-                    taskMemoryLowSignal = null;
+                    applicationTaskMemoryLowEventHandler -= value;
+                    if (applicationTaskMemoryLowEventHandler == null)
+                    {
+                        taskMemoryLowSignal?.Disconnect(applicationTaskMemoryLowEventCallbackDelegate);
+                        taskMemoryLowSignal?.Dispose();
+                        taskMemoryLowSignal = null;
+                        applicationTaskMemoryLowEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTaskMemoryLowEventHandler -= value;
             }
         }
 
@@ -1392,10 +1495,13 @@ namespace Tizen.NUI
                 if (applicationTaskDeviceOrientationChangedEventHandler == null)
                 {
                     applicationTaskDeviceOrientationChangedEventHandler += value;
-
                     applicationTaskDeviceOrientationChangedEventCallback = new NUIApplicationDeviceOrientationChangedEventCallback(OnNUIApplicationTaskDeviceOrientationChanged);
                     taskDeviceOrientationChangedSignal = this.TaskDeviceOrientationChangedSignal();
                     taskDeviceOrientationChangedSignal?.Connect(applicationTaskDeviceOrientationChangedEventCallback);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskDeviceOrientationChanged] Only one listener is allowed\n");
                 }
             }
 
@@ -1403,12 +1509,15 @@ namespace Tizen.NUI
             {
                 if (applicationTaskDeviceOrientationChangedEventHandler != null)
                 {
-                    taskDeviceOrientationChangedSignal?.Disconnect(applicationTaskDeviceOrientationChangedEventCallback);
-                    taskDeviceOrientationChangedSignal?.Dispose();
-                    taskDeviceOrientationChangedSignal = null;
+                    applicationTaskDeviceOrientationChangedEventHandler -= value;
+                    if (applicationTaskDeviceOrientationChangedEventHandler == null)
+                    {
+                        taskDeviceOrientationChangedSignal?.Disconnect(applicationTaskDeviceOrientationChangedEventCallback);
+                        taskDeviceOrientationChangedSignal?.Dispose();
+                        taskDeviceOrientationChangedSignal = null;
+                        applicationTaskDeviceOrientationChangedEventCallback = null;
+                    }
                 }
-
-                applicationTaskDeviceOrientationChangedEventHandler -= value;
             }
         }
 
@@ -1437,18 +1546,25 @@ namespace Tizen.NUI
                     taskAppControlSignal = this.TaskAppControlSignal();
                     taskAppControlSignal?.Connect(applicationTaskAppControlEventCallbackDelegate);
                 }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Application.TaskAppControl] Only one listener is allowed\n");
+                }
             }
 
             remove
             {
                 if (applicationTaskAppControlEventHandler != null)
                 {
-                    taskAppControlSignal?.Disconnect(applicationTaskAppControlEventCallbackDelegate);
-                    taskAppControlSignal?.Dispose();
-                    taskAppControlSignal = null;
+                    applicationTaskAppControlEventHandler -= value;
+                    if (applicationTaskAppControlEventHandler == null)
+                    {
+                        taskAppControlSignal?.Disconnect(applicationTaskAppControlEventCallbackDelegate);
+                        taskAppControlSignal?.Dispose();
+                        taskAppControlSignal = null;
+                        applicationTaskAppControlEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationTaskAppControlEventHandler -= value;
             }
         }
 

--- a/src/Tizen.NUI/src/internal/Application/ComponentApplication.cs
+++ b/src/Tizen.NUI/src/internal/Application/ComponentApplication.cs
@@ -104,9 +104,12 @@ namespace Tizen.NUI
                 if (applicationCreateNativeEventHandler == null)
                 {
                     applicationCreateNativeEventHandler += value;
-
                     applicationCreateNativeEventCallbackDelegate = new NUIComponentApplicationCreatenativeEventCallbackDelegate(OnApplicationCreateNative);
                     Connect(applicationCreateNativeEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[ComponentApplication.CreateNative] Only one listener is allowed\n");
                 }
             }
 
@@ -114,10 +117,13 @@ namespace Tizen.NUI
             {
                 if (applicationCreateNativeEventHandler != null)
                 {
-                    Disconnect(applicationCreateNativeEventCallbackDelegate);
+                    applicationCreateNativeEventHandler -= value;
+                    if (applicationCreateNativeEventHandler == null)
+                    {
+                        Disconnect(applicationCreateNativeEventCallbackDelegate);
+                        applicationCreateNativeEventCallbackDelegate = null;
+                    }
                 }
-
-                applicationCreateNativeEventHandler -= value;
             }
         }
 

--- a/src/Tizen.NUI/src/internal/Application/WatchApplication.cs
+++ b/src/Tizen.NUI/src/internal/Application/WatchApplication.cs
@@ -153,9 +153,10 @@ namespace Tizen.NUI
             {
                 timeTickEventHandler -= value;
 
-                if (timeTickEventHandler == null && TimeTickSignal().Empty() == false)
+                if (timeTickEventHandler == null && timeTickCallback != null)
                 {
                     TimeTickSignal().Disconnect(timeTickCallback);
+                    timeTickCallback = null;
                 }
             }
         }
@@ -225,9 +226,10 @@ namespace Tizen.NUI
             {
                 ambientTickEventHandler -= value;
 
-                if (ambientTickEventHandler == null && AmbientTickSignal().Empty() == false)
+                if (ambientTickEventHandler == null && ambientTickCallback != null)
                 {
                     AmbientTickSignal().Disconnect(ambientTickCallback);
+                    ambientTickCallback = null;
                 }
             }
         }
@@ -297,9 +299,10 @@ namespace Tizen.NUI
             {
                 ambientChangedEventHandler -= value;
 
-                if (ambientChangedEventHandler == null && AmbientChangedSignal().Empty() == false)
+                if (ambientChangedEventHandler == null && ambientChangedCallback != null)
                 {
                     AmbientChangedSignal().Disconnect(ambientChangedCallback);
+                    ambientChangedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
+++ b/src/Tizen.NUI/src/internal/Common/ObjectRegistry.cs
@@ -91,16 +91,23 @@ namespace Tizen.NUI
                     objectRegistryObjectCreatedEventCallbackDelegate = new ObjectCreatedEventCallbackDelegate(OnObjectCreated);
                     this.ObjectCreatedSignal().Connect(objectRegistryObjectCreatedEventCallbackDelegate);
                 }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[ObjectRegistry.ObjectCreated] Only one listener is allowed\n");
+                }
             }
 
             remove
             {
                 if (objectRegistryObjectCreatedEventHandler != null)
                 {
-                    this.ObjectCreatedSignal().Disconnect(objectRegistryObjectCreatedEventCallbackDelegate);
+                    objectRegistryObjectCreatedEventHandler -= value;
+                    if (objectRegistryObjectCreatedEventHandler == null)
+                    {
+                        this.ObjectCreatedSignal().Disconnect(objectRegistryObjectCreatedEventCallbackDelegate);
+                        objectRegistryObjectCreatedEventCallbackDelegate = null;
+                    }
                 }
-
-                objectRegistryObjectCreatedEventHandler -= value;
             }
         }
 
@@ -131,16 +138,23 @@ namespace Tizen.NUI
                     objectRegistryObjectDestroyedEventCallbackDelegate = new ObjectDestroyedEventCallbackDelegate(OnObjectDestroyed);
                     this.ObjectDestroyedSignal().Connect(objectRegistryObjectDestroyedEventCallbackDelegate);
                 }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[ObjectRegistry.ObjectDestroyed] Only one listener is allowed\n");
+                }
             }
 
             remove
             {
                 if (objectRegistryObjectDestroyedEventHandler != null)
                 {
-                    this.ObjectDestroyedSignal().Disconnect(objectRegistryObjectDestroyedEventCallbackDelegate);
+                    objectRegistryObjectDestroyedEventHandler -= value;
+                    if (objectRegistryObjectDestroyedEventHandler == null)
+                    {
+                        this.ObjectDestroyedSignal().Disconnect(objectRegistryObjectDestroyedEventCallbackDelegate);
+                        objectRegistryObjectDestroyedEventCallbackDelegate = null;
+                    }
                 }
-
-                objectRegistryObjectDestroyedEventHandler -= value;
             }
         }
 

--- a/src/Tizen.NUI/src/internal/Utility/Builder.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Builder.cs
@@ -51,10 +51,13 @@ namespace Tizen.NUI
                 if (builderQuitEventHandler == null)
                 {
                     builderQuitEventHandler += value;
-
                     builderQuitEventCallbackDelegate = new QuitEventCallbackDelegate(OnQuit);
                     quitSignal = this.QuitSignal();
                     quitSignal?.Connect(builderQuitEventCallbackDelegate);
+                }
+                else
+                {
+                    Tizen.Log.Error("NUI", "[Builder.Quit] Only one listener is allowed\n");
                 }
             }
 
@@ -62,10 +65,13 @@ namespace Tizen.NUI
             {
                 if (builderQuitEventHandler != null)
                 {
-                    quitSignal?.Disconnect(builderQuitEventCallbackDelegate);
+                    builderQuitEventHandler -= value;
+                    if (builderQuitEventHandler == null)
+                    {
+                        quitSignal?.Disconnect(builderQuitEventCallbackDelegate);
+                        builderQuitEventCallbackDelegate = null;
+                    }
                 }
-
-                builderQuitEventHandler -= value;
             }
         }
 

--- a/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
+++ b/src/Tizen.NUI/src/internal/Utility/GaussianBlurView.cs
@@ -109,12 +109,12 @@ namespace Tizen.NUI
         {
             add
             {
-                // Restricted to only one listener
                 if (finishedEventHandler == null)
                 {
                     finishedCallback = new FinishedCallbackType(OnFinished);
                     FinishedSignal().Connect(finishedCallback);
                 }
+
                 finishedEventHandler += value;
             }
 
@@ -122,9 +122,10 @@ namespace Tizen.NUI
             {
                 finishedEventHandler -= value;
 
-                if (finishedEventHandler == null && FinishedSignal().Empty() == false)
+                if (finishedEventHandler == null && finishedCallback != null)
                 {
                     FinishedSignal().Disconnect(finishedCallback);
+                    finishedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -305,12 +305,12 @@ namespace Tizen.NUI.BaseComponents
             {
                 _resourceReadyEventHandler -= value;
 
-                ViewResourceReadySignal resourceReadySignal = ResourceReadySignal(this);
-                if (_resourceReadyEventHandler == null && resourceReadySignal?.Empty() == false)
+                if (_resourceReadyEventHandler == null && _resourceReadyEventCallback != null)
                 {
+                    using ViewResourceReadySignal resourceReadySignal = ResourceReadySignal(this);
                     resourceReadySignal?.Disconnect(_resourceReadyEventCallback);
+                    _resourceReadyEventCallback = null;
                 }
-                resourceReadySignal?.Dispose();
             }
         }
 
@@ -331,12 +331,12 @@ namespace Tizen.NUI.BaseComponents
             remove
             {
                 _resourceLoadedEventHandler -= value;
-                ViewResourceReadySignal resourceReadySignal = this.ResourceReadySignal(this);
-                if (_resourceLoadedEventHandler == null && resourceReadySignal?.Empty() == false)
+                if (_resourceLoadedEventHandler == null && _resourceLoadedCallback != null)
                 {
+                    using ViewResourceReadySignal resourceReadySignal = this.ResourceReadySignal(this);
                     resourceReadySignal?.Disconnect(_resourceLoadedCallback);
+                    _resourceLoadedCallback = null;
                 }
-                resourceReadySignal?.Dispose();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1166,11 +1166,8 @@ namespace Tizen.NUI.BaseComponents
                 if (finishedEventHandler == null && visualEventSignalCallback != null)
                 {
                     using VisualEventSignal visualEvent = VisualEventSignal();
-                    visualEvent.Disconnect(visualEventSignalCallback);
-                    if (visualEvent?.Empty() == true)
-                    {
-                        visualEventSignalCallback = null;
-                    }
+                    visualEvent?.Disconnect(visualEventSignalCallback);
+                    visualEventSignalCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -305,6 +305,7 @@ namespace Tizen.NUI.BaseComponents
                     gestureInfoSignal?.Disconnect(gestureInfoCallback);
                     gestureInfoSignal?.Dispose();
                     gestureInfoSignal = null;
+                    gestureInfoCallback = null;
                 }
             }
         }
@@ -367,6 +368,7 @@ namespace Tizen.NUI.BaseComponents
                     getDescriptionSignal?.Disconnect(getDescriptionCallback);
                     getDescriptionSignal?.Dispose();
                     getDescriptionSignal = null;
+                    getDescriptionCallback = null;
                 }
             }
         }
@@ -429,6 +431,7 @@ namespace Tizen.NUI.BaseComponents
                     getNameSignal?.Disconnect(getNameCallback);
                     getNameSignal?.Dispose();
                     getNameSignal = null;
+                    getNameCallback = null;
                 }
             }
         }
@@ -491,6 +494,7 @@ namespace Tizen.NUI.BaseComponents
                     ActivateSignal?.Disconnect(activateCallback);
                     ActivateSignal?.Dispose();
                     ActivateSignal = null;
+                    activateCallback = null;
                 }
             }
         }
@@ -540,6 +544,7 @@ namespace Tizen.NUI.BaseComponents
                     ReadingSkippedSignal?.Disconnect(readingSkippedCallback);
                     ReadingSkippedSignal?.Dispose();
                     ReadingSkippedSignal = null;
+                    readingSkippedCallback = null;
                 }
             }
         }
@@ -589,6 +594,7 @@ namespace Tizen.NUI.BaseComponents
                     ReadingPausedSignal?.Disconnect(readingPausedCallback);
                     ReadingPausedSignal?.Dispose();
                     ReadingPausedSignal = null;
+                    readingPausedCallback = null;
                 }
             }
         }
@@ -638,6 +644,7 @@ namespace Tizen.NUI.BaseComponents
                     ReadingResumedSignal?.Disconnect(readingResumedCallback);
                     ReadingResumedSignal?.Dispose();
                     ReadingResumedSignal = null;
+                    readingResumedCallback = null;
                 }
             }
         }
@@ -687,6 +694,7 @@ namespace Tizen.NUI.BaseComponents
                     ReadingCancelledSignal?.Disconnect(readingCancelledCallback);
                     ReadingCancelledSignal?.Dispose();
                     ReadingCancelledSignal = null;
+                    readingCancelledCallback = null;
                 }
             }
         }
@@ -736,6 +744,7 @@ namespace Tizen.NUI.BaseComponents
                     ReadingStoppedSignal?.Disconnect(readingStoppedCallback);
                     ReadingStoppedSignal?.Dispose();
                     ReadingStoppedSignal = null;
+                    readingStoppedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1619,6 +1619,14 @@ namespace Tizen.NUI.BaseComponents
                 hitTestResultDataCallback = null;
             }
 
+            if (visibilityChangedEventCallback != null)
+            {
+                NUILog.Debug($"[Dispose] visibilityChangedEventCallback");
+
+                Interop.ActorSignal.VisibilityChangedDisconnect(SwigCPtr, visibilityChangedEventCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                visibilityChangedEventCallback = null;
+            }
 
             if (interceptTouchDataCallback != null)
             {
@@ -1627,6 +1635,15 @@ namespace Tizen.NUI.BaseComponents
                 Interop.ActorSignal.InterceptTouchDisconnect(GetBaseHandleCPtrHandleRef, interceptTouchDataCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExistsDebug();
                 interceptTouchDataCallback = null;
+            }
+
+            if (layoutDirectionChangedEventCallback != null)
+            {
+                NUILog.Debug($"[Dispose] layoutDirectionChangedEventCallback");
+
+                Interop.ActorSignal.LayoutDirectionChangedDisconnect(SwigCPtr, layoutDirectionChangedEventCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                layoutDirectionChangedEventCallback = null;
             }
 
             if (touchDataCallback != null)
@@ -1683,6 +1700,97 @@ namespace Tizen.NUI.BaseComponents
                 Interop.ViewSignal.ResourceReadyDisconnect(GetBaseHandleCPtrHandleRef, backgroundResourceLoadedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExistsDebug();
                 backgroundResourceLoadedCallback = null;
+            }
+
+            // For ViewAccessibility
+            if (gestureInfoCallback != null)
+            {
+                NUILog.Debug($"[Dispose] gestureInfoCallback");
+
+                gestureInfoSignal?.Disconnect(gestureInfoCallback);
+                gestureInfoSignal?.Dispose();
+                gestureInfoSignal = null;
+                gestureInfoCallback = null;
+            }
+
+            if (getDescriptionCallback != null)
+            {
+                NUILog.Debug($"[Dispose] getDescriptionCallback");
+
+                getDescriptionSignal?.Disconnect(getDescriptionCallback);
+                getDescriptionSignal?.Dispose();
+                getDescriptionSignal = null;
+                getDescriptionCallback = null;
+            }
+
+            if (getNameCallback != null)
+            {
+                NUILog.Debug($"[Dispose] getNameCallback");
+
+                getNameSignal?.Disconnect(getNameCallback);
+                getNameSignal?.Dispose();
+                getNameSignal = null;
+                getNameCallback = null;
+            }
+
+            if (activateCallback != null)
+            {
+                NUILog.Debug($"[Dispose] activateCallback");
+
+                ActivateSignal?.Disconnect(activateCallback);
+                ActivateSignal?.Dispose();
+                ActivateSignal = null;
+                activateCallback = null;
+            }
+
+            if (readingSkippedCallback != null)
+            {
+                NUILog.Debug($"[Dispose] readingSkippedCallback");
+                
+                ReadingSkippedSignal?.Disconnect(readingSkippedCallback);
+                ReadingSkippedSignal?.Dispose();
+                ReadingSkippedSignal = null;
+                readingSkippedCallback = null;
+            }
+
+            if (readingPausedCallback != null)
+            {
+                NUILog.Debug($"[Dispose] readingPausedCallback");
+
+                ReadingPausedSignal?.Disconnect(readingPausedCallback);
+                ReadingPausedSignal?.Dispose();
+                ReadingPausedSignal = null;
+                readingPausedCallback = null;
+            }
+
+            if (readingResumedCallback != null)
+            {
+                NUILog.Debug($"[Dispose] readingResumedCallback");
+
+                ReadingResumedSignal?.Disconnect(readingResumedCallback);
+                ReadingResumedSignal?.Dispose();
+                ReadingResumedSignal = null;
+                readingResumedCallback = null;
+            }
+
+            if (readingCancelledCallback != null)
+            {
+                NUILog.Debug($"[Dispose] readingCancelledCallback");
+
+                ReadingCancelledSignal?.Disconnect(readingCancelledCallback);
+                ReadingCancelledSignal?.Dispose();
+                ReadingCancelledSignal = null;
+                readingCancelledCallback = null;
+            }
+
+            if (readingStoppedCallback != null)
+            {
+                NUILog.Debug($"[Dispose] readingStoppedCallback");
+
+                ReadingStoppedSignal?.Disconnect(readingStoppedCallback);
+                ReadingStoppedSignal?.Dispose();
+                ReadingStoppedSignal = null;
+                readingStoppedCallback = null;
             }
 
             NDalicPINVOKE.ThrowExceptionIfExists();

--- a/src/Tizen.NUI/src/public/Clipboard/Clipboard.cs
+++ b/src/Tizen.NUI/src/public/Clipboard/Clipboard.cs
@@ -214,11 +214,13 @@ namespace Tizen.NUI
                 if (clipboardDataReceivedCallback != null)
                 {
                     this.ClipboardDataReceivedSignal().Disconnect(clipboardDataReceivedCallback);
+                    clipboardDataReceivedCallback = null;
                 }
 
                 if (clipboardDataSelectedCallback != null)
                 {
                     this.ClipboardDataSelectedSignal().Disconnect(clipboardDataSelectedCallback);
+                    clipboardDataSelectedCallback = null;
                 }
             }
 

--- a/src/Tizen.NUI/src/public/Clipboard/ClipboardEvent.cs
+++ b/src/Tizen.NUI/src/public/Clipboard/ClipboardEvent.cs
@@ -121,9 +121,10 @@ namespace Tizen.NUI
             remove
             {
                 clipboardDataSelectedEventHandler -= value;
-                if (clipboardDataSelectedEventHandler == null && ClipboardDataSelectedSignal().Empty() == false)
+                if (clipboardDataSelectedEventHandler == null && clipboardDataSelectedCallback != null)
                 {
                     ClipboardDataSelectedSignal().Disconnect(clipboardDataSelectedCallback);
+                    clipboardDataSelectedCallback = null;
                 }
             }
         }
@@ -142,9 +143,10 @@ namespace Tizen.NUI
             remove
             {
                 clipboardDataReceivedEventHandler -= value;
-                if (clipboardDataReceivedEventHandler == null && ClipboardDataReceivedSignal().Empty() == false)
+                if (clipboardDataReceivedEventHandler == null && clipboardDataReceivedCallback != null)
                 {
                     ClipboardDataReceivedSignal().Disconnect(clipboardDataReceivedCallback);
+                    clipboardDataReceivedCallback = null;
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/Utility/Capture.cs
+++ b/src/Tizen.NUI/src/public/Utility/Capture.cs
@@ -81,6 +81,13 @@ namespace Tizen.NUI
                 //Called by User
                 //Release your own managed resources here.
                 //You should release all of your own disposable objects here.
+                if (finishedCallback != null)
+                {
+                    finishedSignal?.Disconnect(finishedCallback);
+                    finishedSignal?.Dispose();
+                    finishedSignal = null;
+                    finishedCallback = null;
+                }
             }
 
             base.Dispose(type);
@@ -305,8 +312,8 @@ namespace Tizen.NUI
             {
                 if (finishedEventHandler == null && disposed == false)
                 {
-                    finishedSignal = new CaptureSignal(Interop.Capture.Get(SwigCPtr));
                     finishedCallback = onFinished;
+                    finishedSignal = new CaptureSignal(Interop.Capture.Get(SwigCPtr));
                     finishedSignal.Connect(finishedCallback);
                 }
                 finishedEventHandler += value;
@@ -315,10 +322,12 @@ namespace Tizen.NUI
             {
                 finishedEventHandler -= value;
 
-                if (finishedEventHandler == null && finishedSignal?.Empty() == false)
+                if (finishedEventHandler == null && finishedCallback != null)
                 {
-                    finishedCallback = onFinished;
-                    finishedSignal.Disconnect(finishedCallback);
+                    finishedSignal?.Disconnect(finishedCallback);
+                    finishedSignal?.Dispose();
+                    finishedSignal = null;
+                    finishedCallback = null;
                 }
             }
         }


### PR DESCRIPTION
Make we use unified code style when we connect/disconnect native signal to C# EventHandler.

It will be reduce some copy-paste the non-common style implementation.

This PR will change below classes

* (internal)Application and it's family
* (internal)ObjectRegistry
* (internal)Builder
* (internal)GaussianBlurView
* ImageView and it's family
* View, ViewAccessibility
* Clipboard
* Capture
