### PR TITLE
[NUI] Add Outline Offset and BlurRadius at struct Outline

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextConstants.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextConstants.cs
@@ -417,6 +417,20 @@ namespace Tizen.NUI.Text
         public float? Width { get; set; }
 
         /// <summary>
+        /// The offset in pixels of the offset (if null, the default value is 0, 0). <br />
+        /// If not provided then the offset is not enabled. <br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Vector2? Offset { get; set; }
+
+        /// <summary>
+        /// The radius of blurring effect applied to the outline of the text. A higher value results in a more blurred outline. <br />
+        /// If not specified, the default value is 0 which means no blurring effect will be applied. <br />
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float? BlurRadius { get; set; }
+
+        /// <summary>
         /// Determines whether the specified object is equal to the current object.
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
@@ -430,7 +444,7 @@ namespace Tizen.NUI.Text
         /// <param name="other">The Outline to compare with the current Outline.</param>
         /// <returns>true if equal Outline, else false.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Equals(Outline other) => Color == other.Color && Width == other.Width;
+        public bool Equals(Outline other) => Color == other.Color && Width == other.Width && Offset == other.Offset && BlurRadius == other.BlurRadius;
 
         /// <summary>
         /// The == operator.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextMapHelper.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextMapHelper.cs
@@ -384,6 +384,12 @@ namespace Tizen.NUI.BaseComponents
             if (outline.Width != null)
                 map.Add("width", (float)outline.Width);
 
+            if (outline.Offset != null)
+                map.Add("offset", outline.Offset);
+
+            if (outline.BlurRadius != null)
+                map.Add("blurRadius", (float)outline.BlurRadius);
+
             return map;
         }
 
@@ -401,6 +407,8 @@ namespace Tizen.NUI.BaseComponents
             {
                 outline.Color = GetColorFromMap(map, "color");
                 outline.Width = GetFloatFromMap(map, "width", 0.0f);
+                outline.Offset = GetVector2FromMap(map, "offset");
+                outline.BlurRadius = GetFloatFromMap(map, "blurRadius", 0.0f);
             }
 
             return outline;


### PR DESCRIPTION
### Description of Change ###
Fixed a problem where the Offset and BlurRadius options of Outline did not exist in the member variable of Text.Outline Struct.