### PR TITLE
Update deploy documents workflow

### DIFF
--- a/.github/workflows/deploy-documents-for-tizen-docs.yml
+++ b/.github/workflows/deploy-documents-for-tizen-docs.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: tizendotnet/tizenfx-build-worker:2.4
+      image: tizendotnet/tizenfx-build-worker:2.5
       options: --ulimit nofile=10240:10240
 
     steps:
@@ -37,7 +37,6 @@ jobs:
     - name: Build Documents
       if: steps.cache-site.outputs.cache-hit != 'true'
       run: |
-        cp docfx_config/docfx.json docfx.json
         ./build.sh restore
         ./build.sh build
 

--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     container:
-      image: tizendotnet/tizenfx-build-worker:2.4
+      image: tizendotnet/tizenfx-build-worker:2.5
       options: --ulimit nofile=10240:10240
 
     steps:
@@ -31,7 +31,6 @@ jobs:
     - name: Build Documents
       if: steps.cache-site.outputs.cache-hit != 'true'
       run: |
-        cp docfx_config/docfx.json docfx.json
         ./build.sh restore
         ./build.sh build
         ./build.sh index


### PR DESCRIPTION
### Description of Change ###
This PR is to update `deploy-documents` workflow using `tizendotnet/tizenfx-build-worker:2.5` to avoid docfx issues where some APIs are not filtered out.
