### PR TITLE
[NUI] Bind FrameUpdateCallback native release API

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/EventThreadCallback.cs
+++ b/src/Tizen.NUI/src/internal/Common/EventThreadCallback.cs
@@ -31,7 +31,8 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
         {
-            //NDalicManualPINVOKE.DeleteEventThreadCallback(swigCPtr);
+            Interop.EventThreadCallback.DeleteEventThreadCallback(swigCPtr);
+            NDalicPINVOKE.ThrowExceptionIfExists();
         }
 
         public EventThreadCallback(CallbackDelegate func) : this(Interop.EventThreadCallback.NewEventThreadCallback(func), true)

--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -52,6 +52,14 @@ namespace Tizen.NUI
         {
         }
 
+        /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.ProcessorController.DeleteProcessorController(swigCPtr);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ProcessorEventHandler();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.EventThreadCallback.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.EventThreadCallback.cs
@@ -24,6 +24,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_EventThreadCallback")]
             public static extern global::System.IntPtr NewEventThreadCallback(Tizen.NUI.EventThreadCallback.CallbackDelegate delegate1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_EventThreadCallback")]
+            public static extern void DeleteEventThreadCallback(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_EventThreadCallback_Trigger")]
             public static extern void Trigger(global::System.Runtime.InteropServices.HandleRef jarg1);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
@@ -24,6 +24,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_FrameCallbackInterface")]
             public static extern global::System.IntPtr newFrameUpdateCallbackInterface();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_FrameCallbackInterface")]
+            public static extern void DeleteFrameUpdateCallbackInterface(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_director_connect_with_return")]
             public static extern void FrameUpdateCallbackInterfaceDirectorConnectV1(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.FrameUpdateCallbackInterface.DelegateFrameUpdateCallbackInterfaceV1 delegate1);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ProcessorController.cs
@@ -25,6 +25,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ProcessorController_Without_Initialize")]
             public static extern global::System.IntPtr NewWithoutInitialize();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ProcessorController")]
+            public static extern void DeleteProcessorController(global::System.Runtime.InteropServices.HandleRef processorController);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ProcessorController_Initialize")]
             public static extern void Initialize(global::System.Runtime.InteropServices.HandleRef processorController);
 

--- a/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
@@ -49,6 +49,14 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        /// This will not be public opened.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ReleaseSwigCPtr(System.Runtime.InteropServices.HandleRef swigCPtr)
+        {
+            Interop.FrameUpdateCallbackInterface.DeleteFrameUpdateCallbackInterface(swigCPtr);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public uint UpdateCallbackVersion => onUpdateCallbackVersion;


### PR DESCRIPTION
Since Disposable.ReleaseSwigCPtr doesn't do anything, we should implement it each class.

But FrameUpdateCallbackInterface didn't implemen it.

Relative dali patch : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/317106