### PR TITLE
[NUI.Devel.Tests] Do not use ColorFormat.RGBA, which might the behavor will be changed

### DIFF
--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Images/TSNativeImageQueue.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Images/TSNativeImageQueue.cs
@@ -42,7 +42,7 @@ namespace Tizen.NUI.Devel.Tests
 
             try
 			{
-                var testingTarget = new NativeImageQueue(100, 50, NativeImageQueue.ColorFormat.RGBA8888);
+                var testingTarget = new NativeImageQueue(100, 50, NativeImageQueue.ColorFormat.BGRA8888);
                 Assert.IsNotNull(testingTarget, "Can't create success object NativeImageQueue");
                 Assert.IsInstanceOf<NativeImageQueue>(testingTarget, "Should be an instance of NativeImageQueue type.");
             
@@ -130,7 +130,7 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"NativeImageQueueDequeueBuffer START");
 
-            var testingTarget = new NativeImageQueue(100, 50, NativeImageQueue.ColorFormat.RGBA8888);
+            var testingTarget = new NativeImageQueue(100, 50, NativeImageQueue.ColorFormat.BGRA8888);
             Assert.IsNotNull(testingTarget, "Can't create success object NativeImageQueue");
             Assert.IsInstanceOf<NativeImageQueue>(testingTarget, "Should be an instance of NativeImageQueue type.");
 
@@ -162,7 +162,7 @@ namespace Tizen.NUI.Devel.Tests
         {
             tlog.Debug(tag, $"NativeImageQueueEnqueueBuffer START");
 
-            var testingTarget = new NativeImageQueue(100, 50, NativeImageQueue.ColorFormat.RGBA8888);
+            var testingTarget = new NativeImageQueue(100, 50, NativeImageQueue.ColorFormat.BGRA8888);
             Assert.IsNotNull(testingTarget, "Can't create success object NativeImageQueue");
             Assert.IsInstanceOf<NativeImageQueue>(testingTarget, "Should be an instance of NativeImageQueue type.");
 


### PR DESCRIPTION
Let we use BGRA8888 format to keep legacy behavior.