### PR TITLE
[NUI] Add GetLastPanGestureState

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -323,6 +323,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastHoverEvent")]
             public static extern void InternalRetrievingLastHoverEvent(global::System.Runtime.InteropServices.HandleRef window, global::System.Runtime.InteropServices.HandleRef hover);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_InternalRetrievingLastPanGestureState")]
+            public static extern int InternalRetrievingLastPanGestureState(global::System.Runtime.InteropServices.HandleRef window);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetNeedsRotationCompletedAcknowledgement")]
             public static extern void SetNeedsRotationCompletedAcknowledgement(global::System.Runtime.InteropServices.HandleRef window, bool needAcknowledgement);
 

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -425,7 +425,7 @@ namespace Tizen.NUI
 
         /// <summary>
         /// Gets the default window.
-        /// The main window or default window is automatically created when the application is launched, 
+        /// The main window or default window is automatically created when the application is launched,
         /// and it remains constant and unchanged throughout the application's operation.
         /// </summary>
         /// <since_tizen> 12 </since_tizen>
@@ -2224,6 +2224,18 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets the last pan gesture state the window gets.
+        /// </summary>
+        /// <returns>The last pan gesture state the window gets.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Gesture.StateType GetLastPanGestureState()
+        {
+            Gesture.StateType ret = (Gesture.StateType)Interop.Window.InternalRetrievingLastPanGestureState(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
         /// Sets the necessary for window rotation Acknowledgement.
         /// After this function called, SendRotationCompletedAcknowledgement() should be called to complete window rotation.
         ///
@@ -2517,7 +2529,7 @@ namespace Tizen.NUI
 
         /// <summary>
         /// Gets or sets a value indicating whether the window is modal or not.
-        /// The modal property of a window requires that it be set to a parent window. 
+        /// The modal property of a window requires that it be set to a parent window.
         /// The window modal function operates on the specified parent window.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
[NUI] Add GetLastPanGestureState
Use this when you want to know the status value of a pan gesture.

https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-core/+/315444/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/315445/
https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/315446/

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
