### PR TITLE
[Core] Modify exceptions

### DIFF
--- a/src/Tizen.Core/Tizen.Core/ChannelReceiver.cs
+++ b/src/Tizen.Core/Tizen.Core/ChannelReceiver.cs
@@ -66,6 +66,7 @@ namespace Tizen.Core
         /// Receives the channel object from the sender asynchronously.
         /// </summary>
         /// <returns>The received channel object.</returns>
+        /// <exception cref="OutOfMemoryException">Thrown when out of memory.</exception>
         /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <example>
         /// <code>
@@ -87,7 +88,11 @@ namespace Tizen.Core
                 Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCoreChannel.ReceiverReceive(Handle, out IntPtr channelObject);
                 if (error != Interop.LibTizenCore.ErrorCode.None)
                 {
-                    throw new InvalidOperationException("Failed to receive channel object");
+                    if (error != Interop.LibTizenCore.ErrorCode.InvalidParameter)
+                    {
+                        error = Interop.LibTizenCore.ErrorCode.InvalidContext;
+                    }
+                    TCoreErrorFactory.CheckAndThrownException(error, "Failed to receive channel object");
                 }
                 return new ChannelObject(channelObject);
             }).ConfigureAwait(false);

--- a/src/Tizen.Core/Tizen.Core/ChannelReceiver.cs
+++ b/src/Tizen.Core/Tizen.Core/ChannelReceiver.cs
@@ -88,7 +88,7 @@ namespace Tizen.Core
                 Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCoreChannel.ReceiverReceive(Handle, out IntPtr channelObject);
                 if (error != Interop.LibTizenCore.ErrorCode.None)
                 {
-                    if (error != Interop.LibTizenCore.ErrorCode.InvalidParameter)
+                    if (error == Interop.LibTizenCore.ErrorCode.InvalidParameter)
                     {
                         error = Interop.LibTizenCore.ErrorCode.InvalidContext;
                     }

--- a/src/Tizen.Core/Tizen.Core/ChannelReceiver.cs
+++ b/src/Tizen.Core/Tizen.Core/ChannelReceiver.cs
@@ -66,6 +66,7 @@ namespace Tizen.Core
         /// Receives the channel object from the sender asynchronously.
         /// </summary>
         /// <returns>The received channel object.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <example>
         /// <code>
         /// 
@@ -84,7 +85,10 @@ namespace Tizen.Core
             return await System.Threading.Tasks.Task.Run(() =>
             {
                 Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCoreChannel.ReceiverReceive(Handle, out IntPtr channelObject);
-                TCoreErrorFactory.CheckAndThrownException(error, "Failed to receive channel object");
+                if (error != Interop.LibTizenCore.ErrorCode.None)
+                {
+                    throw new InvalidOperationException("Failed to receive channel object");
+                }
                 return new ChannelObject(channelObject);
             }).ConfigureAwait(false);
         }

--- a/src/Tizen.Core/Tizen.Core/ChannelSender.cs
+++ b/src/Tizen.Core/Tizen.Core/ChannelSender.cs
@@ -87,7 +87,7 @@ namespace Tizen.Core
         /// Creates and returns a copy of the channel sender object.
         /// </summary>
         /// <returns>A newly created channel sender instance.</returns>
-        /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <exception cref="OutOfMemoryException">Thrown when out of memory.</exception>
         /// <example>
         /// <code>

--- a/src/Tizen.Core/Tizen.Core/ChannelSender.cs
+++ b/src/Tizen.Core/Tizen.Core/ChannelSender.cs
@@ -44,6 +44,8 @@ namespace Tizen.Core
         /// </summary>
         /// <param name="channelObject">The channel object instance.</param>
         /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <remarks>
         /// It's important to call the Dispose() method on the passed channel object to release resources.
         /// </remarks>
@@ -68,8 +70,16 @@ namespace Tizen.Core
                 throw new ArgumentNullException(nameof(channelObject));
             }
 
+            if (channelObject.Handle == IntPtr.Zero)
+            {
+                throw new ArgumentException(nameof(channelObject));
+            }
+
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCoreChannel.SenderSend(Handle, channelObject.Handle);
-            TCoreErrorFactory.CheckAndThrownException(error, "Failed to send channel object");
+            if (error != Interop.LibTizenCore.ErrorCode.None)
+            {
+                throw new InvalidOperationException("Failed to send channel object");
+            }
             channelObject.IsUsed = true;
         }
 

--- a/src/Tizen.Core/Tizen.Core/ChannelSender.cs
+++ b/src/Tizen.Core/Tizen.Core/ChannelSender.cs
@@ -72,7 +72,7 @@ namespace Tizen.Core
 
             if (channelObject.Handle == IntPtr.Zero)
             {
-                throw new ArgumentException(nameof(channelObject));
+                throw new ArgumentException("Invalid argument");
             }
 
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCoreChannel.SenderSend(Handle, channelObject.Handle);
@@ -102,6 +102,10 @@ namespace Tizen.Core
         public ChannelSender Clone()
         {
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCoreChannel.SenderClone(Handle, out IntPtr clonedHandle);
+            if (error == Interop.LibTizenCore.ErrorCode.InvalidParameter)
+            {
+                error = Interop.LibTizenCore.ErrorCode.InvalidContext;
+            }
             TCoreErrorFactory.CheckAndThrownException(error, "Failed to clone channel sender");
 
             return new ChannelSender(clonedHandle);

--- a/src/Tizen.Core/Tizen.Core/Task.cs
+++ b/src/Tizen.Core/Tizen.Core/Task.cs
@@ -129,7 +129,11 @@ namespace Tizen.Core
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCore.AddIdleJob(_handle, NativeActionCallback, (IntPtr)id, out IntPtr handle);
             if (error != Interop.LibTizenCore.ErrorCode.None)
             {
-                throw new InvalidOperationException("Failed to add idle job");
+                if (error == Interop.LibTizenCore.ErrorCode.InvalidParameter)
+                {
+                    error = Interop.LibTizenCore.ErrorCode.InvalidContext;
+                }
+                TCoreErrorFactory.CheckAndThrownException(error, "Failed to add idle job");
             }
         }
 
@@ -181,7 +185,11 @@ namespace Tizen.Core
             if (error != Interop.LibTizenCore.ErrorCode.None)
             {
                 _taskMap.TryRemove(id, out var _);
-                throw new InvalidOperationException("Failed to add idle job");
+                if (error == Interop.LibTizenCore.ErrorCode.InvalidParameter)
+                {
+                    error = Interop.LibTizenCore.ErrorCode.InvalidContext;
+                }
+                TCoreErrorFactory.CheckAndThrownException(error, "Failed to add idle job");
             }            
         }
 
@@ -300,6 +308,11 @@ namespace Tizen.Core
 
             if (receiver.Handle == IntPtr.Zero)
             {
+                if (receiver.Source != IntPtr.Zero)
+                {
+                    throw new ArgumentException("The receiver is already added");
+                }
+
                 throw new ArgumentException("Invalid argument");
             }
 
@@ -412,9 +425,14 @@ namespace Tizen.Core
                 throw new ArgumentNullException(nameof(coreEvent));
             }
 
-            if (coreEvent.Source != IntPtr.Zero)
+            if (coreEvent.Handle == IntPtr.Zero)
             {
                 throw new ArgumentException("Invalid argument");
+            }
+
+            if (coreEvent.Source != IntPtr.Zero)
+            {
+                throw new ArgumentException("The event is already added");
             }
 
             int id;

--- a/src/Tizen.Core/Tizen.Core/Task.cs
+++ b/src/Tizen.Core/Tizen.Core/Task.cs
@@ -541,7 +541,7 @@ namespace Tizen.Core
 
             if (eventObject.Handle == IntPtr.Zero)
             {
-                throw new ArgumentException(nameof(eventObject));
+                throw new ArgumentException("Invalid argument");
             }
 
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCore.EmitEvent(_handle, eventObject.Handle);

--- a/src/Tizen.Core/Tizen.Core/Task.cs
+++ b/src/Tizen.Core/Tizen.Core/Task.cs
@@ -93,7 +93,7 @@ namespace Tizen.Core
         /// </summary>
         /// <param name="action">The action callback to post.</param>
         /// <exception cref="ArgumentNullException">Thrown when the action argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when failed because of the instance is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <exception cref="OutOfMemoryException">Thrown when out of memory.</exception>
         /// <remarks>
         /// The action callback will be executed by the main loop of the task.
@@ -127,7 +127,10 @@ namespace Tizen.Core
             }
             _actionkMap[id] = action;
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCore.AddIdleJob(_handle, NativeActionCallback, (IntPtr)id, out IntPtr handle);
-            TCoreErrorFactory.CheckAndThrownException(error, "Failed to add idle job");
+            if (error != Interop.LibTizenCore.ErrorCode.None)
+            {
+                throw new InvalidOperationException("Failed to add idle job");
+            }
         }
 
         /// <summary>
@@ -135,7 +138,7 @@ namespace Tizen.Core
         /// </summary>
         /// <param name="task">The task to post.</param>
         /// <exception cref="ArgumentNullException">Thrown when the task argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when failed because of the instance is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <exception cref="OutOfMemoryException">Thrown when out of memory.</exception>
         /// <remarks>
         /// The task will be stored in the internal map using its unique identifier.
@@ -178,7 +181,7 @@ namespace Tizen.Core
             if (error != Interop.LibTizenCore.ErrorCode.None)
             {
                 _taskMap.TryRemove(id, out var _);
-                TCoreErrorFactory.CheckAndThrownException(error, "Failed to add idle job");
+                throw new InvalidOperationException("Failed to add idle job");
             }            
         }
 
@@ -189,7 +192,7 @@ namespace Tizen.Core
         /// <param name="callback">The recurring timer callback function which returns whether or not to continue triggering the timer.</param>
         /// <returns>The registered timer ID to be used with <see cref="RemoveTimer"/>.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the callback argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when failed because of the instance is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <exception cref="OutOfMemoryException">Thrown when out of memory.</exception>
         /// <remarks>
         /// The callback function will be called every time the specified interval elapses. It should return true to keep the timer running, otherwise the timer will be stopped.
@@ -227,7 +230,7 @@ namespace Tizen.Core
                 if (error != Interop.LibTizenCore.ErrorCode.None)
                 {
                     _timerMap.TryRemove(id, out var _);
-                    TCoreErrorFactory.CheckAndThrownException(error, "Failed to add a timer");
+                    throw new InvalidOperationException("Failed to add timer");
                 }
 
                 timerSource.Handle = handle;
@@ -275,6 +278,7 @@ namespace Tizen.Core
         /// <param name="receiver">The channel receiver instance.</param>
         /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <exception cref="OutOfMemoryException">Thrown when out of memory.</exception>
         /// <example>
         /// <code>
@@ -313,6 +317,10 @@ namespace Tizen.Core
                 if (error != Interop.LibTizenCore.ErrorCode.None)
                 {
                     _channelMap.TryRemove(id, out var _);
+                    if (error == Interop.LibTizenCore.ErrorCode.InvalidParameter)
+                    {
+                        error = Interop.LibTizenCore.ErrorCode.InvalidContext;
+                    }
                     TCoreErrorFactory.CheckAndThrownException(error, "Failed to add a channel to the task");
                 }
 
@@ -376,6 +384,7 @@ namespace Tizen.Core
         /// <param name="coreEvent">The event instance.</param>
         /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <exception cref="OutOfMemoryException">Thrown when out of memory.</exception>
         /// <remarks>
         /// This method allows you to associate an event with a specific task. By adding an event to a task's main loop, other threads can utilize this event to communicate with the task.
@@ -425,6 +434,10 @@ namespace Tizen.Core
                 if (error != Interop.LibTizenCore.ErrorCode.None)
                 {
                     _eventMap.TryRemove(id, out var _);
+                    if (error == Interop.LibTizenCore.ErrorCode.InvalidParameter)
+                    {
+                        error = Interop.LibTizenCore.ErrorCode.InvalidContext;
+                    }
                     TCoreErrorFactory.CheckAndThrownException(error, "Failed to add an event to the task");
                 }
 
@@ -486,6 +499,7 @@ namespace Tizen.Core
         /// <param name="eventObject">The event object instance.</param>
         /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <example>
         /// <code>
         /// 
@@ -507,8 +521,17 @@ namespace Tizen.Core
                 throw new ArgumentNullException(nameof(eventObject));
             }
 
+            if (eventObject.Handle == IntPtr.Zero)
+            {
+                throw new ArgumentException(nameof(eventObject));
+            }
+
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCore.EmitEvent(_handle, eventObject.Handle);
-            TCoreErrorFactory.CheckAndThrownException(error, "Failed to emit event");
+            if (error != Interop.LibTizenCore.ErrorCode.None)
+            {
+                throw new InvalidOperationException("Failed to emit event");
+            }
+
             eventObject.Handle = IntPtr.Zero;
         }
 
@@ -632,7 +655,7 @@ namespace Tizen.Core
         /// <summary>
         /// Runs the main loop of the task.
         /// </summary>
-        /// <exception cref="ArgumentException">Thrown when the unmanaged handle is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <example>
         /// <code>
         /// 
@@ -645,13 +668,16 @@ namespace Tizen.Core
         public void Run()
         {
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCore.TaskRun(_handle);
-            TCoreErrorFactory.CheckAndThrownException(error, "Failed to run task");
+            if (error != Interop.LibTizenCore.ErrorCode.None)
+            {
+                throw new InvalidOperationException("Failed to run task");
+            }
         }
 
         /// <summary>
         /// Quits the main loop of the task.
         /// </summary>
-        /// <exception cref="ArgumentException">Thrown when the unmanaged handle is invalid.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
         /// <remarks>
         /// This function can be called from any thread.
         /// It requests the task to finish the current iteration of its loop and stop running.
@@ -674,7 +700,10 @@ namespace Tizen.Core
         public void Quit()
         {
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCore.TaskQuit(_handle);
-            TCoreErrorFactory.CheckAndThrownException(error, "Failed to quit task");
+            if (error != Interop.LibTizenCore.ErrorCode.None)
+            {
+                throw new InvalidOperationException("Failed to run task");
+            }
         }
 
         /// <summary>

--- a/src/Tizen.Core/Tizen.Core/Task.cs
+++ b/src/Tizen.Core/Tizen.Core/Task.cs
@@ -300,7 +300,7 @@ namespace Tizen.Core
 
             if (receiver.Handle == IntPtr.Zero)
             {
-                throw new ArgumentException("The receiver is already added");
+                throw new ArgumentException("Invalid argument");
             }
 
             int id;
@@ -414,7 +414,7 @@ namespace Tizen.Core
 
             if (coreEvent.Source != IntPtr.Zero)
             {
-                throw new ArgumentException("The event is already added");
+                throw new ArgumentException("Invalid argument");
             }
 
             int id;

--- a/src/Tizen.Core/Tizen.Core/Task.cs
+++ b/src/Tizen.Core/Tizen.Core/Task.cs
@@ -720,7 +720,7 @@ namespace Tizen.Core
             Interop.LibTizenCore.ErrorCode error = Interop.LibTizenCore.TizenCore.TaskQuit(_handle);
             if (error != Interop.LibTizenCore.ErrorCode.None)
             {
-                throw new InvalidOperationException("Failed to run task");
+                throw new InvalidOperationException("Failed to quit task");
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This pull request modifies the descriptions and codes of methods as follows:
- The ChannelReceiver.Receive() can throw the InvalidOperationException. 
- The ChannelSender.Send() can throw ArgumentException and InvalidOperationException.
- The Task.Post(action) cannot throw ArgumentException.
- The Task.Post(action) can throw InvalidOperationException.
- The Task.AddChannelReceiver() can throw InvalidOperationException.
- The Task.AddEvent() can throw InvalidOperationException.
- The Task.EmitEvent() can throw InvalidOperationException.
- The Task.Run() can throw InvalidOperationException.
- The Task.Quit() can throw InvalidOperationException.