### PR TITLE
[Tizen.Core] Fix managing native handle of Event

### DIFF
--- a/src/Tizen.Core/Tizen.Core/Event.cs
+++ b/src/Tizen.Core/Tizen.Core/Event.cs
@@ -135,7 +135,7 @@ namespace Tizen.Core
             eventObject.Handle = IntPtr.Zero;
         }
 
-        internal IntPtr Handle { get { return _handle; } set { _handle = value; } }
+        internal IntPtr Handle { get { return _handle; } }
         internal IntPtr Source { get; set; }
         internal int Id { get; set; }
 

--- a/src/Tizen.Core/Tizen.Core/Task.cs
+++ b/src/Tizen.Core/Tizen.Core/Task.cs
@@ -402,7 +402,7 @@ namespace Tizen.Core
                 throw new ArgumentNullException(nameof(coreEvent));
             }
 
-            if (coreEvent.Handle == IntPtr.Zero)
+            if (coreEvent.Source != IntPtr.Zero)
             {
                 throw new ArgumentException("The event is already added");
             }
@@ -428,7 +428,6 @@ namespace Tizen.Core
                 }
 
                 coreEvent.Source = handle;
-                coreEvent.Handle = IntPtr.Zero;
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The native handle should not be null before calling Dispose() method.
