### PR TITLE
[WebAuthn] Enable concurrent Authenticator requests where supported by the native API

### DIFF
--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn.csproj
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/Authenticator.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/Authenticator.cs
@@ -31,7 +31,7 @@ namespace Tizen.Security.WebAuthn
         private const int API_VERSION_NUMBER = 0x00000001;
         private static bool _apiVersionSet = false;
         private static object _userData = null;
-        private static Dictionary<int, IDisposable> _apiCalls = new();
+        private static Dictionary<int, AuthenticatorStorage> _apiCalls = new();
         private static int _callId = 0;
 
         #region Public API

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorAssertionResponse.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorAssertionResponse.cs
@@ -31,7 +31,7 @@ namespace Tizen.Security.WebAuthn
         internal AuthenticatorAssertionResponse(WauthnAuthenticatorAssertionResponse wauthnResponse)
         {
             ClientDataJson = NullSafeMarshal.PtrToArray(wauthnResponse.clientDataJson);
-            AuthenticatorData = NullSafeMarshal.PtrToArray(wauthnResponse.attestationObject);
+            AuthenticatorData = NullSafeMarshal.PtrToArray(wauthnResponse.authenticatorData);
             Signature = NullSafeMarshal.PtrToArray(wauthnResponse.signature);
             UserHandle = NullSafeMarshal.PtrToArray(wauthnResponse.userHandle);
             AttestationObject = NullSafeMarshal.PtrToArray(wauthnResponse.attestationObject);

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorGetAssertionStorage.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorGetAssertionStorage.cs
@@ -23,65 +23,95 @@ using static Tizen.Security.WebAuthn.ErrorFactory;
 
 namespace Tizen.Security.WebAuthn
 {
-    internal static class AuthenticatorGetAssertionStorage
+    internal class AuthenticatorGetAssertionStorage : IDisposable
     {
         #region Internal unmanaged memory
-        private static UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
-        private static UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
-        private static UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
-        private static UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
-        private static UnmanagedMemory[] _extensionIdUnmanagedDataArray;
-        private static UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
-        private static UnmanagedMemory[] _extensionValueUnmanagedDataArray;
-        private static UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
-        private static UnmanagedMemory _jsonDataUnmanaged = new();
-        private static UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
-        private static UnmanagedMemory _rpNameUnmanaged = new();
-        private static UnmanagedMemory _rpIdUnmanaged = new();
-        private static UnmanagedMemory _rpUnmanaged = new();
-        private static UnmanagedMemory _userNameUnmanaged = new();
-        private static UnmanagedMemory _userIdDataUnmanaged = new();
-        private static UnmanagedMemory _userIdConstBufferUnmanaged = new();
-        private static UnmanagedMemory _userDisplayNameUnmanaged = new();
-        private static UnmanagedMemory _userUnmanaged = new();
-        private static UnmanagedMemory _pubkeyCredParamsParametersUnmanaged = new();
-        private static UnmanagedMemory _pubkeyCredParamsUnmanaged = new();
-        private static UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
-        private static UnmanagedMemory _credentialsUnmanaged = new();
-        private static UnmanagedMemory _authenticatorSelectionUnmanaged = new();
-        private static UnmanagedMemory _hintsArrayUnmanaged = new();
-        private static UnmanagedMemory _hintsUnmanaged = new();
-        private static UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
-        private static UnmanagedMemory _attestationFormatsUnmanaged = new();
-        private static UnmanagedMemory _extensionsArrayUnmanaged = new();
-        private static UnmanagedMemory _extensionsUnmanaged = new();
-        private static UnmanagedMemory _contactIdDataUnmanaged = new();
-        private static UnmanagedMemory _contactIdUnmanaged = new();
-        private static UnmanagedMemory _linkIdDataUnmanaged = new();
-        private static UnmanagedMemory _linkIdUnmanaged = new();
-        private static UnmanagedMemory _linkSecretDataUnmanaged = new();
-        private static UnmanagedMemory _linkSecretUnmanaged = new();
-        private static UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
-        private static UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
-        private static UnmanagedMemory _authenticatorNameDataUnmanaged = new();
-        private static UnmanagedMemory _authenticatorNameUnmanaged = new();
-        private static UnmanagedMemory _signatureDataUnmanaged = new();
-        private static UnmanagedMemory _signatureUnmanaged = new();
-        private static UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
-        private static UnmanagedMemory _tunnelServerDomainUnmanaged = new();
-        private static UnmanagedMemory _identityKeyDataUnmanaged = new();
-        private static UnmanagedMemory _identityKeyUnmanaged = new();
-        private static UnmanagedMemory _linkedDeviceUnmanaged = new();
+        private UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
+        private UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
+        private UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _extensionIdUnmanagedDataArray;
+        private UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _extensionValueUnmanagedDataArray;
+        private UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
+        private UnmanagedMemory _jsonDataUnmanaged = new();
+        private UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
+        private UnmanagedMemory _rpNameUnmanaged = new();
+        private UnmanagedMemory _rpIdUnmanaged = new();
+        private UnmanagedMemory _rpUnmanaged = new();
+        private UnmanagedMemory _userNameUnmanaged = new();
+        private UnmanagedMemory _userIdDataUnmanaged = new();
+        private UnmanagedMemory _userIdConstBufferUnmanaged = new();
+        private UnmanagedMemory _userDisplayNameUnmanaged = new();
+        private UnmanagedMemory _userUnmanaged = new();
+        private UnmanagedMemory _pubkeyCredParamsParametersUnmanaged = new();
+        private UnmanagedMemory _pubkeyCredParamsUnmanaged = new();
+        private UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
+        private UnmanagedMemory _credentialsUnmanaged = new();
+        private UnmanagedMemory _authenticatorSelectionUnmanaged = new();
+        private UnmanagedMemory _hintsArrayUnmanaged = new();
+        private UnmanagedMemory _hintsUnmanaged = new();
+        private UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
+        private UnmanagedMemory _attestationFormatsUnmanaged = new();
+        private UnmanagedMemory _extensionsArrayUnmanaged = new();
+        private UnmanagedMemory _extensionsUnmanaged = new();
+        private UnmanagedMemory _contactIdDataUnmanaged = new();
+        private UnmanagedMemory _contactIdUnmanaged = new();
+        private UnmanagedMemory _linkIdDataUnmanaged = new();
+        private UnmanagedMemory _linkIdUnmanaged = new();
+        private UnmanagedMemory _linkSecretDataUnmanaged = new();
+        private UnmanagedMemory _linkSecretUnmanaged = new();
+        private UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
+        private UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
+        private UnmanagedMemory _authenticatorNameDataUnmanaged = new();
+        private UnmanagedMemory _authenticatorNameUnmanaged = new();
+        private UnmanagedMemory _signatureDataUnmanaged = new();
+        private UnmanagedMemory _signatureUnmanaged = new();
+        private UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
+        private UnmanagedMemory _tunnelServerDomainUnmanaged = new();
+        private UnmanagedMemory _identityKeyDataUnmanaged = new();
+        private UnmanagedMemory _identityKeyUnmanaged = new();
+        private UnmanagedMemory _linkedDeviceUnmanaged = new();
+        private WauthnDisplayQrcodeCallback _qrcodeCallback;
+        private WauthnGaOnResponseCallback _responseCallback;
+        private WauthnUpdateLinkedDataCallback _linkedDataCallback;
         #endregion
 
-        public static void SetDataForGetAssertion(ClientData clientData, PubkeyCredRequestOptions options)
+        private bool _disposed = false;
+
+        public AuthenticatorGetAssertionStorage(ClientData clientData, PubkeyCredRequestOptions options)
         {
             CopyClientData(clientData);
             CopyCredRequestOptions(options);
         }
 
-        public static void Cleanup()
+        ~AuthenticatorGetAssertionStorage()
         {
+            Dispose(false);
+        }
+
+        public void SetCallbacks(
+            WauthnDisplayQrcodeCallback qrcodeCallback,
+            WauthnGaOnResponseCallback responseCallback,
+            WauthnUpdateLinkedDataCallback linkedDataCallback)
+        {
+            _qrcodeCallback = qrcodeCallback;
+            _responseCallback = responseCallback;
+            _linkedDataCallback = linkedDataCallback;
+
+            WauthnGaCallbacks = new WauthnGaCallbacks(_qrcodeCallback, _responseCallback, _linkedDataCallback);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed || !disposing)
+                return;
             CleanupArray(_credentialsIdUnmanagedDataArray);
             CleanupArray(_credentialsIdUnmanagedConstBufferArray);
             CleanupArray(_attestationFormatsUnmanagedDataArray);
@@ -130,14 +160,14 @@ namespace Tizen.Security.WebAuthn
             _linkedDeviceUnmanaged.Dispose();
         }
 
-        private static void CopyClientData(ClientData clientData)
+        private void CopyClientData(ClientData clientData)
         {
             _jsonDataUnmanaged = UnmanagedMemory.PinArray(clientData.JsonData);
             _jsonDataConstBufferUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_jsonDataUnmanaged, (nuint)clientData.JsonData.Length));
             WauthnClientData = new WauthnClientData(_jsonDataConstBufferUnmanaged, clientData.HashAlgo);
         }
 
-        private static void CopyCredRequestOptions(PubkeyCredRequestOptions options)
+        private void CopyCredRequestOptions(PubkeyCredRequestOptions options)
         {
             CopyCredentials(options.AllowCredentials);
             CopyHints(options.Hints);
@@ -156,7 +186,7 @@ namespace Tizen.Security.WebAuthn
                 _linkedDeviceUnmanaged);
         }
 
-        private static void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
+        private void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
         {
             if (credentials is null || !credentials.Any())
                 return;
@@ -178,7 +208,7 @@ namespace Tizen.Security.WebAuthn
             _credentialsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredDescriptors((nuint)credentialsCount, _credentialsDescriptorsUnmanaged));
         }
 
-        private static void CopyHints(IEnumerable<PubkeyCredHint> hints)
+        private void CopyHints(IEnumerable<PubkeyCredHint> hints)
         {
             if (hints is null || !hints.Any())
                 return;
@@ -188,7 +218,7 @@ namespace Tizen.Security.WebAuthn
             _hintsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredHints((nuint)hintsArray.Length, _hintsArrayUnmanaged));
         }
 
-        private static void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
+        private void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
         {
             if (attestationFormats is null || !attestationFormats.Any())
                 return;
@@ -210,7 +240,7 @@ namespace Tizen.Security.WebAuthn
             _attestationFormatsUnmanaged = new UnmanagedMemory(new WauthnAttestationFormats((nuint)attestationFormatsCount, _attestationFormatsArrayUnmanaged));
         }
 
-        private static void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
+        private void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
         {
             if (extensions is null || !extensions.Any())
                 return;
@@ -239,7 +269,7 @@ namespace Tizen.Security.WebAuthn
             _extensionsUnmanaged = new UnmanagedMemory(new WauthnAuthenticationExts((nuint)extensionCount, _extensionsArrayUnmanaged));
         }
 
-        private static void CopyLinkedDevice(HybridLinkedData linkedDevice)
+        private void CopyLinkedDevice(HybridLinkedData linkedDevice)
         {
             if (linkedDevice is null)
                 return;
@@ -282,7 +312,7 @@ namespace Tizen.Security.WebAuthn
                 throw new TimeoutException("linked null");
         }
 
-        public static void CleanupArray(UnmanagedMemory[] array)
+        public void CleanupArray(UnmanagedMemory[] array)
         {
             if (array is null)
                 return;
@@ -290,7 +320,8 @@ namespace Tizen.Security.WebAuthn
                 memory.Dispose();
         }
 
-        public static WauthnClientData WauthnClientData { get; private set; }
-        public static WauthnPubkeyCredRequestOptions WauthnPubkeyCredRequestOptions { get; private set; }
+        public WauthnGaCallbacks WauthnGaCallbacks { get; private set; }
+        public WauthnClientData WauthnClientData { get; private set; }
+        public WauthnPubkeyCredRequestOptions WauthnPubkeyCredRequestOptions { get; private set; }
     }
 }

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorGetAssertionStorage.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorGetAssertionStorage.cs
@@ -1,0 +1,296 @@
+/*
+ *  Copyright (c) 2024 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using static Interop;
+using static Tizen.Security.WebAuthn.ErrorFactory;
+
+namespace Tizen.Security.WebAuthn
+{
+    internal static class AuthenticatorGetAssertionStorage
+    {
+        #region Internal unmanaged memory
+        private static UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
+        private static UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
+        private static UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
+        private static UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
+        private static UnmanagedMemory[] _extensionIdUnmanagedDataArray;
+        private static UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
+        private static UnmanagedMemory[] _extensionValueUnmanagedDataArray;
+        private static UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
+        private static UnmanagedMemory _jsonDataUnmanaged = new();
+        private static UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
+        private static UnmanagedMemory _rpNameUnmanaged = new();
+        private static UnmanagedMemory _rpIdUnmanaged = new();
+        private static UnmanagedMemory _rpUnmanaged = new();
+        private static UnmanagedMemory _userNameUnmanaged = new();
+        private static UnmanagedMemory _userIdDataUnmanaged = new();
+        private static UnmanagedMemory _userIdConstBufferUnmanaged = new();
+        private static UnmanagedMemory _userDisplayNameUnmanaged = new();
+        private static UnmanagedMemory _userUnmanaged = new();
+        private static UnmanagedMemory _pubkeyCredParamsParametersUnmanaged = new();
+        private static UnmanagedMemory _pubkeyCredParamsUnmanaged = new();
+        private static UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
+        private static UnmanagedMemory _credentialsUnmanaged = new();
+        private static UnmanagedMemory _authenticatorSelectionUnmanaged = new();
+        private static UnmanagedMemory _hintsArrayUnmanaged = new();
+        private static UnmanagedMemory _hintsUnmanaged = new();
+        private static UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
+        private static UnmanagedMemory _attestationFormatsUnmanaged = new();
+        private static UnmanagedMemory _extensionsArrayUnmanaged = new();
+        private static UnmanagedMemory _extensionsUnmanaged = new();
+        private static UnmanagedMemory _contactIdDataUnmanaged = new();
+        private static UnmanagedMemory _contactIdUnmanaged = new();
+        private static UnmanagedMemory _linkIdDataUnmanaged = new();
+        private static UnmanagedMemory _linkIdUnmanaged = new();
+        private static UnmanagedMemory _linkSecretDataUnmanaged = new();
+        private static UnmanagedMemory _linkSecretUnmanaged = new();
+        private static UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
+        private static UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
+        private static UnmanagedMemory _authenticatorNameDataUnmanaged = new();
+        private static UnmanagedMemory _authenticatorNameUnmanaged = new();
+        private static UnmanagedMemory _signatureDataUnmanaged = new();
+        private static UnmanagedMemory _signatureUnmanaged = new();
+        private static UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
+        private static UnmanagedMemory _tunnelServerDomainUnmanaged = new();
+        private static UnmanagedMemory _identityKeyDataUnmanaged = new();
+        private static UnmanagedMemory _identityKeyUnmanaged = new();
+        private static UnmanagedMemory _linkedDeviceUnmanaged = new();
+        #endregion
+
+        public static void SetDataForGetAssertion(ClientData clientData, PubkeyCredRequestOptions options)
+        {
+            CopyClientData(clientData);
+            CopyCredRequestOptions(options);
+        }
+
+        public static void Cleanup()
+        {
+            CleanupArray(_credentialsIdUnmanagedDataArray);
+            CleanupArray(_credentialsIdUnmanagedConstBufferArray);
+            CleanupArray(_attestationFormatsUnmanagedDataArray);
+            CleanupArray(_attestationFormatsUnmanagedConstBufferArray);
+            CleanupArray(_extensionIdUnmanagedDataArray);
+            CleanupArray(_extensionIdUnmanagedConstBufferArray);
+            CleanupArray(_extensionValueUnmanagedDataArray);
+            CleanupArray(_extensionValueUnmanagedConstBufferArray);
+
+            _jsonDataUnmanaged.Dispose();
+            _jsonDataConstBufferUnmanaged.Dispose();
+            _rpNameUnmanaged.Dispose();
+            _rpIdUnmanaged.Dispose();
+            _rpUnmanaged.Dispose();
+            _userNameUnmanaged.Dispose();
+            _userIdConstBufferUnmanaged.Dispose();
+            _userDisplayNameUnmanaged.Dispose();
+            _userUnmanaged.Dispose();
+            _pubkeyCredParamsParametersUnmanaged.Dispose();
+            _pubkeyCredParamsUnmanaged.Dispose();
+            _credentialsDescriptorsUnmanaged.Dispose();
+            _credentialsUnmanaged.Dispose();
+            _authenticatorSelectionUnmanaged.Dispose();
+            _hintsArrayUnmanaged.Dispose();
+            _hintsUnmanaged.Dispose();
+            _attestationFormatsArrayUnmanaged.Dispose();
+            _attestationFormatsUnmanaged.Dispose();
+            _extensionsArrayUnmanaged.Dispose();
+            _extensionsUnmanaged.Dispose();
+            _contactIdDataUnmanaged.Dispose();
+            _contactIdUnmanaged.Dispose();
+            _linkIdDataUnmanaged.Dispose();
+            _linkIdUnmanaged.Dispose();
+            _linkSecretDataUnmanaged.Dispose();
+            _linkSecretUnmanaged.Dispose();
+            _authenticatorPubkeyDataUnmanaged.Dispose();
+            _authenticatorPubkeyUnmanaged.Dispose();
+            _authenticatorNameDataUnmanaged.Dispose();
+            _authenticatorNameUnmanaged.Dispose();
+            _signatureDataUnmanaged.Dispose();
+            _signatureUnmanaged.Dispose();
+            _tunnelServerDomainDataUnmanaged.Dispose();
+            _tunnelServerDomainUnmanaged.Dispose();
+            _identityKeyDataUnmanaged.Dispose();
+            _identityKeyUnmanaged.Dispose();
+            _linkedDeviceUnmanaged.Dispose();
+        }
+
+        private static void CopyClientData(ClientData clientData)
+        {
+            _jsonDataUnmanaged = UnmanagedMemory.PinArray(clientData.JsonData);
+            _jsonDataConstBufferUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_jsonDataUnmanaged, (nuint)clientData.JsonData.Length));
+            WauthnClientData = new WauthnClientData(_jsonDataConstBufferUnmanaged, clientData.HashAlgo);
+        }
+
+        private static void CopyCredRequestOptions(PubkeyCredRequestOptions options)
+        {
+            CopyCredentials(options.AllowCredentials);
+            CopyHints(options.Hints);
+            CopyAttestationFormats(options.AttestationFormats);
+            CopyExtensions(options.Extensions);
+            CopyLinkedDevice(options.LinkedDevice);
+            WauthnPubkeyCredRequestOptions = new WauthnPubkeyCredRequestOptions(
+                (nuint)options.Timeout,
+                options.RpId,
+                _credentialsUnmanaged,
+                options.UserVerification,
+                _hintsUnmanaged,
+                options.Attestation,
+                _attestationFormatsUnmanaged,
+                _extensionsUnmanaged,
+                _linkedDeviceUnmanaged);
+        }
+
+        private static void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
+        {
+            if (credentials is null || !credentials.Any())
+                return;
+
+            var credentialsCount = credentials.Count();
+            _credentialsIdUnmanagedDataArray = new UnmanagedMemory[credentialsCount];
+            _credentialsIdUnmanagedConstBufferArray = new UnmanagedMemory[credentialsCount];
+            var credentialsStructArray = new WauthnPubkeyCredDescriptor[credentialsCount];
+
+            for (int i = 0; i < credentialsCount; i++)
+            {
+                PubkeyCredDescriptor descriptor = credentials.ElementAt(i);
+                _credentialsIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(descriptor.Id);
+                var credentialIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_credentialsIdUnmanagedDataArray[i], (nuint)descriptor.Id.Length));
+                _credentialsIdUnmanagedConstBufferArray[i] = credentialIdUnmanagedConstBuffer;
+                credentialsStructArray[i] = new WauthnPubkeyCredDescriptor(descriptor.Type, credentialIdUnmanagedConstBuffer, descriptor.Transport);
+            }
+            _credentialsDescriptorsUnmanaged = UnmanagedMemory.PinArray(credentialsStructArray);
+            _credentialsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredDescriptors((nuint)credentialsCount, _credentialsDescriptorsUnmanaged));
+        }
+
+        private static void CopyHints(IEnumerable<PubkeyCredHint> hints)
+        {
+            if (hints is null || !hints.Any())
+                return;
+
+            int[] hintsArray = hints.Select((PubkeyCredHint hint) => (int)hint).ToArray();
+            _hintsArrayUnmanaged = UnmanagedMemory.PinArray(hintsArray);
+            _hintsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredHints((nuint)hintsArray.Length, _hintsArrayUnmanaged));
+        }
+
+        private static void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
+        {
+            if (attestationFormats is null || !attestationFormats.Any())
+                return;
+
+            var attestationFormatsCount = attestationFormats.Count();
+            _attestationFormatsUnmanagedDataArray = new UnmanagedMemory[attestationFormatsCount];
+            _attestationFormatsUnmanagedConstBufferArray = new UnmanagedMemory[attestationFormatsCount];
+            var attestationFormatConstBufferStructArray = new WauthnConstBuffer[attestationFormatsCount];
+
+
+            for (int i = 0; i < attestationFormatsCount; i++)
+            {
+                byte[] attestationFormat = attestationFormats.ElementAt(i);
+                _attestationFormatsUnmanagedDataArray[i] = UnmanagedMemory.PinArray(attestationFormat);
+                attestationFormatConstBufferStructArray[i] = new WauthnConstBuffer(_attestationFormatsUnmanagedDataArray[i], (nuint)attestationFormat.Length);
+                _attestationFormatsUnmanagedConstBufferArray[i] = new UnmanagedMemory(attestationFormatConstBufferStructArray[i]);
+            }
+            _attestationFormatsArrayUnmanaged = UnmanagedMemory.PinArray(attestationFormatConstBufferStructArray);
+            _attestationFormatsUnmanaged = new UnmanagedMemory(new WauthnAttestationFormats((nuint)attestationFormatsCount, _attestationFormatsArrayUnmanaged));
+        }
+
+        private static void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
+        {
+            if (extensions is null || !extensions.Any())
+                return;
+
+            var extensionCount = extensions.Count();
+            var extensionStructArray = new WauthnAuthenticationExt[extensionCount];
+            _extensionIdUnmanagedDataArray = new UnmanagedMemory[extensionCount];
+            _extensionIdUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
+            _extensionValueUnmanagedDataArray = new UnmanagedMemory[extensionCount];
+            _extensionValueUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
+
+            for (int i = 0; i < extensionCount; i++)
+            {
+                AuthenticationExtension ext = extensions.ElementAt(i);
+                _extensionIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionId);
+                var extensionIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionIdUnmanagedDataArray[i], (nuint)ext.ExtensionId.Length));
+                _extensionIdUnmanagedConstBufferArray[i] = extensionIdUnmanagedConstBuffer;
+
+                _extensionValueUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionValue);
+                var extensionValueUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionValueUnmanagedDataArray[i], (nuint)ext.ExtensionValue.Length));
+                _extensionValueUnmanagedConstBufferArray[i] = extensionValueUnmanagedConstBuffer;
+
+                extensionStructArray[i] = new WauthnAuthenticationExt(extensionIdUnmanagedConstBuffer, extensionValueUnmanagedConstBuffer);
+            }
+            _extensionsArrayUnmanaged = UnmanagedMemory.PinArray(extensionStructArray);
+            _extensionsUnmanaged = new UnmanagedMemory(new WauthnAuthenticationExts((nuint)extensionCount, _extensionsArrayUnmanaged));
+        }
+
+        private static void CopyLinkedDevice(HybridLinkedData linkedDevice)
+        {
+            if (linkedDevice is null)
+                return;
+
+            _contactIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.ContactId);
+            _contactIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_contactIdDataUnmanaged, (nuint)linkedDevice.ContactId.Length));
+
+            _linkIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkId);
+            _linkIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkIdDataUnmanaged, (nuint)linkedDevice.LinkId.Length));
+
+            _linkSecretDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkSecret);
+            _linkSecretUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkSecretDataUnmanaged, (nuint)linkedDevice.LinkSecret.Length));
+
+            _authenticatorPubkeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorPubkey);
+            _authenticatorPubkeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorPubkeyDataUnmanaged, (nuint)linkedDevice.AuthenticatorPubkey.Length));
+
+            _authenticatorNameDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorName);
+            _authenticatorNameUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorNameDataUnmanaged, (nuint)linkedDevice.AuthenticatorName.Length));
+
+            _signatureDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.Signature);
+            _signatureUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_signatureDataUnmanaged, (nuint)linkedDevice.Signature.Length));
+
+            _tunnelServerDomainDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.TunnelServerDomain);
+            _tunnelServerDomainUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_tunnelServerDomainDataUnmanaged, (nuint)linkedDevice.TunnelServerDomain.Length));
+
+            _identityKeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.IdentityKey);
+            _identityKeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_identityKeyDataUnmanaged, (nuint)linkedDevice.IdentityKey.Length));
+
+            _linkedDeviceUnmanaged = new UnmanagedMemory(new WauthnHybridLinkedData(
+                _contactIdUnmanaged,
+                _linkIdUnmanaged,
+                _linkSecretUnmanaged,
+                _authenticatorPubkeyUnmanaged,
+                _authenticatorNameUnmanaged,
+                _signatureUnmanaged,
+                _tunnelServerDomainUnmanaged,
+                _identityKeyUnmanaged));
+
+            if (_linkedDeviceUnmanaged == IntPtr.Zero)
+                throw new TimeoutException("linked null");
+        }
+
+        public static void CleanupArray(UnmanagedMemory[] array)
+        {
+            if (array is null)
+                return;
+            foreach (var memory in array)
+                memory.Dispose();
+        }
+
+        public static WauthnClientData WauthnClientData { get; private set; }
+        public static WauthnPubkeyCredRequestOptions WauthnPubkeyCredRequestOptions { get; private set; }
+    }
+}

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorGetAssertionStorage.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorGetAssertionStorage.cs
@@ -14,80 +14,19 @@
  *  limitations under the License
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
 using static Interop;
-using static Tizen.Security.WebAuthn.ErrorFactory;
 
 namespace Tizen.Security.WebAuthn
 {
-    internal class AuthenticatorGetAssertionStorage : IDisposable
+    internal class AuthenticatorGetAssertionStorage : AuthenticatorStorage
     {
-        #region Internal unmanaged memory
-        private UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
-        private UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
-        private UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
-        private UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
-        private UnmanagedMemory[] _extensionIdUnmanagedDataArray;
-        private UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
-        private UnmanagedMemory[] _extensionValueUnmanagedDataArray;
-        private UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
-        private UnmanagedMemory _jsonDataUnmanaged = new();
-        private UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
-        private UnmanagedMemory _rpNameUnmanaged = new();
-        private UnmanagedMemory _rpIdUnmanaged = new();
-        private UnmanagedMemory _rpUnmanaged = new();
-        private UnmanagedMemory _userNameUnmanaged = new();
-        private UnmanagedMemory _userIdDataUnmanaged = new();
-        private UnmanagedMemory _userIdConstBufferUnmanaged = new();
-        private UnmanagedMemory _userDisplayNameUnmanaged = new();
-        private UnmanagedMemory _userUnmanaged = new();
-        private UnmanagedMemory _pubkeyCredParamsParametersUnmanaged = new();
-        private UnmanagedMemory _pubkeyCredParamsUnmanaged = new();
-        private UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
-        private UnmanagedMemory _credentialsUnmanaged = new();
-        private UnmanagedMemory _authenticatorSelectionUnmanaged = new();
-        private UnmanagedMemory _hintsArrayUnmanaged = new();
-        private UnmanagedMemory _hintsUnmanaged = new();
-        private UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
-        private UnmanagedMemory _attestationFormatsUnmanaged = new();
-        private UnmanagedMemory _extensionsArrayUnmanaged = new();
-        private UnmanagedMemory _extensionsUnmanaged = new();
-        private UnmanagedMemory _contactIdDataUnmanaged = new();
-        private UnmanagedMemory _contactIdUnmanaged = new();
-        private UnmanagedMemory _linkIdDataUnmanaged = new();
-        private UnmanagedMemory _linkIdUnmanaged = new();
-        private UnmanagedMemory _linkSecretDataUnmanaged = new();
-        private UnmanagedMemory _linkSecretUnmanaged = new();
-        private UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
-        private UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
-        private UnmanagedMemory _authenticatorNameDataUnmanaged = new();
-        private UnmanagedMemory _authenticatorNameUnmanaged = new();
-        private UnmanagedMemory _signatureDataUnmanaged = new();
-        private UnmanagedMemory _signatureUnmanaged = new();
-        private UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
-        private UnmanagedMemory _tunnelServerDomainUnmanaged = new();
-        private UnmanagedMemory _identityKeyDataUnmanaged = new();
-        private UnmanagedMemory _identityKeyUnmanaged = new();
-        private UnmanagedMemory _linkedDeviceUnmanaged = new();
-        private WauthnDisplayQrcodeCallback _qrcodeCallback;
         private WauthnGaOnResponseCallback _responseCallback;
-        private WauthnUpdateLinkedDataCallback _linkedDataCallback;
-        #endregion
-
         private bool _disposed = false;
 
         public AuthenticatorGetAssertionStorage(ClientData clientData, PubkeyCredRequestOptions options)
         {
             CopyClientData(clientData);
             CopyCredRequestOptions(options);
-        }
-
-        ~AuthenticatorGetAssertionStorage()
-        {
-            Dispose(false);
         }
 
         public void SetCallbacks(
@@ -102,69 +41,14 @@ namespace Tizen.Security.WebAuthn
             WauthnGaCallbacks = new WauthnGaCallbacks(_qrcodeCallback, _responseCallback, _linkedDataCallback);
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed || !disposing)
+            if (_disposed)
                 return;
-            CleanupArray(_credentialsIdUnmanagedDataArray);
-            CleanupArray(_credentialsIdUnmanagedConstBufferArray);
-            CleanupArray(_attestationFormatsUnmanagedDataArray);
-            CleanupArray(_attestationFormatsUnmanagedConstBufferArray);
-            CleanupArray(_extensionIdUnmanagedDataArray);
-            CleanupArray(_extensionIdUnmanagedConstBufferArray);
-            CleanupArray(_extensionValueUnmanagedDataArray);
-            CleanupArray(_extensionValueUnmanagedConstBufferArray);
 
-            _jsonDataUnmanaged.Dispose();
-            _jsonDataConstBufferUnmanaged.Dispose();
-            _rpNameUnmanaged.Dispose();
-            _rpIdUnmanaged.Dispose();
-            _rpUnmanaged.Dispose();
-            _userNameUnmanaged.Dispose();
-            _userIdConstBufferUnmanaged.Dispose();
-            _userDisplayNameUnmanaged.Dispose();
-            _userUnmanaged.Dispose();
-            _pubkeyCredParamsParametersUnmanaged.Dispose();
-            _pubkeyCredParamsUnmanaged.Dispose();
-            _credentialsDescriptorsUnmanaged.Dispose();
-            _credentialsUnmanaged.Dispose();
-            _authenticatorSelectionUnmanaged.Dispose();
-            _hintsArrayUnmanaged.Dispose();
-            _hintsUnmanaged.Dispose();
-            _attestationFormatsArrayUnmanaged.Dispose();
-            _attestationFormatsUnmanaged.Dispose();
-            _extensionsArrayUnmanaged.Dispose();
-            _extensionsUnmanaged.Dispose();
-            _contactIdDataUnmanaged.Dispose();
-            _contactIdUnmanaged.Dispose();
-            _linkIdDataUnmanaged.Dispose();
-            _linkIdUnmanaged.Dispose();
-            _linkSecretDataUnmanaged.Dispose();
-            _linkSecretUnmanaged.Dispose();
-            _authenticatorPubkeyDataUnmanaged.Dispose();
-            _authenticatorPubkeyUnmanaged.Dispose();
-            _authenticatorNameDataUnmanaged.Dispose();
-            _authenticatorNameUnmanaged.Dispose();
-            _signatureDataUnmanaged.Dispose();
-            _signatureUnmanaged.Dispose();
-            _tunnelServerDomainDataUnmanaged.Dispose();
-            _tunnelServerDomainUnmanaged.Dispose();
-            _identityKeyDataUnmanaged.Dispose();
-            _identityKeyUnmanaged.Dispose();
-            _linkedDeviceUnmanaged.Dispose();
-        }
+            base.Dispose();
 
-        private void CopyClientData(ClientData clientData)
-        {
-            _jsonDataUnmanaged = UnmanagedMemory.PinArray(clientData.JsonData);
-            _jsonDataConstBufferUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_jsonDataUnmanaged, (nuint)clientData.JsonData.Length));
-            WauthnClientData = new WauthnClientData(_jsonDataConstBufferUnmanaged, clientData.HashAlgo);
+            _disposed = true;
         }
 
         private void CopyCredRequestOptions(PubkeyCredRequestOptions options)
@@ -186,142 +70,7 @@ namespace Tizen.Security.WebAuthn
                 _linkedDeviceUnmanaged);
         }
 
-        private void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
-        {
-            if (credentials is null || !credentials.Any())
-                return;
-
-            var credentialsCount = credentials.Count();
-            _credentialsIdUnmanagedDataArray = new UnmanagedMemory[credentialsCount];
-            _credentialsIdUnmanagedConstBufferArray = new UnmanagedMemory[credentialsCount];
-            var credentialsStructArray = new WauthnPubkeyCredDescriptor[credentialsCount];
-
-            for (int i = 0; i < credentialsCount; i++)
-            {
-                PubkeyCredDescriptor descriptor = credentials.ElementAt(i);
-                _credentialsIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(descriptor.Id);
-                var credentialIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_credentialsIdUnmanagedDataArray[i], (nuint)descriptor.Id.Length));
-                _credentialsIdUnmanagedConstBufferArray[i] = credentialIdUnmanagedConstBuffer;
-                credentialsStructArray[i] = new WauthnPubkeyCredDescriptor(descriptor.Type, credentialIdUnmanagedConstBuffer, descriptor.Transport);
-            }
-            _credentialsDescriptorsUnmanaged = UnmanagedMemory.PinArray(credentialsStructArray);
-            _credentialsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredDescriptors((nuint)credentialsCount, _credentialsDescriptorsUnmanaged));
-        }
-
-        private void CopyHints(IEnumerable<PubkeyCredHint> hints)
-        {
-            if (hints is null || !hints.Any())
-                return;
-
-            int[] hintsArray = hints.Select((PubkeyCredHint hint) => (int)hint).ToArray();
-            _hintsArrayUnmanaged = UnmanagedMemory.PinArray(hintsArray);
-            _hintsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredHints((nuint)hintsArray.Length, _hintsArrayUnmanaged));
-        }
-
-        private void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
-        {
-            if (attestationFormats is null || !attestationFormats.Any())
-                return;
-
-            var attestationFormatsCount = attestationFormats.Count();
-            _attestationFormatsUnmanagedDataArray = new UnmanagedMemory[attestationFormatsCount];
-            _attestationFormatsUnmanagedConstBufferArray = new UnmanagedMemory[attestationFormatsCount];
-            var attestationFormatConstBufferStructArray = new WauthnConstBuffer[attestationFormatsCount];
-
-
-            for (int i = 0; i < attestationFormatsCount; i++)
-            {
-                byte[] attestationFormat = attestationFormats.ElementAt(i);
-                _attestationFormatsUnmanagedDataArray[i] = UnmanagedMemory.PinArray(attestationFormat);
-                attestationFormatConstBufferStructArray[i] = new WauthnConstBuffer(_attestationFormatsUnmanagedDataArray[i], (nuint)attestationFormat.Length);
-                _attestationFormatsUnmanagedConstBufferArray[i] = new UnmanagedMemory(attestationFormatConstBufferStructArray[i]);
-            }
-            _attestationFormatsArrayUnmanaged = UnmanagedMemory.PinArray(attestationFormatConstBufferStructArray);
-            _attestationFormatsUnmanaged = new UnmanagedMemory(new WauthnAttestationFormats((nuint)attestationFormatsCount, _attestationFormatsArrayUnmanaged));
-        }
-
-        private void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
-        {
-            if (extensions is null || !extensions.Any())
-                return;
-
-            var extensionCount = extensions.Count();
-            var extensionStructArray = new WauthnAuthenticationExt[extensionCount];
-            _extensionIdUnmanagedDataArray = new UnmanagedMemory[extensionCount];
-            _extensionIdUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
-            _extensionValueUnmanagedDataArray = new UnmanagedMemory[extensionCount];
-            _extensionValueUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
-
-            for (int i = 0; i < extensionCount; i++)
-            {
-                AuthenticationExtension ext = extensions.ElementAt(i);
-                _extensionIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionId);
-                var extensionIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionIdUnmanagedDataArray[i], (nuint)ext.ExtensionId.Length));
-                _extensionIdUnmanagedConstBufferArray[i] = extensionIdUnmanagedConstBuffer;
-
-                _extensionValueUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionValue);
-                var extensionValueUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionValueUnmanagedDataArray[i], (nuint)ext.ExtensionValue.Length));
-                _extensionValueUnmanagedConstBufferArray[i] = extensionValueUnmanagedConstBuffer;
-
-                extensionStructArray[i] = new WauthnAuthenticationExt(extensionIdUnmanagedConstBuffer, extensionValueUnmanagedConstBuffer);
-            }
-            _extensionsArrayUnmanaged = UnmanagedMemory.PinArray(extensionStructArray);
-            _extensionsUnmanaged = new UnmanagedMemory(new WauthnAuthenticationExts((nuint)extensionCount, _extensionsArrayUnmanaged));
-        }
-
-        private void CopyLinkedDevice(HybridLinkedData linkedDevice)
-        {
-            if (linkedDevice is null)
-                return;
-
-            _contactIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.ContactId);
-            _contactIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_contactIdDataUnmanaged, (nuint)linkedDevice.ContactId.Length));
-
-            _linkIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkId);
-            _linkIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkIdDataUnmanaged, (nuint)linkedDevice.LinkId.Length));
-
-            _linkSecretDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkSecret);
-            _linkSecretUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkSecretDataUnmanaged, (nuint)linkedDevice.LinkSecret.Length));
-
-            _authenticatorPubkeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorPubkey);
-            _authenticatorPubkeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorPubkeyDataUnmanaged, (nuint)linkedDevice.AuthenticatorPubkey.Length));
-
-            _authenticatorNameDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorName);
-            _authenticatorNameUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorNameDataUnmanaged, (nuint)linkedDevice.AuthenticatorName.Length));
-
-            _signatureDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.Signature);
-            _signatureUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_signatureDataUnmanaged, (nuint)linkedDevice.Signature.Length));
-
-            _tunnelServerDomainDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.TunnelServerDomain);
-            _tunnelServerDomainUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_tunnelServerDomainDataUnmanaged, (nuint)linkedDevice.TunnelServerDomain.Length));
-
-            _identityKeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.IdentityKey);
-            _identityKeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_identityKeyDataUnmanaged, (nuint)linkedDevice.IdentityKey.Length));
-
-            _linkedDeviceUnmanaged = new UnmanagedMemory(new WauthnHybridLinkedData(
-                _contactIdUnmanaged,
-                _linkIdUnmanaged,
-                _linkSecretUnmanaged,
-                _authenticatorPubkeyUnmanaged,
-                _authenticatorNameUnmanaged,
-                _signatureUnmanaged,
-                _tunnelServerDomainUnmanaged,
-                _identityKeyUnmanaged));
-
-            if (_linkedDeviceUnmanaged == IntPtr.Zero)
-                throw new TimeoutException("linked null");
-        }
-
-        public void CleanupArray(UnmanagedMemory[] array)
-        {
-            if (array is null)
-                return;
-            foreach (var memory in array)
-                memory.Dispose();
-        }
-
         public WauthnGaCallbacks WauthnGaCallbacks { get; private set; }
-        public WauthnClientData WauthnClientData { get; private set; }
         public WauthnPubkeyCredRequestOptions WauthnPubkeyCredRequestOptions { get; private set; }
     }
 }

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorMakeCredentialStorage.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorMakeCredentialStorage.cs
@@ -23,7 +23,7 @@ using static Tizen.Security.WebAuthn.ErrorFactory;
 
 namespace Tizen.Security.WebAuthn
 {
-    internal static class AuthenticatorStorage
+    internal static class AuthenticatorMakeCredentialStorage
     {
         #region Internal unmanaged memory
         private static UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
@@ -78,12 +78,6 @@ namespace Tizen.Security.WebAuthn
         {
             CopyClientData(clientData);
             CopyCredCreationOptions(options);
-        }
-
-        public static void SetDataForGetAssertion(ClientData clientData, PubkeyCredRequestOptions options)
-        {
-            CopyClientData(clientData);
-            CopyCredRequestOptions(options);
         }
 
         public static void Cleanup()
@@ -167,25 +161,6 @@ namespace Tizen.Security.WebAuthn
                     _attestationFormatsUnmanaged,
                     _extensionsUnmanaged,
                     _linkedDeviceUnmanaged);
-        }
-
-        private static void CopyCredRequestOptions(PubkeyCredRequestOptions options)
-        {
-            CopyCredentials(options.AllowCredentials);
-            CopyHints(options.Hints);
-            CopyAttestationFormats(options.AttestationFormats);
-            CopyExtensions(options.Extensions);
-            CopyLinkedDevice(options.LinkedDevice);
-            WauthnPubkeyCredRequestOptions = new WauthnPubkeyCredRequestOptions(
-                (nuint)options.Timeout,
-                options.RpId,
-                _credentialsUnmanaged,
-                options.UserVerification,
-                _hintsUnmanaged,
-                options.Attestation,
-                _attestationFormatsUnmanaged,
-                _extensionsUnmanaged,
-                _linkedDeviceUnmanaged);
         }
 
         private static void CopyRp(RelyingPartyEntity rp)
@@ -365,6 +340,5 @@ namespace Tizen.Security.WebAuthn
 
         public static WauthnClientData WauthnClientData { get; private set; }
         public static WauthnPubkeyCredCreationOptions WauthnPubkeyCredCreationOptions { get; private set; }
-        public static WauthnPubkeyCredRequestOptions WauthnPubkeyCredRequestOptions { get; private set; }
     }
 }

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorMakeCredentialStorage.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorMakeCredentialStorage.cs
@@ -23,65 +23,96 @@ using static Tizen.Security.WebAuthn.ErrorFactory;
 
 namespace Tizen.Security.WebAuthn
 {
-    internal static class AuthenticatorMakeCredentialStorage
+    internal class AuthenticatorMakeCredentialStorage : IDisposable
     {
         #region Internal unmanaged memory
-        private static UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
-        private static UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
-        private static UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
-        private static UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
-        private static UnmanagedMemory[] _extensionIdUnmanagedDataArray;
-        private static UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
-        private static UnmanagedMemory[] _extensionValueUnmanagedDataArray;
-        private static UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
-        private static UnmanagedMemory _jsonDataUnmanaged = new();
-        private static UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
-        private static UnmanagedMemory _rpNameUnmanaged = new();
-        private static UnmanagedMemory _rpIdUnmanaged = new();
-        private static UnmanagedMemory _rpUnmanaged = new();
-        private static UnmanagedMemory _userNameUnmanaged = new();
-        private static UnmanagedMemory _userIdDataUnmanaged = new();
-        private static UnmanagedMemory _userIdConstBufferUnmanaged = new();
-        private static UnmanagedMemory _userDisplayNameUnmanaged = new();
-        private static UnmanagedMemory _userUnmanaged = new();
-        private static UnmanagedMemory _pubkeyCredParamsParametersUnmanaged = new();
-        private static UnmanagedMemory _pubkeyCredParamsUnmanaged = new();
-        private static UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
-        private static UnmanagedMemory _credentialsUnmanaged = new();
-        private static UnmanagedMemory _authenticatorSelectionUnmanaged = new();
-        private static UnmanagedMemory _hintsArrayUnmanaged = new();
-        private static UnmanagedMemory _hintsUnmanaged = new();
-        private static UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
-        private static UnmanagedMemory _attestationFormatsUnmanaged = new();
-        private static UnmanagedMemory _extensionsArrayUnmanaged = new();
-        private static UnmanagedMemory _extensionsUnmanaged = new();
-        private static UnmanagedMemory _contactIdDataUnmanaged = new();
-        private static UnmanagedMemory _contactIdUnmanaged = new();
-        private static UnmanagedMemory _linkIdDataUnmanaged = new();
-        private static UnmanagedMemory _linkIdUnmanaged = new();
-        private static UnmanagedMemory _linkSecretDataUnmanaged = new();
-        private static UnmanagedMemory _linkSecretUnmanaged = new();
-        private static UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
-        private static UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
-        private static UnmanagedMemory _authenticatorNameDataUnmanaged = new();
-        private static UnmanagedMemory _authenticatorNameUnmanaged = new();
-        private static UnmanagedMemory _signatureDataUnmanaged = new();
-        private static UnmanagedMemory _signatureUnmanaged = new();
-        private static UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
-        private static UnmanagedMemory _tunnelServerDomainUnmanaged = new();
-        private static UnmanagedMemory _identityKeyDataUnmanaged = new();
-        private static UnmanagedMemory _identityKeyUnmanaged = new();
-        private static UnmanagedMemory _linkedDeviceUnmanaged = new();
+        private UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
+        private UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
+        private UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _extensionIdUnmanagedDataArray;
+        private UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _extensionValueUnmanagedDataArray;
+        private UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
+        private UnmanagedMemory _jsonDataUnmanaged = new();
+        private UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
+        private UnmanagedMemory _rpNameUnmanaged = new();
+        private UnmanagedMemory _rpIdUnmanaged = new();
+        private UnmanagedMemory _rpUnmanaged = new();
+        private UnmanagedMemory _userNameUnmanaged = new();
+        private UnmanagedMemory _userIdDataUnmanaged = new();
+        private UnmanagedMemory _userIdConstBufferUnmanaged = new();
+        private UnmanagedMemory _userDisplayNameUnmanaged = new();
+        private UnmanagedMemory _userUnmanaged = new();
+        private UnmanagedMemory _pubkeyCredParamsParametersUnmanaged = new();
+        private UnmanagedMemory _pubkeyCredParamsUnmanaged = new();
+        private UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
+        private UnmanagedMemory _credentialsUnmanaged = new();
+        private UnmanagedMemory _authenticatorSelectionUnmanaged = new();
+        private UnmanagedMemory _hintsArrayUnmanaged = new();
+        private UnmanagedMemory _hintsUnmanaged = new();
+        private UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
+        private UnmanagedMemory _attestationFormatsUnmanaged = new();
+        private UnmanagedMemory _extensionsArrayUnmanaged = new();
+        private UnmanagedMemory _extensionsUnmanaged = new();
+        private UnmanagedMemory _contactIdDataUnmanaged = new();
+        private UnmanagedMemory _contactIdUnmanaged = new();
+        private UnmanagedMemory _linkIdDataUnmanaged = new();
+        private UnmanagedMemory _linkIdUnmanaged = new();
+        private UnmanagedMemory _linkSecretDataUnmanaged = new();
+        private UnmanagedMemory _linkSecretUnmanaged = new();
+        private UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
+        private UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
+        private UnmanagedMemory _authenticatorNameDataUnmanaged = new();
+        private UnmanagedMemory _authenticatorNameUnmanaged = new();
+        private UnmanagedMemory _signatureDataUnmanaged = new();
+        private UnmanagedMemory _signatureUnmanaged = new();
+        private UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
+        private UnmanagedMemory _tunnelServerDomainUnmanaged = new();
+        private UnmanagedMemory _identityKeyDataUnmanaged = new();
+        private UnmanagedMemory _identityKeyUnmanaged = new();
+        private UnmanagedMemory _linkedDeviceUnmanaged = new();
+        private WauthnDisplayQrcodeCallback _qrcodeCallback;
+        private WauthnMcOnResponseCallback _responseCallback;
+        private WauthnUpdateLinkedDataCallback _linkedDataCallback;
         #endregion
 
-        public static void SetDataForMakeCredential(ClientData clientData, PubkeyCredCreationOptions options)
+        private bool _disposed = false;
+
+        public AuthenticatorMakeCredentialStorage(ClientData clientData, PubkeyCredCreationOptions options)
         {
             CopyClientData(clientData);
             CopyCredCreationOptions(options);
         }
 
-        public static void Cleanup()
+        ~AuthenticatorMakeCredentialStorage()
         {
+            Dispose(false);
+        }
+
+        public void SetCallbacks(
+            WauthnDisplayQrcodeCallback qrcodeCallback,
+            WauthnMcOnResponseCallback responseCallback,
+            WauthnUpdateLinkedDataCallback linkedDataCallback)
+        {
+            _qrcodeCallback = qrcodeCallback;
+            _responseCallback = responseCallback;
+            _linkedDataCallback = linkedDataCallback;
+
+            WauthnMcCallbacks = new WauthnMcCallbacks(_qrcodeCallback, _responseCallback, _linkedDataCallback);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed || !disposing)
+                return;
+
             CleanupArray(_credentialsIdUnmanagedDataArray);
             CleanupArray(_credentialsIdUnmanagedConstBufferArray);
             CleanupArray(_attestationFormatsUnmanagedDataArray);
@@ -128,16 +159,18 @@ namespace Tizen.Security.WebAuthn
             _identityKeyDataUnmanaged.Dispose();
             _identityKeyUnmanaged.Dispose();
             _linkedDeviceUnmanaged.Dispose();
+
+            _disposed = true;
         }
 
-        private static void CopyClientData(ClientData clientData)
+        private void CopyClientData(ClientData clientData)
         {
             _jsonDataUnmanaged = UnmanagedMemory.PinArray(clientData.JsonData);
             _jsonDataConstBufferUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_jsonDataUnmanaged, (nuint)clientData.JsonData.Length));
             WauthnClientData = new WauthnClientData(_jsonDataConstBufferUnmanaged, clientData.HashAlgo);
         }
 
-        private static void CopyCredCreationOptions(PubkeyCredCreationOptions options)
+        private void CopyCredCreationOptions(PubkeyCredCreationOptions options)
         {
             CopyRp(options.Rp);
             CopyUser(options.User);
@@ -163,14 +196,14 @@ namespace Tizen.Security.WebAuthn
                     _linkedDeviceUnmanaged);
         }
 
-        private static void CopyRp(RelyingPartyEntity rp)
+        private void CopyRp(RelyingPartyEntity rp)
         {
             _rpNameUnmanaged = new UnmanagedMemory(rp.Name);
             _rpIdUnmanaged = new UnmanagedMemory(rp.Id);
             _rpUnmanaged = new UnmanagedMemory(new WauthnRpEntity(_rpNameUnmanaged, _rpIdUnmanaged));
         }
 
-        private static void CopyUser(UserEntity user)
+        private void CopyUser(UserEntity user)
         {
                 _userNameUnmanaged = new UnmanagedMemory(user.Name);
                 _userIdDataUnmanaged = UnmanagedMemory.PinArray(user.Id);
@@ -182,7 +215,7 @@ namespace Tizen.Security.WebAuthn
                     _userDisplayNameUnmanaged));
         }
 
-        private static void CopyCredParams(IEnumerable<PubkeyCredParam> credParams)
+        private void CopyCredParams(IEnumerable<PubkeyCredParam> credParams)
         {
             if (credParams is null || !credParams.Any())
                 return;
@@ -192,7 +225,7 @@ namespace Tizen.Security.WebAuthn
             _pubkeyCredParamsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredParams((nuint)pubkeyCredParamStructArray.Length, _pubkeyCredParamsParametersUnmanaged));
         }
 
-        private static void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
+        private void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
         {
             if (credentials is null || !credentials.Any())
                 return;
@@ -214,7 +247,7 @@ namespace Tizen.Security.WebAuthn
             _credentialsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredDescriptors((nuint)credentialsCount, _credentialsDescriptorsUnmanaged));
         }
 
-        private static void CopyAuthenticatorSelection(AuthenticationSelectionCriteria selection)
+        private void CopyAuthenticatorSelection(AuthenticationSelectionCriteria selection)
         {
             if (selection is null)
                 return;
@@ -226,7 +259,7 @@ namespace Tizen.Security.WebAuthn
                 selection.UserVerification));
         }
 
-        private static void CopyHints(IEnumerable<PubkeyCredHint> hints)
+        private void CopyHints(IEnumerable<PubkeyCredHint> hints)
         {
             if (hints is null || !hints.Any())
                 return;
@@ -236,7 +269,7 @@ namespace Tizen.Security.WebAuthn
             _hintsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredHints((nuint)hintsArray.Length, _hintsArrayUnmanaged));
         }
 
-        private static void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
+        private void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
         {
             if (attestationFormats is null || !attestationFormats.Any())
                 return;
@@ -258,7 +291,7 @@ namespace Tizen.Security.WebAuthn
             _attestationFormatsUnmanaged = new UnmanagedMemory(new WauthnAttestationFormats((nuint)attestationFormatsCount, _attestationFormatsArrayUnmanaged));
         }
 
-        private static void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
+        private void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
         {
             if (extensions is null || !extensions.Any())
                 return;
@@ -287,7 +320,7 @@ namespace Tizen.Security.WebAuthn
             _extensionsUnmanaged = new UnmanagedMemory(new WauthnAuthenticationExts((nuint)extensionCount, _extensionsArrayUnmanaged));
         }
 
-        private static void CopyLinkedDevice(HybridLinkedData linkedDevice)
+        private void CopyLinkedDevice(HybridLinkedData linkedDevice)
         {
             if (linkedDevice is null)
                 return;
@@ -330,7 +363,7 @@ namespace Tizen.Security.WebAuthn
                 throw new TimeoutException("linked null");
         }
 
-        public static void CleanupArray(UnmanagedMemory[] array)
+        public void CleanupArray(UnmanagedMemory[] array)
         {
             if (array is null)
                 return;
@@ -338,7 +371,8 @@ namespace Tizen.Security.WebAuthn
                 memory.Dispose();
         }
 
-        public static WauthnClientData WauthnClientData { get; private set; }
-        public static WauthnPubkeyCredCreationOptions WauthnPubkeyCredCreationOptions { get; private set; }
+        public WauthnMcCallbacks WauthnMcCallbacks { get; private set; }
+        public WauthnClientData WauthnClientData { get; private set; }
+        public WauthnPubkeyCredCreationOptions WauthnPubkeyCredCreationOptions { get; private set; }
     }
 }

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorMakeCredentialStorage.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorMakeCredentialStorage.cs
@@ -14,28 +14,15 @@
  *  limitations under the License
  */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using static Interop;
-using static Tizen.Security.WebAuthn.ErrorFactory;
 
 namespace Tizen.Security.WebAuthn
 {
-    internal class AuthenticatorMakeCredentialStorage : IDisposable
+    internal class AuthenticatorMakeCredentialStorage : AuthenticatorStorage
     {
         #region Internal unmanaged memory
-        private UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
-        private UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
-        private UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
-        private UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
-        private UnmanagedMemory[] _extensionIdUnmanagedDataArray;
-        private UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
-        private UnmanagedMemory[] _extensionValueUnmanagedDataArray;
-        private UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
-        private UnmanagedMemory _jsonDataUnmanaged = new();
-        private UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
         private UnmanagedMemory _rpNameUnmanaged = new();
         private UnmanagedMemory _rpIdUnmanaged = new();
         private UnmanagedMemory _rpUnmanaged = new();
@@ -46,35 +33,9 @@ namespace Tizen.Security.WebAuthn
         private UnmanagedMemory _userUnmanaged = new();
         private UnmanagedMemory _pubkeyCredParamsParametersUnmanaged = new();
         private UnmanagedMemory _pubkeyCredParamsUnmanaged = new();
-        private UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
-        private UnmanagedMemory _credentialsUnmanaged = new();
         private UnmanagedMemory _authenticatorSelectionUnmanaged = new();
-        private UnmanagedMemory _hintsArrayUnmanaged = new();
-        private UnmanagedMemory _hintsUnmanaged = new();
-        private UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
-        private UnmanagedMemory _attestationFormatsUnmanaged = new();
-        private UnmanagedMemory _extensionsArrayUnmanaged = new();
-        private UnmanagedMemory _extensionsUnmanaged = new();
-        private UnmanagedMemory _contactIdDataUnmanaged = new();
-        private UnmanagedMemory _contactIdUnmanaged = new();
-        private UnmanagedMemory _linkIdDataUnmanaged = new();
-        private UnmanagedMemory _linkIdUnmanaged = new();
-        private UnmanagedMemory _linkSecretDataUnmanaged = new();
-        private UnmanagedMemory _linkSecretUnmanaged = new();
-        private UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
-        private UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
-        private UnmanagedMemory _authenticatorNameDataUnmanaged = new();
-        private UnmanagedMemory _authenticatorNameUnmanaged = new();
-        private UnmanagedMemory _signatureDataUnmanaged = new();
-        private UnmanagedMemory _signatureUnmanaged = new();
-        private UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
-        private UnmanagedMemory _tunnelServerDomainUnmanaged = new();
-        private UnmanagedMemory _identityKeyDataUnmanaged = new();
-        private UnmanagedMemory _identityKeyUnmanaged = new();
-        private UnmanagedMemory _linkedDeviceUnmanaged = new();
-        private WauthnDisplayQrcodeCallback _qrcodeCallback;
+
         private WauthnMcOnResponseCallback _responseCallback;
-        private WauthnUpdateLinkedDataCallback _linkedDataCallback;
         #endregion
 
         private bool _disposed = false;
@@ -83,11 +44,6 @@ namespace Tizen.Security.WebAuthn
         {
             CopyClientData(clientData);
             CopyCredCreationOptions(options);
-        }
-
-        ~AuthenticatorMakeCredentialStorage()
-        {
-            Dispose(false);
         }
 
         public void SetCallbacks(
@@ -102,28 +58,11 @@ namespace Tizen.Security.WebAuthn
             WauthnMcCallbacks = new WauthnMcCallbacks(_qrcodeCallback, _responseCallback, _linkedDataCallback);
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed || !disposing)
+            if (_disposed)
                 return;
 
-            CleanupArray(_credentialsIdUnmanagedDataArray);
-            CleanupArray(_credentialsIdUnmanagedConstBufferArray);
-            CleanupArray(_attestationFormatsUnmanagedDataArray);
-            CleanupArray(_attestationFormatsUnmanagedConstBufferArray);
-            CleanupArray(_extensionIdUnmanagedDataArray);
-            CleanupArray(_extensionIdUnmanagedConstBufferArray);
-            CleanupArray(_extensionValueUnmanagedDataArray);
-            CleanupArray(_extensionValueUnmanagedConstBufferArray);
-
-            _jsonDataUnmanaged.Dispose();
-            _jsonDataConstBufferUnmanaged.Dispose();
             _rpNameUnmanaged.Dispose();
             _rpIdUnmanaged.Dispose();
             _rpUnmanaged.Dispose();
@@ -133,43 +72,13 @@ namespace Tizen.Security.WebAuthn
             _userUnmanaged.Dispose();
             _pubkeyCredParamsParametersUnmanaged.Dispose();
             _pubkeyCredParamsUnmanaged.Dispose();
-            _credentialsDescriptorsUnmanaged.Dispose();
-            _credentialsUnmanaged.Dispose();
-            _authenticatorSelectionUnmanaged.Dispose();
-            _hintsArrayUnmanaged.Dispose();
-            _hintsUnmanaged.Dispose();
-            _attestationFormatsArrayUnmanaged.Dispose();
-            _attestationFormatsUnmanaged.Dispose();
-            _extensionsArrayUnmanaged.Dispose();
-            _extensionsUnmanaged.Dispose();
-            _contactIdDataUnmanaged.Dispose();
-            _contactIdUnmanaged.Dispose();
-            _linkIdDataUnmanaged.Dispose();
-            _linkIdUnmanaged.Dispose();
-            _linkSecretDataUnmanaged.Dispose();
-            _linkSecretUnmanaged.Dispose();
-            _authenticatorPubkeyDataUnmanaged.Dispose();
-            _authenticatorPubkeyUnmanaged.Dispose();
-            _authenticatorNameDataUnmanaged.Dispose();
-            _authenticatorNameUnmanaged.Dispose();
-            _signatureDataUnmanaged.Dispose();
-            _signatureUnmanaged.Dispose();
-            _tunnelServerDomainDataUnmanaged.Dispose();
-            _tunnelServerDomainUnmanaged.Dispose();
-            _identityKeyDataUnmanaged.Dispose();
-            _identityKeyUnmanaged.Dispose();
-            _linkedDeviceUnmanaged.Dispose();
+
+            base.Dispose();
 
             _disposed = true;
         }
 
-        private void CopyClientData(ClientData clientData)
-        {
-            _jsonDataUnmanaged = UnmanagedMemory.PinArray(clientData.JsonData);
-            _jsonDataConstBufferUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_jsonDataUnmanaged, (nuint)clientData.JsonData.Length));
-            WauthnClientData = new WauthnClientData(_jsonDataConstBufferUnmanaged, clientData.HashAlgo);
-        }
-
+        #region Data marshalling
         private void CopyCredCreationOptions(PubkeyCredCreationOptions options)
         {
             CopyRp(options.Rp);
@@ -225,29 +134,7 @@ namespace Tizen.Security.WebAuthn
             _pubkeyCredParamsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredParams((nuint)pubkeyCredParamStructArray.Length, _pubkeyCredParamsParametersUnmanaged));
         }
 
-        private void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
-        {
-            if (credentials is null || !credentials.Any())
-                return;
-
-            var credentialsCount = credentials.Count();
-            _credentialsIdUnmanagedDataArray = new UnmanagedMemory[credentialsCount];
-            _credentialsIdUnmanagedConstBufferArray = new UnmanagedMemory[credentialsCount];
-            var credentialsStructArray = new WauthnPubkeyCredDescriptor[credentialsCount];
-
-            for (int i = 0; i < credentialsCount; i++)
-            {
-                PubkeyCredDescriptor descriptor = credentials.ElementAt(i);
-                _credentialsIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(descriptor.Id);
-                var credentialIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_credentialsIdUnmanagedDataArray[i], (nuint)descriptor.Id.Length));
-                _credentialsIdUnmanagedConstBufferArray[i] = credentialIdUnmanagedConstBuffer;
-                credentialsStructArray[i] = new WauthnPubkeyCredDescriptor(descriptor.Type, credentialIdUnmanagedConstBuffer, descriptor.Transport);
-            }
-            _credentialsDescriptorsUnmanaged = UnmanagedMemory.PinArray(credentialsStructArray);
-            _credentialsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredDescriptors((nuint)credentialsCount, _credentialsDescriptorsUnmanaged));
-        }
-
-        private void CopyAuthenticatorSelection(AuthenticationSelectionCriteria selection)
+        protected void CopyAuthenticatorSelection(AuthenticationSelectionCriteria selection)
         {
             if (selection is null)
                 return;
@@ -258,121 +145,9 @@ namespace Tizen.Security.WebAuthn
                 (byte)(selection.RequireResidentKey ? 1 : 0),
                 selection.UserVerification));
         }
-
-        private void CopyHints(IEnumerable<PubkeyCredHint> hints)
-        {
-            if (hints is null || !hints.Any())
-                return;
-
-            int[] hintsArray = hints.Select((PubkeyCredHint hint) => (int)hint).ToArray();
-            _hintsArrayUnmanaged = UnmanagedMemory.PinArray(hintsArray);
-            _hintsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredHints((nuint)hintsArray.Length, _hintsArrayUnmanaged));
-        }
-
-        private void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
-        {
-            if (attestationFormats is null || !attestationFormats.Any())
-                return;
-
-            var attestationFormatsCount = attestationFormats.Count();
-            _attestationFormatsUnmanagedDataArray = new UnmanagedMemory[attestationFormatsCount];
-            _attestationFormatsUnmanagedConstBufferArray = new UnmanagedMemory[attestationFormatsCount];
-            var attestationFormatConstBufferStructArray = new WauthnConstBuffer[attestationFormatsCount];
-
-
-            for (int i = 0; i < attestationFormatsCount; i++)
-            {
-                byte[] attestationFormat = attestationFormats.ElementAt(i);
-                _attestationFormatsUnmanagedDataArray[i] = UnmanagedMemory.PinArray(attestationFormat);
-                attestationFormatConstBufferStructArray[i] = new WauthnConstBuffer(_attestationFormatsUnmanagedDataArray[i], (nuint)attestationFormat.Length);
-                _attestationFormatsUnmanagedConstBufferArray[i] = new UnmanagedMemory(attestationFormatConstBufferStructArray[i]);
-            }
-            _attestationFormatsArrayUnmanaged = UnmanagedMemory.PinArray(attestationFormatConstBufferStructArray);
-            _attestationFormatsUnmanaged = new UnmanagedMemory(new WauthnAttestationFormats((nuint)attestationFormatsCount, _attestationFormatsArrayUnmanaged));
-        }
-
-        private void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
-        {
-            if (extensions is null || !extensions.Any())
-                return;
-
-            var extensionCount = extensions.Count();
-            var extensionStructArray = new WauthnAuthenticationExt[extensionCount];
-            _extensionIdUnmanagedDataArray = new UnmanagedMemory[extensionCount];
-            _extensionIdUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
-            _extensionValueUnmanagedDataArray = new UnmanagedMemory[extensionCount];
-            _extensionValueUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
-
-            for (int i = 0; i < extensionCount; i++)
-            {
-                AuthenticationExtension ext = extensions.ElementAt(i);
-                _extensionIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionId);
-                var extensionIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionIdUnmanagedDataArray[i], (nuint)ext.ExtensionId.Length));
-                _extensionIdUnmanagedConstBufferArray[i] = extensionIdUnmanagedConstBuffer;
-
-                _extensionValueUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionValue);
-                var extensionValueUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionValueUnmanagedDataArray[i], (nuint)ext.ExtensionValue.Length));
-                _extensionValueUnmanagedConstBufferArray[i] = extensionValueUnmanagedConstBuffer;
-
-                extensionStructArray[i] = new WauthnAuthenticationExt(extensionIdUnmanagedConstBuffer, extensionValueUnmanagedConstBuffer);
-            }
-            _extensionsArrayUnmanaged = UnmanagedMemory.PinArray(extensionStructArray);
-            _extensionsUnmanaged = new UnmanagedMemory(new WauthnAuthenticationExts((nuint)extensionCount, _extensionsArrayUnmanaged));
-        }
-
-        private void CopyLinkedDevice(HybridLinkedData linkedDevice)
-        {
-            if (linkedDevice is null)
-                return;
-
-            _contactIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.ContactId);
-            _contactIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_contactIdDataUnmanaged, (nuint)linkedDevice.ContactId.Length));
-
-            _linkIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkId);
-            _linkIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkIdDataUnmanaged, (nuint)linkedDevice.LinkId.Length));
-
-            _linkSecretDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkSecret);
-            _linkSecretUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkSecretDataUnmanaged, (nuint)linkedDevice.LinkSecret.Length));
-
-            _authenticatorPubkeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorPubkey);
-            _authenticatorPubkeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorPubkeyDataUnmanaged, (nuint)linkedDevice.AuthenticatorPubkey.Length));
-
-            _authenticatorNameDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorName);
-            _authenticatorNameUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorNameDataUnmanaged, (nuint)linkedDevice.AuthenticatorName.Length));
-
-            _signatureDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.Signature);
-            _signatureUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_signatureDataUnmanaged, (nuint)linkedDevice.Signature.Length));
-
-            _tunnelServerDomainDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.TunnelServerDomain);
-            _tunnelServerDomainUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_tunnelServerDomainDataUnmanaged, (nuint)linkedDevice.TunnelServerDomain.Length));
-
-            _identityKeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.IdentityKey);
-            _identityKeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_identityKeyDataUnmanaged, (nuint)linkedDevice.IdentityKey.Length));
-
-            _linkedDeviceUnmanaged = new UnmanagedMemory(new WauthnHybridLinkedData(
-                _contactIdUnmanaged,
-                _linkIdUnmanaged,
-                _linkSecretUnmanaged,
-                _authenticatorPubkeyUnmanaged,
-                _authenticatorNameUnmanaged,
-                _signatureUnmanaged,
-                _tunnelServerDomainUnmanaged,
-                _identityKeyUnmanaged));
-
-            if (_linkedDeviceUnmanaged == IntPtr.Zero)
-                throw new TimeoutException("linked null");
-        }
-
-        public void CleanupArray(UnmanagedMemory[] array)
-        {
-            if (array is null)
-                return;
-            foreach (var memory in array)
-                memory.Dispose();
-        }
+        #endregion
 
         public WauthnMcCallbacks WauthnMcCallbacks { get; private set; }
-        public WauthnClientData WauthnClientData { get; private set; }
         public WauthnPubkeyCredCreationOptions WauthnPubkeyCredCreationOptions { get; private set; }
     }
 }

--- a/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorStorage.cs
+++ b/src/Tizen.Security.WebAuthn/Tizen.Security.WebAuthn/AuthenticatorStorage.cs
@@ -1,0 +1,258 @@
+/*
+ *  Copyright (c) 2024 Samsung Electronics Co., Ltd All Rights Reserved
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Interop;
+
+namespace Tizen.Security.WebAuthn
+{
+    internal abstract class AuthenticatorStorage : IDisposable
+    {
+        #region Internal unmanaged memory
+        protected UnmanagedMemory _credentialsUnmanaged = new();
+        protected UnmanagedMemory _hintsUnmanaged = new();
+        protected UnmanagedMemory _attestationFormatsUnmanaged = new();
+        protected UnmanagedMemory _extensionsUnmanaged = new();
+        protected UnmanagedMemory _linkedDeviceUnmanaged = new();
+
+        protected WauthnDisplayQrcodeCallback _qrcodeCallback;
+        protected WauthnUpdateLinkedDataCallback _linkedDataCallback;
+
+        private UnmanagedMemory[] _credentialsIdUnmanagedDataArray;
+        private UnmanagedMemory[] _credentialsIdUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _attestationFormatsUnmanagedDataArray;
+        private UnmanagedMemory[] _attestationFormatsUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _extensionIdUnmanagedDataArray;
+        private UnmanagedMemory[] _extensionIdUnmanagedConstBufferArray;
+        private UnmanagedMemory[] _extensionValueUnmanagedDataArray;
+        private UnmanagedMemory[] _extensionValueUnmanagedConstBufferArray;
+
+        private UnmanagedMemory _jsonDataUnmanaged = new();
+        private UnmanagedMemory _jsonDataConstBufferUnmanaged = new();
+        private UnmanagedMemory _credentialsDescriptorsUnmanaged = new();
+        private UnmanagedMemory _hintsArrayUnmanaged = new();
+        private UnmanagedMemory _attestationFormatsArrayUnmanaged = new();
+        private UnmanagedMemory _extensionsArrayUnmanaged = new();
+        private UnmanagedMemory _contactIdDataUnmanaged = new();
+        private UnmanagedMemory _contactIdUnmanaged = new();
+        private UnmanagedMemory _linkIdDataUnmanaged = new();
+        private UnmanagedMemory _linkIdUnmanaged = new();
+        private UnmanagedMemory _linkSecretDataUnmanaged = new();
+        private UnmanagedMemory _linkSecretUnmanaged = new();
+        private UnmanagedMemory _authenticatorPubkeyDataUnmanaged = new();
+        private UnmanagedMemory _authenticatorPubkeyUnmanaged = new();
+        private UnmanagedMemory _authenticatorNameDataUnmanaged = new();
+        private UnmanagedMemory _authenticatorNameUnmanaged = new();
+        private UnmanagedMemory _signatureDataUnmanaged = new();
+        private UnmanagedMemory _signatureUnmanaged = new();
+        private UnmanagedMemory _tunnelServerDomainDataUnmanaged = new();
+        private UnmanagedMemory _tunnelServerDomainUnmanaged = new();
+        private UnmanagedMemory _identityKeyDataUnmanaged = new();
+        private UnmanagedMemory _identityKeyUnmanaged = new();
+        #endregion
+
+        private bool _disposed = false;
+
+        public virtual void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            CleanupArray(_credentialsIdUnmanagedDataArray);
+            CleanupArray(_credentialsIdUnmanagedConstBufferArray);
+            CleanupArray(_attestationFormatsUnmanagedDataArray);
+            CleanupArray(_attestationFormatsUnmanagedConstBufferArray);
+            CleanupArray(_extensionIdUnmanagedDataArray);
+            CleanupArray(_extensionIdUnmanagedConstBufferArray);
+            CleanupArray(_extensionValueUnmanagedDataArray);
+            CleanupArray(_extensionValueUnmanagedConstBufferArray);
+
+            _jsonDataUnmanaged.Dispose();
+            _jsonDataConstBufferUnmanaged.Dispose();
+            _credentialsDescriptorsUnmanaged.Dispose();
+            _credentialsUnmanaged.Dispose();
+            _hintsArrayUnmanaged.Dispose();
+            _hintsUnmanaged.Dispose();
+            _attestationFormatsArrayUnmanaged.Dispose();
+            _attestationFormatsUnmanaged.Dispose();
+            _extensionsArrayUnmanaged.Dispose();
+            _extensionsUnmanaged.Dispose();
+            _contactIdDataUnmanaged.Dispose();
+            _contactIdUnmanaged.Dispose();
+            _linkIdDataUnmanaged.Dispose();
+            _linkIdUnmanaged.Dispose();
+            _linkSecretDataUnmanaged.Dispose();
+            _linkSecretUnmanaged.Dispose();
+            _authenticatorPubkeyDataUnmanaged.Dispose();
+            _authenticatorPubkeyUnmanaged.Dispose();
+            _authenticatorNameDataUnmanaged.Dispose();
+            _authenticatorNameUnmanaged.Dispose();
+            _signatureDataUnmanaged.Dispose();
+            _signatureUnmanaged.Dispose();
+            _tunnelServerDomainDataUnmanaged.Dispose();
+            _tunnelServerDomainUnmanaged.Dispose();
+            _identityKeyDataUnmanaged.Dispose();
+            _identityKeyUnmanaged.Dispose();
+            _linkedDeviceUnmanaged.Dispose();
+
+            _disposed = true;
+        }
+
+        #region Data marshalling
+        protected void CopyClientData(ClientData clientData)
+        {
+            _jsonDataUnmanaged = UnmanagedMemory.PinArray(clientData.JsonData);
+            _jsonDataConstBufferUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_jsonDataUnmanaged, (nuint)clientData.JsonData.Length));
+            WauthnClientData = new WauthnClientData(_jsonDataConstBufferUnmanaged, clientData.HashAlgo);
+        }
+
+        protected void CopyCredentials(IEnumerable<PubkeyCredDescriptor> credentials)
+        {
+            if (credentials is null || !credentials.Any())
+                return;
+
+            var credentialsCount = credentials.Count();
+            _credentialsIdUnmanagedDataArray = new UnmanagedMemory[credentialsCount];
+            _credentialsIdUnmanagedConstBufferArray = new UnmanagedMemory[credentialsCount];
+            var credentialsStructArray = new WauthnPubkeyCredDescriptor[credentialsCount];
+
+            for (int i = 0; i < credentialsCount; i++)
+            {
+                PubkeyCredDescriptor descriptor = credentials.ElementAt(i);
+                _credentialsIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(descriptor.Id);
+                var credentialIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_credentialsIdUnmanagedDataArray[i], (nuint)descriptor.Id.Length));
+                _credentialsIdUnmanagedConstBufferArray[i] = credentialIdUnmanagedConstBuffer;
+                credentialsStructArray[i] = new WauthnPubkeyCredDescriptor(descriptor.Type, credentialIdUnmanagedConstBuffer, descriptor.Transport);
+            }
+            _credentialsDescriptorsUnmanaged = UnmanagedMemory.PinArray(credentialsStructArray);
+            _credentialsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredDescriptors((nuint)credentialsCount, _credentialsDescriptorsUnmanaged));
+        }
+
+        protected void CopyHints(IEnumerable<PubkeyCredHint> hints)
+        {
+            if (hints is null || !hints.Any())
+                return;
+
+            int[] hintsArray = hints.Select((PubkeyCredHint hint) => (int)hint).ToArray();
+            _hintsArrayUnmanaged = UnmanagedMemory.PinArray(hintsArray);
+            _hintsUnmanaged = new UnmanagedMemory(new WauthnPubkeyCredHints((nuint)hintsArray.Length, _hintsArrayUnmanaged));
+        }
+
+        protected void CopyAttestationFormats(IEnumerable<byte[]> attestationFormats)
+        {
+            if (attestationFormats is null || !attestationFormats.Any())
+                return;
+
+            var attestationFormatsCount = attestationFormats.Count();
+            _attestationFormatsUnmanagedDataArray = new UnmanagedMemory[attestationFormatsCount];
+            _attestationFormatsUnmanagedConstBufferArray = new UnmanagedMemory[attestationFormatsCount];
+            var attestationFormatConstBufferStructArray = new WauthnConstBuffer[attestationFormatsCount];
+
+
+            for (int i = 0; i < attestationFormatsCount; i++)
+            {
+                byte[] attestationFormat = attestationFormats.ElementAt(i);
+                _attestationFormatsUnmanagedDataArray[i] = UnmanagedMemory.PinArray(attestationFormat);
+                attestationFormatConstBufferStructArray[i] = new WauthnConstBuffer(_attestationFormatsUnmanagedDataArray[i], (nuint)attestationFormat.Length);
+                _attestationFormatsUnmanagedConstBufferArray[i] = new UnmanagedMemory(attestationFormatConstBufferStructArray[i]);
+            }
+            _attestationFormatsArrayUnmanaged = UnmanagedMemory.PinArray(attestationFormatConstBufferStructArray);
+            _attestationFormatsUnmanaged = new UnmanagedMemory(new WauthnAttestationFormats((nuint)attestationFormatsCount, _attestationFormatsArrayUnmanaged));
+        }
+
+        protected void CopyExtensions(IEnumerable<AuthenticationExtension> extensions)
+        {
+            if (extensions is null || !extensions.Any())
+                return;
+
+            var extensionCount = extensions.Count();
+            var extensionStructArray = new WauthnAuthenticationExt[extensionCount];
+            _extensionIdUnmanagedDataArray = new UnmanagedMemory[extensionCount];
+            _extensionIdUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
+            _extensionValueUnmanagedDataArray = new UnmanagedMemory[extensionCount];
+            _extensionValueUnmanagedConstBufferArray = new UnmanagedMemory[extensionCount];
+
+            for (int i = 0; i < extensionCount; i++)
+            {
+                AuthenticationExtension ext = extensions.ElementAt(i);
+                _extensionIdUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionId);
+                var extensionIdUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionIdUnmanagedDataArray[i], (nuint)ext.ExtensionId.Length));
+                _extensionIdUnmanagedConstBufferArray[i] = extensionIdUnmanagedConstBuffer;
+
+                _extensionValueUnmanagedDataArray[i] = UnmanagedMemory.PinArray(ext.ExtensionValue);
+                var extensionValueUnmanagedConstBuffer = new UnmanagedMemory(new WauthnConstBuffer(_extensionValueUnmanagedDataArray[i], (nuint)ext.ExtensionValue.Length));
+                _extensionValueUnmanagedConstBufferArray[i] = extensionValueUnmanagedConstBuffer;
+
+                extensionStructArray[i] = new WauthnAuthenticationExt(extensionIdUnmanagedConstBuffer, extensionValueUnmanagedConstBuffer);
+            }
+            _extensionsArrayUnmanaged = UnmanagedMemory.PinArray(extensionStructArray);
+            _extensionsUnmanaged = new UnmanagedMemory(new WauthnAuthenticationExts((nuint)extensionCount, _extensionsArrayUnmanaged));
+        }
+
+        protected void CopyLinkedDevice(HybridLinkedData linkedDevice)
+        {
+            if (linkedDevice is null)
+                return;
+
+            _contactIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.ContactId);
+            _contactIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_contactIdDataUnmanaged, (nuint)linkedDevice.ContactId.Length));
+
+            _linkIdDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkId);
+            _linkIdUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkIdDataUnmanaged, (nuint)linkedDevice.LinkId.Length));
+
+            _linkSecretDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.LinkSecret);
+            _linkSecretUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_linkSecretDataUnmanaged, (nuint)linkedDevice.LinkSecret.Length));
+
+            _authenticatorPubkeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorPubkey);
+            _authenticatorPubkeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorPubkeyDataUnmanaged, (nuint)linkedDevice.AuthenticatorPubkey.Length));
+
+            _authenticatorNameDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.AuthenticatorName);
+            _authenticatorNameUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_authenticatorNameDataUnmanaged, (nuint)linkedDevice.AuthenticatorName.Length));
+
+            _signatureDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.Signature);
+            _signatureUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_signatureDataUnmanaged, (nuint)linkedDevice.Signature.Length));
+
+            _tunnelServerDomainDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.TunnelServerDomain);
+            _tunnelServerDomainUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_tunnelServerDomainDataUnmanaged, (nuint)linkedDevice.TunnelServerDomain.Length));
+
+            _identityKeyDataUnmanaged = UnmanagedMemory.PinArray(linkedDevice.IdentityKey);
+            _identityKeyUnmanaged = new UnmanagedMemory(new WauthnConstBuffer(_identityKeyDataUnmanaged, (nuint)linkedDevice.IdentityKey.Length));
+
+            _linkedDeviceUnmanaged = new UnmanagedMemory(new WauthnHybridLinkedData(
+                _contactIdUnmanaged,
+                _linkIdUnmanaged,
+                _linkSecretUnmanaged,
+                _authenticatorPubkeyUnmanaged,
+                _authenticatorNameUnmanaged,
+                _signatureUnmanaged,
+                _tunnelServerDomainUnmanaged,
+                _identityKeyUnmanaged));
+        }
+        #endregion
+
+        protected static void CleanupArray(UnmanagedMemory[] array)
+        {
+            if (array is null)
+                return;
+            foreach (var memory in array)
+                memory.Dispose();
+        }
+
+        public WauthnClientData WauthnClientData { get; private set; }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
In certain situations it should be possible to make concurrent MakeCredential/GetAssertion calls. Therefore the authenticator being busy is no longer checked in the C# API. Instead, concurrent calls are unconditionally forwarded and it is now up to the native API whether it will honor the request or return an error.

Additionally, this pull request fixes an error in AuthenticatorAssertionResponse data marshalling.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - No public API changes

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
