### PR TITLE
[NUI] Apply comments at VisualBase (phase 1)

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/VisualObjectsContainer.cs
+++ b/src/Tizen.NUI/src/internal/Common/VisualObjectsContainer.cs
@@ -159,10 +159,6 @@ namespace Tizen.NUI.Visuals
             {
                 Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, cPtr));
             }
-            else
-            {
-                ret = new Visuals.VisualBase(cPtr, true);
-            }
             NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }


### PR DESCRIPTION
Apply some comments that report at PR #6079

- `Color.A` getter apply `Opacity` changeness
- Make `VisualFittingMode` have no effect for `ColorVisual` and `BorderVisual`
- `GetVisualProperty` return valid value after call `GetCurrentVisualProperty`
- Make `VisualBase` class as abstract. Let we don't allow to call this class constructor.
