### PR TITLE
[Tizen.NUI.Gadget] Change visibility of the NUIGadgetInfo.Assembly to public

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
@@ -95,7 +95,11 @@ namespace Tizen.NUI
 
         internal string ResourceClassName { get; set; }
 
-        internal Assembly Assembly { get; set; }
+        /// <summary>
+        /// Gets the assembly of the gadget.
+        /// </summary>
+        /// <since_tizen> 12 </since_tizen>
+        public Assembly Assembly { get; internal set; }
 
         /// <summary>
         /// Gets the assembly of the gadget.


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->
Change visibility of the NUIGadgetInfo.Assembly to public

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
