### PR TITLE
[NUI] Async text feature

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -199,6 +199,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MANUAL_RENDERED_get")]
             public static extern int ManualRenderedGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ASYNC_LINE_COUNT_get")]
+            public static extern int AsyncLineCountGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
             public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -199,6 +199,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedWidth")]
             public static extern void RequestAsyncRenderWithFixedWidth(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithConstraint")]
+            public static extern void RequestAsyncRenderWithConstraint(global::System.Runtime.InteropServices.HandleRef textLabelRef, float widthConstraint);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal")]
             public static extern global::System.IntPtr AsyncTextRenderedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+using System.Runtime.InteropServices;
 
 namespace Tizen.NUI
 {
@@ -21,210 +22,219 @@ namespace Tizen.NUI
     {
         internal static partial class TextLabel
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_get")]
             public static extern int TextGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_FAMILY_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_FAMILY_get")]
             public static extern int FontFamilyGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_STYLE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_STYLE_get")]
             public static extern int FontStyleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_POINT_SIZE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_POINT_SIZE_get")]
             public static extern int PointSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MULTI_LINE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MULTI_LINE_get")]
             public static extern int MultiLineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_HORIZONTAL_ALIGNMENT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_HORIZONTAL_ALIGNMENT_get")]
             public static extern int HorizontalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_VERTICAL_ALIGNMENT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_VERTICAL_ALIGNMENT_get")]
             public static extern int VerticalAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_COLOR_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_TEXT_COLOR_get")]
             public static extern int TextColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_MARKUP_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_MARKUP_get")]
             public static extern int EnableMarkupGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_AUTO_SCROLL_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_AUTO_SCROLL_get")]
             public static extern int EnableAutoScrollGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_SPEED_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_SPEED_get")]
             public static extern int AutoScrollSpeedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_LOOP_COUNT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_LOOP_COUNT_get")]
             public static extern int AutoScrollLoopCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_GAP_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_AUTO_SCROLL_GAP_get")]
             public static extern int AutoScrollGapGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_LINE_SPACING_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_LINE_SPACING_get")]
             public static extern int LineSpacingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RELATIVE_LINE_SIZE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RELATIVE_LINE_SIZE_get")]
             public static extern int RelativeLineHeightGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_UNDERLINE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_UNDERLINE_get")]
             public static extern int UnderlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_SHADOW_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_SHADOW_get")]
             public static extern int ShadowGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_EMBOSS_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_EMBOSS_get")]
             public static extern int EmbossGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_OUTLINE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_OUTLINE_get")]
             public static extern int OutlineGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New__SWIG_0")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New__SWIG_0")]
             public static extern global::System.IntPtr New();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_Style")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_Style")]
             public static extern global::System.IntPtr New(bool hasStyle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_String_Style")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_New_With_String_Style")]
             public static extern global::System.IntPtr New(string text, bool hasStyle);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabel")]
-            public static extern void DeleteTextLabel(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabel")]
+            public static extern void DeleteTextLabel(HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_PIXEL_SIZE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_PIXEL_SIZE_get")]
             public static extern int PixelSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_get")]
             public static extern int EllipsisGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_POSITION_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_ELLIPSIS_POSITION_get")]
             public static extern int EllipsisPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_COUNT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_COUNT_get")]
             public static extern int LineCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_WRAP_MODE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_LINE_WRAP_MODE_get")]
             public static extern int LineWrapModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_DIRECTION_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_DIRECTION_get")]
             public static extern int TextDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_VERTICAL_LINE_ALIGNMENT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_VERTICAL_LINE_ALIGNMENT_get")]
             public static extern int VerticalLineAlignmentGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_STOP_MODE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_STOP_MODE_get")]
             public static extern int AutoScrollStopModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_LOOP_DELAY_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_AUTO_SCROLL_LOOP_DELAY_get")]
             public static extern int AutoScrollLoopDelayGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MATCH_SYSTEM_LANGUAGE_DIRECTION_get")]
             public static extern int MatchSystemLanguageDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_FIT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_TEXT_FIT_get")]
             public static extern int TextFitGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_TextFitChangedSignal")]
-            public static extern global::System.IntPtr TextFitChangedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_TextFitChangedSignal")]
+            public static extern global::System.IntPtr TextFitChangedSignal(HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MIN_LINE_SIZE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_TextLabel_Property_MIN_LINE_SIZE_get")]
             public static extern int MinLineSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_SIZE_SCALE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_FONT_SIZE_SCALE_get")]
             public static extern int FontSizeScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_FONT_SIZE_SCALE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ENABLE_FONT_SIZE_SCALE_get")]
             public static extern int EnableFontSizeScaleGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextSize")]
-            public static extern global::System.IntPtr GetTextSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, uint start, uint end);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextSize")]
+            public static extern global::System.IntPtr GetTextSize(HandleRef textLabelRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextPosition")]
-            public static extern global::System.IntPtr GetTextPosition(global::System.Runtime.InteropServices.HandleRef textLabelRef, uint start, uint end);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextPosition")]
+            public static extern global::System.IntPtr GetTextPosition(HandleRef textLabelRef, uint start, uint end);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_SetTextFitArray")]
-            public static extern void SetTextFitArray(global::System.Runtime.InteropServices.HandleRef textLabel, bool enable, uint arraySize, float[] pointSizeArray, float[] minLineSizeArray);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_SetTextFitArray")]
+            public static extern void SetTextFitArray(HandleRef textLabel, bool enable, uint arraySize, float[] pointSizeArray, float[] minLineSizeArray);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextFitArray")]
-            public static extern global::System.IntPtr GetTextFitArray(global::System.Runtime.InteropServices.HandleRef textLabel);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_GetTextFitArray")]
+            public static extern global::System.IntPtr GetTextFitArray(HandleRef textLabel);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AnchorClickedSignal")]
-            public static extern global::System.IntPtr AnchorClickedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AnchorClickedSignal")]
+            public static extern global::System.IntPtr AnchorClickedSignal(HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Empty")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool TextLabelSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Empty")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool TextLabelSignalEmpty(HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_GetConnectionCount")]
-            public static extern uint TextLabelSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_GetConnectionCount")]
+            public static extern uint TextLabelSignalGetConnectionCount(HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Connect")]
-            public static extern void TextLabelSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Connect")]
+            public static extern void TextLabelSignalConnect(HandleRef jarg1, HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Disconnect")]
-            public static extern void TextLabelSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Disconnect")]
+            public static extern void TextLabelSignalDisconnect(HandleRef jarg1, HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Emit")]
-            public static extern void TextLabelSignalEmit(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabelSignal_Emit")]
+            public static extern void TextLabelSignalEmit(HandleRef jarg1, HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextLabelSignal")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_TextLabelSignal")]
             public static extern global::System.IntPtr NewTextLabelSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabelSignal")]
-            public static extern void DeleteTextLabelSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TextLabelSignal")]
+            public static extern void DeleteTextLabelSignal(HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_STRIKETHROUGH_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_STRIKETHROUGH_get")]
             public static extern int StrikethroughGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CHARACTER_SPACING_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CHARACTER_SPACING_get")]
             public static extern int CharacterSpacingGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_COLOR_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_COLOR_get")]
             public static extern int AnchorColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_CLICKED_COLOR_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ANCHOR_CLICKED_COLOR_get")]
             public static extern int AnchorClickedColorGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_FRONT_INSET_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_FRONT_INSET_get")]
             public static extern int RemoveFrontInsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_BACK_INSET_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_REMOVE_BACK_INSET_get")]
             public static extern int RemoveBackInsetGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CUTOUT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CUTOUT_get")]
             public static extern int CutoutGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_MODE_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_MODE_get")]
             public static extern int RenderModeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MANUAL_RENDERED_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MANUAL_RENDERED_get")]
             public static extern int ManualRenderedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ASYNC_LINE_COUNT_get")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_ASYNC_LINE_COUNT_get")]
             public static extern int AsyncLineCountGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
-            public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
+            public static extern void RequestAsyncRenderWithFixedSize(HandleRef textLabelRef, float width, float height);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedWidth")]
-            public static extern void RequestAsyncRenderWithFixedWidth(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float heightConstraint);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedWidth")]
+            public static extern void RequestAsyncRenderWithFixedWidth(HandleRef textLabelRef, float width, float heightConstraint);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithConstraint")]
-            public static extern void RequestAsyncRenderWithConstraint(global::System.Runtime.InteropServices.HandleRef textLabelRef, float widthConstraint, float heightConstraint);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithConstraint")]
+            public static extern void RequestAsyncRenderWithConstraint(HandleRef textLabelRef, float widthConstraint, float heightConstraint);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncNaturalSize")]
-            public static extern void RequestAsyncNaturalSize(global::System.Runtime.InteropServices.HandleRef textLabelRef);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncNaturalSize")]
+            public static extern void RequestAsyncNaturalSize(HandleRef textLabelRef);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncHeightForWidth")]
-            public static extern void RequestAsyncHeightForWidth(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncHeightForWidth")]
+            public static extern void RequestAsyncHeightForWidth(HandleRef textLabelRef, float width);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal")]
-            public static extern global::System.IntPtr AsyncTextRenderedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal_Connect")]
+            public static extern void AsyncTextRenderedConnect(HandleRef textLabelRef, HandleRef handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal")]
-            public static extern global::System.IntPtr AsyncNaturalSizeComputedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal_Disconnect")]
+            public static extern void AsyncTextRenderedDisconnect(HandleRef textLabelRef, HandleRef handler);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal")]
-            public static extern global::System.IntPtr AsyncHeightForWidthComputedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal_Connect")]
+            public static extern void AsyncNaturalSizeComputedConnect(HandleRef textLabelRef, HandleRef handler);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal_Disconnect")]
+            public static extern void AsyncNaturalSizeComputedDisconnect(HandleRef textLabelRef, HandleRef handler);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal_Connect")]
+            public static extern void AsyncHeightForWidthComputedConnect(HandleRef textLabelRef, HandleRef handler);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal_Disconnect")]
+            public static extern void AsyncHeightForWidthComputedDisconnect(HandleRef textLabelRef, HandleRef handler);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -196,6 +196,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
             public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedWidth")]
+            public static extern void RequestAsyncRenderWithFixedWidth(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal")]
             public static extern global::System.IntPtr AsyncTextRenderedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -211,11 +211,17 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncNaturalSize")]
             public static extern void RequestAsyncNaturalSize(global::System.Runtime.InteropServices.HandleRef textLabelRef);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncHeightForWidth")]
+            public static extern void RequestAsyncHeightForWidth(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal")]
             public static extern global::System.IntPtr AsyncTextRenderedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal")]
             public static extern global::System.IntPtr AsyncNaturalSizeComputedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncHeightForWidthComputedSignal")]
+            public static extern global::System.IntPtr AsyncHeightForWidthComputedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -197,10 +197,10 @@ namespace Tizen.NUI
             public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedWidth")]
-            public static extern void RequestAsyncRenderWithFixedWidth(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width);
+            public static extern void RequestAsyncRenderWithFixedWidth(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float heightConstraint);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithConstraint")]
-            public static extern void RequestAsyncRenderWithConstraint(global::System.Runtime.InteropServices.HandleRef textLabelRef, float widthConstraint);
+            public static extern void RequestAsyncRenderWithConstraint(global::System.Runtime.InteropServices.HandleRef textLabelRef, float widthConstraint, float heightConstraint);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal")]
             public static extern global::System.IntPtr AsyncTextRenderedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -208,8 +208,14 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithConstraint")]
             public static extern void RequestAsyncRenderWithConstraint(global::System.Runtime.InteropServices.HandleRef textLabelRef, float widthConstraint, float heightConstraint);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncNaturalSize")]
+            public static extern void RequestAsyncNaturalSize(global::System.Runtime.InteropServices.HandleRef textLabelRef);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal")]
             public static extern global::System.IntPtr AsyncTextRenderedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncNaturalSizeComputedSignal")]
+            public static extern global::System.IntPtr AsyncNaturalSizeComputedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -195,6 +195,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
             public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_AsyncTextRenderedSignal")]
+            public static extern global::System.IntPtr AsyncTextRenderedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -192,6 +192,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CUTOUT_get")]
             public static extern int CutoutGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
+            public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -196,6 +196,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_MODE_get")]
             public static extern int RenderModeGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_MANUAL_RENDERED_get")]
+            public static extern int ManualRenderedGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
             public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TextLabel.cs
@@ -193,6 +193,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_CUTOUT_get")]
             public static extern int CutoutGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_Property_RENDER_MODE_get")]
+            public static extern int RenderModeGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TextLabel_RequestAsyncRenderWithFixedSize")]
             public static extern void RequestAsyncRenderWithFixedSize(global::System.Runtime.InteropServices.HandleRef textLabelRef, float width, float height);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
@@ -70,4 +70,27 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         public float Height { get; }
     }
+
+    /// <summary>
+    /// AsyncTextSizeComputedEventArgs is a class to record async text size computed event arguments which will be sent to user.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AsyncTextSizeComputedEventArgs : EventArgs
+    {
+        public AsyncTextSizeComputedEventArgs(float width, float height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        /// The computed width.
+        /// </summary>
+        public float Width { get; }
+
+        /// <summary>
+        /// The computed height.
+        /// </summary>
+        public float Height { get; }
+    }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEvent.cs
@@ -47,4 +47,27 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public InputFilterType Type { get; set; }
     }
+
+    /// <summary>
+    /// AsyncTextRenderedEventArgs is a class to record async text rendered event arguments which will be sent to user.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AsyncTextRenderedEventArgs : EventArgs
+    {
+        public AsyncTextRenderedEventArgs(float width, float height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        /// The rendered width.
+        /// </summary>
+        public float Width { get; }
+
+        /// <summary>
+        /// The rendered height.
+        /// </summary>
+        public float Height { get; }
+    }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -217,9 +217,6 @@ namespace Tizen.NUI.BaseComponents
 
                 CutoutProperty = BindableProperty.Create(nameof(Cutout), typeof(bool), typeof(TextLabel), false,
                     propertyChanged: SetInternalCutoutProperty, defaultValueCreator: GetInternalCutoutProperty);
-
-                RenderModeProperty = BindableProperty.Create(nameof(RenderMode), typeof(TextRenderMode), typeof(TextLabel), TextRenderMode.Sync,
-                    propertyChanged: SetInternalRenderModeProperty, defaultValueCreator: GetInternalRenderModeProperty);
             }
         }
 
@@ -2614,25 +2611,11 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                if (NUIApplication.IsUsingXaml)
-                {
-                    return (TextRenderMode)GetValue(RenderModeProperty);
-                }
-                else
-                {
-                    return (TextRenderMode)GetInternalRenderModeProperty(this);
-                }
+                return (TextRenderMode)Object.InternalGetPropertyInt(this.SwigCPtr, TextLabel.Property.RenderMode);
             }
             set
             {
-                if (NUIApplication.IsUsingXaml)
-                {
-                    SetValue(RenderModeProperty, value);
-                }
-                else
-                {
-                    SetInternalRenderModeProperty(this, null, value);
-                }
+                Object.InternalSetPropertyInt(this.SwigCPtr, TextLabel.Property.RenderMode, (int)value);
                 NotifyPropertyChanged();
             }
         }
@@ -2751,17 +2734,20 @@ namespace Tizen.NUI.BaseComponents
 
                 if (textLabelAsyncTextRenderedCallbackDelegate != null)
                 {
-                    AsyncTextRenderedSignal().Disconnect(textLabelAsyncTextRenderedCallbackDelegate);
+                    Interop.TextLabel.AsyncTextRenderedDisconnect(this.SwigCPtr, textLabelAsyncTextRenderedCallbackDelegate.ToHandleRef(this));
+                    textLabelAsyncTextRenderedCallbackDelegate = null;
                 }
 
                 if (textLabelAsyncNaturalSizeComputedCallbackDelegate != null)
                 {
-                    AsyncNaturalSizeComputedSignal().Disconnect(textLabelAsyncNaturalSizeComputedCallbackDelegate);
+                    Interop.TextLabel.AsyncNaturalSizeComputedDisconnect(this.SwigCPtr, textLabelAsyncNaturalSizeComputedCallbackDelegate.ToHandleRef(this));
+                    textLabelAsyncNaturalSizeComputedCallbackDelegate = null;
                 }
 
                 if (textLabelAsyncHeightForWidthComputedCallbackDelegate != null)
                 {
-                    AsyncHeightForWidthComputedSignal().Disconnect(textLabelAsyncHeightForWidthComputedCallbackDelegate);
+                    Interop.TextLabel.AsyncHeightForWidthComputedDisconnect(this.SwigCPtr, textLabelAsyncHeightForWidthComputedCallbackDelegate.ToHandleRef(this));
+                    textLabelAsyncHeightForWidthComputedCallbackDelegate = null;
                 }
             }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -329,7 +329,9 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width of text to render.</param>
         /// <param name="height">The height of text to render.</param>
         /// <remarks>
-        /// Only works when AsyncAuto and AsyncManual.
+        /// Only works when AsyncAuto and AsyncManual.<br />
+        /// If another request occurs before the requested render is completed, the previous request will be canceled.<br />
+        /// In AsyncAuto, the manual request is not canceled by an auto request caused by OnRealyout.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RequestAsyncRenderWithFixedSize(float width, float height)
@@ -346,8 +348,10 @@ namespace Tizen.NUI.BaseComponents
         /// <remarks>
         /// Only works when AsyncAuto and AsyncManual.<br />
         /// The height is determined by the content of the text when rendered with the given width.<br />
-        /// The result will be the same as the height returned by GetHeightForWidth.
-        /// If the heightConstraint is given, the maximum height will be the heightConstraint.
+        /// The result will be the same as the height returned by GetHeightForWidth.<br />
+        /// If the heightConstraint is given, the maximum height will be the heightConstraint.<br />
+        /// If another request occurs before the requested render is completed, the previous request will be canceled.<br />
+        /// In AsyncAuto, the manual request is not canceled by an auto request caused by OnRealyout.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RequestAsyncRenderWithFixedWidth(float width, float heightConstraint = float.PositiveInfinity)
@@ -366,8 +370,10 @@ namespace Tizen.NUI.BaseComponents
         /// If the width of the text content is smaller than the widthConstraint, the width will be determined by the width of the text.<br />
         /// If the width of the text content is larger than the widthConstraint, the width will be determined by the widthConstraint.<br />
         /// The height is determined by the content of the text when rendered with the given width.<br />
-        /// In this case, the result will be the same as the height returned by GetHeightForWidth.
-        /// If the heightConstraint is given, the maximum height will be the heightConstraint.
+        /// In this case, the result will be the same as the height returned by GetHeightForWidth.<br />
+        /// If the heightConstraint is given, the maximum height will be the heightConstraint.<br />
+        /// If another request occurs before the requested render is completed, the previous request will be canceled.<br />
+        /// In AsyncAuto, the manual request is not canceled by an auto request caused by OnRealyout.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RequestAsyncRenderWithConstraint(float widthConstraint, float heightConstraint = float.PositiveInfinity)
@@ -379,6 +385,9 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Requests asynchronous text natural size computation.
         /// </summary>
+        /// <remarks>
+        /// If another request occurs before the requested natural size computation is completed, the previous request will be canceled.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RequestAsyncNaturalSize()
         {
@@ -390,6 +399,9 @@ namespace Tizen.NUI.BaseComponents
         /// Requests asynchronous computation of the height of the text based on the given width.
         /// </summary>
         /// <param name="width">The width of text to compute.</param>
+        /// <remarks>
+        /// If another request occurs before the requested height for width computation is completed, the previous request will be canceled.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RequestAsyncHeightForWidth(float width)
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -386,6 +386,17 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Requests asynchronous computation of the height of the text based on the given width.
+        /// </summary>
+        /// <param name="width">The width of text to compute.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void RequestAsyncHeightForWidth(float width)
+        {
+            Interop.TextLabel.RequestAsyncHeightForWidth(SwigCPtr, width);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// The TranslatableText property.<br />
         /// The text can set the SID value.<br />
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -321,6 +321,21 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Requests asynchronous rendering of text with a fixed size.
+        /// </summary>
+        /// <param name="width">The width of text to render.</param>
+        /// <param name="height">The height of text to render.</param>
+        /// <remarks>
+        /// Only works when AsyncLoad is true.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void RequestAsyncRenderWithFixedSize(float width, float height)
+        {
+            Interop.TextLabel.RequestAsyncRenderWithFixedSize(SwigCPtr, width, height);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// The TranslatableText property.<br />
         /// The text can set the SID value.<br />
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -217,6 +217,9 @@ namespace Tizen.NUI.BaseComponents
 
                 CutoutProperty = BindableProperty.Create(nameof(Cutout), typeof(bool), typeof(TextLabel), false,
                     propertyChanged: SetInternalCutoutProperty, defaultValueCreator: GetInternalCutoutProperty);
+
+                RenderModeProperty = BindableProperty.Create(nameof(RenderMode), typeof(TextRenderMode), typeof(TextLabel), TextRenderMode.Sync,
+                    propertyChanged: SetInternalRenderModeProperty, defaultValueCreator: GetInternalRenderModeProperty);
             }
         }
 
@@ -326,7 +329,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width of text to render.</param>
         /// <param name="height">The height of text to render.</param>
         /// <remarks>
-        /// Only works when AsyncLoad is true.
+        /// Only works when AsyncMode.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RequestAsyncRenderWithFixedSize(float width, float height)
@@ -341,7 +344,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width of text to render.</param>
         /// <param name="heightConstraint">The maximum available height of text to render.</param>
         /// <remarks>
-        /// Only works when AsyncLoad is true.<br />
+        /// Only works when AsyncMode.<br />
         /// The height is determined by the content of the text when rendered with the given width.<br />
         /// The result will be the same as the height returned by GetHeightForWidth.
         /// If the heightConstraint is given, the maximum height will be the heightConstraint.
@@ -2563,6 +2566,44 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// The RenderMode property.
+        /// </summary>
+        /// <remarks>
+        /// Sync : default, synchronous text loading.<br />
+        /// AsyncAuto : automatically requests an asynchronous text load in OnRelayout.<br />
+        /// AsyncManual : users should manually request rendering using the async text method.<br />
+        /// All text rendering processes (update/layout/render) are performed asynchronously in AsyncAuto and AsyncManual.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TextRenderMode RenderMode
+        {
+            get
+            {
+                if (NUIApplication.IsUsingXaml)
+                {
+                    return (TextRenderMode)GetValue(RenderModeProperty);
+                }
+                else
+                {
+                    return (TextRenderMode)GetInternalRenderModeProperty(this);
+                }
+            }
+            set
+            {
+                if (NUIApplication.IsUsingXaml)
+                {
+                    SetValue(RenderModeProperty, value);
+                }
+                else
+                {
+                    SetInternalRenderModeProperty(this, null, value);
+                }
+                NotifyPropertyChanged();
+            }
+        }
+
+
         private TextLabelSelectorData EnsureSelectorData() => selectorData ?? (selectorData = new TextLabelSelectorData());
 
         /// <summary>
@@ -2789,6 +2830,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int RemoveFrontInset = Interop.TextLabel.RemoveFrontInsetGet();
             internal static readonly int RemoveBackInset = Interop.TextLabel.RemoveBackInsetGet();
             internal static readonly int Cutout = Interop.TextLabel.CutoutGet();
+            internal static readonly int RenderMode = Interop.TextLabel.RenderModeGet();
 
 
             internal static void Preload()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -329,7 +329,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width of text to render.</param>
         /// <param name="height">The height of text to render.</param>
         /// <remarks>
-        /// Only works when AsyncMode.
+        /// Only works when AsyncAuto and AsyncManual.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RequestAsyncRenderWithFixedSize(float width, float height)
@@ -344,7 +344,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">The width of text to render.</param>
         /// <param name="heightConstraint">The maximum available height of text to render.</param>
         /// <remarks>
-        /// Only works when AsyncMode.<br />
+        /// Only works when AsyncAuto and AsyncManual.<br />
         /// The height is determined by the content of the text when rendered with the given width.<br />
         /// The result will be the same as the height returned by GetHeightForWidth.
         /// If the heightConstraint is given, the maximum height will be the heightConstraint.
@@ -362,6 +362,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="widthConstraint">The maximum available width of text to render.</param>
         /// <param name="heightConstraint">The maximum available height of text to render.</param>
         /// <remarks>
+        /// Only works when AsyncAuto and AsyncManual.<br />
         /// If the width of the text content is smaller than the widthConstraint, the width will be determined by the width of the text.<br />
         /// If the width of the text content is larger than the widthConstraint, the width will be determined by the widthConstraint.<br />
         /// The height is determined by the content of the text when rendered with the given width.<br />
@@ -2642,6 +2643,33 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// Number of lines after latest asynchronous computing or rendering of text.
+        /// </summary>
+        /// <example>
+        /// The following example demonstrates how to obtain the LineCount asynchronously.
+        /// <code>
+        /// label.RequestAsyncHeightForWidth(label.Size.Width);
+        /// label.AsyncHeightForWidthComputed += (s, e) =>
+        /// {
+        ///    int lineCount = label.AsyncLineCount;
+        /// };
+        /// </code>
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int AsyncLineCount
+        {
+            get
+            {
+                int asyncLineCount = 0;
+                using (var propertyValue = GetProperty(TextLabel.Property.AsyncLineCount))
+                {
+                    propertyValue.Get(out asyncLineCount);
+                }
+                return asyncLineCount;
+            }
+        }
+
         private TextLabelSelectorData EnsureSelectorData() => selectorData ?? (selectorData = new TextLabelSelectorData());
 
         /// <summary>
@@ -2870,6 +2898,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int Cutout = Interop.TextLabel.CutoutGet();
             internal static readonly int RenderMode = Interop.TextLabel.RenderModeGet();
             internal static readonly int ManualRendered = Interop.TextLabel.ManualRenderedGet();
+            internal static readonly int AsyncLineCount = Interop.TextLabel.AsyncLineCountGet();
 
 
             internal static void Preload()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -339,15 +339,17 @@ namespace Tizen.NUI.BaseComponents
         /// Requests asynchronous text rendering with a fixed width.
         /// </summary>
         /// <param name="width">The width of text to render.</param>
+        /// <param name="heightConstraint">The maximum available height of text to render.</param>
         /// <remarks>
         /// Only works when AsyncLoad is true.<br />
         /// The height is determined by the content of the text when rendered with the given width.<br />
         /// The result will be the same as the height returned by GetHeightForWidth.
+        /// If the heightConstraint is given, the maximum height will be the heightConstraint.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void RequestAsyncRenderWithFixedWidth(float width)
+        public void RequestAsyncRenderWithFixedWidth(float width, float heightConstraint = float.PositiveInfinity)
         {
-            Interop.TextLabel.RequestAsyncRenderWithFixedWidth(SwigCPtr, width);
+            Interop.TextLabel.RequestAsyncRenderWithFixedWidth(SwigCPtr, width, heightConstraint);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
@@ -355,16 +357,18 @@ namespace Tizen.NUI.BaseComponents
         /// Requests asynchronous rendering with the maximum available width using the given widthConstraint.
         /// </summary>
         /// <param name="widthConstraint">The maximum available width of text to render.</param>
+        /// <param name="heightConstraint">The maximum available height of text to render.</param>
         /// <remarks>
         /// If the width of the text content is smaller than the widthConstraint, the width will be determined by the width of the text.<br />
         /// If the width of the text content is larger than the widthConstraint, the width will be determined by the widthConstraint.<br />
         /// The height is determined by the content of the text when rendered with the given width.<br />
         /// In this case, the result will be the same as the height returned by GetHeightForWidth.
+        /// If the heightConstraint is given, the maximum height will be the heightConstraint.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void RequestAsyncRenderWithConstraint(float widthConstraint)
+        public void RequestAsyncRenderWithConstraint(float widthConstraint, float heightConstraint = float.PositiveInfinity)
         {
-            Interop.TextLabel.RequestAsyncRenderWithConstraint(SwigCPtr, widthConstraint);
+            Interop.TextLabel.RequestAsyncRenderWithConstraint(SwigCPtr, widthConstraint, heightConstraint);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -2603,6 +2603,23 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        /// <summary>
+        /// Whether the last async rendering result is a manual render. <br />
+        /// If it's false, the render result was automatically requested by OnRelayout.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ManualRendered
+        {
+            get
+            {
+                bool manualRendered = false;
+                using (var propertyValue = GetProperty(TextLabel.Property.ManualRendered))
+                {
+                    propertyValue.Get(out manualRendered);
+                }
+                return manualRendered;
+            }
+        }
 
         private TextLabelSelectorData EnsureSelectorData() => selectorData ?? (selectorData = new TextLabelSelectorData());
 
@@ -2831,6 +2848,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int RemoveBackInset = Interop.TextLabel.RemoveBackInsetGet();
             internal static readonly int Cutout = Interop.TextLabel.CutoutGet();
             internal static readonly int RenderMode = Interop.TextLabel.RenderModeGet();
+            internal static readonly int ManualRendered = Interop.TextLabel.ManualRenderedGet();
 
 
             internal static void Preload()

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -352,6 +352,23 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Requests asynchronous rendering with the maximum available width using the given widthConstraint.
+        /// </summary>
+        /// <param name="widthConstraint">The maximum available width of text to render.</param>
+        /// <remarks>
+        /// If the width of the text content is smaller than the widthConstraint, the width will be determined by the width of the text.<br />
+        /// If the width of the text content is larger than the widthConstraint, the width will be determined by the widthConstraint.<br />
+        /// The height is determined by the content of the text when rendered with the given width.<br />
+        /// In this case, the result will be the same as the height returned by GetHeightForWidth.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void RequestAsyncRenderWithConstraint(float widthConstraint)
+        {
+            Interop.TextLabel.RequestAsyncRenderWithConstraint(SwigCPtr, widthConstraint);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// The TranslatableText property.<br />
         /// The text can set the SID value.<br />
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -376,6 +376,16 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Requests asynchronous text natural size computation.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void RequestAsyncNaturalSize()
+        {
+            Interop.TextLabel.RequestAsyncNaturalSize(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// The TranslatableText property.<br />
         /// The text can set the SID value.<br />
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -2739,9 +2739,29 @@ namespace Tizen.NUI.BaseComponents
 
             if (this.HasBody())
             {
+                if (textLabelAnchorClickedCallbackDelegate != null)
+                {
+                    AnchorClickedSignal().Disconnect(textLabelAnchorClickedCallbackDelegate);
+                }
+
                 if (textLabelTextFitChangedCallbackDelegate != null)
                 {
                     TextFitChangedSignal().Disconnect(textLabelTextFitChangedCallbackDelegate);
+                }
+
+                if (textLabelAsyncTextRenderedCallbackDelegate != null)
+                {
+                    AsyncTextRenderedSignal().Disconnect(textLabelAsyncTextRenderedCallbackDelegate);
+                }
+
+                if (textLabelAsyncNaturalSizeComputedCallbackDelegate != null)
+                {
+                    AsyncNaturalSizeComputedSignal().Disconnect(textLabelAsyncNaturalSizeComputedCallbackDelegate);
+                }
+
+                if (textLabelAsyncHeightForWidthComputedCallbackDelegate != null)
+                {
+                    AsyncHeightForWidthComputedSignal().Disconnect(textLabelAsyncHeightForWidthComputedCallbackDelegate);
                 }
             }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -336,6 +336,22 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Requests asynchronous text rendering with a fixed width.
+        /// </summary>
+        /// <param name="width">The width of text to render.</param>
+        /// <remarks>
+        /// Only works when AsyncLoad is true.<br />
+        /// The height is determined by the content of the text when rendered with the given width.<br />
+        /// The result will be the same as the height returned by GetHeightForWidth.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void RequestAsyncRenderWithFixedWidth(float width)
+        {
+            Interop.TextLabel.RequestAsyncRenderWithFixedWidth(SwigCPtr, width);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// The TranslatableText property.<br />
         /// The text can set the SID value.<br />
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -953,26 +953,6 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.Cutout);
         }
 
-        /// <summary>
-        /// RenderModeProperty
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly BindableProperty RenderModeProperty = null;
-        internal static void SetInternalRenderModeProperty(BindableObject bindable, object oldValue, object newValue)
-        {
-            var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.RenderMode, (int)newValue);
-            }
-        }
-        internal static object GetInternalRenderModeProperty(BindableObject bindable)
-        {
-            var textLabel = (TextLabel)bindable;
-
-            return (TextRenderMode)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.RenderMode);
-        }
-
         internal Selector<string> TranslatableTextSelector
         {
             get => GetSelector<string>(selectorData?.TranslatableText, TextLabel.TranslatableTextProperty);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -953,6 +953,26 @@ namespace Tizen.NUI.BaseComponents
             return Object.InternalGetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.Cutout);
         }
 
+        /// <summary>
+        /// RenderModeProperty
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly BindableProperty RenderModeProperty = null;
+        internal static void SetInternalRenderModeProperty(BindableObject bindable, object oldValue, object newValue)
+        {
+            var textLabel = (TextLabel)bindable;
+            if (newValue != null)
+            {
+                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.RenderMode, (int)newValue);
+            }
+        }
+        internal static object GetInternalRenderModeProperty(BindableObject bindable)
+        {
+            var textLabel = (TextLabel)bindable;
+
+            return (TextRenderMode)Object.InternalGetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.RenderMode);
+        }
+
         internal Selector<string> TranslatableTextSelector
         {
             get => GetSelector<string>(selectorData?.TranslatableText, TextLabel.TranslatableTextProperty);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
@@ -70,34 +70,32 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (textLabelAsyncHeightForWidthComputedEventHandler == null)
                 {
-                    textLabelAsyncHeightForWidthComputedCallbackDelegate = (OnAsyncHeightForWidthComputed);
-                    AsyncHeightForWidthComputedSignal().Connect(textLabelAsyncHeightForWidthComputedCallbackDelegate);
+                    textLabelAsyncHeightForWidthComputedCallbackDelegate = OnAsyncHeightForWidthComputed;
+                    Interop.TextLabel.AsyncHeightForWidthComputedConnect(SwigCPtr, textLabelAsyncHeightForWidthComputedCallbackDelegate.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
                 }
                 textLabelAsyncHeightForWidthComputedEventHandler += value;
             }
             remove
             {
                 textLabelAsyncHeightForWidthComputedEventHandler -= value;
-                if (textLabelAsyncHeightForWidthComputedEventHandler == null && AsyncHeightForWidthComputedSignal().Empty() == false)
+                if (textLabelAsyncHeightForWidthComputedEventHandler == null && textLabelAsyncHeightForWidthComputedCallbackDelegate != null)
                 {
-                    AsyncHeightForWidthComputedSignal().Disconnect(textLabelAsyncHeightForWidthComputedCallbackDelegate);
+                    Interop.TextLabel.AsyncHeightForWidthComputedDisconnect(SwigCPtr, textLabelAsyncHeightForWidthComputedCallbackDelegate.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    textLabelAsyncHeightForWidthComputedCallbackDelegate = null;
                 }
             }
-        }
-
-        internal TextLabelSignal AsyncHeightForWidthComputedSignal()
-        {
-            TextLabelSignal ret = new TextLabelSignal(Interop.TextLabel.AsyncHeightForWidthComputedSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         private void OnAsyncHeightForWidthComputed(IntPtr textLabel, float width, float height)
         {
             AsyncTextSizeComputedEventArgs e = new AsyncTextSizeComputedEventArgs(width, height);
 
-            //here we send all data to user event handlers
-            textLabelAsyncHeightForWidthComputedEventHandler?.Invoke(this, e);
+            if (textLabelAsyncHeightForWidthComputedEventHandler != null)
+            {
+                textLabelAsyncHeightForWidthComputedEventHandler(this, e);
+            }
         }
 
         /// <summary>
@@ -110,34 +108,32 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (textLabelAsyncNaturalSizeComputedEventHandler == null)
                 {
-                    textLabelAsyncNaturalSizeComputedCallbackDelegate = (OnAsyncNaturalSizeComputed);
-                    AsyncNaturalSizeComputedSignal().Connect(textLabelAsyncNaturalSizeComputedCallbackDelegate);
+                    textLabelAsyncNaturalSizeComputedCallbackDelegate = OnAsyncNaturalSizeComputed;
+                    Interop.TextLabel.AsyncNaturalSizeComputedConnect(SwigCPtr, textLabelAsyncNaturalSizeComputedCallbackDelegate.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
                 }
                 textLabelAsyncNaturalSizeComputedEventHandler += value;
             }
             remove
             {
                 textLabelAsyncNaturalSizeComputedEventHandler -= value;
-                if (textLabelAsyncNaturalSizeComputedEventHandler == null && AsyncNaturalSizeComputedSignal().Empty() == false)
+                if (textLabelAsyncNaturalSizeComputedEventHandler == null && textLabelAsyncNaturalSizeComputedCallbackDelegate != null)
                 {
-                    AsyncNaturalSizeComputedSignal().Disconnect(textLabelAsyncNaturalSizeComputedCallbackDelegate);
+                    Interop.TextLabel.AsyncNaturalSizeComputedDisconnect(SwigCPtr, textLabelAsyncNaturalSizeComputedCallbackDelegate.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    textLabelAsyncNaturalSizeComputedCallbackDelegate = null;
                 }
             }
-        }
-
-        internal TextLabelSignal AsyncNaturalSizeComputedSignal()
-        {
-            TextLabelSignal ret = new TextLabelSignal(Interop.TextLabel.AsyncNaturalSizeComputedSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         private void OnAsyncNaturalSizeComputed(IntPtr textLabel, float width, float height)
         {
             AsyncTextSizeComputedEventArgs e = new AsyncTextSizeComputedEventArgs(width, height);
 
-            //here we send all data to user event handlers
-            textLabelAsyncNaturalSizeComputedEventHandler?.Invoke(this, e);
+            if (textLabelAsyncNaturalSizeComputedEventHandler != null)
+            {
+                textLabelAsyncNaturalSizeComputedEventHandler(this, e);
+            }
         }
 
         /// <summary>
@@ -150,34 +146,32 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (textLabelAsyncTextRenderedEventHandler == null)
                 {
-                    textLabelAsyncTextRenderedCallbackDelegate = (OnAsyncTextRendered);
-                    AsyncTextRenderedSignal().Connect(textLabelAsyncTextRenderedCallbackDelegate);
+                    textLabelAsyncTextRenderedCallbackDelegate = OnAsyncTextRendered;
+                    Interop.TextLabel.AsyncTextRenderedConnect(SwigCPtr, textLabelAsyncTextRenderedCallbackDelegate.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
                 }
                 textLabelAsyncTextRenderedEventHandler += value;
             }
             remove
             {
                 textLabelAsyncTextRenderedEventHandler -= value;
-                if (textLabelAsyncTextRenderedEventHandler == null && AsyncTextRenderedSignal().Empty() == false)
+                if (textLabelAsyncTextRenderedEventHandler == null && textLabelAsyncTextRenderedCallbackDelegate != null)
                 {
-                    AsyncTextRenderedSignal().Disconnect(textLabelAsyncTextRenderedCallbackDelegate);
+                    Interop.TextLabel.AsyncTextRenderedDisconnect(SwigCPtr, textLabelAsyncTextRenderedCallbackDelegate.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    textLabelAsyncTextRenderedCallbackDelegate = null;
                 }
             }
-        }
-
-        internal TextLabelSignal AsyncTextRenderedSignal()
-        {
-            TextLabelSignal ret = new TextLabelSignal(Interop.TextLabel.AsyncTextRenderedSignal(SwigCPtr), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
         }
 
         private void OnAsyncTextRendered(IntPtr textLabel, float width, float height)
         {
             AsyncTextRenderedEventArgs e = new AsyncTextRenderedEventArgs(width, height);
 
-            //here we send all data to user event handlers
-            textLabelAsyncTextRenderedEventHandler?.Invoke(this, e);
+            if (textLabelAsyncTextRenderedEventHandler != null)
+            {
+                textLabelAsyncTextRenderedEventHandler(this, e);
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
@@ -38,11 +38,11 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<AsyncTextRenderedEventArgs> textLabelAsyncTextRenderedEventHandler;
         private AsyncTextRenderedCallbackDelegate textLabelAsyncTextRenderedCallbackDelegate;
 
-        private EventHandler<AsyncTextSizeComputedEventArgs> textLabelAsyncTextNaturalSizeComputedEventHandler;
-        private AsyncTextNaturalSizeComputedCallbackDelegate textLabelAsyncTextNaturalSizeComputedCallbackDelegate;
+        private EventHandler<AsyncTextSizeComputedEventArgs> textLabelAsyncNaturalSizeComputedEventHandler;
+        private AsyncNaturalSizeComputedCallbackDelegate textLabelAsyncNaturalSizeComputedCallbackDelegate;
 
-        private EventHandler<AsyncTextSizeComputedEventArgs> textLabelAsyncTextHeightForWidthComputedEventHandler;
-        private AsyncTextHeightForWidthComputedCallbackDelegate textLabelAsyncTextHeightForWidthComputedCallbackDelegate;
+        private EventHandler<AsyncTextSizeComputedEventArgs> textLabelAsyncHeightForWidthComputedEventHandler;
+        private AsyncHeightForWidthComputedCallbackDelegate textLabelAsyncHeightForWidthComputedCallbackDelegate;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnchorClickedCallbackDelegate(IntPtr textLabel, IntPtr href, uint hrefLength);
@@ -54,10 +54,10 @@ namespace Tizen.NUI.BaseComponents
         private delegate void AsyncTextRenderedCallbackDelegate(IntPtr textLabel, float width, float height);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void AsyncTextNaturalSizeComputedCallbackDelegate(IntPtr textLabel, float width, float height);
+        private delegate void AsyncNaturalSizeComputedCallbackDelegate(IntPtr textLabel, float width, float height);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void AsyncTextHeightForWidthComputedCallbackDelegate(IntPtr textLabel, float width, float height);
+        private delegate void AsyncHeightForWidthComputedCallbackDelegate(IntPtr textLabel, float width, float height);
 
 
         /// <summary>
@@ -68,19 +68,19 @@ namespace Tizen.NUI.BaseComponents
         {
             add
             {
-                if (textLabelAsyncTextHeightForWidthComputedEventHandler == null)
+                if (textLabelAsyncHeightForWidthComputedEventHandler == null)
                 {
-                    textLabelAsyncTextHeightForWidthComputedCallbackDelegate = (OnAsyncHeightForWidthComputed);
-                    AsyncHeightForWidthComputedSignal().Connect(textLabelAsyncTextHeightForWidthComputedCallbackDelegate);
+                    textLabelAsyncHeightForWidthComputedCallbackDelegate = (OnAsyncHeightForWidthComputed);
+                    AsyncHeightForWidthComputedSignal().Connect(textLabelAsyncHeightForWidthComputedCallbackDelegate);
                 }
-                textLabelAsyncTextHeightForWidthComputedEventHandler += value;
+                textLabelAsyncHeightForWidthComputedEventHandler += value;
             }
             remove
             {
-                textLabelAsyncTextHeightForWidthComputedEventHandler -= value;
-                if (textLabelAsyncTextHeightForWidthComputedEventHandler == null && AsyncHeightForWidthComputedSignal().Empty() == false)
+                textLabelAsyncHeightForWidthComputedEventHandler -= value;
+                if (textLabelAsyncHeightForWidthComputedEventHandler == null && AsyncHeightForWidthComputedSignal().Empty() == false)
                 {
-                    AsyncHeightForWidthComputedSignal().Disconnect(textLabelAsyncTextHeightForWidthComputedCallbackDelegate);
+                    AsyncHeightForWidthComputedSignal().Disconnect(textLabelAsyncHeightForWidthComputedCallbackDelegate);
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace Tizen.NUI.BaseComponents
             AsyncTextSizeComputedEventArgs e = new AsyncTextSizeComputedEventArgs(width, height);
 
             //here we send all data to user event handlers
-            textLabelAsyncTextHeightForWidthComputedEventHandler?.Invoke(this, e);
+            textLabelAsyncHeightForWidthComputedEventHandler?.Invoke(this, e);
         }
 
         /// <summary>
@@ -108,19 +108,19 @@ namespace Tizen.NUI.BaseComponents
         {
             add
             {
-                if (textLabelAsyncTextNaturalSizeComputedEventHandler == null)
+                if (textLabelAsyncNaturalSizeComputedEventHandler == null)
                 {
-                    textLabelAsyncTextNaturalSizeComputedCallbackDelegate = (OnAsyncNaturalSizeComputed);
-                    AsyncNaturalSizeComputedSignal().Connect(textLabelAsyncTextNaturalSizeComputedCallbackDelegate);
+                    textLabelAsyncNaturalSizeComputedCallbackDelegate = (OnAsyncNaturalSizeComputed);
+                    AsyncNaturalSizeComputedSignal().Connect(textLabelAsyncNaturalSizeComputedCallbackDelegate);
                 }
-                textLabelAsyncTextNaturalSizeComputedEventHandler += value;
+                textLabelAsyncNaturalSizeComputedEventHandler += value;
             }
             remove
             {
-                textLabelAsyncTextNaturalSizeComputedEventHandler -= value;
-                if (textLabelAsyncTextNaturalSizeComputedEventHandler == null && AsyncNaturalSizeComputedSignal().Empty() == false)
+                textLabelAsyncNaturalSizeComputedEventHandler -= value;
+                if (textLabelAsyncNaturalSizeComputedEventHandler == null && AsyncNaturalSizeComputedSignal().Empty() == false)
                 {
-                    AsyncNaturalSizeComputedSignal().Disconnect(textLabelAsyncTextNaturalSizeComputedCallbackDelegate);
+                    AsyncNaturalSizeComputedSignal().Disconnect(textLabelAsyncNaturalSizeComputedCallbackDelegate);
                 }
             }
         }
@@ -137,7 +137,7 @@ namespace Tizen.NUI.BaseComponents
             AsyncTextSizeComputedEventArgs e = new AsyncTextSizeComputedEventArgs(width, height);
 
             //here we send all data to user event handlers
-            textLabelAsyncTextNaturalSizeComputedEventHandler?.Invoke(this, e);
+            textLabelAsyncNaturalSizeComputedEventHandler?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
@@ -35,11 +35,57 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler textLabelTextFitChangedEventHandler;
         private TextFitChangedCallbackDelegate textLabelTextFitChangedCallbackDelegate;
 
+        private EventHandler<AsyncTextRenderedEventArgs> textLabelAsyncTextRenderedEventHandler;
+        private AsyncTextRenderedCallbackDelegate textLabelAsyncTextRenderedCallbackDelegate;
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnchorClickedCallbackDelegate(IntPtr textLabel, IntPtr href, uint hrefLength);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void TextFitChangedCallbackDelegate(IntPtr textLabel);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void AsyncTextRenderedCallbackDelegate(IntPtr textLabel, float width, float height);
+
+        /// <summary>
+        /// The AsyncTextRendered signal is emitted when the async text rendered.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<AsyncTextRenderedEventArgs> AsyncTextRendered
+        {
+            add
+            {
+                if (textLabelAsyncTextRenderedEventHandler == null)
+                {
+                    textLabelAsyncTextRenderedCallbackDelegate = (OnAsyncTextRendered);
+                    AsyncTextRenderedSignal().Connect(textLabelAsyncTextRenderedCallbackDelegate);
+                }
+                textLabelAsyncTextRenderedEventHandler += value;
+            }
+            remove
+            {
+                textLabelAsyncTextRenderedEventHandler -= value;
+                if (textLabelAsyncTextRenderedEventHandler == null && AsyncTextRenderedSignal().Empty() == false)
+                {
+                    AsyncTextRenderedSignal().Disconnect(textLabelAsyncTextRenderedCallbackDelegate);
+                }
+            }
+        }
+
+        internal TextLabelSignal AsyncTextRenderedSignal()
+        {
+            TextLabelSignal ret = new TextLabelSignal(Interop.TextLabel.AsyncTextRenderedSignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        private void OnAsyncTextRendered(IntPtr textLabel, float width, float height)
+        {
+            AsyncTextRenderedEventArgs e = new AsyncTextRenderedEventArgs(width, height);
+
+            //here we send all data to user event handlers
+            textLabelAsyncTextRenderedEventHandler?.Invoke(this, e);
+        }
 
         /// <summary>
         /// The AnchorClicked signal is emitted when the anchor is clicked.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
@@ -38,6 +38,9 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<AsyncTextRenderedEventArgs> textLabelAsyncTextRenderedEventHandler;
         private AsyncTextRenderedCallbackDelegate textLabelAsyncTextRenderedCallbackDelegate;
 
+        private EventHandler<AsyncTextSizeComputedEventArgs> textLabelAsyncTextNaturalSizeComputedEventHandler;
+        private AsyncTextNaturalSizeComputedCallbackDelegate textLabelAsyncTextNaturalSizeComputedCallbackDelegate;
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnchorClickedCallbackDelegate(IntPtr textLabel, IntPtr href, uint hrefLength);
 
@@ -46,6 +49,50 @@ namespace Tizen.NUI.BaseComponents
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AsyncTextRenderedCallbackDelegate(IntPtr textLabel, float width, float height);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void AsyncTextNaturalSizeComputedCallbackDelegate(IntPtr textLabel, float width, float height);
+
+
+        /// <summary>
+        /// The AsyncNaturalSizeComputed signal is emitted when the async natural size computed.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<AsyncTextSizeComputedEventArgs> AsyncNaturalSizeComputed
+        {
+            add
+            {
+                if (textLabelAsyncTextNaturalSizeComputedEventHandler == null)
+                {
+                    textLabelAsyncTextNaturalSizeComputedCallbackDelegate = (OnAsyncNaturalSizeComputed);
+                    AsyncNaturalSizeComputedSignal().Connect(textLabelAsyncTextNaturalSizeComputedCallbackDelegate);
+                }
+                textLabelAsyncTextNaturalSizeComputedEventHandler += value;
+            }
+            remove
+            {
+                textLabelAsyncTextNaturalSizeComputedEventHandler -= value;
+                if (textLabelAsyncTextNaturalSizeComputedEventHandler == null && AsyncNaturalSizeComputedSignal().Empty() == false)
+                {
+                    AsyncNaturalSizeComputedSignal().Disconnect(textLabelAsyncTextNaturalSizeComputedCallbackDelegate);
+                }
+            }
+        }
+
+        internal TextLabelSignal AsyncNaturalSizeComputedSignal()
+        {
+            TextLabelSignal ret = new TextLabelSignal(Interop.TextLabel.AsyncNaturalSizeComputedSignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        private void OnAsyncNaturalSizeComputed(IntPtr textLabel, float width, float height)
+        {
+            AsyncTextSizeComputedEventArgs e = new AsyncTextSizeComputedEventArgs(width, height);
+
+            //here we send all data to user event handlers
+            textLabelAsyncTextNaturalSizeComputedEventHandler?.Invoke(this, e);
+        }
 
         /// <summary>
         /// The AsyncTextRendered signal is emitted when the async text rendered.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelEvent.cs
@@ -41,6 +41,9 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<AsyncTextSizeComputedEventArgs> textLabelAsyncTextNaturalSizeComputedEventHandler;
         private AsyncTextNaturalSizeComputedCallbackDelegate textLabelAsyncTextNaturalSizeComputedCallbackDelegate;
 
+        private EventHandler<AsyncTextSizeComputedEventArgs> textLabelAsyncTextHeightForWidthComputedEventHandler;
+        private AsyncTextHeightForWidthComputedCallbackDelegate textLabelAsyncTextHeightForWidthComputedCallbackDelegate;
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AnchorClickedCallbackDelegate(IntPtr textLabel, IntPtr href, uint hrefLength);
 
@@ -53,6 +56,49 @@ namespace Tizen.NUI.BaseComponents
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void AsyncTextNaturalSizeComputedCallbackDelegate(IntPtr textLabel, float width, float height);
 
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void AsyncTextHeightForWidthComputedCallbackDelegate(IntPtr textLabel, float width, float height);
+
+
+        /// <summary>
+        /// The AsyncHeightForWidthComputed signal is emitted when the async natural size computed.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler<AsyncTextSizeComputedEventArgs> AsyncHeightForWidthComputed
+        {
+            add
+            {
+                if (textLabelAsyncTextHeightForWidthComputedEventHandler == null)
+                {
+                    textLabelAsyncTextHeightForWidthComputedCallbackDelegate = (OnAsyncHeightForWidthComputed);
+                    AsyncHeightForWidthComputedSignal().Connect(textLabelAsyncTextHeightForWidthComputedCallbackDelegate);
+                }
+                textLabelAsyncTextHeightForWidthComputedEventHandler += value;
+            }
+            remove
+            {
+                textLabelAsyncTextHeightForWidthComputedEventHandler -= value;
+                if (textLabelAsyncTextHeightForWidthComputedEventHandler == null && AsyncHeightForWidthComputedSignal().Empty() == false)
+                {
+                    AsyncHeightForWidthComputedSignal().Disconnect(textLabelAsyncTextHeightForWidthComputedCallbackDelegate);
+                }
+            }
+        }
+
+        internal TextLabelSignal AsyncHeightForWidthComputedSignal()
+        {
+            TextLabelSignal ret = new TextLabelSignal(Interop.TextLabel.AsyncHeightForWidthComputedSignal(SwigCPtr), false);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        private void OnAsyncHeightForWidthComputed(IntPtr textLabel, float width, float height)
+        {
+            AsyncTextSizeComputedEventArgs e = new AsyncTextSizeComputedEventArgs(width, height);
+
+            //here we send all data to user event handlers
+            textLabelAsyncTextHeightForWidthComputedEventHandler?.Invoke(this, e);
+        }
 
         /// <summary>
         /// The AsyncNaturalSizeComputed signal is emitted when the async natural size computed.

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -2208,6 +2208,28 @@ namespace Tizen.NUI
     }
 
     /// <summary>
+    /// Enumeration for the render mode of text.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum TextRenderMode
+    {
+        /// <summary>
+        /// default, synchronous text loading.
+        /// </summary>
+        Sync,
+
+        /// <summary>
+        /// automatically requests an asynchronous text load in OnRelayout.
+        /// </summary>
+        AsyncAuto,
+
+        /// <summary>
+        /// users should manually request rendering using the async text method.
+        /// </summary>
+        AsyncManual
+    }
+
+    /// <summary>
     /// Pre-defined SlideTransition Direction
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
# Async text feature

## Related patches
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/315160/
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/315140/
* https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/315818/

## Added RenderMode property
* Sync : default, synchronous text loading.
* AsyncAuto : automatically requests an asynchronous text load in OnRelayout.
* AsyncManual : users should manually request rendering using the async text method.

* All text rendering processes (update/layout/render) are performed asynchronously in AsyncAuto and AsyncManual.

## Added manual async render method
* RequestAsyncRenderWithFixedSize : Requests asynchronous rendering of text with a fixed size.

* RequestAsyncRenderWithFixedWidth : Requests asynchronous text rendering with a fixed width.
The height is determined by the content of the text when rendered with the given width.
If the heightConstraint is given, the maximum height will be the heightConstraint.

* RequestAsyncRenderWithConstraint : Requests asynchronous rendering with the maximum available width using the given widthConstraint.
If the heightConstraint is given, the maximum height will be the heightConstraint.

## Added async size compuation method
* RequestAsyncNaturalSize : Requests asynchronous text natural size computation.

* RequestAsyncHeightForWidth : Requests asynchronous computation of the height of the text based on the given width.

## Added event
* AsyncTextRendered,
* AsyncNaturalSizeComputed,
* AsyncHeightForWidthComputed

## Test & Video
I cannot upload demo video to public github.
* https://github.sec.samsung.net/bowon-ryu/NUI_Text

* https://github.com/wonrst/NUI-Text/tree/main/async_text_1_tpk
* https://github.com/wonrst/NUI-Text/tree/main/async_text_2_tpk

# More information
https://confluence.sec.samsung.net/pages/viewpage.action?spaceKey=GFX&title=Async+Text+Load