### PR TITLE
[NUI] Fix Animation issue for Background and BoxShadow color

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
+++ b/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
@@ -30,12 +30,10 @@ namespace Tizen.NUI
     {
         private static readonly Dictionary<string, VisualPropertyData> visualPropertyTable = new Dictionary<string, VisualPropertyData>()
         {
-            { "backgroundColor",        new VisualPropertyData(View.Property.BACKGROUND, ColorVisualProperty.MixColor, ObjectColorToVector3, PropertyValueColorToVector3,
-                                        new VisualPropertyData(View.Property.BACKGROUND, Visual.Property.Opacity, ObjectColorToAlpha, PropertyValueColorToAlpha)) },
+            { "backgroundColor",        new VisualPropertyData(View.Property.BACKGROUND, ColorVisualProperty.MixColor, ObjectColorToVector4, PropertyValueColorToVector4) },
             { "backgroundOpacity",      new VisualPropertyData(View.Property.BACKGROUND, Visual.Property.Opacity, ObjectIntToFloat) },
             { "boxShadow.BlurRadius",   new VisualPropertyData(View.Property.SHADOW, ColorVisualProperty.BlurRadius) },
-            { "boxShadow.Color",        new VisualPropertyData(View.Property.SHADOW, ColorVisualProperty.MixColor, ObjectColorToVector3, PropertyValueColorToVector3,
-                                        new VisualPropertyData(View.Property.SHADOW, Visual.Property.Opacity, ObjectColorToAlpha, PropertyValueColorToAlpha)) },
+            { "boxShadow.Color",        new VisualPropertyData(View.Property.SHADOW, ColorVisualProperty.MixColor, ObjectColorToVector4, PropertyValueColorToVector4) },
             { "boxShadow.CornerRadius", new VisualPropertyData(View.Property.SHADOW, Visual.Property.CornerRadius, ObjectIntToFloat) },
             { "boxShadow.Offset",       new VisualPropertyData(View.Property.SHADOW, (int)VisualTransformPropertyType.Offset) },
             { "boxShadow.Opacity",      new VisualPropertyData(View.Property.SHADOW, Visual.Property.Opacity, ObjectIntToFloat) },
@@ -141,24 +139,24 @@ namespace Tizen.NUI
             return sb.ToString();
         }
 
-        private static object ObjectColorToVector3(object value)
+        private static object ObjectColorToVector4(object value)
         {
             if (value is Vector4)
             {
                 var colorValue = value as Vector4;
-                return new Vector3(colorValue.R, colorValue.G, colorValue.B);
+                return new Vector4(colorValue.R, colorValue.G, colorValue.B, colorValue.A);
             }
 
             if (value is Color)
             {
                 var colorValue = value as Color;
-                return new Vector3(colorValue.R, colorValue.G, colorValue.B);
+                return new Vector4(colorValue.R, colorValue.G, colorValue.B, colorValue.A);
             }
 
             return null;
         }
 
-        private static PropertyValue PropertyValueColorToVector3(PropertyValue value)
+        private static PropertyValue PropertyValueColorToVector4(PropertyValue value)
         {
             var valueType = value.GetType();
 
@@ -169,43 +167,10 @@ namespace Tizen.NUI
 
             var colorValue = new Vector4();
             value.Get(colorValue);
-            using (var v3 = new Vector3(colorValue.R, colorValue.G, colorValue.B))
+            using (var v4 = new Vector4(colorValue.R, colorValue.G, colorValue.B, colorValue.A))
             {
                 colorValue.Dispose();
-                return new PropertyValue(v3);
-            }
-        }
-
-        private static object ObjectColorToAlpha(object value)
-        {
-            if (value is Vector4)
-            {
-                var colorValue = value as Vector4;
-                return colorValue.A;
-            }
-
-            if (value is Color)
-            {
-                var colorValue = value as Color;
-                return colorValue.A;
-            }
-
-            return null;
-        }
-
-        private static PropertyValue PropertyValueColorToAlpha(PropertyValue value)
-        {
-            var valueType = value.GetType();
-
-            if (valueType != PropertyType.Vector4)
-            {
-                return null;
-            }
-
-            using (var colorValue = new Vector4())
-            {
-                value.Get(colorValue);
-                return new PropertyValue(colorValue.A);
+                return new PropertyValue(v4);
             }
         }
 


### PR DESCRIPTION
Since dali_2.3.41, MixColor property animate by Vector4 type. But NUI animation property helper doesn't apply those changeness.

To match the previous behavior, let we make BackgroundColor and BoxShadow.Color animate by Color class well.

