### PR TITLE
[NUI] Support FrameSpeedFactor for AnimatedImage relative classes

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedImageView.cs
@@ -42,6 +42,7 @@ namespace Tizen.NUI.BaseComponents
             ImageVisualProperty.FrameDelay,
             ImageVisualProperty.LoopCount,
             ImageVisualProperty.StopBehavior,
+            ImageVisualProperty.FrameSpeedFactor,
         };
         private List<string> resourceURLs = new List<string>();
         #endregion Private
@@ -281,6 +282,50 @@ namespace Tizen.NUI.BaseComponents
             {
                 using PropertyValue setValue = new PropertyValue((int)value);
                 UpdateImage(ImageVisualProperty.StopBehavior, setValue);
+            }
+        }
+
+        /// <summary>
+        /// Specifies a speed factor for the animated image frame.
+        /// </summary>
+        /// <remarks>
+        /// The speed factor is a multiplier of the normal velocity of the animation. Values between [0,1] will
+        /// slow down the animation and values above one will speed up the animation.
+        ///
+        /// The range of this value is clamped between [0.01f ~ 100.0f].
+        ///
+        /// Inhouse API.
+        /// The default is 1.0f.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float FrameSpeedFactor
+        {
+            get
+            {
+                return InternalFrameSpeedFactor;
+            }
+            set
+            {
+                InternalFrameSpeedFactor = value;
+                NotifyPropertyChanged();
+            }
+        }
+
+        private float InternalFrameSpeedFactor
+        {
+            get
+            {
+                float ret = 1.0f;
+
+                using PropertyValue frameSpeedFactor = GetCachedImageVisualProperty(ImageVisualProperty.FrameSpeedFactor);
+                frameSpeedFactor?.Get(out ret);
+
+                return ret;
+            }
+            set
+            {
+                using PropertyValue setValue = new PropertyValue(value);
+                UpdateImage(ImageVisualProperty.FrameSpeedFactor, setValue);
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -77,6 +77,7 @@ namespace Tizen.NUI.BaseComponents
             currentStates.loopCount = 1;
             currentStates.loopMode = LoopingModeType.Restart;
             currentStates.stopEndAction = StopBehaviorType.CurrentFrame;
+            currentStates.frameSpeedFactor = 1.0f;
             currentStates.framePlayRangeMin = -1;
             currentStates.framePlayRangeMax = -1;
             currentStates.totalFrame = -1;
@@ -216,6 +217,7 @@ namespace Tizen.NUI.BaseComponents
                 using PropertyValue synchronousLoading = new PropertyValue(currentStates.synchronousLoading);
                 using PropertyValue enableFrameCache = new PropertyValue(currentStates.enableFrameCache);
                 using PropertyValue notifyAfterRasterization = new PropertyValue(currentStates.notifyAfterRasterization);
+                using PropertyValue frameSpeedFactor = new PropertyValue(currentStates.frameSpeedFactor);
 
                 map.Add(Visual.Property.Type, type)
                     .Add(ImageVisualProperty.URL, url)
@@ -225,7 +227,8 @@ namespace Tizen.NUI.BaseComponents
                     .Add(ImageVisualProperty.RedrawInScalingDown, redrawInScalingDown)
                     .Add(ImageVisualProperty.SynchronousLoading, synchronousLoading)
                     .Add(ImageVisualProperty.EnableFrameCache, enableFrameCache)
-                    .Add(ImageVisualProperty.NotifyAfterRasterization, notifyAfterRasterization);
+                    .Add(ImageVisualProperty.NotifyAfterRasterization, notifyAfterRasterization)
+                    .Add(ImageVisualProperty.FrameSpeedFactor, frameSpeedFactor);
 
                 if (currentStates.desiredWidth > 0)
                 {
@@ -779,6 +782,53 @@ namespace Tizen.NUI.BaseComponents
                 return currentStates.notifyAfterRasterization;
             }
         }
+
+        /// <summary>
+        /// Specifies a speed factor for the animated image frame.
+        /// </summary>
+        /// <remarks>
+        /// The speed factor is a multiplier of the normal velocity of the animation. Values between [0,1] will
+        /// slow down the animation and values above one will speed up the animation.
+        ///
+        /// The range of this value is clamped between [0.01f ~ 100.0f].
+        ///
+        /// Inhouse API.
+        /// The default is 1.0f.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float FrameSpeedFactor
+        {
+            get
+            {
+                return InternalFrameSpeedFactor;
+            }
+            set
+            {
+                InternalFrameSpeedFactor = value;
+                NotifyPropertyChanged();
+            }
+        }
+
+        private float InternalFrameSpeedFactor
+        {
+            set
+            {
+                if (currentStates.frameSpeedFactor != value)
+                {
+                    currentStates.changed = true;
+                    currentStates.frameSpeedFactor = value;
+
+                    NUILog.Debug($"<[{GetId()}]SET currentStates.FrameSpeedFactor={currentStates.frameSpeedFactor}>");
+
+                    Interop.View.InternalUpdateVisualPropertyFloat(this.SwigCPtr, ImageView.Property.IMAGE, ImageVisualProperty.FrameSpeedFactor, currentStates.frameSpeedFactor);
+                }
+            }
+            get
+            {
+                NUILog.Debug($"FrameSpeedFactor get! {currentStates.frameSpeedFactor}");
+                return currentStates.frameSpeedFactor;
+            }
+        }
         #endregion Property
 
 
@@ -1103,6 +1153,7 @@ namespace Tizen.NUI.BaseComponents
                 UpdateImage(ImageVisualProperty.SynchronousLoading, new PropertyValue(currentStates.synchronousLoading), false);
                 UpdateImage(ImageVisualProperty.EnableFrameCache, new PropertyValue(currentStates.enableFrameCache), false);
                 UpdateImage(ImageVisualProperty.NotifyAfterRasterization, new PropertyValue(currentStates.notifyAfterRasterization), false);
+                UpdateImage(ImageVisualProperty.FrameSpeedFactor, new PropertyValue(currentStates.frameSpeedFactor), false);
 
                 // Do not cache PlayRange and TotalFrameNumber into cachedImagePropertyMap.
                 // (To keep legacy implements behaviour)
@@ -1495,6 +1546,7 @@ namespace Tizen.NUI.BaseComponents
             ImageVisualProperty.RedrawInScalingDown,
             ImageVisualProperty.EnableFrameCache,
             ImageVisualProperty.NotifyAfterRasterization,
+            ImageVisualProperty.FrameSpeedFactor,
         };
 
         private struct states
@@ -1503,6 +1555,7 @@ namespace Tizen.NUI.BaseComponents
             internal int loopCount;
             internal LoopingModeType loopMode;
             internal StopBehaviorType stopEndAction;
+            internal float frameSpeedFactor;
             internal int framePlayRangeMin;
             internal int framePlayRangeMax;
             internal int totalFrame;

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -1032,6 +1032,20 @@ namespace Tizen.NUI
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly int SynchronousSizing = NDalic.ImageVisualOrientationCorrection + 18;
+
+        /// <summary>
+        /// @brief Specifies a speed factor for the animated image frame.
+        /// @details Name "frameSpeedFactor", type Property::FLOAT.
+        ///
+        /// The speed factor is a multiplier of the normal velocity of the animation. Values between [0,1] will
+        /// slow down the animation and values above one will speed up the animation.
+        ///
+        /// @note The range of this value is clamped between [0.01f ~ 100.0f].
+        /// It might be supported out of bound, and negative value in future.
+        /// @note Used by the ImageVisual and AnimatedVectorImageVisual. The default is 1.0f.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static readonly int FrameSpeedFactor = NDalic.ImageVisualOrientationCorrection + 19;
     }
 
     /// <summary>

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
@@ -143,6 +143,28 @@ namespace Tizen.NUI.Visuals
         }
 
         /// <summary>
+        /// Gets and sets the speed factor for the AnimatedImageVisual frame rendering.
+        /// The default is 1.0f. If the number is less than 1.0f then it will play slower than normal case.
+        /// If the number is greater than 1.0f then it will play faster than normal case.
+        /// We will clamp the value between [0.01f 100.0f] internally.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float FrameSpeedFactor
+        {
+            set
+            {
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameSpeedFactor, new PropertyValue(value));
+            }
+            get
+            {
+                float ret = 1.0f;
+                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameSpeedFactor);
+                propertyValue?.Get(out ret);
+                return ret;
+            }
+        }
+
+        /// <summary>
         /// Get the number of total frames.
         /// Or -1 if image is invalid, or not loaded yet.
         /// </summary>

--- a/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSAnimatedImageView.cs
+++ b/test/Tizen.NUI.Devel.Tests.Ubuntu/Tizen.NUI.Devel.Tests/testcase/TSAnimatedImageView.cs
@@ -284,5 +284,34 @@ namespace Tizen.NUI.Devel.Tests
 
             testView.Dispose();
         }
+
+        [Test]
+        [Category("P1")]
+        [Description("internal API test in Ubuntu, AnimatedImageView.FrameSpeedFactor")]
+        [Property("SPEC", "Tizen.NUI.BaseComponents.AnimatedImageView.FrameSpeedFactor")]
+        [Property("SPEC_URL", "-")]
+        [Property("CRITERIA", "PRO")]
+        [Property("AUTHOR", "eunkiki.hong@samsung.com")]
+        public void FrameSpeedFactor_SET_GET_VALUE()
+        {
+            /* TEST CODE */
+            AnimatedImageView testView = new AnimatedImageView();
+
+            Assert.AreEqual(1.0f, testView.FrameSpeedFactor, "FrameSpeedFactor should be 1.0f when ResourceUrl is not setup");
+
+            testView.ResourceUrl = animated_image_path;
+
+            Assert.AreEqual(1.0f, testView.FrameSpeedFactor, "FrameSpeedFactor should be 1.0f even ResourceUrl is setup");
+
+            float expectSpeedFactor = 3.0f;
+            testView.FrameSpeedFactor = expectSpeedFactor;
+            Assert.AreEqual(expectSpeedFactor, testView.FrameSpeedFactor, "FrameSpeedFactor doesn't matched!");
+
+            expectSpeedFactor = 0.5f;
+            testView.FrameSpeedFactor = expectSpeedFactor;
+            Assert.AreEqual(expectSpeedFactor, testView.FrameSpeedFactor, "FrameSpeedFactor doesn't matched!");
+
+            testView.Dispose();
+        }
     }
 }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LottieAnimationTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LottieAnimationTest.cs
@@ -12,6 +12,7 @@ namespace Tizen.NUI.Samples
             lav.NotifyAfterRasterization = true;
             lav.URL = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "a.json";
             lav.LoopCount = -1;
+            lav.FrameSpeedFactor = 2.0f; // 2x speed
             lav.BackgroundColor = Color.White;
             NUIApplication.GetDefaultWindow().GetDefaultLayer().Add(lav);
             Tizen.Log.Error("NUI", $"Total frame before resource ready : {lav.TotalFrame} / might be 0 if still load images. or, might be valid value if load finished during above logic running.\n");


### PR DESCRIPTION
Let we make some property to control the speed of animated image.

If we want to play animation 2x speed, Set this value as 2.0f.

If we want to play animation 0.5x speed, Set this value as 0.5f.

Note : For the platform safety reason, let we constraint the input value as 0.01f to 100.0f

Relative dali patch :

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/316847
