### PR TITLE
[NUI] Add multi-mimetype feature for Drag and Drop

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.DragAndDrop.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DragAndDrop.cs
@@ -33,11 +33,11 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr New();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_StartDragAndDrop")]
-            public static extern bool StartDragAndDrop(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef sourceView, global::System.Runtime.InteropServices.HandleRef shadow, string mimeType, string data, global::System.Runtime.InteropServices.HandleRef callback);
+            public static extern bool StartDragAndDrop(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef sourceView, global::System.Runtime.InteropServices.HandleRef shadow, string [] mimeTypes, int mimeTypsSize, string data, global::System.Runtime.InteropServices.HandleRef callback);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_AddListener")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool AddListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetView, global::System.Runtime.InteropServices.HandleRef callback);
+            public static extern bool AddListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetView, string mimeType, global::System.Runtime.InteropServices.HandleRef callback);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_RemoveListener")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
@@ -45,7 +45,7 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_Window_AddListener")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool WindowAddListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetWindow, global::System.Runtime.InteropServices.HandleRef callback);
+            public static extern bool WindowAddListener(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef targetWindow, string mimeType, global::System.Runtime.InteropServices.HandleRef callback);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_Window_RemoveListener")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
@@ -59,6 +59,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetMimeType")]
             public static extern string GetMimeType(global::System.IntPtr dragAndDrop);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetMimeTypes")]
+            public static extern bool GetMimeTypes(global::System.IntPtr dragAndDrop, out global::System.IntPtr mimeTypes, out int count);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetData")]
             public static extern string GetData(global::System.IntPtr dragAndDrop);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.DragAndDrop.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.DragAndDrop.cs
@@ -33,7 +33,7 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr New();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_StartDragAndDrop")]
-            public static extern bool StartDragAndDrop(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef sourceView, global::System.Runtime.InteropServices.HandleRef shadow, string [] mimeTypes, int mimeTypsSize, string data, global::System.Runtime.InteropServices.HandleRef callback);
+            public static extern bool StartDragAndDrop(global::System.Runtime.InteropServices.HandleRef dragAndDrop, global::System.Runtime.InteropServices.HandleRef sourceView, global::System.Runtime.InteropServices.HandleRef shadow, string [] mimeTypes, int mimeTypsSize, string [] dataSet, int dataSetSize, global::System.Runtime.InteropServices.HandleRef callback);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragAndDrop_AddListener")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
@@ -56,9 +56,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetPosition")]
             public static extern global::System.IntPtr GetPosition(global::System.IntPtr dragAndDrop);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetMimeType")]
-            public static extern string GetMimeType(global::System.IntPtr dragAndDrop);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_DragEvent_GetMimeTypes")]
             public static extern bool GetMimeTypes(global::System.IntPtr dragAndDrop, out global::System.IntPtr mimeTypes, out int count);

--- a/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
+++ b/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
@@ -34,6 +34,7 @@ namespace Tizen.NUI
         public delegate void SourceEventHandler(DragSourceEventType sourceEventType);
         private delegate void InternalSourceEventHandler(int sourceEventType);
         public delegate void DragAndDropEventHandler(View targetView, DragEvent navtiveDragEvent);
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public delegate void DragAndDropWindowEventHandler(Window targetWindow, DragEvent navtiveDragEvent);
         private delegate void InternalDragAndDropEventHandler(global::System.IntPtr navtiveDragEvent);
         private InternalSourceEventHandler sourceEventCb;
@@ -257,7 +258,7 @@ namespace Tizen.NUI
                 string [] mimeTypes;
                 string [] dataSet;
 
-                if (string.IsNullOrEmpty(dragData.MimeType))
+                if (string.IsNullOrEmpty(dragData.MimeType) && dragData.DataMap != null)
                 {
                     mimeTypes = dragData.DataMap.Keys.ToArray();
                     dataSet = dragData.DataMap.Values.ToArray();
@@ -287,15 +288,7 @@ namespace Tizen.NUI
         /// <since_tizen> 10 </since_tizen>
         public void AddListener(View targetView, DragAndDropEventHandler callback)
         {
-            InternalDragAndDropEventHandler cb = (navtiveDragEvent) => ProcessDragEventTargetCallback(navtiveDragEvent, targetView, callback);
-
-            targetEventDictionary.Add(targetView, cb);
-
-            if (!Interop.DragAndDrop.AddListener(SwigCPtr, View.getCPtr(targetView), "*/*",
-                                                 new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(cb))))
-            {
-                 throw new InvalidOperationException("Fail to AddListener for View");
-            }
+            AddListener(targetView, "*/*", callback);
         }
 
         /// <summary>
@@ -348,15 +341,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddListener(Window targetWindow, DragAndDropWindowEventHandler callback)
         {
-            InternalDragAndDropEventHandler cb = (navtiveDragEvent) => ProcessDragEventWindowCallback(navtiveDragEvent, targetWindow, callback);
-
-            targetWindowEventDictionary.Add(targetWindow, cb);
-
-            if (!Interop.DragAndDrop.WindowAddListener(SwigCPtr, Window.getCPtr(targetWindow), "*/*",
-                                                       new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(cb))))
-            {
-                 throw new InvalidOperationException("Fail to AddListener for Window");
-            }
+            AddListener(targetWindow, "*/*", callback);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
+++ b/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
@@ -32,10 +32,11 @@ namespace Tizen.NUI
     {
         public delegate void SourceEventHandler(DragSourceEventType sourceEventType);
         private delegate void InternalSourceEventHandler(int sourceEventType);
-        public delegate void DragAndDropEventHandler(View targetView, DragEvent dragEvent);
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public delegate void DragAndDropWindowEventHandler(Window targetWindow, DragEvent dragEvent);
-        private delegate void InternalDragAndDropEventHandler(global::System.IntPtr dragEvent);
+        public delegate void DragAndDropEventHandler(View targetView, DragEvent navtiveDragEvent);
+        public delegate void DragAndDropDragInfoEventHandler(View targetView, DragInfoEvent dragInfoEvent);
+        public delegate void DragAndDropWindowEventHandler(Window targetWindow, DragEvent navtiveDragEvent);
+        public delegate void DragAndDropWindowDragInfoEventHandler(Window targetWindow, DragInfoEvent dragInfoEvent);
+        private delegate void InternalDragAndDropEventHandler(global::System.IntPtr navtiveDragEvent);
         private InternalSourceEventHandler sourceEventCb;
         private Dictionary<View, InternalDragAndDropEventHandler> targetEventDictionary = new Dictionary<View, InternalDragAndDropEventHandler>();
         private Dictionary<Window, InternalDragAndDropEventHandler> targetWindowEventDictionary = new Dictionary<Window, InternalDragAndDropEventHandler>();
@@ -165,14 +166,106 @@ namespace Tizen.NUI
                 //Show Drag Window before StartDragAndDrop
                 mDragWindow.Show();
 
-                if (!Interop.DragAndDrop.StartDragAndDrop(SwigCPtr, View.getCPtr(sourceView), Window.getCPtr(mDragWindow), dragData.MimeType, dragData.Data,
+                string [] mimeTypes = new string[1];
+                mimeTypes[0] = dragData.MimeType;
+
+                if (!Interop.DragAndDrop.StartDragAndDrop(SwigCPtr, View.getCPtr(sourceView), Window.getCPtr(mDragWindow), mimeTypes, 1, dragData.Data,
                                                         new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(sourceEventCb))))
                 {
                     throw new InvalidOperationException("Fail to StartDragAndDrop");
                 }
+            } 
+            initDrag = false;
+        }
 
-            }         
-            
+        /// <summary>
+        /// Starts drag and drop.
+        /// </summary>
+        /// <param name="sourceView">The soruce view</param>
+        /// <param name="shadowView">The shadow view for drag object</param>
+        /// <param name="dragData">The data to send</param>
+        /// <param name="callback">The source event callback</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void StartDragAndDrop(View sourceView, View shadowView, DragInfo dragInfo, SourceEventHandler callback)
+        {
+            if (initDrag)
+            {
+                 Tizen.Log.Fatal("NUI", "Start Drag And Drop Initializing...");
+                 return;
+            }
+            initDrag = true;
+
+            if (Window.IsSupportedMultiWindow() == false)
+            {
+                throw new NotSupportedException("This device does not support surfaceless_context. So Window cannot be created.");
+            }
+
+            if (null == shadowView)
+            {
+                throw new ArgumentNullException(nameof(shadowView));
+            }
+
+            ReleaseDragWindow();
+
+            shadowWidth = (int)shadowView.Size.Width;
+            shadowHeight = (int)shadowView.Size.Height;
+
+            if (shadowView.Size.Width < MinDragWindowWidth)
+            {
+                shadowWidth = MinDragWindowWidth;
+            }
+
+            if (shadowView.Size.Height < MinDragWindowHeight)
+            {
+                shadowHeight = MinDragWindowHeight;
+            }
+
+            mDragWindow = new Window("DragWindow", new Rectangle(dragWindowOffsetX, dragWindowOffsetY, shadowWidth, shadowHeight), true)
+            {
+                BackgroundColor = Color.Transparent,
+            };
+
+            if (mDragWindow)
+            {
+                //Set Window Orientation Available
+                List<Window.WindowOrientation> list = new List<Window.WindowOrientation>();
+                list.Add(Window.WindowOrientation.Landscape);
+                list.Add(Window.WindowOrientation.LandscapeInverse);
+                list.Add(Window.WindowOrientation.NoOrientationPreference);
+                list.Add(Window.WindowOrientation.Portrait);
+                list.Add(Window.WindowOrientation.PortraitInverse);
+                mDragWindow.SetAvailableOrientations(list);
+
+                //Initialize Drag Window Size based on Shadow View Size,
+                //Don't set Drag Window Posiiton, Window Server sets Position Internally
+                mDragWindow.SetWindowSize(new Size(shadowWidth, shadowHeight));
+
+                //Make Position 0, 0 for Moving into Drag Window
+                shadowView.Position = new Position(0, 0);
+
+                mShadowView = shadowView;
+                mDragWindow.Add(mShadowView);
+
+                sourceEventCb = (sourceEventType) =>
+                {
+                    if ((DragSourceEventType)sourceEventType != DragSourceEventType.Start)
+                    {
+                        Tizen.Log.Fatal("NUI", "DnD Source Event is Called");
+                        ReleaseDragWindow();
+                    }
+
+                    callback((DragSourceEventType)sourceEventType);
+                };
+
+                //Show Drag Window before StartDragAndDrop
+                mDragWindow.Show();
+
+                if (!Interop.DragAndDrop.StartDragAndDrop(SwigCPtr, View.getCPtr(sourceView), Window.getCPtr(mDragWindow), dragInfo.MimeTypes, dragInfo.MimeTypes.Length, dragInfo.Data,
+                                                        new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(sourceEventCb))))
+                {
+                    throw new InvalidOperationException("Fail to StartDragAndDrop");
+                }
+            }
             initDrag = false;
         }
 
@@ -184,42 +277,108 @@ namespace Tizen.NUI
         /// <since_tizen> 10 </since_tizen>
         public void AddListener(View targetView, DragAndDropEventHandler callback)
         {
-            InternalDragAndDropEventHandler cb = (dragEvent) =>
+            InternalDragAndDropEventHandler cb = (navtiveDragEvent) =>
             {
-                DragType type = (DragType)Interop.DragAndDrop.GetAction(dragEvent);
-                DragEvent ev = new DragEvent();
-                global::System.IntPtr cPtr = Interop.DragAndDrop.GetPosition(dragEvent);
-                ev.Position = (cPtr == global::System.IntPtr.Zero) ? null : new Position(cPtr, true);
+                DragType type = (DragType)Interop.DragAndDrop.GetAction(navtiveDragEvent);
+                DragEvent event_ = new DragEvent();
+                global::System.IntPtr cPtr = Interop.DragAndDrop.GetPosition(navtiveDragEvent);
+                event_.Position = (cPtr == global::System.IntPtr.Zero) ? null : new Position(cPtr, true);
 
                 if (type == DragType.Enter)
                 {
-                    ev.DragType = type;
-                    ev.MimeType = Interop.DragAndDrop.GetMimeType(dragEvent);
-                    callback(targetView, ev);
+                    event_.DragType = type;
+                    event_.MimeType = Interop.DragAndDrop.GetMimeType(navtiveDragEvent);
+                    callback(targetView, event_);
                 }
                 else if (type == DragType.Leave)
                 {
-                    ev.DragType = type;
-                    callback(targetView, ev);
+                    event_.DragType = type;
+                    callback(targetView, event_);
                 }
                 else if (type == DragType.Move)
                 {
-                    ev.DragType = type;
-                    ev.MimeType = Interop.DragAndDrop.GetMimeType(dragEvent);
-                    callback(targetView, ev);
+                    event_.DragType = type;
+                    event_.MimeType = Interop.DragAndDrop.GetMimeType(navtiveDragEvent);
+                    callback(targetView, event_);
                 }
                 else if (type == DragType.Drop)
                 {
-                    ev.DragType = type;
-                    ev.MimeType = Interop.DragAndDrop.GetMimeType(dragEvent);
-                    ev.Data = Interop.DragAndDrop.GetData(dragEvent);
-                    callback(targetView, ev);
+                    event_.DragType = type;
+                    event_.MimeType = Interop.DragAndDrop.GetMimeType(navtiveDragEvent);
+                    event_.Data = Interop.DragAndDrop.GetData(navtiveDragEvent);
+                    callback(targetView, event_);
                 }
             };
 
             targetEventDictionary.Add(targetView, cb);
 
-            if (!Interop.DragAndDrop.AddListener(SwigCPtr, View.getCPtr(targetView),
+            if (!Interop.DragAndDrop.AddListener(SwigCPtr, View.getCPtr(targetView), "*/*",
+                                                 new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(cb))))
+            {
+                 throw new InvalidOperationException("Fail to AddListener for View");
+            }
+        }
+
+        /// <summary>
+        /// Adds listener for drop targets
+        /// </summary>
+        /// <param name="targetView">The target view</param>
+        /// <param name="mimeType">The mime type for target view</param>
+        /// <param name="callback">The callback function to get drag event when the drag source enters, moves, leaves and drops on the drop target</param> 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddListener(View targetView, string mimeType, DragAndDropDragInfoEventHandler callback)
+        {
+            InternalDragAndDropEventHandler cb = (navtiveDragEvent) =>
+            {
+                DragType type = (DragType)Interop.DragAndDrop.GetAction(navtiveDragEvent);
+                DragInfoEvent event_ = new DragInfoEvent();
+                global::System.IntPtr cPtr = Interop.DragAndDrop.GetPosition(navtiveDragEvent);
+                event_.Position = (cPtr == global::System.IntPtr.Zero) ? null : new Position(cPtr, true);
+
+                IntPtr nativeMimeTypes;
+                int count;
+                Interop.DragAndDrop.GetMimeTypes(navtiveDragEvent, out nativeMimeTypes, out count);
+                if (count > 0)
+                {
+                  IntPtr [] _nativeMimeTypes = new IntPtr[count];
+                  Marshal.Copy(nativeMimeTypes, _nativeMimeTypes, 0, count);
+
+                  string [] managedMimeTypes = new string[count];
+
+                  for (int iterator = 0; iterator < count; iterator++)
+                  {
+                    managedMimeTypes[iterator] = Marshal.PtrToStringAnsi(_nativeMimeTypes[iterator]);
+                  }
+
+                  event_.MimeTypes = managedMimeTypes;
+                }
+
+                if (type == DragType.Enter)
+                {
+                    event_.DragType = type;
+                    callback(targetView, event_);
+                }
+                else if (type == DragType.Leave)
+                {
+                    event_.DragType = type;
+                    callback(targetView, event_);
+                }
+                else if (type == DragType.Move)
+                {
+                    event_.DragType = type;
+                    callback(targetView, event_);
+                }
+                else if (type == DragType.Drop)
+                {
+                    event_.DragType = type;
+                    event_.Data = Interop.DragAndDrop.GetData(navtiveDragEvent);
+                    callback(targetView, event_);
+                }
+            };
+
+            targetEventDictionary.Add(targetView, cb);
+
+            if (!Interop.DragAndDrop.AddListener(SwigCPtr, View.getCPtr(targetView), mimeType,
                                                  new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(cb))))
             {
                  throw new InvalidOperationException("Fail to AddListener for View");
@@ -256,40 +415,107 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void AddListener(Window targetWindow, DragAndDropWindowEventHandler callback)
         {
-            InternalDragAndDropEventHandler cb = (dragEvent) =>
+            InternalDragAndDropEventHandler cb = (navtiveDragEvent) =>
             {
-                DragType type = (DragType)Interop.DragAndDrop.GetAction(dragEvent);
-                DragEvent ev = new DragEvent();
-                global::System.IntPtr cPtr = Interop.DragAndDrop.GetPosition(dragEvent);
-                ev.Position = (cPtr == global::System.IntPtr.Zero) ? null : new Position(cPtr, false);
+                DragType type = (DragType)Interop.DragAndDrop.GetAction(navtiveDragEvent);
+                DragEvent event_ = new DragEvent();
+                global::System.IntPtr cPtr = Interop.DragAndDrop.GetPosition(navtiveDragEvent);
+                event_.Position = (cPtr == global::System.IntPtr.Zero) ? null : new Position(cPtr, false);
 
                 if (type == DragType.Enter)
                 {
-                    ev.DragType = type;
-                    callback(targetWindow, ev);
+                    event_.DragType = type;
+                    callback(targetWindow, event_);
                 }
                 else if (type == DragType.Leave)
                 {
-                    ev.DragType = type;
-                    callback(targetWindow, ev);
+                    event_.DragType = type;
+                    callback(targetWindow, event_);
                 }
                 else if (type == DragType.Move)
                 {
-                    ev.DragType = type;
-                    callback(targetWindow, ev);
+                    event_.DragType = type;
+                    callback(targetWindow, event_);
                 }
                 else if (type == DragType.Drop)
                 {
-                    ev.DragType = type;
-                    ev.MimeType = Interop.DragAndDrop.GetMimeType(dragEvent);
-                    ev.Data = Interop.DragAndDrop.GetData(dragEvent);
-                    callback(targetWindow, ev);
+                    event_.DragType = type;
+                    event_.MimeType = Interop.DragAndDrop.GetMimeType(navtiveDragEvent);
+                    event_.Data = Interop.DragAndDrop.GetData(navtiveDragEvent);
+                    callback(targetWindow, event_);
                 }
             };
 
             targetWindowEventDictionary.Add(targetWindow, cb);
 
-            if (!Interop.DragAndDrop.WindowAddListener(SwigCPtr, Window.getCPtr(targetWindow),
+            if (!Interop.DragAndDrop.WindowAddListener(SwigCPtr, Window.getCPtr(targetWindow), "*/*",
+                                                       new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(cb))))
+            {
+                 throw new InvalidOperationException("Fail to AddListener for Window");
+            }
+        }
+
+        /// <summary>
+        /// Adds listener for drop targets
+        /// </summary>
+        /// <param name="targetWindow">The target Window</param>
+        /// <param name="mimeType">The mime type for target view</param>
+        /// <param name="callback">The callback function to get drag event when the drag source enters, moves, leaves and drops on the drop target</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddListener(Window targetWindow, string mimeType, DragAndDropWindowDragInfoEventHandler callback)
+        {
+            InternalDragAndDropEventHandler cb = (navtiveDragEvent) =>
+            {
+                DragType type = (DragType)Interop.DragAndDrop.GetAction(navtiveDragEvent);
+                DragInfoEvent event_ = new DragInfoEvent();
+                global::System.IntPtr cPtr = Interop.DragAndDrop.GetPosition(navtiveDragEvent);
+                event_.Position = (cPtr == global::System.IntPtr.Zero) ? null : new Position(cPtr, false);
+
+                IntPtr nativeMimeTypes;
+                int count;
+                Interop.DragAndDrop.GetMimeTypes(navtiveDragEvent, out nativeMimeTypes, out count);
+                if (count > 0)
+                {
+
+                  IntPtr [] _nativeMimeTypes = new IntPtr[count];
+                  Marshal.Copy(nativeMimeTypes, _nativeMimeTypes, 0, count);
+
+                  string [] managedMimeTypes = new string[count];
+
+                  for (int iterator = 0; iterator < count; iterator++)
+                  {
+                    managedMimeTypes[iterator] = Marshal.PtrToStringAnsi(_nativeMimeTypes[iterator]);
+                  }
+
+                  event_.MimeTypes = managedMimeTypes;
+                }
+
+                if (type == DragType.Enter)
+                {
+                    event_.DragType = type;
+                    callback(targetWindow, event_);
+                }
+                else if (type == DragType.Leave)
+                {
+                    event_.DragType = type;
+                    callback(targetWindow, event_);
+                }
+                else if (type == DragType.Move)
+                {
+                    event_.DragType = type;
+                    callback(targetWindow, event_);
+                }
+                else if (type == DragType.Drop)
+                {
+                    event_.DragType = type;
+                    event_.Data = Interop.DragAndDrop.GetData(navtiveDragEvent);
+                    callback(targetWindow, event_);
+                }
+            };
+
+            targetWindowEventDictionary.Add(targetWindow, cb);
+
+            if (!Interop.DragAndDrop.WindowAddListener(SwigCPtr, Window.getCPtr(targetWindow), mimeType,
                                                        new global::System.Runtime.InteropServices.HandleRef(this, Marshal.GetFunctionPointerForDelegate<Delegate>(cb))))
             {
                  throw new InvalidOperationException("Fail to AddListener for Window");

--- a/src/Tizen.NUI/src/public/DragAndDrop/DragEvent.cs
+++ b/src/Tizen.NUI/src/public/DragAndDrop/DragEvent.cs
@@ -16,6 +16,7 @@
  */
 using System;
 using System.ComponentModel;
+using System.Collections.Generic;
 using Tizen.NUI.Binding;
 
 namespace Tizen.NUI
@@ -60,24 +61,11 @@ namespace Tizen.NUI
         /// The drag data to send
         /// </summary>
         public string Data { get; set; }
-    }
 
-    /// <summary>
-    /// This specifies drag info
-    /// </summary>
-    // Suppress warning : This struct will be used data of callback, so override equals and operator does not necessary.
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815: Override equals and operator equals on value types")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct DragInfo
-    {
         /// <summary>
-        /// The mime types of drag data
+        /// The mime types and drag data set
         /// </summary>
-        public string [] MimeTypes { get; set; }
-        /// <summary>
-        /// The drag data to send
-        /// </summary>
-        public string Data { get; set; }
+        public Dictionary<string, string> DataMap;
     }
 
     /// <summary>
@@ -124,32 +112,12 @@ namespace Tizen.NUI
         /// The mime type of drag object
         /// </summary>
         public string MimeType { get; set; }
-        /// <summary>
-        /// The drag data to receive
-        /// </summary>
-        public string Data { get; set; }
-    }
 
-    /// <summary>
-    /// This specifies drag info event.
-    /// </summary>
-    // Suppress warning : This struct will be used data of callback, so override equals and operator does not necessary.
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815: Override equals and operator equals on value types")]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct DragInfoEvent
-    {
-        /// <summary>
-        /// The drag event type
-        /// </summary>
-        public DragType DragType { get; set; }
-        /// <summary>
-        /// The drag object position in target view
-        /// </summary>
-        public Position Position  { get; set; }
         /// <summary>
         /// The mime types of drag object
         /// </summary>
         public string [] MimeTypes { get; set; }
+
         /// <summary>
         /// The drag data to receive
         /// </summary>

--- a/src/Tizen.NUI/src/public/DragAndDrop/DragEvent.cs
+++ b/src/Tizen.NUI/src/public/DragAndDrop/DragEvent.cs
@@ -63,6 +63,24 @@ namespace Tizen.NUI
     }
 
     /// <summary>
+    /// This specifies drag info
+    /// </summary>
+    // Suppress warning : This struct will be used data of callback, so override equals and operator does not necessary.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815: Override equals and operator equals on value types")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct DragInfo
+    {
+        /// <summary>
+        /// The mime types of drag data
+        /// </summary>
+        public string [] MimeTypes { get; set; }
+        /// <summary>
+        /// The drag data to send
+        /// </summary>
+        public string Data { get; set; }
+    }
+
+    /// <summary>
     /// Drag event type.
     /// </summary>
     /// <since_tizen> 10 </since_tizen>
@@ -106,6 +124,32 @@ namespace Tizen.NUI
         /// The mime type of drag object
         /// </summary>
         public string MimeType { get; set; }
+        /// <summary>
+        /// The drag data to receive
+        /// </summary>
+        public string Data { get; set; }
+    }
+
+    /// <summary>
+    /// This specifies drag info event.
+    /// </summary>
+    // Suppress warning : This struct will be used data of callback, so override equals and operator does not necessary.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815: Override equals and operator equals on value types")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct DragInfoEvent
+    {
+        /// <summary>
+        /// The drag event type
+        /// </summary>
+        public DragType DragType { get; set; }
+        /// <summary>
+        /// The drag object position in target view
+        /// </summary>
+        public Position Position  { get; set; }
+        /// <summary>
+        /// The mime types of drag object
+        /// </summary>
+        public string [] MimeTypes { get; set; }
         /// <summary>
         /// The drag data to receive
         /// </summary>

--- a/src/Tizen.NUI/src/public/DragAndDrop/DragEvent.cs
+++ b/src/Tizen.NUI/src/public/DragAndDrop/DragEvent.cs
@@ -65,6 +65,7 @@ namespace Tizen.NUI
         /// <summary>
         /// The mime types and drag data set
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Dictionary<string, string> DataMap;
     }
 
@@ -116,6 +117,7 @@ namespace Tizen.NUI
         /// <summary>
         /// The mime types of drag object
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string [] MimeTypes { get; set; }
 
         /// <summary>

--- a/test/NUIDnDMultiWindow/NUIDnDMultiWindow.cs
+++ b/test/NUIDnDMultiWindow/NUIDnDMultiWindow.cs
@@ -89,7 +89,7 @@ namespace NUIDnDMultiWindow
                 Tizen.Log.Debug("NUIDnDMultiWindow", "StartDragAndDrop");
                 shadowView = new ImageView(Tizen.Applications.Application.Current.DirectoryInfo.SharedResource + "dragsource.png");
                 shadowView.Size = new Size(150, 150);
-                DragData dragData;
+                DragData dragData = new DragData();
                 dragData.MimeType = "text/uri-list";
                 dragData.Data = Tizen.Applications.Application.Current.DirectoryInfo.SharedResource + "dragsource.png";
                 dnd.StartDragAndDrop(sourceView, shadowView, dragData, OnSourceApp_SourceFunc);

--- a/test/NUIDnDSource/NUIDnDSource.cs
+++ b/test/NUIDnDSource/NUIDnDSource.cs
@@ -91,7 +91,7 @@ namespace NUIDnDSource
                 Tizen.Log.Debug("NUIDnDSource", "StartDragAndDrop");
                 shadowView = new ImageView(Tizen.Applications.Application.Current.DirectoryInfo.SharedResource + "dragsource.png");
                 shadowView.Size = new Size(150, 150);
-                DragData dragData;
+                DragData dragData = new DragData();
                 dragData.MimeType = "text/uri-list";
                 dragData.Data = Tizen.Applications.Application.Current.DirectoryInfo.SharedResource + "dragsource.png";
                 dnd.StartDragAndDrop(sourceView, shadowView, dragData, OnSourceEventFunc);


### PR DESCRIPTION
### Contents
 - Allow to set multi-mimetypes for source client (use DragInfo)
 - Target client receive source's mimetypes from source client when Enter, Move, Leave
 - Target client can set mimetype to receive
 - Refactoring code for readability
### Dependency
**[dali-adaptor]**
- patch : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/316807/


**[dali-csharp-binder]**
- patch : https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/316808/