### PR TITLE
[NUI][API12] Match ViewImpl Connector parameter with csharp binder

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewImpl.cs
@@ -471,7 +471,7 @@ namespace Tizen.NUI
                 swigDelegate39 = new SwigDelegateViewImpl_39(SwigDirectorSignalConnected);
             if (SwigDerivedClassHasMethod("SignalDisconnected", swigMethodTypes40))
                 swigDelegate40 = new SwigDelegateViewImpl_40(SwigDirectorSignalDisconnected);
-            Interop.ViewImpl.DirectorConnect(SwigCPtr, swigDelegate0, swigDelegate1, swigDelegate2, swigDelegate3, swigDelegate4, swigDelegate5, swigDelegate6, swigDelegate9, swigDelegate11, swigDelegate12, swigDelegate13, swigDelegate14, swigDelegate15, swigDelegate16, swigDelegate17, swigDelegate18, swigDelegate19, swigDelegate20, swigDelegate21, swigDelegate24, swigDelegate25, swigDelegate26, swigDelegate28, swigDelegate29, swigDelegate30, swigDelegate31, swigDelegate32, swigDelegate33, swigDelegate34, swigDelegate35, swigDelegate36, swigDelegate37, swigDelegate38, swigDelegate39, swigDelegate40);
+            Interop.ViewImpl.DirectorConnect(SwigCPtr, swigDelegate0, swigDelegate1, swigDelegate2, swigDelegate3, swigDelegate4, swigDelegate5, swigDelegate6, swigDelegate9, swigDelegate11, swigDelegate12, swigDelegate13, swigDelegate14, swigDelegate15, swigDelegate16, swigDelegate17, swigDelegate18, swigDelegate19, swigDelegate20, swigDelegate21, swigDelegate24, swigDelegate25, swigDelegate30, swigDelegate31, swigDelegate32, swigDelegate33, swigDelegate34, swigDelegate35, swigDelegate36, swigDelegate37, swigDelegate38, swigDelegate39, swigDelegate40);
         }
 
         private void SwigDirectorDisconnect()
@@ -497,9 +497,6 @@ namespace Tizen.NUI
             swigDelegate21 = null;
             swigDelegate24 = null;
             swigDelegate25 = null;
-            swigDelegate26 = null;
-            swigDelegate28 = null;
-            swigDelegate29 = null;
             swigDelegate30 = null;
             swigDelegate31 = null;
             swigDelegate32 = null;
@@ -511,7 +508,7 @@ namespace Tizen.NUI
             swigDelegate38 = null;
             swigDelegate39 = null;
             swigDelegate40 = null;
-            Interop.ViewImpl.DirectorConnect(SwigCPtr, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            Interop.ViewImpl.DirectorConnect(SwigCPtr, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         }
 
         private bool SwigDerivedClassHasMethod(string methodName, global::System.Type[] methodTypes)
@@ -762,9 +759,6 @@ namespace Tizen.NUI
         private SwigDelegateViewImpl_21 swigDelegate21;
         private SwigDelegateViewImpl_24 swigDelegate24;
         private SwigDelegateViewImpl_25 swigDelegate25;
-        private SwigDelegateViewImpl_26 swigDelegate26;
-        private SwigDelegateViewImpl_28 swigDelegate28;
-        private SwigDelegateViewImpl_29 swigDelegate29;
         private SwigDelegateViewImpl_30 swigDelegate30;
         private SwigDelegateViewImpl_31 swigDelegate31;
         private SwigDelegateViewImpl_32 swigDelegate32;
@@ -798,9 +792,6 @@ namespace Tizen.NUI
         private static global::System.Type[] swigMethodTypes21 = System.Array.Empty<global::System.Type>();
         private static global::System.Type[] swigMethodTypes24 = new global::System.Type[] { typeof(StyleManager), typeof(StyleChangeType) };
         private static global::System.Type[] swigMethodTypes25 = System.Array.Empty<global::System.Type>();
-        private static global::System.Type[] swigMethodTypes26 = new global::System.Type[] { typeof(PanGesture) };
-        private static global::System.Type[] swigMethodTypes28 = new global::System.Type[] { typeof(bool) };
-        private static global::System.Type[] swigMethodTypes29 = System.Array.Empty<global::System.Type>();
         private static global::System.Type[] swigMethodTypes30 = System.Array.Empty<global::System.Type>();
         private static global::System.Type[] swigMethodTypes31 = System.Array.Empty<global::System.Type>();
         private static global::System.Type[] swigMethodTypes32 = new global::System.Type[] { typeof(View), typeof(View.FocusDirection), typeof(bool) };

--- a/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ViewWrapperImpl.cs
@@ -289,7 +289,7 @@ namespace Tizen.NUI
             Delegate36 = new DelegateViewWrapperImpl_36(DirectorOnPan);
             Delegate37 = new DelegateViewWrapperImpl_37(DirectorOnTap);
             Delegate38 = new DelegateViewWrapperImpl_38(DirectorOnLongPress);
-            Interop.ViewWrapperImpl.DirectorConnect(SwigCPtr, Delegate0, Delegate1, Delegate2, Delegate3, Delegate4, Delegate5, Delegate6, Delegate9, Delegate11, Delegate12, Delegate13, Delegate14, Delegate15, Delegate16, Delegate17, Delegate18, Delegate19, Delegate20, Delegate21, Delegate24, Delegate25, Delegate26, Delegate28, Delegate29, Delegate30, Delegate31, Delegate32, Delegate33, Delegate34, Delegate35, Delegate36, Delegate37, Delegate38, null, null);
+            Interop.ViewWrapperImpl.DirectorConnect(SwigCPtr, Delegate0, Delegate1, Delegate2, Delegate3, Delegate4, Delegate5, Delegate6, Delegate9, Delegate11, Delegate12, Delegate13, Delegate14, Delegate15, Delegate16, Delegate17, Delegate18, Delegate19, Delegate20, Delegate21, Delegate24, Delegate25, Delegate30, Delegate31, Delegate32, Delegate33, Delegate34, Delegate35, Delegate36, Delegate37, Delegate38, null, null);
         }
 
 
@@ -316,9 +316,6 @@ namespace Tizen.NUI
             Delegate21 = null;
             Delegate24 = null;
             Delegate25 = null;
-            Delegate26 = null;
-            Delegate28 = null;
-            Delegate29 = null;
             Delegate30 = null;
             Delegate31 = null;
             Delegate32 = null;
@@ -328,7 +325,7 @@ namespace Tizen.NUI
             Delegate36 = null;
             Delegate37 = null;
             Delegate38 = null;
-            Interop.ViewWrapperImpl.DirectorConnect(SwigCPtr, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+            Interop.ViewWrapperImpl.DirectorConnect(SwigCPtr, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
         }
 
         private void DirectorOnSceneConnection(int depth)
@@ -656,9 +653,6 @@ namespace Tizen.NUI
         private DelegateViewWrapperImpl_21 Delegate21;
         private DelegateViewWrapperImpl_24 Delegate24;
         private DelegateViewWrapperImpl_25 Delegate25;
-        private DelegateViewWrapperImpl_26 Delegate26;
-        private DelegateViewWrapperImpl_28 Delegate28;
-        private DelegateViewWrapperImpl_29 Delegate29;
         private DelegateViewWrapperImpl_30 Delegate30;
         private DelegateViewWrapperImpl_31 Delegate31;
         private DelegateViewWrapperImpl_32 Delegate32;

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewImpl.cs
@@ -147,8 +147,6 @@ namespace Tizen.NUI
                 Tizen.NUI.ViewImpl.SwigDelegateViewImpl_18 delegate18, Tizen.NUI.ViewImpl.SwigDelegateViewImpl_19 delegate19,
                 Tizen.NUI.ViewImpl.SwigDelegateViewImpl_20 delegate20, Tizen.NUI.ViewImpl.SwigDelegateViewImpl_21 delegate21,
                 Tizen.NUI.ViewImpl.SwigDelegateViewImpl_24 delegate24, Tizen.NUI.ViewImpl.SwigDelegateViewImpl_25 delegate25,
-                Tizen.NUI.ViewImpl.SwigDelegateViewImpl_26 delegate26,
-                Tizen.NUI.ViewImpl.SwigDelegateViewImpl_28 delegate28, Tizen.NUI.ViewImpl.SwigDelegateViewImpl_29 delegate29,
                 Tizen.NUI.ViewImpl.SwigDelegateViewImpl_30 delegate30, Tizen.NUI.ViewImpl.SwigDelegateViewImpl_31 delegate31,
                 Tizen.NUI.ViewImpl.SwigDelegateViewImpl_32 delegate32, Tizen.NUI.ViewImpl.SwigDelegateViewImpl_33 delegate33,
                 Tizen.NUI.ViewImpl.SwigDelegateViewImpl_34 delegate34, Tizen.NUI.ViewImpl.SwigDelegateViewImpl_35 delegate35,

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewWrapperImpl.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewWrapperImpl.cs
@@ -44,8 +44,6 @@ namespace Tizen.NUI
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_18 delegate18, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_19 delegate19,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_20 delegate20, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_21 delegate21,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_24 delegate24, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_25 delegate25,
-                Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_26 delegate26,
-                Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_28 delegate28, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_29 delegate29,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_30 delegate30, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_31 delegate31,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_32 delegate32, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_33 delegate33,
                 Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_34 delegate34, Tizen.NUI.ViewWrapperImpl.DelegateViewWrapperImpl_35 delegate35,


### PR DESCRIPTION
After PR #6419 merged, some director callback parameter not matched with dali-csharp-binder.

We also need to remove delegater 26, 28, and 29 at binder level.