### PR TITLE
[NUI.Scene3D] Support SceneView CornerRadius and Borderline Property applied

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.SceneView.cs
@@ -126,6 +126,22 @@ namespace Tizen.NUI.Scene3D
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_CaptureFinishedSignal_Disconnect")]
             public static extern void CaptureFinishedDisconnect(global::System.Runtime.InteropServices.HandleRef actor, global::System.Runtime.InteropServices.HandleRef handler);
+
+            /// Property enum get
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_Property_CornerRadius_get")]
+            public static extern int CornerRadiusGet();
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_Property_CornerRadiusPolicy_get")]
+            public static extern int CornerRadiusPolicyGet();
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_Property_BorderlineWidth_get")]
+            public static extern int BorderlineWidthGet();
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_Property_BorderlineColor_get")]
+            public static extern int BorderlineColorGet();
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_SceneView_Property_BorderlineOffset_get")]
+            public static extern int BorderlineOffsetGet();
         }
     }
 }

--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -835,6 +835,59 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// Callback when CornerRadius property changed.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ApplyCornerRadius()
+        {
+            base.ApplyCornerRadius();
+
+            if (backgroundExtraData == null) return;
+
+            // Update corner radius properties to image by ActionUpdateProperty
+            if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.ContentsCornerRadius))
+            {
+                if (backgroundExtraData.CornerRadius != null)
+                {
+                    using var setValue = new Tizen.NUI.PropertyValue(backgroundExtraData.CornerRadius);
+                    SetProperty(Interop.SceneView.CornerRadiusGet(), setValue);
+                }
+                {
+                    using var setValue = new Tizen.NUI.PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
+                    SetProperty(Interop.SceneView.CornerRadiusPolicyGet(), setValue);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Callback when Borderline property changed.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ApplyBorderline()
+        {
+            base.ApplyBorderline();
+
+            if (backgroundExtraData == null) return;
+
+            // Update corner radius properties to image by ActionUpdateProperty
+            if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.ContentsBorderline))
+            {
+                {
+                    using var setValue = new Tizen.NUI.PropertyValue(backgroundExtraData.BorderlineWidth);
+                    SetProperty(Interop.SceneView.BorderlineWidthGet(), setValue);
+                }
+                {
+                    using var setValue = new Tizen.NUI.PropertyValue((backgroundExtraData.BorderlineColor ?? Color.Black));
+                    SetProperty(Interop.SceneView.BorderlineColorGet(), setValue);
+                }
+                {
+                    using var setValue = new Tizen.NUI.PropertyValue(backgroundExtraData.BorderlineOffset);
+                    SetProperty(Interop.SceneView.BorderlineOffsetGet(), setValue);
+                }
+            }
+        }
+
+        /// <summary>
         /// Release swigCPtr.
         /// </summary>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -1923,7 +1923,8 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        internal override void ApplyCornerRadius()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ApplyCornerRadius()
         {
             base.ApplyCornerRadius();
 
@@ -1940,7 +1941,8 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        internal override void ApplyBorderline()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ApplyBorderline()
         {
             base.ApplyBorderline();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1258,8 +1258,8 @@ namespace Tizen.NUI.BaseComponents
             backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
         }
 
-        /// TODO open as a protected level
-        internal virtual void ApplyCornerRadius()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual void ApplyCornerRadius()
         {
             if (backgroundExtraData == null) return;
 
@@ -1282,8 +1282,8 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        /// TODO open as a protected level
-        internal virtual void ApplyBorderline()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected virtual void ApplyBorderline()
         {
             if (backgroundExtraData == null) return;
 

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -2867,8 +2867,8 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
-
-        internal override void ApplyCornerRadius()
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override void ApplyCornerRadius()
         {
             base.ApplyCornerRadius();
 

--- a/test/Tizen.NUI.Scene3D.Sample/Scene3DSample.cs
+++ b/test/Tizen.NUI.Scene3D.Sample/Scene3DSample.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Samsung Electronics Co., Ltd.
+ * Copyright (c) 2024 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ class Scene3DSample : NUIApplication
 
     Window mWindow;
     Vector2 mWindowSize;
+
+    private float mSceneViewSizeRate = 0.95f; // The scene view size relation as window size.
 
     SceneView mSceneView;
     Model mModel;
@@ -130,13 +132,16 @@ class Scene3DSample : NUIApplication
     {
         mSceneView = new SceneView()
         {
-            SizeWidth = mWindowSize.Width,
-            SizeHeight = mWindowSize.Height,
+            SizeWidth = mWindowSize.Width * mSceneViewSizeRate,
+            SizeHeight = mWindowSize.Height * mSceneViewSizeRate,
             PositionX = 0.0f,
             PositionY = 0.0f,
-            PivotPoint = PivotPoint.TopLeft,
-            ParentOrigin = ParentOrigin.TopLeft,
+            PivotPoint = PivotPoint.Center,
+            ParentOrigin = ParentOrigin.Center,
             PositionUsesPivotPoint = true,
+
+            UseFramebuffer = true,
+            BackgroundColor = Color.DarkOrchid,
         };
 
         mSceneView.CameraTransitionFinished += (o, e) =>
@@ -480,6 +485,18 @@ class Scene3DSample : NUIApplication
                     }
                     break;
                 }
+                case "c":
+                {
+                    if (mSceneView != null)
+                    {
+                        mSceneView.CornerRadius = new Vector4(40.0f, 40.0f, 40.0f, 40.0f);
+                        mSceneView.CornerRadiusPolicy = VisualTransformPolicyType.Absolute;
+                        mSceneView.BorderlineWidth = 20.0f;
+                        mSceneView.BorderlineColor = new Vector4(1.0f, 1.0f, 1.0f, 0.2f);
+                        mSceneView.BorderlineOffset = -1.0f;
+                    }
+                    break;
+                }
             }
 
             FullGC();
@@ -501,19 +518,24 @@ class Scene3DSample : NUIApplication
                     mModelAnimation.Play();
                 }
             }
+            if (mSceneView != null)
+            {
+                mSceneView.CornerRadius = Vector4.Zero;
+                mSceneView.BorderlineWidth = 0.0f;
+            }
         }
     }
 
     public void Activate()
     {
         mWindow = Window.Default;
-        mWindow.BackgroundColor = Color.DarkOrchid;
+        mWindow.BackgroundColor = Color.Blue;
         mWindowSize = mWindow.WindowSize;
 
         mWindow.Resized += (o, e) =>
         {
             mWindowSize = mWindow.WindowSize;
-            mSceneView.Size = new Size(mWindowSize);
+            mSceneView.Size = new Size(mWindowSize * mSceneViewSizeRate);
         };
 
         mWindow.KeyEvent += OnKeyEvent;


### PR DESCRIPTION
Let we support CornerRadius and Borderline feature to SceneView.

Note that those features are available only if UseFramebuffer = true;

Relative dali patch :

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/318377
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/318385