### PR TITLE
[TCSACR-586][NUI] Add IWindowProvider to be used as a common window interface across different modules

### DIFF
--- a/src/Tizen.Multimedia/Common/Display.cs
+++ b/src/Tizen.Multimedia/Common/Display.cs
@@ -15,6 +15,7 @@
  */
 using System;
 using ElmSharp;
+using Tizen.Common;
 
 namespace Tizen.Multimedia
 {
@@ -175,9 +176,9 @@ namespace Tizen.Multimedia
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Display"/> class with an <see cref="IWindowProvider"/> interface.
+        /// Initializes a new instance of the <see cref="Display"/> class with an <see cref="Tizen.Common.IWindowProvider"/> interface.
         /// </summary>
-        /// <param name="window">An <see cref="IWindowProvider"/> object that provides a handle to a window.</param>
+        /// <param name="window">An <see cref="Tizen.Common.IWindowProvider"/> object that provides a handle to a window.</param>
         /// <since_tizen> 12 </since_tizen>
         public Display(IWindowProvider window)
             : this(window, false)
@@ -185,9 +186,9 @@ namespace Tizen.Multimedia
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Display"/> class with an <see cref="IWindowProvider"/> interface.
+        /// Initializes a new instance of the <see cref="Display"/> class with an <see cref="Tizen.Common.IWindowProvider"/> interface.
         /// </summary>
-        /// <param name="window">An <see cref="IWindowProvider"/> object that provides a handle to a window.</param>
+        /// <param name="window">An <see cref="Tizen.Common.IWindowProvider"/> object that provides a handle to a window.</param>
         /// <param name="uiSync">A value indicating whether video and UI are in sync or not.</param>
         /// <remarks>
         /// UI sync is only for <see cref="T:Tizen.Multimedia.Player"/> and
@@ -207,7 +208,6 @@ namespace Tizen.Multimedia
 
             UiSync = uiSync;
         }
-
 
         private EvasObject EvasObject { get; }
 

--- a/src/Tizen.NUI.WindowSystem/Tizen.NUI.WindowSystem.sln
+++ b/src/Tizen.NUI.WindowSystem/Tizen.NUI.WindowSystem.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI.WindowSystem", "Tizen.NUI.WindowSystem.csproj", "{4736851E-294E-4EBA-9DF1-79D2D78176B9}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4736851E-294E-4EBA-9DF1-79D2D78176B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4736851E-294E-4EBA-9DF1-79D2D78176B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4736851E-294E-4EBA-9DF1-79D2D78176B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4736851E-294E-4EBA-9DF1-79D2D78176B9}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0EBD4ED2-63CC-4DCC-A57A-68DBC451B9F2}
+	EndGlobalSection
+EndGlobal

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.EcoreWl2.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.EcoreWl2.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tizen.NUI.WindowSystem
+{
+    internal static partial class Interop
+    {
+        internal static partial class EcoreWl2
+        {
+            const string lib = "libecore_wl2.so.1";
+
+            [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "ecore_wl2_window_id_get")]
+            internal static extern int GetWindowId(IntPtr win);
+        }
+    }
+}

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.KVMService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.KVMService.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.WindowSystem.Shell
             const string lib = "libtzsh_kvm_service.so.0";
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_kvm_service_create")]
-            internal static extern IntPtr Create(IntPtr tzsh, IntPtr win);
+            internal static extern IntPtr Create(IntPtr tzsh, uint win);
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_kvm_service_destroy")]
             internal static extern int Destroy(IntPtr kvmService);

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.QuickPanelClient.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.QuickPanelClient.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.WindowSystem.Shell
             const string lib = "libtzsh_quickpanel.so.0";
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_quickpanel_create_with_type")]
-            internal static extern IntPtr CreateWithType(IntPtr tzsh, IntPtr win, int type);
+            internal static extern IntPtr CreateWithType(IntPtr tzsh, uint win, int type);
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_quickpanel_destroy")]
             internal static extern int Destroy(IntPtr qpClient);

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.QuickPanelService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.QuickPanelService.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.WindowSystem.Shell
             const string lib = "libtzsh_quickpanel_service.so.0";
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_quickpanel_service_create_with_type")]
-            internal static extern IntPtr CreateWithType(IntPtr tzsh, IntPtr win, int type);
+            internal static extern IntPtr CreateWithType(IntPtr tzsh, uint win, int type);
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_quickpanel_service_destroy")]
             internal static extern int Destroy(IntPtr service);

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.SoftkeyClient.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.SoftkeyClient.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.WindowSystem.Shell
             const string lib = "libtzsh_softkey.so.0";
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_softkey_create")]
-            internal static extern IntPtr Create(IntPtr tzsh, IntPtr win);
+            internal static extern IntPtr Create(IntPtr tzsh, uint win);
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_softkey_destroy")]
             internal static extern int Destroy(IntPtr softkeyClient);

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.SoftkeyService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.SoftkeyService.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.WindowSystem.Shell
             const string lib = "libtzsh_softkey_service.so.0";
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_softkey_service_create")]
-            internal static extern IntPtr Create(IntPtr tzsh, IntPtr win);
+            internal static extern IntPtr Create(IntPtr tzsh, uint win);
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_softkey_service_destroy")]
             internal static extern int Destroy(IntPtr softkeyService);

--- a/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.TaskbarService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/internal/Interop/Interop.TaskbarService.cs
@@ -11,7 +11,7 @@ namespace Tizen.NUI.WindowSystem.Shell
             const string lib = "libtzsh_taskbar_service.so.0";
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_taskbar_service_create")]
-            internal static extern IntPtr Create(IntPtr tzsh, IntPtr win);
+            internal static extern IntPtr Create(IntPtr tzsh, uint win);
 
             [global::System.Runtime.InteropServices.DllImport(lib, EntryPoint = "tzsh_taskbar_service_destroy")]
             internal static extern int Destroy(IntPtr taskbarService);

--- a/src/Tizen.NUI.WindowSystem/src/public/KVMService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/KVMService.cs
@@ -18,6 +18,7 @@
 using System;
 using System.ComponentModel;
 using System.Collections.Generic;
+using Tizen.Common;
 
 namespace Tizen.NUI.WindowSystem.Shell
 {
@@ -62,7 +63,7 @@ namespace Tizen.NUI.WindowSystem.Shell
         /// <param name="tzShell">The TizenShell instance.</param>
         /// <param name="win">The window to provide service of the quickpanel.</param>
         /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
         public KVMService(TizenShell tzShell, Window win)
         {
             if (tzShell == null)
@@ -80,7 +81,40 @@ namespace Tizen.NUI.WindowSystem.Shell
 
             _tzsh = tzShell;
             _tzshWin = win.GetNativeId();
-            _kvmService = Interop.KVMService.Create(_tzsh.GetNativeHandle(), (IntPtr)_tzshWin);
+            _kvmService = Interop.KVMService.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
+            if (_kvmService == IntPtr.Zero)
+            {
+                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
+                _tzsh.ErrorCodeThrow(err);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new KVM Service handle.
+        /// </summary>
+        /// <param name="tzShell">The TizenShell instance.</param>
+        /// <param name="win">The window provider for the quickpanel service.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when an argument is null.</exception>
+        /// <since_tizen> 12 </since_tizen>
+        public KVMService(TizenShell tzShell, IWindowProvider win)
+        {
+            if (tzShell == null)
+            {
+                throw new ArgumentNullException(nameof(tzShell));
+            }
+            if (tzShell.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new ArgumentException("tzShell is not initialized.");
+            }
+            if (win == null)
+            {
+                throw new ArgumentNullException(nameof(win));
+            }
+
+            _tzsh = tzShell;
+            _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);
+            _kvmService = Interop.KVMService.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
             if (_kvmService == IntPtr.Zero)
             {
                 int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();

--- a/src/Tizen.NUI.WindowSystem/src/public/QuickPanelService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/QuickPanelService.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using Tizen.Common;
 
 namespace Tizen.NUI.WindowSystem.Shell
 {
@@ -103,7 +104,42 @@ namespace Tizen.NUI.WindowSystem.Shell
 
             _tzsh = tzShell;
             _tzshWin = win.GetNativeId();
-            _tzshQpService = Interop.QuickPanelService.CreateWithType(_tzsh.GetNativeHandle(), (IntPtr)_tzshWin, (int)type);
+            _tzshQpService = Interop.QuickPanelService.CreateWithType(_tzsh.GetNativeHandle(), (uint)_tzshWin, (int)type);
+            if (_tzshQpService == IntPtr.Zero)
+            {
+                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
+                _tzsh.ErrorCodeThrow(err);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Quickpanel Service handle.
+        /// </summary>
+        /// <param name="tzShell">The TzShell instance.</param>
+        /// <param name="win">The window provider for the quickpanel service.</param>
+        /// <param name="type">The type of quickpanel service.</param>
+        /// <exception cref="Tizen.Applications.Exceptions.OutOfMemoryException">Thrown when the memory is not enough to allocate.</exception>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        /// <since_tizen> 12 </since_tizen>
+        public QuickPanelService(TizenShell tzShell, IWindowProvider win, Types type)
+        {
+            if (tzShell == null)
+            {
+                throw new ArgumentNullException(nameof(tzShell));
+            }
+            if (tzShell.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new ArgumentException("tzShell is not initialized.");
+            }
+            if (win == null)
+            {
+                throw new ArgumentNullException(nameof(win));
+            }
+
+            _tzsh = tzShell;
+            _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);
+            _tzshQpService = Interop.QuickPanelService.CreateWithType(_tzsh.GetNativeHandle(), (uint)_tzshWin, (int)type);
             if (_tzshQpService == IntPtr.Zero)
             {
                 int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();

--- a/src/Tizen.NUI.WindowSystem/src/public/SoftkeyClient.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/SoftkeyClient.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using Tizen.Common;
 
 namespace Tizen.NUI.WindowSystem.Shell
 {
@@ -61,7 +62,44 @@ namespace Tizen.NUI.WindowSystem.Shell
 
             _tzsh = tzShell;
             _tzshWin = win.GetNativeId();
-            _softkeyClient = Interop.SoftkeyClient.Create(_tzsh.GetNativeHandle(), (IntPtr)_tzshWin);
+            _softkeyClient = Interop.SoftkeyClient.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
+            if (_softkeyClient == IntPtr.Zero)
+            {
+                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
+                _tzsh.ErrorCodeThrow(err);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Softkey Client handle.
+        /// </summary>
+        /// <param name="tzShell">The TizenShell instance.</param>
+        /// <param name="win">The window provider for the quickpanel service.</param>
+        /// <privilege>http://tizen.org/privilege/windowsystem.admin</privilege>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation or no service.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when the caller does not have privilege to use this method.</exception>
+        /// <exception cref="NotSupportedException">Thrown when the feature is not supported.</exception>
+        /// <since_tizen> 12 </since_tizen>        
+        public SoftkeyClient(TizenShell tzShell, IWindowProvider win)
+        {
+            if (tzShell == null)
+            {
+                throw new ArgumentNullException(nameof(tzShell));
+            }
+            if (tzShell.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new ArgumentException("tzShell is not initialized.");
+            }
+            if (win == null)
+            {
+                throw new ArgumentNullException(nameof(win));
+            }
+
+            _tzsh = tzShell;
+            _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);
+            _softkeyClient = Interop.SoftkeyClient.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
             if (_softkeyClient == IntPtr.Zero)
             {
                 int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();

--- a/src/Tizen.NUI.WindowSystem/src/public/SoftkeyService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/SoftkeyService.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using Tizen.Common;
 
 namespace Tizen.NUI.WindowSystem.Shell
 {
@@ -65,7 +66,39 @@ namespace Tizen.NUI.WindowSystem.Shell
 
             _tzsh = tzShell;
             _tzshWin = win.GetNativeId();
-            _softkeyService = Interop.SoftkeyService.Create(_tzsh.GetNativeHandle(), (IntPtr)_tzshWin);
+            _softkeyService = Interop.SoftkeyService.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
+            if (_softkeyService == IntPtr.Zero)
+            {
+                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
+                _tzsh.ErrorCodeThrow(err);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new Softkey Service handle.
+        /// </summary>
+        /// <param name="tzShell">The TizenShell instance.</param>
+        /// <param name="win">The window provider for the quickpanel service.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        public SoftkeyService(TizenShell tzShell, IWindowProvider win)
+        {
+            if (tzShell == null)
+            {
+                throw new ArgumentNullException(nameof(tzShell));
+            }
+            if (tzShell.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new ArgumentException("tzShell is not initialized.");
+            }
+            if (win == null)
+            {
+                throw new ArgumentNullException(nameof(win));
+            }
+
+            _tzsh = tzShell;
+            _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);
+            _softkeyService = Interop.SoftkeyService.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
             if (_softkeyService == IntPtr.Zero)
             {
                 int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();

--- a/src/Tizen.NUI.WindowSystem/src/public/TaskbarService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/TaskbarService.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using Tizen.Common;
 
 namespace Tizen.NUI.WindowSystem.Shell
 {
@@ -81,7 +82,46 @@ namespace Tizen.NUI.WindowSystem.Shell
 
             _tzsh = tzShell;
             _tzshWin = win.GetNativeId();
-            _taskbarService = Interop.TaskbarService.Create(_tzsh.GetNativeHandle(), (IntPtr)_tzshWin);
+            _taskbarService = Interop.TaskbarService.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
+            if (_taskbarService == IntPtr.Zero)
+            {
+                int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();
+                _tzsh.ErrorCodeThrow(err);
+            }
+
+            Interop.TaskbarService.SetPlaceType(_taskbarService, (int)type);
+        }
+
+        /// <summary>
+        /// Creates a new Taskbar Service handle.
+        /// </summary>
+        /// <param name="tzShell">The TizenShell instance.</param>
+        /// <param name="win">The window provider for the taskbar service.</param>
+        /// <param name="type">The selected, predefined location on the screen the Taskbar should be placed on the screen.</param>
+        /// <exception cref="ArgumentException">Thrown when failed of invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when a argument is null.</exception>
+        public TaskbarService(TizenShell tzShell, IWindowProvider win, PlaceType type = PlaceType.Bottom)
+        {
+            if (tzShell == null)
+            {
+                throw new ArgumentNullException(nameof(tzShell));
+            }
+            if (tzShell.GetNativeHandle() == IntPtr.Zero)
+            {
+                throw new ArgumentException("tzShell is not initialized.");
+            }
+            if (win == null)
+            {
+                throw new ArgumentNullException(nameof(win));
+            }
+            if (!(win is Tizen.NUI.Window))
+            {
+                throw new ArgumentNullException("win should be NUI.Window because this is for NUI.WindowSystem");
+            }
+
+            _tzsh = tzShell;
+            _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);
+            _taskbarService = Interop.TaskbarService.Create(_tzsh.GetNativeHandle(), (uint)_tzshWin);
             if (_taskbarService == IntPtr.Zero)
             {
                 int err = Tizen.Internals.Errors.ErrorFacts.GetLastResult();

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -22,8 +22,8 @@ using System;
 using System.ComponentModel;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-
 using Tizen.NUI.BaseComponents;
+using Tizen.Common;
 
 namespace Tizen.NUI
 {
@@ -32,7 +32,7 @@ namespace Tizen.NUI
     /// The window has an orientation and indicator properties.<br />
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    public partial class Window : BaseHandle
+    public partial class Window : BaseHandle, IWindowProvider
     {
         private HandleRef stageCPtr;
         private Layer rootLayer;
@@ -2568,5 +2568,12 @@ namespace Tizen.NUI
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
+
+        IntPtr IWindowProvider.WindowHandle => GetNativeWindowHandler();
+        float IWindowProvider.X => WindowPosition.X;
+        float IWindowProvider.Y => WindowPosition.Y;
+        float IWindowProvider.Width => WindowSize.Width;
+        float IWindowProvider.Height => WindowSize.Height;
+        int IWindowProvider.Rotation => (int)GetCurrentOrientation();
     }
 }

--- a/src/Tizen/Tizen.Common/IWindowProvider.cs
+++ b/src/Tizen/Tizen.Common/IWindowProvider.cs
@@ -1,9 +1,25 @@
-﻿using System;
+﻿/*
+* Copyright (c) 2024 Samsung Electronics Co., Ltd All Rights Reserved
+*
+* Licensed under the Apache License, Version 2.0 (the License);
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an AS IS BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
-namespace Tizen.Multimedia
+using System;
+
+namespace Tizen.Common
 {
     /// <summary>
-    /// The IWindowProvider interface provides the window handle and information about the window's position, size, and rotation.
+    /// The IWindowProvider interface provides the window handle and information about the window's position, size, etc.
     /// </summary>
     /// <since_tizen> 12 </since_tizen>
     public interface IWindowProvider

--- a/test/Tizen.NUI.WindowSystem.InputGenerator/Tizen.NUI.WindowSystem.InputGenerator.sln
+++ b/test/Tizen.NUI.WindowSystem.InputGenerator/Tizen.NUI.WindowSystem.InputGenerator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI.WindowSystem.InputGenerator", "Tizen.NUI.WindowSystem.InputGenerator.csproj", "{3957344B-8BDF-4DA5-A299-F8CF5251BF8A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3957344B-8BDF-4DA5-A299-F8CF5251BF8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3957344B-8BDF-4DA5-A299-F8CF5251BF8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3957344B-8BDF-4DA5-A299-F8CF5251BF8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3957344B-8BDF-4DA5-A299-F8CF5251BF8A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C811B5D5-B735-43BC-B299-9984D91237AF}
+	EndGlobalSection
+EndGlobal

--- a/test/Tizen.NUI.WindowSystem.Samples/Tizen.NUI.WindowSystem.Samples.cs
+++ b/test/Tizen.NUI.WindowSystem.Samples/Tizen.NUI.WindowSystem.Samples.cs
@@ -6,6 +6,7 @@ using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Components;
 using Tizen.NUI.WindowSystem;
+using Tizen.Common;
 
 namespace Tizen.NUI.WindowSystem.Samples
 {
@@ -123,7 +124,7 @@ namespace Tizen.NUI.WindowSystem.Samples
             window.Remove(BtnClient);
             window.Remove(BtnSoftkeyService);
             window.Remove(BtnSoftkeyClient);
-            qpClient = new Shell.QuickPanelClient(tzShell, window, Shell.QuickPanelClient.Types.SystemDefault);
+            qpClient = new Shell.QuickPanelClient(tzShell, (IWindowProvider)window, Shell.QuickPanelClient.Types.SystemDefault);
 
             qpClient.VisibleChanged += OnVisibleEvent;
             qpClient.OrientationChanged += OnOrientationEvent;
@@ -239,7 +240,7 @@ namespace Tizen.NUI.WindowSystem.Samples
             window.Remove(BtnClient);
             window.Remove(BtnSoftkeyService);
             window.Remove(BtnSoftkeyClient);
-            qpService = new Shell.QuickPanelService(tzShell, window, type);
+            qpService = new Shell.QuickPanelService(tzShell, (IWindowProvider)window, type);
             //if ((type == Shell.QuickPanelService.Types.ContextMenu) || (type == Shell.QuickPanelService.Types.AppsMenu))
                 //window.AddAuxiliaryHint("wm.policy.win.user.geometry", "1");
 
@@ -410,7 +411,7 @@ namespace Tizen.NUI.WindowSystem.Samples
             window.Remove(BtnClient);
             window.Remove(BtnSoftkeyService);
             window.Remove(BtnSoftkeyClient);
-            softkeyClient = new Shell.SoftkeyClient(tzShell, window);
+            softkeyClient = new Shell.SoftkeyClient(tzShell, (IWindowProvider)window);
 
             textSoftkeyClientVisible = new TextLabel($"Visible: {softkeyClient.Visible}");
             textSoftkeyClientVisible.Position = new Position(0, -100);
@@ -554,7 +555,7 @@ namespace Tizen.NUI.WindowSystem.Samples
             window.Remove(BtnClient);
             window.Remove(BtnSoftkeyService);
             window.Remove(BtnSoftkeyClient);
-            softkeyService = new Shell.SoftkeyService(tzShell, window);
+            softkeyService = new Shell.SoftkeyService(tzShell, (IWindowProvider)window);
 
             textSoftkeyServiceVisible = new TextLabel($"Visible: None");
             textSoftkeyServiceVisible.Position = new Position(0, -100);

--- a/test/Tizen.NUI.WindowSystem.Samples/Tizen.NUI.WindowSystem.Samples.sln
+++ b/test/Tizen.NUI.WindowSystem.Samples/Tizen.NUI.WindowSystem.Samples.sln
@@ -21,10 +21,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI.Components", "..\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.System.Information", "..\..\src\Tizen.System.Information\Tizen.System.Information.csproj", "{1C93CF1D-452C-4EF8-BE4F-01023FC7318A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.framework", "..\..\..\charp_api\tct-suite-vs\nunit.framework\nunit.framework.csproj", "{37B85E87-6F6B-410A-9471-0774C3263033}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunitlite", "..\..\..\charp_api\tct-suite-vs\nunitlite\nunitlite.csproj", "{5E92B3C2-BF09-4C15-943C-8E251D0A7B58}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI.WindowSystem", "..\..\src\Tizen.NUI.WindowSystem\Tizen.NUI.WindowSystem.csproj", "{FB1E79E8-90E1-4AB4-8C69-D3A17E33865E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tizen.NUI.Samples", "..\Tizen.NUI.Samples\Tizen.NUI.Samples\Tizen.NUI.Samples.csproj", "{E43F3735-04C1-4BC6-84E1-7316D22AA488}"


### PR DESCRIPTION
### Description of Change ###
[NUI] Add IWindowProvider to be used as a common window interface across different modules

- move Tizen.Multimedia.Common.IWindowProvider to Tizen.Common.IWindowProvider.
- The Window is used not only for Multimedia but also in other places (such as WindowSystem), so this change seems to be right.
- This will be review requested to Multimedia team and Window System team.
- ACR will be done and the link will be updated soon.
- The QuickPanel sample could not be tested because there is no mobile target for the tizen_9.0 version (e.g., no TM1, no FHUB).

### API Changes ###
https://jira.sec.samsung.net/browse/TCSACR-586