### PR TITLE
[NUI.Gadget] Fix a description typo

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
@@ -71,7 +71,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Gets the allowed resourced path of the gadget.
+        /// Gets the allowed resource path of the gadget.
         /// </summary>
         /// <since_tizen> 12 </since_tizen>
         public string AllowedResourcePath


### PR DESCRIPTION
Fix a typo error from resourced to resource.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
