### PR TITLE
[NUI] Use generic delegate to avoid boxing unboxing 

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -334,11 +334,11 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (NUIApplication.IsUsingXaml)
                 {
-                    return (string)GetValue(TranslatableTextProperty);
+                    return GetValue<string>(TranslatableTextProperty);
                 }
                 else
                 {
-                    return (string)GetInternalTranslatableTextProperty(this);
+                    return GetInternalTranslatableTextProperty(this);
                 }
             }
             set

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -86,136 +86,136 @@ namespace Tizen.NUI.BaseComponents
         { 
             if (NUIApplication.IsUsingXaml)
             {
-                TranslatableTextProperty = BindableProperty.Create(nameof(TranslatableText), typeof(string), typeof(TextLabel), string.Empty, 
+                TranslatableTextProperty = BindableProperty.Create<TextLabel, string>(nameof(TranslatableText), string.Empty,
                     propertyChanged: SetInternalTranslatableTextProperty, defaultValueCreator: GetInternalTranslatableTextProperty);
 
-                TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(TextLabel), string.Empty, 
+                TextProperty = BindableProperty.Create<TextLabel, string>(nameof(Text), string.Empty,
                     propertyChanged: SetInternalTextProperty, defaultValueCreator: GetInternalTextProperty);
 
-                FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(TextLabel), string.Empty, 
+                FontFamilyProperty = BindableProperty.Create<TextLabel, string>(nameof(FontFamily), string.Empty,
                     propertyChanged: SetInternalFontFamilyProperty, defaultValueCreator: GetInternalFontFamilyProperty);
 
-                FontStyleProperty = BindableProperty.Create(nameof(FontStyle), typeof(PropertyMap), typeof(TextLabel), null, 
+                FontStyleProperty = BindableProperty.Create<TextLabel, PropertyMap>(nameof(FontStyle), null,
                     propertyChanged: SetInternalFontStyleProperty, defaultValueCreator: GetInternalFontStyleProperty);
 
-                PointSizeProperty = BindableProperty.Create(nameof(PointSize), typeof(float), typeof(TextLabel), default(float), 
+                PointSizeProperty = BindableProperty.Create<TextLabel, float>(nameof(PointSize), default(float),
                     propertyChanged: SetInternalPointSizeProperty, defaultValueCreator: GetInternalPointSizeProperty);
 
-                MultiLineProperty = BindableProperty.Create(nameof(MultiLine), typeof(bool), typeof(TextLabel), false, 
+                MultiLineProperty = BindableProperty.Create<TextLabel, bool>(nameof(MultiLine), false,
                     propertyChanged: SetInternalMultiLineProperty, defaultValueCreator: GetInternalMultiLineProperty);
 
-                HorizontalAlignmentProperty = BindableProperty.Create(nameof(HorizontalAlignment), typeof(HorizontalAlignment), typeof(TextLabel), HorizontalAlignment.Begin, 
+                HorizontalAlignmentProperty = BindableProperty.Create<TextLabel, HorizontalAlignment>(nameof(HorizontalAlignment), HorizontalAlignment.Begin,
                     propertyChanged: SetInternalHorizontalAlignmentProperty, defaultValueCreator: GetInternalHorizontalAlignmentProperty);
 
-                VerticalAlignmentProperty = BindableProperty.Create(nameof(VerticalAlignment), typeof(VerticalAlignment), typeof(TextLabel), VerticalAlignment.Bottom, 
+                VerticalAlignmentProperty = BindableProperty.Create<TextLabel, VerticalAlignment>(nameof(VerticalAlignment), VerticalAlignment.Bottom,
                     propertyChanged: SetInternalVerticalAlignmentProperty, defaultValueCreator: GetInternalVerticalAlignmentProperty);
 
-                TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(TextLabel), null, 
+                TextColorProperty = BindableProperty.Create<TextLabel, Color>(nameof(TextColor), null,
                     propertyChanged: SetInternalTextColorProperty, defaultValueCreator: GetInternalTextColorProperty);
 
-                AnchorColorProperty = BindableProperty.Create(nameof(TextLabel.AnchorColor), typeof(Color), typeof(TextLabel), null, 
+                AnchorColorProperty = BindableProperty.Create<TextLabel, Color>(nameof(TextLabel.AnchorColor), null,
                     propertyChanged: SetInternalAnchorColorProperty, defaultValueCreator: GetInternalAnchorColorProperty);
 
-                AnchorClickedColorProperty = BindableProperty.Create(nameof(TextLabel.AnchorClickedColor), typeof(Color), typeof(TextLabel), null, 
+                AnchorClickedColorProperty = BindableProperty.Create<TextLabel, Color>(nameof(TextLabel.AnchorClickedColor), null,
                     propertyChanged: SetInternalAnchorClickedColorProperty, defaultValueCreator: GetInternalAnchorClickedColorProperty);
 
-                RemoveFrontInsetProperty = BindableProperty.Create(nameof(RemoveFrontInset), typeof(bool), typeof(TextLabel), false, 
+                RemoveFrontInsetProperty = BindableProperty.Create<TextLabel, bool>(nameof(RemoveFrontInset), false,
                     propertyChanged: SetInternalRemoveFrontInsetProperty, defaultValueCreator: GetInternalRemoveFrontInsetProperty);
 
-                RemoveBackInsetProperty = BindableProperty.Create(nameof(RemoveBackInset), typeof(bool), typeof(TextLabel), false, 
+                RemoveBackInsetProperty = BindableProperty.Create<TextLabel, bool>(nameof(RemoveBackInset), false,
                     propertyChanged: SetInternalRemoveBackInsetProperty, defaultValueCreator: GetInternalRemoveBackInsetProperty);
 
-                EnableMarkupProperty = BindableProperty.Create(nameof(EnableMarkup), typeof(bool), typeof(TextLabel), false, 
+                EnableMarkupProperty = BindableProperty.Create<TextLabel, bool>(nameof(EnableMarkup), false,
                     propertyChanged: SetInternalEnableMarkupProperty, defaultValueCreator: GetInternalEnableMarkupProperty);
 
-                EnableAutoScrollProperty = BindableProperty.Create(nameof(EnableAutoScroll), typeof(bool), typeof(TextLabel), false, 
+                EnableAutoScrollProperty = BindableProperty.Create<TextLabel, bool>(nameof(EnableAutoScroll), false,
                     propertyChanged: SetInternalEnableAutoScrollProperty, defaultValueCreator: GetInternalEnableAutoScrollProperty);
 
-                AutoScrollSpeedProperty = BindableProperty.Create(nameof(AutoScrollSpeed), typeof(int), typeof(TextLabel), default(int), 
+                AutoScrollSpeedProperty = BindableProperty.Create<TextLabel, int>(nameof(AutoScrollSpeed), default(int),
                     propertyChanged: SetInternalAutoScrollSpeedProperty, defaultValueCreator: GetInternalAutoScrollSpeedProperty);
 
-                AutoScrollLoopCountProperty = BindableProperty.Create(nameof(AutoScrollLoopCount), typeof(int), typeof(TextLabel), default(int), 
+                AutoScrollLoopCountProperty = BindableProperty.Create<TextLabel, int>(nameof(AutoScrollLoopCount), default(int),
                     propertyChanged: SetInternalAutoScrollLoopCountProperty, defaultValueCreator: GetInternalAutoScrollLoopCountProperty);
 
-                AutoScrollGapProperty = BindableProperty.Create(nameof(AutoScrollGap), typeof(float), typeof(TextLabel), default(float), 
+                AutoScrollGapProperty = BindableProperty.Create<TextLabel, float>(nameof(AutoScrollGap), default(float),
                     propertyChanged: SetInternalAutoScrollGapProperty, defaultValueCreator: GetInternalAutoScrollGapProperty);
 
-                LineSpacingProperty = BindableProperty.Create(nameof(LineSpacing), typeof(float), typeof(TextLabel), default(float), 
+                LineSpacingProperty = BindableProperty.Create<TextLabel, float>(nameof(LineSpacing), default(float),
                     propertyChanged: SetInternalLineSpacingProperty, defaultValueCreator: GetInternalLineSpacingProperty);
 
-                RelativeLineHeightProperty = BindableProperty.Create(nameof(RelativeLineHeight), typeof(float), typeof(TextLabel), default(float), 
+                RelativeLineHeightProperty = BindableProperty.Create<TextLabel, float>(nameof(RelativeLineHeight), default(float),
                     propertyChanged: SetInternalRelativeLineHeightProperty, defaultValueCreator: GetInternalRelativeLineHeightProperty);
 
-                UnderlineProperty = BindableProperty.Create(nameof(Underline), typeof(PropertyMap), typeof(TextLabel), null, 
+                UnderlineProperty = BindableProperty.Create<TextLabel, PropertyMap>(nameof(Underline), null,
                     propertyChanged: SetInternalUnderlineProperty, defaultValueCreator: GetInternalUnderlineProperty);
 
-                ShadowProperty = BindableProperty.Create(nameof(Shadow), typeof(PropertyMap), typeof(TextLabel), null, 
+                ShadowProperty = BindableProperty.Create<TextLabel, PropertyMap>(nameof(Shadow), null,
                     propertyChanged: SetInternalShadowProperty, defaultValueCreator: GetInternalShadowProperty);
 
-                TextShadowProperty = BindableProperty.Create(nameof(TextShadow), typeof(TextShadow), typeof(TextLabel), null, 
+                TextShadowProperty = BindableProperty.Create<TextLabel, TextShadow>(nameof(TextShadow), null,
                     propertyChanged: SetInternalTextShadowProperty, defaultValueCreator: GetInternalTextShadowProperty);
 
-                EmbossProperty = BindableProperty.Create(nameof(Emboss), typeof(string), typeof(TextLabel), string.Empty, 
+                EmbossProperty = BindableProperty.Create<TextLabel, string>(nameof(Emboss), string.Empty,
                     propertyChanged: SetInternalEmbossProperty, defaultValueCreator: GetInternalEmbossProperty);
 
-                OutlineProperty = BindableProperty.Create(nameof(Outline), typeof(PropertyMap), typeof(TextLabel), null, 
+                OutlineProperty = BindableProperty.Create<TextLabel, PropertyMap>(nameof(Outline), null,
                     propertyChanged: SetInternalOutlineProperty, defaultValueCreator: GetInternalOutlineProperty);
 
-                PixelSizeProperty = BindableProperty.Create(nameof(PixelSize), typeof(float), typeof(TextLabel), default(float), 
+                PixelSizeProperty = BindableProperty.Create<TextLabel, float>(nameof(PixelSize), default(float),
                     propertyChanged: SetInternalPixelSizeProperty, defaultValueCreator: GetInternalPixelSizeProperty);
 
-                EllipsisProperty = BindableProperty.Create(nameof(Ellipsis), typeof(bool), typeof(TextLabel), false, 
+                EllipsisProperty = BindableProperty.Create<TextLabel, bool>(nameof(Ellipsis), false,
                     propertyChanged: SetInternalEllipsisProperty, defaultValueCreator: GetInternalEllipsisProperty);
 
-                EllipsisPositionProperty = BindableProperty.Create(nameof(EllipsisPosition), typeof(EllipsisPosition), typeof(TextLabel), EllipsisPosition.End, 
+                EllipsisPositionProperty = BindableProperty.Create<TextLabel, EllipsisPosition>(nameof(EllipsisPosition), EllipsisPosition.End,
                     propertyChanged: SetInternalEllipsisPositionProperty, defaultValueCreator: GetInternalEllipsisPositionProperty);
 
-                AutoScrollLoopDelayProperty = BindableProperty.Create(nameof(AutoScrollLoopDelay), typeof(float), typeof(TextLabel), default(float), 
+                AutoScrollLoopDelayProperty = BindableProperty.Create<TextLabel, float>(nameof(AutoScrollLoopDelay), default(float),
                     propertyChanged: SetInternalAutoScrollLoopDelayProperty, defaultValueCreator: GetInternalAutoScrollLoopDelayProperty);
 
-                AutoScrollStopModeProperty = BindableProperty.Create(nameof(AutoScrollStopMode), typeof(AutoScrollStopMode), typeof(TextLabel), AutoScrollStopMode.FinishLoop, 
+                AutoScrollStopModeProperty = BindableProperty.Create<TextLabel, AutoScrollStopMode>(nameof(AutoScrollStopMode), AutoScrollStopMode.FinishLoop,
                     propertyChanged: SetInternalAutoScrollStopModeProperty, defaultValueCreator: GetInternalAutoScrollStopModeProperty);
 
-                LineWrapModeProperty = BindableProperty.Create(nameof(LineWrapMode), typeof(LineWrapMode), typeof(TextLabel), LineWrapMode.Word, 
+                LineWrapModeProperty = BindableProperty.Create<TextLabel, LineWrapMode>(nameof(LineWrapMode), LineWrapMode.Word,
                     propertyChanged: SetInternalLineWrapModeProperty, defaultValueCreator: GetInternalLineWrapModeProperty);
 
-                VerticalLineAlignmentProperty = BindableProperty.Create(nameof(VerticalLineAlignment), typeof(VerticalLineAlignment), typeof(TextLabel), VerticalLineAlignment.Bottom, 
+                VerticalLineAlignmentProperty = BindableProperty.Create<TextLabel, VerticalLineAlignment>(nameof(VerticalLineAlignment), VerticalLineAlignment.Bottom,
                     propertyChanged: SetInternalVerticalLineAlignmentProperty, defaultValueCreator: GetInternalVerticalLineAlignmentProperty);
 
-                MatchSystemLanguageDirectionProperty = BindableProperty.Create(nameof(MatchSystemLanguageDirection), typeof(bool), typeof(TextLabel), false, 
+                MatchSystemLanguageDirectionProperty = BindableProperty.Create<TextLabel, bool>(nameof(MatchSystemLanguageDirection), false,
                     propertyChanged: SetInternalMatchSystemLanguageDirectionProperty, defaultValueCreator: GetInternalMatchSystemLanguageDirectionProperty);
 
-                CharacterSpacingProperty = BindableProperty.Create(nameof(CharacterSpacing), typeof(float), typeof(TextLabel), default(float), 
+                CharacterSpacingProperty = BindableProperty.Create<TextLabel, float>(nameof(CharacterSpacing), default(float),
                     propertyChanged: SetInternalCharacterSpacingProperty, defaultValueCreator: GetInternalCharacterSpacingProperty);
 
-                TextFitProperty = BindableProperty.Create(nameof(TextFit), typeof(PropertyMap), typeof(TextLabel), null, 
+                TextFitProperty = BindableProperty.Create<TextLabel, PropertyMap>(nameof(TextFit), null,
                     propertyChanged: SetInternalTextFitProperty, defaultValueCreator: GetInternalTextFitProperty);
 
-                MinLineSizeProperty = BindableProperty.Create(nameof(MinLineSize), typeof(float), typeof(TextLabel), default(float), 
+                MinLineSizeProperty = BindableProperty.Create<TextLabel, float>(nameof(MinLineSize), default(float),
                     propertyChanged: SetInternalMinLineSizeProperty, defaultValueCreator: GetInternalMinLineSizeProperty);
 
-                FontSizeScaleProperty = BindableProperty.Create(nameof(FontSizeScale), typeof(float), typeof(TextLabel), default(float), 
+                FontSizeScaleProperty = BindableProperty.Create<TextLabel, float>(nameof(FontSizeScale), default(float),
                     propertyChanged: SetInternalFontSizeScaleProperty, defaultValueCreator: GetInternalFontSizeScaleProperty);
 
-                EnableFontSizeScaleProperty = BindableProperty.Create(nameof(EnableFontSizeScale), typeof(bool), typeof(TextLabel), default(bool), 
+                EnableFontSizeScaleProperty = BindableProperty.Create<TextLabel, bool>(nameof(EnableFontSizeScale), default(bool),
                     propertyChanged: SetInternalEnableFontSizeScaleProperty, defaultValueCreator: GetInternalEnableFontSizeScaleProperty);
 
-                ShadowOffsetProperty = BindableProperty.Create(nameof(ShadowOffset), typeof(Tizen.NUI.Vector2), typeof(TextLabel), null, 
+                ShadowOffsetProperty = BindableProperty.Create<TextLabel, Vector2>(nameof(ShadowOffset), null,
                     propertyChanged: SetInternalShadowOffsetProperty, defaultValueCreator: GetInternalShadowOffsetProperty);
 
-                ShadowColorProperty = BindableProperty.Create(nameof(ShadowColor), typeof(Tizen.NUI.Vector4), typeof(TextLabel), null, 
+                ShadowColorProperty = BindableProperty.Create<TextLabel, Vector4>(nameof(ShadowColor), null,
                     propertyChanged: SetInternalShadowColorProperty, defaultValueCreator: GetInternalShadowColorProperty);
 
-                UnderlineEnabledProperty = BindableProperty.Create(nameof(UnderlineEnabled), typeof(bool), typeof(TextLabel), false, 
+                UnderlineEnabledProperty = BindableProperty.Create<TextLabel, bool>(nameof(UnderlineEnabled), false,
                     propertyChanged: SetInternalUnderlineEnabledProperty, defaultValueCreator: GetInternalUnderlineEnabledProperty);
 
-                UnderlineColorProperty = BindableProperty.Create(nameof(UnderlineColor), typeof(Tizen.NUI.Vector4), typeof(TextLabel), null, 
+                UnderlineColorProperty = BindableProperty.Create<TextLabel, Vector4>(nameof(UnderlineColor), null,
                     propertyChanged: SetInternalUnderlineColorProperty, defaultValueCreator: GetInternalUnderlineColorProperty);
 
-                UnderlineHeightProperty = BindableProperty.Create(nameof(UnderlineHeight), typeof(float), typeof(TextLabel), 0.0f, 
+                UnderlineHeightProperty = BindableProperty.Create<TextLabel, float>(nameof(UnderlineHeight), 0.0f,
                     propertyChanged: SetInternalUnderlineHeightProperty, defaultValueCreator: GetInternalUnderlineHeightProperty);
 
-                CutoutProperty = BindableProperty.Create(nameof(Cutout), typeof(bool), typeof(TextLabel), false,
+                CutoutProperty = BindableProperty.Create<TextLabel, bool>(nameof(Cutout), false,
                     propertyChanged: SetInternalCutoutProperty, defaultValueCreator: GetInternalCutoutProperty);
             }
         }
@@ -604,7 +604,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalPointSizeProperty(this, null, value);
+                    SetInternalPointSizeProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -636,7 +636,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalMultiLineProperty(this, null, value);
+                    SetInternalMultiLineProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -657,7 +657,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (HorizontalAlignment)GetInternalHorizontalAlignmentProperty(this);
+                    return GetInternalHorizontalAlignmentProperty(this);
                 }
             }
             set
@@ -668,7 +668,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalHorizontalAlignmentProperty(this, null, value);
+                    SetInternalHorizontalAlignmentProperty(this, HorizontalAlignment.Begin, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -689,7 +689,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (VerticalAlignment)GetInternalVerticalAlignmentProperty(this);
+                    return GetInternalVerticalAlignmentProperty(this);
                 }
             }
             set
@@ -700,7 +700,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalVerticalAlignmentProperty(this, null, value);
+                    SetInternalVerticalAlignmentProperty(this, VerticalAlignment.Top, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -727,7 +727,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    temp = (Color)GetInternalTextColorProperty(this);
+                    temp = GetInternalTextColorProperty(this);
                 }
                 return new Color(OnTextColorChanged, temp.R, temp.G, temp.B, temp.A);
             }
@@ -765,7 +765,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return GetInternalShadowOffsetProperty(this) as Vector2;
+                    return GetInternalShadowOffsetProperty(this);
                 }
             }
             set
@@ -911,7 +911,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalUnderlineEnabledProperty(this, null, value);
+                    SetInternalUnderlineEnabledProperty(this, false, value);
                 }
             }
         }
@@ -1041,7 +1041,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalUnderlineHeightProperty(this, null, value);
+                    SetInternalUnderlineHeightProperty(this, 0, value);
                 }
             }
         }
@@ -1088,7 +1088,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalEnableMarkupProperty(this);
+                    return GetInternalEnableMarkupProperty(this);
                 }
             }
             set
@@ -1099,7 +1099,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalEnableMarkupProperty(this, null, value);
+                    SetInternalEnableMarkupProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1120,7 +1120,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalEnableAutoScrollProperty(this);
+                    return GetInternalEnableAutoScrollProperty(this);
                 }
             }
             set
@@ -1131,7 +1131,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalEnableAutoScrollProperty(this, null, value);
+                    SetInternalEnableAutoScrollProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1152,7 +1152,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (int)GetInternalAutoScrollSpeedProperty(this);
+                    return GetInternalAutoScrollSpeedProperty(this);
                 }
             }
             set
@@ -1163,7 +1163,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalAutoScrollSpeedProperty(this, null, value);
+                    SetInternalAutoScrollSpeedProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1184,7 +1184,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (int)GetInternalAutoScrollLoopCountProperty(this);
+                    return GetInternalAutoScrollLoopCountProperty(this);
                 }
             }
             set
@@ -1195,7 +1195,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalAutoScrollLoopCountProperty(this, null, value);
+                    SetInternalAutoScrollLoopCountProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1216,7 +1216,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalAutoScrollGapProperty(this);
+                    return GetInternalAutoScrollGapProperty(this);
                 }
             }
             set
@@ -1227,7 +1227,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalAutoScrollGapProperty(this, null, value);
+                    SetInternalAutoScrollGapProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1248,7 +1248,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalLineSpacingProperty(this);
+                    return GetInternalLineSpacingProperty(this);
                 }
             }
             set
@@ -1259,7 +1259,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalLineSpacingProperty(this, null, value);
+                    SetInternalLineSpacingProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1280,7 +1280,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalRelativeLineHeightProperty(this);
+                    return GetInternalRelativeLineHeightProperty(this);
                 }
             }
             set
@@ -1291,7 +1291,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalRelativeLineHeightProperty(this, null, value);
+                    SetInternalRelativeLineHeightProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1319,7 +1319,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (PropertyMap)GetInternalUnderlineProperty(this);
+                    return GetInternalUnderlineProperty(this);
                 }
             }
             set
@@ -1402,7 +1402,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (PropertyMap)GetInternalShadowProperty(this);
+                    return GetInternalShadowProperty(this);
                 }
             }
             set
@@ -1478,7 +1478,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (TextShadow)GetInternalTextShadowProperty(this);
+                    return GetInternalTextShadowProperty(this);
                 }
             }
             set
@@ -1510,7 +1510,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (string)GetInternalEmbossProperty(this);
+                    return GetInternalEmbossProperty(this);
                 }
             }
             set
@@ -1548,7 +1548,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (PropertyMap)GetInternalOutlineProperty(this);
+                    return GetInternalOutlineProperty(this);
                 }
             }
             set
@@ -1671,7 +1671,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalPixelSizeProperty(this);
+                    return GetInternalPixelSizeProperty(this);
                 }
             }
             set
@@ -1682,7 +1682,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalPixelSizeProperty(this, null, value);
+                    SetInternalPixelSizeProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1703,7 +1703,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalEllipsisProperty(this);
+                    return GetInternalEllipsisProperty(this);
                 }
             }
             set
@@ -1714,7 +1714,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalEllipsisProperty(this, null, value);
+                    SetInternalEllipsisProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1735,7 +1735,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (EllipsisPosition)GetInternalEllipsisPositionProperty(this);
+                    return GetInternalEllipsisPositionProperty(this);
                 }
             }
             set
@@ -1746,7 +1746,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalEllipsisPositionProperty(this, null, value);
+                    SetInternalEllipsisPositionProperty(this, EllipsisPosition.End, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1767,7 +1767,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalAutoScrollLoopDelayProperty(this);
+                    return GetInternalAutoScrollLoopDelayProperty(this);
                 }
             }
             set
@@ -1778,7 +1778,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalAutoScrollLoopDelayProperty(this, null, value);
+                    SetInternalAutoScrollLoopDelayProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1800,7 +1800,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (AutoScrollStopMode)GetInternalAutoScrollStopModeProperty(this);
+                    return GetInternalAutoScrollStopModeProperty(this);
                 }
             }
             set
@@ -1811,7 +1811,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalAutoScrollStopModeProperty(this, null, value);
+                    SetInternalAutoScrollStopModeProperty(this, AutoScrollStopMode.FinishLoop, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1849,7 +1849,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (LineWrapMode)GetInternalLineWrapModeProperty(this);
+                    return GetInternalLineWrapModeProperty(this);
                 }
             }
             set
@@ -1860,7 +1860,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalLineWrapModeProperty(this, null, value);
+                    SetInternalLineWrapModeProperty(this, LineWrapMode.Word, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1899,7 +1899,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (VerticalLineAlignment)GetInternalVerticalLineAlignmentProperty(this);
+                    return GetInternalVerticalLineAlignmentProperty(this);
                 }
             }
             set
@@ -1910,7 +1910,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalVerticalLineAlignmentProperty(this, null, value);
+                    SetInternalVerticalLineAlignmentProperty(this, VerticalLineAlignment.Bottom, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -1930,7 +1930,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalMatchSystemLanguageDirectionProperty(this);
+                    return GetInternalMatchSystemLanguageDirectionProperty(this);
                 }
             }
             set
@@ -1941,7 +1941,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalMatchSystemLanguageDirectionProperty(this, null, value);
+                    SetInternalMatchSystemLanguageDirectionProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -2152,7 +2152,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalMinLineSizeProperty(this);
+                    return GetInternalMinLineSizeProperty(this);
                 }
             }
             set
@@ -2163,7 +2163,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalMinLineSizeProperty(this, null, value);
+                    SetInternalMinLineSizeProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -2187,7 +2187,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalCharacterSpacingProperty(this);
+                    return GetInternalCharacterSpacingProperty(this);
                 }
             }
             set
@@ -2198,7 +2198,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalCharacterSpacingProperty(this, null, value);
+                    SetInternalCharacterSpacingProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -2264,7 +2264,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    color = (Color)GetInternalAnchorClickedColorProperty(this);
+                    color = GetInternalAnchorClickedColorProperty(this);
                 }
                 return new Color(OnAnchorClickedColorChanged, color.R, color.G, color.B, color.A);
             }
@@ -2300,7 +2300,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalRemoveFrontInsetProperty(this);
+                    return GetInternalRemoveFrontInsetProperty(this);
                 }
             }
             set
@@ -2311,7 +2311,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalRemoveFrontInsetProperty(this, null, value);
+                    SetInternalRemoveFrontInsetProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -2335,7 +2335,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalRemoveBackInsetProperty(this);
+                    return GetInternalRemoveBackInsetProperty(this);
                 }
             }
             set
@@ -2346,7 +2346,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalRemoveBackInsetProperty(this, null, value);
+                    SetInternalRemoveBackInsetProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -2369,7 +2369,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (float)GetInternalFontSizeScaleProperty(this);
+                    return GetInternalFontSizeScaleProperty(this);
                 }
             }
             set
@@ -2380,7 +2380,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalFontSizeScaleProperty(this, null, value);
+                    SetInternalFontSizeScaleProperty(this, 0, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -2447,7 +2447,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalEnableFontSizeScaleProperty(this);
+                    return GetInternalEnableFontSizeScaleProperty(this);
                 }
             }
             set
@@ -2458,7 +2458,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else 
                 {
-                    SetInternalEnableFontSizeScaleProperty(this, null, value);
+                    SetInternalEnableFontSizeScaleProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }
@@ -2494,7 +2494,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    return (bool)GetInternalCutoutProperty(this);
+                    return GetInternalCutoutProperty(this);
                 }
             }
             set
@@ -2505,7 +2505,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    SetInternalCutoutProperty(this, null, value);
+                    SetInternalCutoutProperty(this, false, value);
                 }
                 NotifyPropertyChanged();
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -33,7 +33,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TranslatableTextProperty = null;
-        internal static void SetInternalTranslatableTextProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalTranslatableTextProperty(BindableObject bindable, string oldValue, string newValue)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -47,7 +47,7 @@ namespace Tizen.NUI.BaseComponents
                 textLabel.SetTranslatableText((string)newValue);
             }
         }
-        internal static object GetInternalTranslatableTextProperty(BindableObject bindable)
+        internal static string GetInternalTranslatableTextProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             return textLabel.translatableText;
@@ -56,21 +56,21 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextProperty = null;
-        internal static void SetInternalTextProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalTextProperty(BindableObject bindable, string oldValue, string newValue)
         {
             var textLabel = (TextLabel)bindable;
 
-            if (newValue is Selector<string> selector)
-            {
-                textLabel.TextSelector = selector;
-            }
-            else
+            //if (newValue is Selector<string> selector)
+            //{
+            //    textLabel.TextSelector = selector;
+            //}
+            //else
             {
                 textLabel.selectorData?.Text?.Reset(textLabel);
                 textLabel.SetText((string)newValue);
             }
         }
-        internal static object GetInternalTextProperty(BindableObject bindable)
+        internal static string GetInternalTextProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -81,21 +81,21 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontFamilyProperty = null;
-        internal static void SetInternalFontFamilyProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalFontFamilyProperty(BindableObject bindable, string oldValue, string newValue)
         {
             var textLabel = (TextLabel)bindable;
 
-            if (newValue is Selector<string> selector)
-            {
-                textLabel.FontFamilySelector = selector;
-            }
-            else
+            //if (newValue is Selector<string> selector)
+            //{
+            //    textLabel.FontFamilySelector = selector;
+            //}
+            //else
             {
                 textLabel.selectorData?.FontFamily?.Reset(textLabel);
                 textLabel.SetFontFamily((string)newValue);
             }
         }
-        internal static object GetInternalFontFamilyProperty(BindableObject bindable)
+        internal static string GetInternalFontFamilyProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             return textLabel.InternalFontFamily;
@@ -104,16 +104,16 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontStyleProperty = null;
-        internal static void SetInternalFontStyleProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalFontStyleProperty(BindableObject bindable, PropertyMap oldValue, PropertyMap newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.FontStyle, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.FontStyle, new Tizen.NUI.PropertyValue(newValue));
                 textLabel.RequestLayout();
             }
         }
-        internal static object GetInternalFontStyleProperty(BindableObject bindable)
+        internal static PropertyMap GetInternalFontStyleProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
@@ -124,21 +124,21 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PointSizeProperty = null;
-        internal static void SetInternalPointSizeProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalPointSizeProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
 
-            if (newValue is Selector<float?> selector)
-            {
-                textLabel.PointSizeSelector = selector;
-            }
-            else
+            //if (newValue is Selector<float?> selector)
+            //{
+            //    textLabel.PointSizeSelector = selector;
+            //}
+            //else
             {
                 textLabel.selectorData?.PointSize?.Reset(textLabel);
                 textLabel.SetPointSize((float?)newValue);
             }
         }
-        internal static object GetInternalPointSizeProperty(BindableObject bindable)
+        internal static float GetInternalPointSizeProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -148,17 +148,13 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MultiLineProperty = null;
-        internal static void SetInternalMultiLineProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalMultiLineProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MultiLine, (bool)newValue);
-                textLabel.RequestLayout();
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MultiLine, (bool)newValue);
+            textLabel.RequestLayout();
         }
-        internal static object GetInternalMultiLineProperty(BindableObject bindable)
+        internal static bool GetInternalMultiLineProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -168,16 +164,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty HorizontalAlignmentProperty = null;
-        internal static void SetInternalHorizontalAlignmentProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalHorizontalAlignmentProperty(BindableObject bindable, HorizontalAlignment oldValue, HorizontalAlignment newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.HorizontalAlignment, (int)newValue);
         }
-        internal static object GetInternalHorizontalAlignmentProperty(BindableObject bindable)
+        internal static HorizontalAlignment GetInternalHorizontalAlignmentProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             string temp;
@@ -205,16 +197,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty VerticalAlignmentProperty = null;
-        internal static void SetInternalVerticalAlignmentProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalVerticalAlignmentProperty(BindableObject bindable, VerticalAlignment oldValue, VerticalAlignment newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalAlignment, (int)newValue);
         }
-        internal static object GetInternalVerticalAlignmentProperty(BindableObject bindable)
+        internal static VerticalAlignment GetInternalVerticalAlignmentProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             string temp;
@@ -242,21 +230,21 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextColorProperty = null;
-        internal static void SetInternalTextColorProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalTextColorProperty(BindableObject bindable, Color oldValue, Color newValue)
         {
             var textLabel = (TextLabel)bindable;
 
-            if (newValue is Selector<Color> selector)
-            {
-                textLabel.TextColorSelector = selector;
-            }
-            else
+            //if (newValue is Selector<Color> selector)
+            //{
+            //    textLabel.TextColorSelector = selector;
+            //}
+            //else
             {
                 textLabel.selectorData?.TextColor?.Reset(textLabel);
                 textLabel.SetTextColor((Color)newValue);
             }
         }
-        internal static object GetInternalTextColorProperty(BindableObject bindable)
+        internal static Color GetInternalTextColorProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -270,15 +258,15 @@ namespace Tizen.NUI.BaseComponents
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AnchorColorProperty = null;
-        internal static void SetInternalAnchorColorProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalAnchorColorProperty(BindableObject bindable, Color oldValue, Color newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Object.InternalSetPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.AnchorColor, ((Color)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.AnchorColor, (newValue).SwigCPtr);
             }
         }
-        internal static object GetInternalAnchorColorProperty(BindableObject bindable)
+        internal static Color GetInternalAnchorColorProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -292,15 +280,15 @@ namespace Tizen.NUI.BaseComponents
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AnchorClickedColorProperty = null;
-        internal static void SetInternalAnchorClickedColorProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalAnchorClickedColorProperty(BindableObject bindable, Color oldValue, Color newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Object.InternalSetPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.AnchorClickedColor, ((Color)newValue).SwigCPtr);
+                Object.InternalSetPropertyVector4(textLabel.SwigCPtr, TextLabel.Property.AnchorClickedColor, (newValue).SwigCPtr);
             }
         }
-        internal static object GetInternalAnchorClickedColorProperty(BindableObject bindable)
+        internal static Color GetInternalAnchorClickedColorProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -317,15 +305,12 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty RemoveFrontInsetProperty = null;
-        internal static void SetInternalRemoveFrontInsetProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalRemoveFrontInsetProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.RemoveFrontInset, (bool)newValue);
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.RemoveFrontInset, newValue);
         }
-        internal static object GetInternalRemoveFrontInsetProperty(BindableObject bindable)
+        internal static bool GetInternalRemoveFrontInsetProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -337,15 +322,12 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty RemoveBackInsetProperty = null;
-        internal static void SetInternalRemoveBackInsetProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalRemoveBackInsetProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.RemoveBackInset, (bool)newValue);
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.RemoveBackInset, newValue);
         }
-        internal static object GetInternalRemoveBackInsetProperty(BindableObject bindable)
+        internal static bool GetInternalRemoveBackInsetProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -355,16 +337,13 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableMarkupProperty = null;
-        internal static void SetInternalEnableMarkupProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalEnableMarkupProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
 
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableMarkup, (bool)newValue);
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableMarkup, newValue);
         }
-        internal static object GetInternalEnableMarkupProperty(BindableObject bindable)
+        internal static bool GetInternalEnableMarkupProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -374,16 +353,13 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableAutoScrollProperty = null;
-        internal static void SetInternalEnableAutoScrollProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalEnableAutoScrollProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
 
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll, (bool)newValue);
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableAutoScroll, newValue);
         }
-        internal static object GetInternalEnableAutoScrollProperty(BindableObject bindable)
+        internal static bool GetInternalEnableAutoScrollProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -393,16 +369,13 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollSpeedProperty = null;
-        internal static void SetInternalAutoScrollSpeedProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalAutoScrollSpeedProperty(BindableObject bindable, int oldValue, int newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
 
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollSpeed, newValue);
         }
-        internal static object GetInternalAutoScrollSpeedProperty(BindableObject bindable)
+        internal static int GetInternalAutoScrollSpeedProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -412,16 +385,13 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollLoopCountProperty = null;
-        internal static void SetInternalAutoScrollLoopCountProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalAutoScrollLoopCountProperty(BindableObject bindable, int oldValue, int newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
 
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopCount, newValue);
         }
-        internal static object GetInternalAutoScrollLoopCountProperty(BindableObject bindable)
+        internal static int GetInternalAutoScrollLoopCountProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -431,16 +401,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollGapProperty = null;
-        internal static void SetInternalAutoScrollGapProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalAutoScrollGapProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap, (float)newValue);
-            }
+            Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollGap, newValue);
         }
-        internal static object GetInternalAutoScrollGapProperty(BindableObject bindable)
+        internal static float GetInternalAutoScrollGapProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -450,17 +416,13 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LineSpacingProperty = null;
-        internal static void SetInternalLineSpacingProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalLineSpacingProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.LineSpacing, (float)newValue);
-                textLabel.RequestLayout();
-            }
+            Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.LineSpacing, newValue);
+            textLabel.RequestLayout();
         }
-        internal static object GetInternalLineSpacingProperty(BindableObject bindable)
+        internal static float GetInternalLineSpacingProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -469,16 +431,16 @@ namespace Tizen.NUI.BaseComponents
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty RelativeLineHeightProperty = null;
-        internal static void SetInternalRelativeLineHeightProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalRelativeLineHeightProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
 
-                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight, (float)newValue);
+                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.RelativeLineHeight, newValue);
             }
         }
-        internal static object GetInternalRelativeLineHeightProperty(BindableObject bindable)
+        internal static float GetInternalRelativeLineHeightProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -488,15 +450,15 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineProperty = null;
-        internal static void SetInternalUnderlineProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalUnderlineProperty(BindableObject bindable, PropertyMap oldValue, PropertyMap newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.UNDERLINE, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.UNDERLINE, new Tizen.NUI.PropertyValue(newValue));
             }
         }
-        internal static object GetInternalUnderlineProperty(BindableObject bindable)
+        internal static PropertyMap GetInternalUnderlineProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
@@ -507,15 +469,15 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowProperty = null;
-        internal static void SetInternalShadowProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalShadowProperty(BindableObject bindable, PropertyMap oldValue, PropertyMap newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.SHADOW, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.SHADOW, new Tizen.NUI.PropertyValue(newValue));
             }
         }
-        internal static object GetInternalShadowProperty(BindableObject bindable)
+        internal static PropertyMap GetInternalShadowProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
@@ -526,21 +488,21 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextShadowProperty = null;
-        internal static void SetInternalTextShadowProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalTextShadowProperty(BindableObject bindable, TextShadow oldValue, TextShadow newValue)
         {
             var textLabel = (TextLabel)bindable;
 
-            if (newValue is Selector<TextShadow> selector)
-            {
-                textLabel.TextShadowSelector = selector;
-            }
-            else
+            //if (newValue is Selector<TextShadow> selector)
+            //{
+            //    textLabel.TextShadowSelector = selector;
+            //}
+            //else
             {
                 textLabel.selectorData?.TextShadow?.Reset(textLabel);
-                textLabel.SetTextShadow((TextShadow)newValue);
+                textLabel.SetTextShadow(newValue);
             }
         }
-        internal static object GetInternalTextShadowProperty(BindableObject bindable)
+        internal static TextShadow GetInternalTextShadowProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
@@ -551,16 +513,16 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EmbossProperty = null;
-        internal static void SetInternalEmbossProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalEmbossProperty(BindableObject bindable, string oldValue, string newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
 
-                Object.InternalSetPropertyString(textLabel.SwigCPtr, TextLabel.Property.EMBOSS, (string)newValue);
+                Object.InternalSetPropertyString(textLabel.SwigCPtr, TextLabel.Property.EMBOSS, newValue);
             }
         }
-        internal static object GetInternalEmbossProperty(BindableObject bindable)
+        internal static string GetInternalEmbossProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -570,15 +532,15 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty OutlineProperty = null;
-        internal static void SetInternalOutlineProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalOutlineProperty(BindableObject bindable, PropertyMap oldValue, PropertyMap newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.OUTLINE, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.OUTLINE, new Tizen.NUI.PropertyValue(newValue));
             }
         }
-        internal static object GetInternalOutlineProperty(BindableObject bindable)
+        internal static PropertyMap GetInternalOutlineProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
@@ -589,21 +551,21 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty PixelSizeProperty = null;
-        internal static void SetInternalPixelSizeProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalPixelSizeProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
 
-            if (newValue is Selector<float?> selector)
-            {
-                textLabel.PixelSizeSelector = selector;
-            }
-            else
+            //if (newValue is Selector<float?> selector)
+            //{
+            //    textLabel.PixelSizeSelector = selector;
+            //}
+            //else
             {
                 textLabel.selectorData?.PixelSize?.Reset(textLabel);
                 textLabel.SetPixelSize((float?)newValue);
             }
         }
-        internal static object GetInternalPixelSizeProperty(BindableObject bindable)
+        internal static float GetInternalPixelSizeProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -613,16 +575,13 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisProperty = null;
-        internal static void SetInternalEllipsisProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalEllipsisProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
 
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS, (bool)newValue);
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.ELLIPSIS, newValue);
         }
-        internal static object GetInternalEllipsisProperty(BindableObject bindable)
+        internal static bool GetInternalEllipsisProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -632,16 +591,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EllipsisPositionProperty = null;
-        internal static void SetInternalEllipsisPositionProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalEllipsisPositionProperty(BindableObject bindable, EllipsisPosition oldValue, EllipsisPosition newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.EllipsisPosition, (int)newValue);
         }
-        internal static object GetInternalEllipsisPositionProperty(BindableObject bindable)
+        internal static EllipsisPosition GetInternalEllipsisPositionProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -651,16 +606,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollLoopDelayProperty = null;
-        internal static void SetInternalAutoScrollLoopDelayProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalAutoScrollLoopDelayProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay, (float)newValue);
-            }
+            Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.AutoScrollLoopDelay, (float)newValue);
         }
-        internal static object GetInternalAutoScrollLoopDelayProperty(BindableObject bindable)
+        internal static float GetInternalAutoScrollLoopDelayProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -670,16 +621,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty AutoScrollStopModeProperty = null;
-        internal static void SetInternalAutoScrollStopModeProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalAutoScrollStopModeProperty(BindableObject bindable, AutoScrollStopMode oldValue, AutoScrollStopMode newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.AutoScrollStopMode, (int)newValue);
         }
-        internal static object GetInternalAutoScrollStopModeProperty(BindableObject bindable)
+        internal static AutoScrollStopMode GetInternalAutoScrollStopModeProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             string temp;
@@ -691,16 +638,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty LineWrapModeProperty = null;
-        internal static void SetInternalLineWrapModeProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalLineWrapModeProperty(BindableObject bindable, LineWrapMode oldValue, LineWrapMode newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.LineWrapMode, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.LineWrapMode, (int)newValue);
         }
-        internal static object GetInternalLineWrapModeProperty(BindableObject bindable)
+        internal static LineWrapMode GetInternalLineWrapModeProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -710,16 +653,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty VerticalLineAlignmentProperty = null;
-        internal static void SetInternalVerticalLineAlignmentProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalVerticalLineAlignmentProperty(BindableObject bindable, VerticalLineAlignment oldValue, VerticalLineAlignment newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment, (int)newValue);
-            }
+            Object.InternalSetPropertyInt(textLabel.SwigCPtr, TextLabel.Property.VerticalLineAlignment, (int)newValue);
         }
-        internal static object GetInternalVerticalLineAlignmentProperty(BindableObject bindable)
+        internal static VerticalLineAlignment GetInternalVerticalLineAlignmentProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -729,16 +668,16 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_5.0 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MatchSystemLanguageDirectionProperty = null;
-        internal static void SetInternalMatchSystemLanguageDirectionProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalMatchSystemLanguageDirectionProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
 
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection, (bool)newValue);
+                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.MatchSystemLanguageDirection, newValue);
             }
         }
-        internal static object GetInternalMatchSystemLanguageDirectionProperty(BindableObject bindable)
+        internal static bool GetInternalMatchSystemLanguageDirectionProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -748,16 +687,12 @@ namespace Tizen.NUI.BaseComponents
         /// This will be public opened in tizen_6.5 after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CharacterSpacingProperty = null;
-        internal static void SetInternalCharacterSpacingProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalCharacterSpacingProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing, (float)newValue);
-            }
+            Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.CharacterSpacing, (float)newValue);
         }
-        internal static object GetInternalCharacterSpacingProperty(BindableObject bindable)
+        internal static float GetInternalCharacterSpacingProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -767,15 +702,15 @@ namespace Tizen.NUI.BaseComponents
         /// Only for XAML. No need of public API. Make hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty TextFitProperty = null;
-        internal static void SetInternalTextFitProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalTextFitProperty(BindableObject bindable, PropertyMap oldValue, PropertyMap newValue)
         {
             var textLabel = (TextLabel)bindable;
             if (newValue != null)
             {
-                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.TextFit, new Tizen.NUI.PropertyValue((PropertyMap)newValue));
+                Tizen.NUI.Object.SetProperty((System.Runtime.InteropServices.HandleRef)textLabel.SwigCPtr, TextLabel.Property.TextFit, new Tizen.NUI.PropertyValue(newValue));
             }
         }
-        internal static object GetInternalTextFitProperty(BindableObject bindable)
+        internal static PropertyMap GetInternalTextFitProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             PropertyMap temp = new PropertyMap();
@@ -786,17 +721,13 @@ namespace Tizen.NUI.BaseComponents
         /// Only for XAML. No need of public API. Make hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty MinLineSizeProperty = null;
-        internal static void SetInternalMinLineSizeProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalMinLineSizeProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.MinLineSize, (float)newValue);
-                textLabel.RequestLayout();
-            }
+            Object.InternalSetPropertyFloat(textLabel.SwigCPtr, TextLabel.Property.MinLineSize, (float)newValue);
+            textLabel.RequestLayout();
         }
-        internal static object GetInternalMinLineSizeProperty(BindableObject bindable)
+        internal static float GetInternalMinLineSizeProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -805,15 +736,12 @@ namespace Tizen.NUI.BaseComponents
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FontSizeScaleProperty = null;
-        internal static void SetInternalFontSizeScaleProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalFontSizeScaleProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-                textLabel.InternalFontSizeScale = (float)newValue;
-            }
+            textLabel.InternalFontSizeScale = newValue;
         }
-        internal static object GetInternalFontSizeScaleProperty(BindableObject bindable)
+        internal static float GetInternalFontSizeScaleProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
             return textLabel.InternalFontSizeScale;
@@ -821,17 +749,13 @@ namespace Tizen.NUI.BaseComponents
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty EnableFontSizeScaleProperty = null;
-        internal static void SetInternalEnableFontSizeScaleProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalEnableFontSizeScaleProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale, (bool)newValue);
-                textLabel.RequestLayout();
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.EnableFontSizeScale, (bool)newValue);
+            textLabel.RequestLayout();
         }
-        internal static object GetInternalEnableFontSizeScaleProperty(BindableObject bindable)
+        internal static bool GetInternalEnableFontSizeScaleProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -843,7 +767,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowOffsetProperty = null;
-        internal static void SetInternalShadowOffsetProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalShadowOffsetProperty(BindableObject bindable, Vector2 oldValue, Vector2 newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             if (newValue != null)
@@ -851,7 +775,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalShadowOffset = (Tizen.NUI.Vector2)newValue;
             }
         }
-        internal static object GetInternalShadowOffsetProperty(BindableObject bindable)
+        internal static Vector2 GetInternalShadowOffsetProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalShadowOffset;
@@ -862,7 +786,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty ShadowColorProperty = null;
-        internal static void SetInternalShadowColorProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalShadowColorProperty(BindableObject bindable, Vector4 oldValue, Vector4 newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             if (newValue != null)
@@ -870,7 +794,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalShadowColor = (Tizen.NUI.Vector4)newValue;
             }
         }
-        internal static object GetInternalShadowColorProperty(BindableObject bindable)
+        internal static Vector4 GetInternalShadowColorProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalShadowColor;
@@ -881,15 +805,12 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineEnabledProperty = null;
-        internal static void SetInternalUnderlineEnabledProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalUnderlineEnabledProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
-            if (newValue != null)
-            {
-                instance.InternalUnderlineEnabled = (bool)newValue;
-            }
+            instance.InternalUnderlineEnabled = (bool)newValue;
         }
-        internal static object GetInternalUnderlineEnabledProperty(BindableObject bindable)
+        internal static bool GetInternalUnderlineEnabledProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalUnderlineEnabled;
@@ -900,7 +821,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineColorProperty = null;
-        internal static void SetInternalUnderlineColorProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalUnderlineColorProperty(BindableObject bindable, Vector4 oldValue, Vector4 newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             if (newValue != null)
@@ -908,7 +829,7 @@ namespace Tizen.NUI.BaseComponents
                 instance.InternalUnderlineColor = (Tizen.NUI.Vector4)newValue;
             }
         }
-        internal static object GetInternalUnderlineColorProperty(BindableObject bindable)
+        internal static Vector4 GetInternalUnderlineColorProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalUnderlineColor;
@@ -919,15 +840,12 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty UnderlineHeightProperty = null;
-        internal static void SetInternalUnderlineHeightProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalUnderlineHeightProperty(BindableObject bindable, float oldValue, float newValue)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
-            if (newValue != null)
-            {
-                instance.InternalUnderlineHeight = (float)newValue;
-            }
+            instance.InternalUnderlineHeight = (float)newValue;
         }
-        internal static object GetInternalUnderlineHeightProperty(BindableObject bindable)
+        internal static float GetInternalUnderlineHeightProperty(BindableObject bindable)
         {
             var instance = (Tizen.NUI.BaseComponents.TextLabel)bindable;
             return instance.InternalUnderlineHeight;
@@ -938,15 +856,12 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty CutoutProperty = null;
-        internal static void SetInternalCutoutProperty(BindableObject bindable, object oldValue, object newValue)
+        internal static void SetInternalCutoutProperty(BindableObject bindable, bool oldValue, bool newValue)
         {
             var textLabel = (TextLabel)bindable;
-            if (newValue != null)
-            {
-                Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.Cutout, (bool)newValue);
-            }
+            Object.InternalSetPropertyBool(textLabel.SwigCPtr, TextLabel.Property.Cutout, (bool)newValue);
         }
-        internal static object GetInternalCutoutProperty(BindableObject bindable)
+        internal static bool GetInternalCutoutProperty(BindableObject bindable)
         {
             var textLabel = (TextLabel)bindable;
 
@@ -1108,7 +1023,6 @@ namespace Tizen.NUI.BaseComponents
         {
             if (value != null)
             {
-
                 Object.InternalSetPropertyFloat(SwigCPtr, TextLabel.Property.PixelSize, (float)value);
                 RequestLayout();
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabelBindableProperty.cs
@@ -37,11 +37,11 @@ namespace Tizen.NUI.BaseComponents
         {
             var textLabel = (TextLabel)bindable;
 
-            if (newValue is Selector<string> selector)
-            {
-                textLabel.TranslatableTextSelector = selector;
-            }
-            else
+            //if (newValue is Selector<string> selector)
+            //{
+            //    textLabel.TranslatableTextSelector = selector;
+            //}
+            //else
             {
                 textLabel.selectorData?.TranslatableText?.Reset(textLabel);
                 textLabel.SetTranslatableText((string)newValue);

--- a/src/Tizen.NUI/src/public/XamlBinding/BindableProperty.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableProperty.cs
@@ -320,7 +320,14 @@ namespace Tizen.NUI.Binding
         internal System.Reflection.TypeInfo ReturnTypeInfo { get; }
 
         internal ValidateValueDelegate ValidateValue { get; private set; }
-
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static BindableProperty Create<TDeclarer, TPropertyType>(string propertyName, TPropertyType defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
+                                                                        ValidateValueDelegate<TPropertyType> validateValue = null, BindingPropertyChangedDelegate<TPropertyType> propertyChanged = null,
+                                                                        BindingPropertyChangingDelegate<TPropertyType> propertyChanging = null, CoerceValueDelegate<TPropertyType> coerceValue = null,
+                                                                        CreateDefaultValueDelegate<TDeclarer, TPropertyType> defaultValueCreator = null) where TDeclarer : BindableObject
+        {
+            return Create(propertyName, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue, null, defaultValueCreator: defaultValueCreator);
+        }
         /// <summary>
         /// Creates a new instance of the BindableProperty class.
         /// </summary>
@@ -408,6 +415,46 @@ namespace Tizen.NUI.Binding
             return
                 new BindablePropertyKey(new BindableProperty(propertyName, returnType, declaringType, defaultValue, defaultBindingMode, validateValue, propertyChanged, propertyChanging, coerceValue,
                     isReadOnly: true, defaultValueCreator: defaultValueCreator));
+        }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal static BindableProperty Create<TDeclarer, TPropertyType>(string propertyName, TPropertyType defaultValue, BindingMode defaultBindingMode,
+                                                                          ValidateValueDelegate<TPropertyType> validateValue, BindingPropertyChangedDelegate<TPropertyType> propertyChanged, BindingPropertyChangingDelegate<TPropertyType> propertyChanging,
+                                                                          CoerceValueDelegate<TPropertyType> coerceValue, BindablePropertyBindingChanging bindingChanging, bool isReadOnly = false,
+                                                                          CreateDefaultValueDelegate<TDeclarer, TPropertyType> defaultValueCreator = null) where TDeclarer : BindableObject
+        {
+            //if (getter == null)
+            //    throw new ArgumentNullException("getter");
+
+            //Expression expr = getter.Body;
+
+            //var unary = expr as UnaryExpression;
+            //if (unary != null)
+            //    expr = unary.Operand;
+
+            //var member = expr as MemberExpression;
+            //if (member == null)
+            //    throw new ArgumentException("getter must be a MemberExpression", "getter");
+
+            //var property = (PropertyInfo)member.Member;
+
+            ValidateValueDelegate untypedValidateValue = null;
+            BindingPropertyChangedDelegate untypedBindingPropertyChanged = null;
+            BindingPropertyChangingDelegate untypedBindingPropertyChanging = null;
+            CoerceValueDelegate untypedCoerceValue = null;
+            CreateDefaultValueDelegate untypedDefaultValueCreator = null;
+            if (validateValue != null)
+                untypedValidateValue = (bindable, value) => validateValue(bindable, (TPropertyType)value);
+            if (propertyChanged != null)
+                untypedBindingPropertyChanged = (bindable, oldValue, newValue) => propertyChanged(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
+            if (propertyChanging != null)
+                untypedBindingPropertyChanging = (bindable, oldValue, newValue) => propertyChanging(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
+            if (coerceValue != null)
+                untypedCoerceValue = (bindable, value) => coerceValue(bindable, (TPropertyType)value);
+            if (defaultValueCreator != null)
+                untypedDefaultValueCreator = o => defaultValueCreator((TDeclarer)o);
+
+            return new BindableProperty(propertyName, typeof(TPropertyType), typeof(TDeclarer), defaultValue, defaultBindingMode, untypedValidateValue, untypedBindingPropertyChanged,
+                untypedBindingPropertyChanging, untypedCoerceValue, bindingChanging, isReadOnly, untypedDefaultValueCreator);
         }
         internal static BindableProperty Create(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode, ValidateValueDelegate validateValue,
                                                 BindingPropertyChangedDelegate propertyChanged, BindingPropertyChangingDelegate propertyChanging, CoerceValueDelegate coerceValue, BindablePropertyBindingChanging bindingChanging,


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This is a draft patch. I added BindableProperty Create<> (generic) api, but it still exists boxing/unboxing it. so I wonder if there is any point in continuing?

```cs
internal static BindableProperty Create<TDeclarer, TPropertyType>(string propertyName, TPropertyType defaultValue, BindingMode defaultBindingMode,
                                                                    ValidateValueDelegate<TPropertyType> validateValue, BindingPropertyChangedDelegate<TPropertyType> propertyChanged, BindingPropertyChangingDelegate<TPropertyType> propertyChanging,
                                                                    CoerceValueDelegate<TPropertyType> coerceValue, BindablePropertyBindingChanging bindingChanging, bool isReadOnly = false,
                                                                    CreateDefaultValueDelegate<TDeclarer, TPropertyType> defaultValueCreator = null) where TDeclarer : BindableObject
{
    ValidateValueDelegate untypedValidateValue = null;
    BindingPropertyChangedDelegate untypedBindingPropertyChanged = null;
    BindingPropertyChangingDelegate untypedBindingPropertyChanging = null;
    CoerceValueDelegate untypedCoerceValue = null;
    CreateDefaultValueDelegate untypedDefaultValueCreator = null;
    if (validateValue != null)
        untypedValidateValue = (bindable, value) => validateValue(bindable, (TPropertyType)value);
    if (propertyChanged != null)
        untypedBindingPropertyChanged = (bindable, oldValue, newValue) => propertyChanged(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
    if (propertyChanging != null)
        untypedBindingPropertyChanging = (bindable, oldValue, newValue) => propertyChanging(bindable, (TPropertyType)oldValue, (TPropertyType)newValue);
    if (coerceValue != null)
        untypedCoerceValue = (bindable, value) => coerceValue(bindable, (TPropertyType)value);
    if (defaultValueCreator != null)
        untypedDefaultValueCreator = o => defaultValueCreator((TDeclarer)o);

    return new BindableProperty(propertyName, typeof(TPropertyType), typeof(TDeclarer), defaultValue, defaultBindingMode, untypedValidateValue, untypedBindingPropertyChanged,
        untypedBindingPropertyChanging, untypedCoerceValue, bindingChanging, isReadOnly, untypedDefaultValueCreator);
}
````

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
