### PR TITLE
[NUI] Binding FrameUpdateCallbackInterface change Orientation

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
@@ -39,6 +39,18 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool FrameCallbackInterfaceBakePosition(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetOrientation")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceGetOrientation(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef orientation);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetOrientation")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceSetOrientation(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef orientation);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeOrientation")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceBakeOrientation(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef orientation);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPositionAndSize")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool FrameCallbackInterfaceGetPositionAndSize(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector, global::System.Runtime.InteropServices.HandleRef vector2);

--- a/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
@@ -138,6 +138,45 @@ namespace Tizen.NUI
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool GetOrientation(uint id, Rotation rotation)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceGetOrientation(proxyIntPtr, id, Rotation.getCPtr(rotation));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool SetOrientation(uint id, Rotation rotation)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceSetOrientation(proxyIntPtr, id, Rotation.getCPtr(rotation));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool BakeOrientation(uint id, Rotation rotation)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceBakeOrientation(proxyIntPtr, id, Rotation.getCPtr(rotation));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected bool GetSize(uint id, Vector3 size)
         {
             if (proxyIntPtr == IntPtr.Zero)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
@@ -65,6 +65,8 @@ namespace Tizen.NUI.Samples
         private const int DEFAULT_SPACE = 9;
         private const int DEVIDE_BAR_SIZE = 4;
 
+        private const float DEGREE_PER_POSITION = 0.05f;
+
         private const uint FRAME_UPDATE_CALLBACK_VERSION = 1u;
 
         public class FrameUpdateCallback : FrameUpdateCallbackInterface
@@ -268,17 +270,20 @@ namespace Tizen.NUI.Samples
 
                     // check views in screen are still moving or stopped.
                     float newPosition = viewPosition[i] + movement - lastMovement;
+                    float positionDiff = 0.0f;
                     if (i >= leftIndex && i <= rightIndex)
                     {
                         Vector3 previousPosition = new Vector3();
                         GetPosition(viewId[i], previousPosition);
-                        if (Math.Abs(previousPosition.X - newPosition) >= 1.0f)
+                        positionDiff = newPosition - previousPosition.X;
+                        if (Math.Abs(positionDiff) >= 1.0f)
                         {
                             isStillMoving = false;
                         }
                     }
-                    // update new position.
+                    // update new position and rotiation
                     SetPosition(viewId[i], new Vector3(newPosition, 0.0f, 0.0f));
+                    SetOrientation(viewId[i], new Rotation(new Radian(new Degree(positionDiff * DEGREE_PER_POSITION)), Vector3.ZAxis));
                     positionChanged = true;
                 }
                 isResetTouchedViewPossible = isStillMoving;


### PR DESCRIPTION
Let we allow to FrameUpdateCallback get and set Orientation.

Required dali patch : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/316498