### PR TITLE
[NUI] Deprecate Dali::Property constructor with componentwise

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Property.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Property.cs
@@ -33,14 +33,8 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_0")]
             public static extern global::System.IntPtr NewProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_1")]
-            public static extern global::System.IntPtr NewProperty(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_2")]
             public static extern global::System.IntPtr NewProperty(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property__SWIG_3")]
-            public static extern global::System.IntPtr NewProperty(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Property")]
             public static extern void DeleteProperty(global::System.Runtime.InteropServices.HandleRef jarg1);
@@ -56,12 +50,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_propertyIndex_get")]
             public static extern int PropertyIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_componentIndex_set")]
-            public static extern void ComponentIndexSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_componentIndex_get")]
-            public static extern int ComponentIndexGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Array__SWIG_0")]
             public static extern global::System.IntPtr NewPropertyArray();

--- a/src/Tizen.NUI/src/public/Common/Property.cs
+++ b/src/Tizen.NUI/src/public/Common/Property.cs
@@ -30,35 +30,12 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// This constructor creates a property instance.
-        /// </summary>
-        /// <param name="animatable">A valid handle to the target object.</param>
-        /// <param name="propertyIndex">The index of a property.</param>
-        /// <param name="componentIndex">Index to a sub component of a property, for use with Vector2, Vector3 and Vector4. -1 for the main property (default is -1).</param>
-        public Property(Animatable animatable, int propertyIndex, int componentIndex) : this(Interop.Property.NewProperty(Animatable.getCPtr(animatable), propertyIndex, componentIndex), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// <summary>
         /// This constructor creates a property instance.<br />
         /// This performs a property index query and is therefore slower than constructing a property directly with the index.<br />
         /// </summary>
         /// <param name="animatable">A valid handle to the target object.</param>
         /// <param name="propertyName">The property name.</param>
         public Property(Animatable animatable, string propertyName) : this(Interop.Property.NewProperty(Animatable.getCPtr(animatable), propertyName), true)
-        {
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
-        /// <summary>
-        /// This constructor creates a property instance.<br />
-        /// This performs a property index query and is therefore slower than constructing a property directly with the index.<br />
-        /// </summary>
-        /// <param name="animatable">A valid handle to the target object.</param>
-        /// <param name="propertyName">The property name.</param>
-        /// <param name="componentIndex">Index to a sub component of a property, for use with Vector2, Vector3 and Vector4. -1 for main property (default is -1).</param>
-        public Property(Animatable animatable, string propertyName, int componentIndex) : this(Interop.Property.NewProperty(Animatable.getCPtr(animatable), propertyName, componentIndex), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -80,24 +57,6 @@ namespace Tizen.NUI
             get
             {
                 int ret = Interop.Property.PropertyIndexGet(SwigCPtr);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the component index of the property.
-        /// </summary>
-        public int ComponentIndex
-        {
-            set
-            {
-                Interop.Property.ComponentIndexSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
-            get
-            {
-                int ret = Interop.Property.ComponentIndexGet(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Common/TSProperty.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Common/TSProperty.cs
@@ -62,31 +62,6 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("Property constructor. With sub component index")]
-        [Property("SPEC", "Tizen.NUI.Property.Property C")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "CONSTR")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void PropertyConstructorWithSubComponentIndex()
-        {
-            tlog.Debug(tag, $"PropertyConstructorWithSubComponentIndex START");
-
-            var animatable = new Animatable();
-            Assert.IsNotNull(animatable, "Should be not null!");
-            Assert.IsInstanceOf<Animatable>(animatable, "Should return PropertyValue instance.");
-
-            var dummyIndex = 28000000;
-            var testingTarget = new Property(animatable, dummyIndex, -1);
-            Assert.IsNotNull(testingTarget, "Should be not null!");
-            Assert.IsInstanceOf<Property>(testingTarget, "Should return PropertyValue instance.");
-
-            testingTarget.Dispose();
-            animatable.Dispose();
-            tlog.Debug(tag, $"PropertyConstructorWithSubComponentIndex END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
         [Description("Property constructor. With property name")]
         [Property("SPEC", "Tizen.NUI.Property.Property C")]
         [Property("SPEC_URL", "-")]
@@ -107,30 +82,6 @@ namespace Tizen.NUI.Devel.Tests
             testingTarget.Dispose();
             animatable.Dispose();
             tlog.Debug(tag, $"PropertyConstructorWithPropertyName END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("Property constructor. With property name and sub component index")]
-        [Property("SPEC", "Tizen.NUI.Property.Property C")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "CONSTR")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void PropertyConstructorWithPropertyNameSubComponentIndex()
-        {
-            tlog.Debug(tag, $"PropertyConstructorWithPropertyNameSubComponentIndex START");
-
-            var animatable = new Animatable();
-            Assert.IsNotNull(animatable, "Should be not null!");
-            Assert.IsInstanceOf<Animatable>(animatable, "Should return PropertyValue instance.");
-
-            var testingTarget = new Property(animatable, "image", -1);
-            Assert.IsNotNull(testingTarget, "Should be not null!");
-            Assert.IsInstanceOf<Property>(testingTarget, "Should return PropertyValue instance.");
-
-            testingTarget.Dispose();
-            animatable.Dispose();
-            tlog.Debug(tag, $"PropertyConstructorWithPropertyNameSubComponentIndex END (OK)");
         }
 
         [Test]
@@ -186,61 +137,6 @@ namespace Tizen.NUI.Devel.Tests
             testingTarget.Dispose();
             animatable.Dispose();
             tlog.Debug(tag, $"PropertyPropertyIndexSet END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("Property componentIndex. Get")]
-        [Property("SPEC", "Tizen.NUI.Property.componentIndex A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void PropertyComponentIndexGet()
-        {
-            tlog.Debug(tag, $"PropertyComponentIndexGet START");
-
-            var animatable = new Animatable();
-            Assert.IsNotNull(animatable, "Should be not null!");
-            Assert.IsInstanceOf<Animatable>(animatable, "Should return PropertyValue instance.");
-
-            var testingTarget = new Property(animatable, 28000000, -1);
-            Assert.IsNotNull(testingTarget, "Should be not null!");
-            Assert.IsInstanceOf<Property>(testingTarget, "Should return PropertyValue instance.");
-
-            var result = testingTarget.componentIndex;
-            Assert.IsTrue(-1 == result);
-
-            testingTarget.Dispose();
-            animatable.Dispose();
-            tlog.Debug(tag, $"PropertyComponentIndexGet END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("Property componentIndex. Get")]
-        [Property("SPEC", "Tizen.NUI.Property.componentIndex A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void PropertyComponentIndexSet()
-        {
-            tlog.Debug(tag, $"PropertyComponentIndexSet START");
-
-            var animatable = new Animatable();
-            Assert.IsNotNull(animatable, "Should be not null!");
-            Assert.IsInstanceOf<Animatable>(animatable, "Should return PropertyValue instance.");
-
-            var testingTarget = new Property(animatable, 28000000, -1);
-            Assert.IsNotNull(testingTarget, "Should be not null!");
-            Assert.IsInstanceOf<Property>(testingTarget, "Should return PropertyValue instance.");
-
-            testingTarget.componentIndex = 30000000;
-            var result = testingTarget.componentIndex;
-            Assert.IsTrue(30000000 == result);
-
-            testingTarget.Dispose();
-            animatable.Dispose();
-            tlog.Debug(tag, $"PropertyComponentIndexSet END (OK)");
         }
     }
 }


### PR DESCRIPTION
Since those usecase break some logic, let we decide to deprecate the componentewise logic.

Instead just create new property index - like COLOR_RED, SIZE_HEIGHT.

Relative dali patches (Not mandatory)
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/317090
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/317091
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/317087
