### PR TITLE
[NUI.Gadget] Export NUIGadgetAssembly class for inhouse developers

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetAssembly.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetAssembly.cs
@@ -15,6 +15,7 @@
 */
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -35,16 +36,21 @@ namespace Tizen.NUI
         }
     }
 
-    internal class NUIGadgetAssembly
+    /// <summary>
+    /// Represents a class that provides access to the methods and properties of the NUIGadgetAssembly.
+    /// </summary>
+    /// <since_tizen> 10 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class NUIGadgetAssembly
     {
         private static readonly object _assemblyLock = new object();
         private readonly string _assemblyPath;
         private WeakReference _assemblyRef;
         private Assembly _assembly = null;
 
-        public NUIGadgetAssembly(string assemblyPath) { _assemblyPath = assemblyPath; }
+        internal NUIGadgetAssembly(string assemblyPath) { _assemblyPath = assemblyPath; }
 
-        public void Load()
+        internal void Load()
         {
             lock (_assemblyLock)
             {
@@ -65,9 +71,9 @@ namespace Tizen.NUI
             }
         }
 
-        public bool IsLoaded { get { return _assembly != null; } }
+        internal bool IsLoaded { get { return _assembly != null; } }
 
-        public NUIGadget CreateInstance(string className)
+        internal NUIGadget CreateInstance(string className)
         {
             lock (_assemblyLock)
             {
@@ -75,7 +81,13 @@ namespace Tizen.NUI
             }
         }
 
-        public void Unload()
+        /// <summary>
+        /// Property indicating whether the weak reference to the gadget assembly is still alive.
+        /// </summary>
+        /// <since_tizen> 12 </since_tizen>
+        public bool IsAlive {  get { return _assemblyRef.IsAlive; } }
+
+        internal void Unload()
         {
             lock (_assemblyLock)
             {

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
@@ -87,7 +87,11 @@ namespace Tizen.NUI
 
         internal Assembly Assembly { get; set; }
 
-        internal NUIGadgetAssembly NUIGadgetAssembly { get; set; }
+        /// <summary>
+        /// Gets the assembly of the gadget.
+        /// </summary>
+        /// <since_tizen> 12 </since_tizen>
+        public NUIGadgetAssembly NUIGadgetAssembly { get; set; }
 
         internal static NUIGadgetInfo CreateNUIGadgetInfo(string packageId)
         {

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -193,7 +193,6 @@ namespace Tizen.NUI
                 if (info.NUIGadgetAssembly != null && info.NUIGadgetAssembly.IsLoaded)
                 {
                     info.NUIGadgetAssembly.Unload();
-                    info.NUIGadgetAssembly = null;
                 }
             }
         }
@@ -221,7 +220,7 @@ namespace Tizen.NUI
                     }
                     else
                     {
-                        if (info.NUIGadgetAssembly == null)
+                        if (info.NUIGadgetAssembly == null || !info.NUIGadgetAssembly.IsLoaded)
                         {
                             Log.Warn("NUIGadgetAssembly.Load(): " + info.ResourcePath + info.ExecutableFile + " ++");
                             info.NUIGadgetAssembly = new NUIGadgetAssembly(info.ResourcePath + info.ExecutableFile);


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The developers want to check whether the assembly is alive or not. This patch provides the NUIGadgetAssembly for inhouse developers.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: Non-ACR

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
