### PR TITLE
[MediaPacket] Add TbmSurface property to get native tbm surface handle

### DIFF
--- a/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
+++ b/src/Tizen.Multimedia/Interop/Interop.MediaTool.cs
@@ -115,6 +115,9 @@ namespace Tizen.Multimedia
 
             [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_duration")]
             internal static extern int GetDuration(IntPtr handle, out ulong value);
+
+            [DllImport(Libraries.MediaTool, EntryPoint = "media_packet_get_tbm_surface")]
+            internal static extern int GetTbmSurface(IntPtr handle, out IntPtr surface);
         }
 
         internal static class MediaFormat

--- a/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
+++ b/src/Tizen.Multimedia/MediaTool/MediaPacket.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using Tizen.Internals.Errors;
 using Native = Tizen.Multimedia.Interop.MediaPacket;
@@ -499,6 +500,30 @@ namespace Tizen.Multimedia
 
                 ret = Native.SetBufferFlags(_handle, (int)value);
                 MultimediaDebug.AssertNoError(ret);
+            }
+        }
+
+        /// <summary>
+        /// Gets the pointer to the tbm_surface object associated with the MediaPacket.
+        /// </summary>
+        /// <value>
+        /// The pointer to the tbm_surface object.
+        /// </value>
+        /// <exception cref="ObjectDisposedException">
+        /// Thrown if the current instance has already been disposed of.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the operation failed.
+        /// </exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IntPtr TbmSurface
+        {
+            get
+            {
+                ValidateNotDisposed();
+                int ret = Native.GetTbmSurface(_handle, out var surface);
+                MultimediaDebug.AssertNoError(ret);
+                return surface;
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
 * Add TbmSurface property on MediaPacket to get native tbm surface handle

### API Changes ###
Added:
 - IntPtr MediaPacket.TbmSurface { get; } // Property
