### PR TITLE
[NUI] Fix lottie dynamic property crash

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1460,7 +1460,6 @@ namespace Tizen.NUI.BaseComponents
                     //do nothing
                     break;
             }
-            ret?.Dispose();
         }
 
         internal void FlushLottieMessages()


### PR DESCRIPTION
### Description of Change ###
NUI should not dispose the return value of dynamic property callback.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
