### PR TITLE
[NUI] Support Tbm dependency image source

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageQueue.cs
@@ -47,6 +47,10 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueue_GenerateUrl")]
             public static extern IntPtr GenerateUrl(IntPtr queue);
+
+            // Platform dependency methods
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageQueuePtr_New_Handle_With_TbmQueue")]
+            public static extern IntPtr NewHandleWithTbmQueue(IntPtr csTbmQueue);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageSource.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageSource.cs
@@ -22,7 +22,6 @@ namespace Tizen.NUI
     {
         internal static partial class NativeImageSource
         {
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New")]
             public static extern IntPtr New(IntPtr handle);
 
@@ -41,6 +40,13 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_GenerateUrl")]
             public static extern IntPtr GenerateUrl(IntPtr handle);
+
+            // Platform dependency methods
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_New_Handle_With_TbmSurface")]
+            public static extern IntPtr NewHandleWithTbmSurface(IntPtr csTbmSurface);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageSource_SetSource")]
+            public static extern void SetSource(IntPtr handle, IntPtr csTbmSurface);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageQueue.cs
@@ -26,15 +26,18 @@ namespace Tizen.NUI
     /// </summary>
     /// <example>
     /// <code>
-    /// NativeImageQueue queue = new NativeImageQueue(width,height,ColorFormat.BGRA8888);
+    /// NativeImageQueue queue = new NativeImageQueue(width, height, ColorFormat.BGRA8888);
     /// if(queue.CanDequeueBuffer())
     /// {
-    ///   var buffer = queue.DequeueBuffer(ref bufferWidth,ref bufferHeight,ref bufferStride);
+    ///   var buffer = queue.DequeueBuffer(ref bufferWidth, ref bufferHeight, ref bufferStride);
     ///
     ///   /* Use buffer */
     ///
     ///   queue.EnqueueBuffer(buffer);
     /// }
+    ///
+    /// ImageUrl imageUrl = queue.GenerateUrl();
+    /// ImageView view = new ImageView(imageUrl.ToString());
     /// </code>
     /// </example>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
+++ b/src/Tizen.NUI/src/public/Images/NativeImageSource.cs
@@ -21,6 +21,23 @@ namespace Tizen.NUI
 {
     using global::System;
 
+    /// <summary>
+    /// NativeImageSource is a class for displaying an native image resource.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// NativeImageSource surface = new NativeImageSource(width, height, ColorDepth.Default);
+    ///
+    /// var buffer = surface.AcquireBuffer(ref bufferWidth, ref bufferHeight, ref bufferStride);
+    ///
+    /// /* Use buffer */
+    ///
+    /// surface.ReleaseBuffer();
+    ///
+    /// ImageUrl imageUrl = surface.GenerateUrl();
+    /// ImageView view = new ImageView(imageUrl.ToString());
+    /// </code>
+    /// </example>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class NativeImageSource : NativeImageInterface
     {

--- a/src/Tizen.NUI/src/public/Images/TbmQueueImageSource.cs
+++ b/src/Tizen.NUI/src/public/Images/TbmQueueImageSource.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    using global::System;
+
+    /// <summary>
+    /// NativeImageQueue with external tbm_queue_h handle, which comes from Native.
+    /// </summary>
+    /// <remarks>
+    /// This class could be used on for Tizen platform.
+    /// This class only be used for advanced Tizen developer.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// IntPtr dangerousTbmQueueHandle = SomeDangerousFunction(); // It will return tbm_queue_h, convert as IntPtr.
+    ///
+    /// TbmQueueImageSource queue = new TbmQueueImageSource(dangerousTbmQueueHandle);
+    /// if(queue.CanDequeueBuffer())
+    /// {
+    ///   var buffer = queue.DequeueBuffer(ref bufferWidth,ref bufferHeight,ref bufferStride);
+    ///
+    ///   /* Use buffer */
+    ///
+    ///   queue.EnqueueBuffer(buffer);
+    /// }
+    /// </code>
+    /// </example>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class TbmQueueImageSource : NativeImageQueue
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TbmQueueImageSource(IntPtr dangerousTbmQueueHandle) : base(Interop.NativeImageQueue.NewHandleWithTbmQueue(dangerousTbmQueueHandle), true)
+        {
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Images/TbmSurfaceImageSource.cs
+++ b/src/Tizen.NUI/src/public/Images/TbmSurfaceImageSource.cs
@@ -1,0 +1,62 @@
+using System;
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    using global::System;
+
+    /// <summary>
+    /// NativeImageSource with external tbm_surface_h handle, which comes from Native.
+    /// </summary>
+    /// <remarks>
+    /// This class could be used on for Tizen platform.
+    /// This class only be used for advanced Tizen developer.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// IntPtr dangerousTbmSurfaceHandle = SomeDangerousFunction(); // It will return tbm_surface_h, convert as IntPtr.
+    ///
+    /// TbmSurfaceImageSource surface = new TbmSurfaceImageSource(dangerousTbmSurfaceHandle);
+    ///
+    /// ImageUrl imageUrl = surface.GenerateUrl();
+    /// ImageView view = new ImageView(imageUrl.ToString());
+    /// </code>
+    /// </example>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class TbmSurfaceImageSource : NativeImageSource
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TbmSurfaceImageSource(IntPtr dangerousTbmSurfaceHandle) : base(Interop.NativeImageSource.NewHandleWithTbmSurface(dangerousTbmSurfaceHandle), true)
+        {
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
+        /// <summary>
+        /// Sets the TBM surface for the native image source.
+        /// </summary>
+        /// <param name="tbmSurface">The TBM surface to set.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetTbmSurface(IntPtr tbmSurface)
+        {
+            Interop.NativeImageSource.SetSource(this.SwigCPtr.Handle, tbmSurface);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+    }
+}


### PR DESCRIPTION
Let we make some class that could create NativeImageSource / NativeImageQueue with raw-buffer-handle of tbm_surface_h / tbm_queue_h.

It will be used for some advanced tizen platform developer.

Relative dali patch :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/318356
