### PR TITLE
[NUI.Gadget] Use bin directory

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetInfo.cs
@@ -71,10 +71,10 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Gets the allowed resource path of the gadget.
+        /// Gets the gadget resource path of the gadget.
         /// </summary>
         /// <since_tizen> 12 </since_tizen>
-        public string AllowedResourcePath
+        public string GadgetResourcePath
         {
             get; private set;
         }
@@ -196,11 +196,16 @@ namespace Tizen.NUI
                 Log.Warn("Failed to destroy package info. error = " + errorCode);
             }
 
-            info.ResourcePath = SystemIO.Path.GetDirectoryName(Application.Current.ApplicationInfo.ExecutablePath) + "/";
-            info.AllowedResourcePath = SystemIO.Path.GetDirectoryName(Application.Current.DirectoryInfo.Resource) + "/mount/allowed/" + info.ResourceType + "/";
-            if (!Directory.Exists(info.AllowedResourcePath))
+            info.ResourcePath = SystemIO.Path.GetDirectoryName(Application.Current.ApplicationInfo.ExecutablePath) + "/.res_mount/";
+            if (!Directory.Exists(info.ResourcePath))
             {
-                info.AllowedResourcePath = SystemIO.Path.GetDirectoryName(Application.Current.DirectoryInfo.Resource) + "/mount/allowed/";
+                info.ResourcePath = SystemIO.Path.GetDirectoryName(Application.Current.ApplicationInfo.ExecutablePath) + "/";
+            }
+
+            info.GadgetResourcePath = info.ResourcePath + info.ResourceType + "/";
+            if (!Directory.Exists(info.GadgetResourcePath))
+            {
+                info.GadgetResourcePath = info.ResourcePath;
             }
             return info;
         }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -243,10 +243,10 @@ namespace Tizen.NUI
                     {
                         if (info.NUIGadgetAssembly == null || !info.NUIGadgetAssembly.IsLoaded)
                         {
-                            Log.Warn("NUIGadgetAssembly.Load(): " + info.AllowedResourcePath + info.ExecutableFile + " ++");
-                            info.NUIGadgetAssembly = new NUIGadgetAssembly(info.AllowedResourcePath + info.ExecutableFile);
+                            Log.Warn("NUIGadgetAssembly.Load(): " + info.GadgetResourcePath + info.ExecutableFile + " ++");
+                            info.NUIGadgetAssembly = new NUIGadgetAssembly(info.GadgetResourcePath + info.ExecutableFile);
                             info.NUIGadgetAssembly.Load();
-                            Log.Warn("NUIGadgetAssembly.Load(): " + info.AllowedResourcePath + info.ExecutableFile + " --");
+                            Log.Warn("NUIGadgetAssembly.Load(): " + info.GadgetResourcePath + info.ExecutableFile + " --");
                         }
                     }
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The gadget mount path will be changed to the 'bin/.res_mount'. If it's applied, the NUIGadgetManager can remount the resources.
