### PR TITLE
[NUI] Add remove WebContext callbacks when disposed

### DIFF
--- a/src/Tizen.NUI/src/internal/WebView/WebContext.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebContext.cs
@@ -40,6 +40,8 @@ namespace Tizen.NUI
         private readonly WebContextPasswordDataListAcquiredProxyCallback passwordDataListAcquiredProxyCallback;
         private HttpRequestInterceptedCallback httpRequestInterceptedCallback;
         private readonly WebContextHttpRequestInterceptedProxyCallback httpRequestInterceptedProxyCallback;
+        private DownloadStartedCallback downloadStartedCallback;
+        private MimeOverriddenCallback mimeOverriddenCallback;
 
         internal WebContext(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {
@@ -518,10 +520,11 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RegisterDownloadStartedCallback(DownloadStartedCallback callback)
         {
+            downloadStartedCallback = callback;
             IntPtr ip = IntPtr.Zero;
-            if (callback != null)
+            if (downloadStartedCallback != null)
             {
-                ip = Marshal.GetFunctionPointerForDelegate(callback);
+                ip = Marshal.GetFunctionPointerForDelegate(downloadStartedCallback);
             }
             Interop.WebContext.RegisterDownloadStartedCallback(SwigCPtr, new HandleRef(this, ip));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
@@ -534,10 +537,11 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void RegisterMimeOverriddenCallback(MimeOverriddenCallback callback)
         {
+            mimeOverriddenCallback = callback;
             IntPtr ip = IntPtr.Zero;
-            if (callback != null)
+            if (mimeOverriddenCallback != null)
             {
-                ip = Marshal.GetFunctionPointerForDelegate(callback);
+                ip = Marshal.GetFunctionPointerForDelegate(mimeOverriddenCallback);
             }
             Interop.WebContext.RegisterMimeOverriddenCallback(SwigCPtr, new HandleRef(this, ip));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -244,6 +244,10 @@ namespace Tizen.NUI.BaseComponents
                 return;
             }
 
+            Context.RegisterDownloadStartedCallback(null);
+            Context.RegisterMimeOverriddenCallback(null);
+            Context.RegisterHttpRequestInterceptedCallback(null);
+
             if (type == DisposeTypes.Explicit)
             {
                 //Called by User


### PR DESCRIPTION
### Description of Change ###
[NUI] Add remove WebContext callbacks when disposed
- fix the crash issue : A callback was made on a garbage collected delegate of type 'Tizen.NUI!Tizen.NUI.WebContext+WebContextHttpRequestInterceptedProxyCallback::Invoke'

### API Changes ###
none