### PR TITLE
[NUI] Fix SVACE

### DIFF
--- a/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
+++ b/src/Tizen.NUI/src/public/EXaml/EXamlExtensions.cs
@@ -180,7 +180,7 @@ namespace Tizen.NUI.EXaml
             object temp = null;
             GlobalDataList eXamlData = null;
             LoadEXaml.Load(temp, eXamlStr, out eXamlData);
-            return eXamlData.Root;
+            return eXamlData?.Root;
         }
 
         /// Internal used, will never be opened.


### PR DESCRIPTION
[NUI] Fix SVACE

- WID:52739702 Value eXamlData, which has null value, is dereferenced in member access expression eXamlData.Root

### Description of Change ###
nothing