### PR TITLE
[NUI.Scene3D] Fix miss used method in SceneView

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -446,7 +446,7 @@ namespace Tizen.NUI.Scene3D
             {
                 // We found matched NUI camera. Reduce cPtr reference count.
                 HandleRef handle = new HandleRef(this, cPtr);
-                Interop.Camera.DeleteCameraProperty(handle);
+                Interop.Camera.DeleteCamera(handle);
                 handle = new HandleRef(null, IntPtr.Zero);
             }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -472,7 +472,7 @@ namespace Tizen.NUI.Scene3D
             {
                 // We found matched NUI camera. Reduce cPtr reference count.
                 HandleRef handle = new HandleRef(this, cPtr);
-                Interop.Camera.DeleteCameraProperty(handle);
+                Interop.Camera.DeleteCamera(handle);
                 handle = new HandleRef(null, IntPtr.Zero);
             }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -569,7 +569,7 @@ namespace Tizen.NUI.Scene3D
             {
                 // We found matched NUI camera. Reduce cPtr reference count.
                 HandleRef handle = new HandleRef(this, cPtr);
-                Interop.Camera.DeleteCameraProperty(handle);
+                Interop.Camera.DeleteCamera(handle);
                 handle = new HandleRef(null, IntPtr.Zero);
             }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();


### PR DESCRIPTION
 - DeleteCameraProperty has been used for the case that should use DeleteCamera.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
