### PR TITLE
[Notification] fix notification when pairing type is set

### DIFF
--- a/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/Notification.cs
+++ b/src/Tizen.Applications.Notification/Tizen.Applications.Notifications/Notification.cs
@@ -528,7 +528,7 @@ namespace Tizen.Applications.Notifications
                 Bundle bundle = new Bundle(new SafeBundleHandle(extension, false));
                 foreach (string key in bundle.Keys)
                 {
-                    if (key.StartsWith("_NOTIFICATION_EXTENSION_EVENT_"))
+                    if (key.StartsWith("_NOTIFICATION_EXTENSION_EVENT_") || key.StartsWith("_NOTIFICATION_TYPE_PAIRING_"))
                         continue;
 
                     SafeBundleHandle sbh;

--- a/src/Tizen.Applications.NotificationEventListener/Tizen.Applications.NotificationEventListener/NotificationEventArgsBinder.cs
+++ b/src/Tizen.Applications.NotificationEventListener/Tizen.Applications.NotificationEventListener/NotificationEventArgsBinder.cs
@@ -172,7 +172,7 @@ namespace Tizen.Applications.NotificationEventListener
                 Bundle bundle = new Bundle(new SafeBundleHandle(extension, false));
                 foreach (string key in bundle.Keys)
                 {
-                    if (key.StartsWith("_NOTIFICATION_EXTENSION_EVENT_"))
+                    if (key.StartsWith("_NOTIFICATION_EXTENSION_EVENT_") || key.StartsWith("_NOTIFICATION_TYPE_PAIRING_"))
                         continue;
 
                     SafeBundleHandle sbh;


### PR DESCRIPTION
notification viewer is not launched properly when pairing type is set.

check the key to do not add extra data.