### PR TITLE
[NUI] Bind SynchronousSizing for ImageView / ImageVisual

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -52,7 +52,7 @@ namespace Tizen.NUI.BaseComponents
                 SynchronousLoadingProperty = BindableProperty.Create(nameof(SynchronousLoading), typeof(bool), typeof(ImageView), false, propertyChanged: SetInternalSynchronousLoadingProperty, defaultValueCreator: GetInternalSynchronousLoadingProperty);
 
                 OrientationCorrectionProperty = BindableProperty.Create(nameof(OrientationCorrection), typeof(bool), typeof(ImageView), false, propertyChanged: SetInternalOrientationCorrectionProperty, defaultValueCreator: GetInternalOrientationCorrectionProperty);
-                        
+
                 MaskingModeProperty = BindableProperty.Create(nameof(MaskingMode), typeof(MaskingModeType), typeof(ImageView), default(MaskingModeType), propertyChanged: SetInternalMaskingModeProperty, defaultValueCreator: GetInternalMaskingModeProperty);
 
                 FastTrackUploadingProperty = BindableProperty.Create(nameof(FastTrackUploading), typeof(bool), typeof(ImageView), false, propertyChanged: SetInternalFastTrackUploadingProperty, defaultValueCreator: GetInternalFastTrackUploadingProperty);
@@ -136,6 +136,7 @@ namespace Tizen.NUI.BaseComponents
             Visual.Property.PremultipliedAlpha,
             ImageVisualProperty.OrientationCorrection,
             ImageVisualProperty.FastTrackUploading,
+            ImageVisualProperty.SynchronousSizing,
             NpatchImageVisualProperty.Border,
             NpatchImageVisualProperty.BorderOnly,
         };
@@ -769,6 +770,27 @@ namespace Tizen.NUI.BaseComponents
                 {
                     SetInternalOrientationCorrectionProperty(this, null, value);
                 }
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether to automatically reload the image as the view size<br />
+        /// If we set this value as true, view size will be works as desired size of image.<br />
+        /// </summary>
+        /// <remarks>
+        /// If we set this value as true, <see cref="DesiredWidth"/> and <see cref="DesiredHeight"/> will be invalidated.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool SynchronousSizing
+        {
+            get
+            {
+                return (bool)GetInternalSynchronousSizingProperty(this);
+            }
+            set
+            {
+                SetInternalSynchronousSizingProperty(this, value);
                 NotifyPropertyChanged();
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageViewBindableProperty.cs
@@ -361,6 +361,23 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// SynchronousSizingProperty
+        /// </summary>
+        internal static void SetInternalSynchronousSizingProperty(ImageView imageView, bool newValue)
+        {
+            imageView.UpdateImage(ImageVisualProperty.SynchronousSizing, new PropertyValue(newValue));
+        }
+
+        internal static object GetInternalSynchronousSizingProperty(ImageView imageView)
+        {
+            bool ret = false;
+
+            imageView.GetCachedImageVisualProperty(ImageVisualProperty.SynchronousSizing)?.Get(out ret);
+
+            return ret;
+        }
+
+        /// <summary>
         /// MaskingModeProperty
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -1023,6 +1023,15 @@ namespace Tizen.NUI
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly int NotifyAfterRasterization = NDalic.ImageVisualOrientationCorrection + 17;
+
+        /// <summary>
+        /// @brief Whether to synchronize image texture size to visual size.
+        /// @details Name "synchronousSizing", type Property::BOOLEAN.
+        /// If this property is true, ImageVisual ignores mDesiredSize.
+        /// @note Used by the ImageVisual. The default is false.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly int SynchronousSizing = NDalic.ImageVisualOrientationCorrection + 18;
     }
 
     /// <summary>

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
@@ -175,6 +175,29 @@ namespace Tizen.NUI.Visuals
         }
 
         /// <summary>
+        /// Gets or sets whether to automatically reload the image as the visual size.<br />
+        /// If we set this value as true, Visual size will be works as desired size of image.<br />
+        /// </summary>
+        /// <remarks>
+        /// If this value is true, <see cref="DesiredWidth"/> and <see cref="DesiredHeight"/> will be invalidated.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool SynchronousSizing
+        {
+            set
+            {
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousSizing, new PropertyValue(value), true);
+            }
+            get
+            {
+                bool ret = false;
+                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousSizing);
+                propertyValue?.Get(out ret);
+                return ret;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the URL of the alpha mask.<br />
         /// Optional.
         /// </summary>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisualTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisualTest.cs
@@ -312,8 +312,7 @@ namespace Tizen.NUI.Samples
                 Width = thumbnailSize,
                 Height = thumbnailSize,
 
-                DesiredWidth = (int)thumbnailSize,
-                DesiredHeight = (int)thumbnailSize,
+                SynchronousSizing = true,
 
                 OffsetXPolicy = VisualTransformPolicyType.Absolute,
                 OffsetYPolicy = VisualTransformPolicyType.Absolute,


### PR DESCRIPTION
Add SynchrousSizing property - reload as size of visual.

It will be useful when we want to load image as specific size of view,
so the memory is reduced.