### PR TITLE
[NUI] Make VisibilityChangedEventArgs.View return visibility changed view

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Actor.cs
@@ -134,6 +134,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_CurrentScreenExtents")]
             public static extern global::System.IntPtr CurrentScreenExtents(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_GetVisiblityChangedActor")]
+            public static extern global::System.IntPtr GetVisiblityChangedActor();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Actor_InternalRetrievingPropertyVector2")]
             public static extern int InternalRetrievingPropertyVector2(HandleRef actor, int propertyType, HandleRef retrievingVector2);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -1063,9 +1063,18 @@ namespace Tizen.NUI.BaseComponents
         private void OnVisibilityChanged(IntPtr data, bool visibility, VisibilityChangeType type)
         {
             VisibilityChangedEventArgs e = new VisibilityChangedEventArgs();
-            if (data != IntPtr.Zero)
+            IntPtr changedViewCPtr = Interop.Actor.GetVisiblityChangedActor();
+            if (changedViewCPtr != IntPtr.Zero)
             {
-                e.View = Registry.GetManagedBaseHandleFromNativePtr(data) as View;
+                e.View = Registry.GetManagedBaseHandleFromNativePtr(changedViewCPtr) as View;
+                if(e.View != null)
+                {
+                    Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, changedViewCPtr));
+                }
+                else
+                {
+                    e.View = new View(changedViewCPtr, true);
+                }
             }
             e.Visibility = visibility;
             e.Type = type;
@@ -1265,7 +1274,7 @@ namespace Tizen.NUI.BaseComponents
             private VisibilityChangeType _type;
 
             /// <summary>
-            /// The view, or child of view, whose visibility has changed.
+            /// The view, whose visibility has changed.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
             public View View

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisibilityChangedTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisibilityChangedTest.cs
@@ -9,7 +9,9 @@ namespace Tizen.NUI.Samples
     public class VisibilityChangedTest : IExample
     {
         Window win, subWin;
-        Timer t1, t2;
+        View dummy1, dummy2;
+        View subDummy1, subDummy2;
+        Timer t1, t2, t3, t4, t5, t6;
         const string t = "NUITEST";
         public void Activate()
         {
@@ -17,11 +19,21 @@ namespace Tizen.NUI.Samples
             win.BackgroundColor = Color.Green;
             win.VisibilityChanged += Win_VisibilityChanged;
 
-            var dummy = new View();
-            dummy.Size = new Size(200, 200);
-            dummy.Position = new Position(10, 10);
-            dummy.BackgroundColor = Color.Red;
-            win.Add(dummy);
+            dummy1 = new View();
+            dummy1.Size = new Size(200, 200);
+            dummy1.Position = new Position(10, 10);
+            dummy1.BackgroundColor = Color.Red;
+            dummy1.Name = "dummy1";
+            dummy1.VisibilityChanged += View_VisibilityChanged;
+            win.Add(dummy1);
+
+            dummy2 = new View();
+            dummy2.Size = new Size(100, 100);
+            dummy2.Position = new Position(10, 10);
+            dummy2.BackgroundColor = Color.Purple;
+            dummy2.Name = "dummy2";
+            dummy2.VisibilityChanged += View_VisibilityChanged;
+            dummy1.Add(dummy2);
 
             subWin = new Window();
             subWin.BackgroundColor = Color.Yellow;
@@ -29,11 +41,23 @@ namespace Tizen.NUI.Samples
             subWin.WindowPosition = new Position2D(100, 200);
             subWin.VisibilityChanged += SubWin_VisibilityChanged;
 
-            var dum2 = new View();
-            dum2.Size = new Size(200, 200);
-            dum2.Position = new Position(10, 10);
-            dum2.BackgroundColor = Color.Blue;
-            subWin.Add(dum2);
+            subDummy1 = new View();
+            subDummy1.Size = new Size(200, 200);
+            subDummy1.Position = new Position(10, 10);
+            subDummy1.BackgroundColor = Color.Blue;
+            subDummy1.Name = "subDummy1";
+            subDummy1.VisibilityChanged += View_VisibilityChanged;
+            subWin.Add(subDummy1);
+
+            subDummy2 = new View();
+            subDummy2.Size = new Size(100, 100);
+            subDummy2.Position = new Position(10, 10);
+            subDummy2.BackgroundColor = Color.Crimson;
+            subDummy2.Name = "subDummy2";
+            subDummy2.VisibilityChanged += View_VisibilityChanged;
+            subDummy1.Add(subDummy2);
+
+            cnt1 = cnt2 = cnt3 = cnt4 = cnt5 = cnt6 = 0;
 
             t1 = new Timer(1300);
             t1.Tick += T1_Tick;
@@ -42,25 +66,99 @@ namespace Tizen.NUI.Samples
             t2 = new Timer(1700);
             t2.Tick += T2_Tick;
             t2.Start();
+
+            t3 = new Timer(2100);
+            t3.Tick += T3_Tick;
+            t3.Start();
+
+            t4 = new Timer(2500);
+            t4.Tick += T4_Tick;
+            t4.Start();
+
+            t5 = new Timer(2900);
+            t5.Tick += T5_Tick;
+            t5.Start();
+
+            t6 = new Timer(3100);
+            t6.Tick += T6_Tick;
+            t6.Start();
         }
 
-        int cnt;
+        int cnt1, cnt2, cnt3, cnt4, cnt5, cnt6;
+        private bool T1_Tick(object source, Timer.TickEventArgs e)
+        {
+            l.Debug(t, $"T1_Tick. {dummy1.Name} visibility change started");
+            if (++cnt1 %2 == 0)
+            {
+                dummy1.Show();
+            }
+            else
+            {
+                dummy1.Hide();
+            }
+            l.Debug(t, $"T1_Tick. {dummy1.Name} visibility change finished");
+            return true;
+        }
         private bool T2_Tick(object source, Timer.TickEventArgs e)
         {
-            if(cnt++ %2 == 0)
+            l.Debug(t, $"T2_Tick. {dummy2.Name} visibility change started");
+            if (++cnt2 %2 == 0)
+            {
+                dummy2.Show();
+            }
+            else
+            {
+                dummy2.Hide();
+            }
+            l.Debug(t, $"T2_Tick. {dummy2.Name} visibility change finished");
+            return true;
+        }
+        private bool T3_Tick(object source, Timer.TickEventArgs e)
+        {
+            l.Debug(t, $"T3_Tick. {subDummy1.Name} visibility change started");
+            if (++cnt3 %2 == 0)
+            {
+                subDummy1.Show();
+            }
+            else
+            {
+                subDummy1.Hide();
+            }
+            l.Debug(t, $"T3_Tick. {subDummy1.Name} visibility change finished");
+            return true;
+        }
+        private bool T4_Tick(object source, Timer.TickEventArgs e)
+        {
+            l.Debug(t, $"T4_Tick. {subDummy2.Name} visibility change started");
+            if (++cnt4 %2 == 0)
+            {
+                subDummy2.Show();
+            }
+            else
+            {
+                subDummy2.Hide();
+            }
+            l.Debug(t, $"T4_Tick. {subDummy2.Name} visibility change finished");
+            return true;
+        }
+        private bool T5_Tick(object source, Timer.TickEventArgs e)
+        {
+            l.Debug(t, $"T5_Tick. win visibility change started");
+            if (++cnt5 %2 == 0)
             {
                 win.Show();
-            }else
+            }
+            else
             {
                 win.Hide();
             }
+            l.Debug(t, $"T5_Tick. win visibility change finished");
             return true;
         }
-
-        int cnt2;
-        private bool T1_Tick(object source, Timer.TickEventArgs e)
+        private bool T6_Tick(object source, Timer.TickEventArgs e)
         {
-            if (cnt2++ % 2 == 0)
+            l.Debug(t, $"T5_Tick. subWin visibility change started");
+            if (++cnt6 % 2 == 0)
             {
                 subWin.Show();
             }
@@ -68,8 +166,8 @@ namespace Tizen.NUI.Samples
             {
                 subWin.Hide();
             }
+            l.Debug(t, $"T5_Tick. subWin visibility change finished");
             return true;
-
         }
 
         private void SubWin_VisibilityChanged(object sender, Window.VisibilityChangedEventArgs e)
@@ -82,18 +180,44 @@ namespace Tizen.NUI.Samples
             l.Debug(t, $"main window visibility changed! e.Visibility={e.Visibility}");
         }
 
+        private void View_VisibilityChanged(object sender, View.VisibilityChangedEventArgs e)
+        {
+            View self = sender as View;
+            l.Debug(t, $"{self.Name} visibility changed! e.View.Name={e.View.Name} e.Visibility={e.Visibility} e.Type={e.Type}");
+        }
+
         public void Deactivate()
         {
-            t1.Stop();
-            t2.Stop();
-            t1.Dispose();
-            t2.Dispose();
-            t1 = t2 = null;
-            
+            t1?.Stop();
+            t2?.Stop();
+            t3?.Stop();
+            t4?.Stop();
+            t5?.Stop();
+            t6?.Stop();
+            t1?.Dispose();
+            t2?.Dispose();
+            t3?.Dispose();
+            t4?.Dispose();
+            t5?.Dispose();
+            t6?.Dispose();
+            t1 = t2 = t3 = t4 = t5 = t6 = null;
+
+            dummy1.VisibilityChanged -= View_VisibilityChanged;
+            dummy2.VisibilityChanged -= View_VisibilityChanged;
+
+            subDummy1.VisibilityChanged -= View_VisibilityChanged;
+            subDummy2.VisibilityChanged -= View_VisibilityChanged;
+
+            dummy1.Dispose();
+            dummy2.Dispose();
+            subDummy1.Dispose();
+            subDummy2.Dispose();
+
             win.VisibilityChanged -= Win_VisibilityChanged;
             subWin.VisibilityChanged -= SubWin_VisibilityChanged;
 
             subWin.Hide();
+            subWin.Dispose();
             win.Show();
         }
     }


### PR DESCRIPTION
Until now, VisibilityChangedEventArgs.View return sender itself.

It is useless information for user.

Follow up some other platform's behavior,
( reference : https://developer.android.com/reference/android/view/View#onVisibilityChanged(android.view.View,%20int) ) Let we make VisibilityChangedEventArgs.View return visibility changed view.

Relative dali patch :

- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/315475
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/315484
