### PR TITLE
[Notification] Add PairingType for do not disturb app

### DIFF
--- a/src/Tizen.Applications.Notification/Interop/Interop.Notification.cs
+++ b/src/Tizen.Applications.Notification/Interop/Interop.Notification.cs
@@ -238,6 +238,21 @@ internal static partial class Interop
         [DllImport(Libraries.Notification, EntryPoint = "notification_get_check_box")]
         internal static extern NotificationError GetCheckBox(NotificationSafeHandle handle, out bool flag, out bool checkedValue);
 
+        /* apis for do not disturb app */
+        internal delegate void DisturbCallback(IntPtr userData);
+
+        [DllImport(Libraries.Notification, EntryPoint = "notification_register_do_not_disturb_app")]
+        internal static extern NotificationError RegisterDndApp(DisturbCallback cb, IntPtr userData);
+
+        [DllImport(Libraries.Notification, EntryPoint = "notification_unregister_do_not_disturb_app")]
+        internal static extern NotificationError UnRegisterDndApp();
+
+        [DllImport(Libraries.Notification, EntryPoint = "notification_set_pairing_type")]
+        internal static extern NotificationError SetPairingType(NotificationSafeHandle handle, bool pairing);
+
+        [DllImport(Libraries.Notification, EntryPoint = "notification_get_pairing_type")]
+        internal static extern NotificationError GetPairingType(NotificationSafeHandle handle, out bool pairing);
+
         internal static NotificationError GetText(NotificationSafeHandle handle, NotificationText type, out string text)
         {
             NotificationError ret;

--- a/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/Notification.cs
+++ b/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/Notification.cs
@@ -212,6 +212,9 @@ namespace Tizen.Applications.Notifications
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool CheckedValue { get; set; } = false;
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool PairingType { get; set; } = false;
+
         /// <summary>
         /// Gets or sets NotificationSafeHandle.
         /// </summary>

--- a/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/NotificationBinder.cs
+++ b/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/NotificationBinder.cs
@@ -62,6 +62,11 @@ namespace Tizen.Applications.Notifications
             {
                 Interop.Notification.SetCheckBox(notification.Handle, notification.CheckBox, notification.CheckedValue);
             }
+
+            if (notification.PairingType == true)
+            {
+                Interop.Notification.SetPairingType(notification.Handle, notification.PairingType);
+            }
         }
 
         internal static void BindSafeHandle(Notification notification)
@@ -91,6 +96,7 @@ namespace Tizen.Applications.Notifications
             BindSafeHandleTag(notification);
             BindSafeHandleAction(notification);
             BindSafeHandleCheckBox(notification);
+            BindSafeHandlePairingType(notification);
         }
 
         private static void BindNotificationSafeHandle(Notification notification)
@@ -249,6 +255,19 @@ namespace Tizen.Applications.Notifications
 
             notification.CheckBox = checkbox;
             notification.CheckedValue = checkedValue;
+        }
+
+        private static void BindSafeHandlePairingType(Notification notification)
+        {
+            NotificationError ret;
+            bool pairingType= false;
+
+            ret = Interop.Notification.GetPairingType(notification.Handle, out pairingType);
+            if (ret != NotificationError.None) {
+                Log.Error(Notification.LogTag, "Failed to get paring type info");
+            }
+
+            notification.PairingType = pairingType;
         }
     }
 }


### PR DESCRIPTION
Add property and API for do not disturb all

internal api.

during the do not disturb app(dnd app) is running, notification viewer is not launched.
if the dnd app is terminated, notification viewer is launched.
if posted notification type is pairing type, request to terminate dnd app.
it's terminated launch notification viewer.