### PR TITLE
[Tizen.System.Device] Add battery power source property

### DIFF
--- a/src/Tizen.System/Device/Battery.cs
+++ b/src/Tizen.System/Device/Battery.cs
@@ -59,6 +59,35 @@ namespace Tizen.System
     }
 
     /// <summary>
+    /// Enumeration for the current device's power source information from the battery.
+    /// These represent the current battery power source type (e.g., ac, usb, etc).
+    /// </summary>
+    /// <since_tizen> 12 </since_tizen>
+    public enum BatteryPowerSource
+    {
+        /// <summary>
+        /// These is no power source.
+        /// </summary>
+        /// <since_tizen> 12 </since_tizen>
+        None = 0,
+        /// <summary>
+        /// AC power cable is connected.
+        /// </summary>
+        /// <since_tizen> 12 </since_tizen>
+        Ac = 1,
+        /// <summary>
+        /// USB power cable is connected.
+        /// </summary>
+        /// <since_tizen> 12 </since_tizen>
+        Usb = 2,
+        /// <summary>
+        /// Power is provided by a wireless source.
+        /// </summary>
+        /// <since_tizen> 12 </since_tizen>
+        Wireless = 3
+    }
+
+    /// <summary>
     /// The Battery class provides the properties and events for the device battery.
     /// </summary>
     /// <remarks>
@@ -162,6 +191,38 @@ namespace Tizen.System
                     Log.Warn(DeviceExceptionFactory.LogTag, "unable to get battery charging state.");
                 }
                 return charging;
+            }
+        }
+        /// <summary>
+        /// Gets the current device's power source information from the battery.
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the current battery power source information (e.g., ac, usb, etc).
+        /// </remarks>
+        /// <since_tizen> 12 </since_tizen>
+        /// <value>The battery power source type.</value>
+        /// <example>
+        /// <code>
+        /// using Tizen.System;
+        /// ...
+        /// BatteryPowerSource PowerSourceType = Battery.PowerSource;
+        /// if (PowerSourceType == BatteryPowerSource.None)
+        ///     ...
+        /// ...
+        /// </code>
+        /// </example>
+        /// <seealso cref="BatteryPowerSource"/>
+        public static BatteryPowerSource PowerSource
+        {
+            get
+            {
+                int power_source_type = 0;
+                DeviceError res = (DeviceError)Interop.Device.DeviceBatteryGetPowerSource(out power_source_type);
+                if (res != DeviceError.None)
+                {
+                    Log.Warn(DeviceExceptionFactory.LogTag, "unable to get battery power source type.");
+                }
+                return (BatteryPowerSource)power_source_type;
             }
         }
 

--- a/src/Tizen.System/Interop/Interop.Device.cs
+++ b/src/Tizen.System/Interop/Interop.Device.cs
@@ -117,6 +117,8 @@ internal static partial class Interop
         public static extern int DeviceBatteryIsCharging(out bool charging);
         [DllImport(Libraries.Device, EntryPoint = "device_battery_get_level_status", CallingConvention = CallingConvention.Cdecl)]
         public static extern int DeviceBatteryGetLevelStatus(out int status);
+        [DllImport(Libraries.Device, EntryPoint = "device_battery_get_power_source", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int DeviceBatteryGetPowerSource(out int power_source_type);
 
         // Display
         [DllImport(Libraries.Device, EntryPoint = "device_display_get_numbers", CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

To support using device_battery_get_power_source(), this battery powersource property addition is necessary. Below enum and property are added.

 - public enum BatteryPowerSource
     -> It represents the battery power source charger type.
 - BatteryPowerSource Battery.PowerSource { get; } // Property
     -> It is possible to get the battery power source type as the BatteryPowerSource enum value.

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
