### PR TITLE
[NUI] Added an option to select the web engine type in the WebView constructor

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WebView.cs
@@ -32,6 +32,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_3")]
             public static extern global::System.IntPtr New3(int jarg1, string[] jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_New_4")]
+            public static extern global::System.IntPtr New4(int argc, string[] argv, int type);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WebView_GetContext")]
             public static extern global::System.IntPtr GetWebContext();
 

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -83,9 +83,6 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        private static readonly WebContext context = new WebContext(Interop.WebView.GetWebContext(), false);
-        private static readonly WebCookieManager cookieManager = new WebCookieManager(Interop.WebView.GetWebCookieManager(), false);
-
         private Color contentBackgroundColor;
         private bool tilesClearedWhenHidden;
         private float tileCoverAreaMultiplier;
@@ -189,6 +186,17 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="args">Arguments passed into web engine. The first value of array must be program's name.</param>
         /// <since_tizen> 9 </since_tizen>
         public WebView(string[] args) : this(Interop.WebView.New3(args?.Length ?? 0, args), true)
+        {
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Creates a WebView with an args list and WebEngine type.
+        /// </summary>
+        /// <param name="args">Arguments passed into web engine. The first value of array must be program's name.</param>
+        /// <param name="webEngineType">Can select the plugin of Web Engine type. Chromium or LWE.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public WebView(string[] args, WebEngineType webEngineType) : this(Interop.WebView.New4(args?.Length ?? 0, args, (int)webEngineType), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -1071,6 +1079,25 @@ namespace Tizen.NUI.BaseComponents
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             All = Default | NodeData | ImageData,
+        }
+
+        /// <summary>
+        /// WebEngine type which can be set by a specific constructor of this WebView.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum WebEngineType
+        {
+            /// <summary>
+            /// Chromium Web Engine type.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Chromium = 0,
+
+            /// <summary>
+            /// LWE, Light Web Engine type.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            LWE = 1,
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -1091,6 +1091,7 @@ namespace Tizen.NUI.BaseComponents
             /// Chromium Web Engine type.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
+            UseSystemSetting = -1,
             Chromium = 0,
 
             /// <summary>

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -1088,10 +1088,15 @@ namespace Tizen.NUI.BaseComponents
         public enum WebEngineType
         {
             /// <summary>
-            /// Chromium Web Engine type.
+            /// Depend on environement value setting. (default)
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             UseSystemSetting = -1,
+
+            /// <summary>
+            /// Chromium Web Engine type.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             Chromium = 0,
 
             /// <summary>


### PR DESCRIPTION
### Description of Change ###
[NUI] Added an option to select the web engine type in the WebView constructor

- Previously, the web engine was fixed and selected for all DALi/NUI APPs in dali.sh, but now it can be chosen in the constructor.
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-adaptor/+/318339/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-toolkit/+/318340/
- https://review.tizen.org/gerrit/#/c/platform/core/uifw/dali-csharp-binder/+/318341/

### API Changes ###
nothing