### PR TITLE
[Network.WiFi] Implement API to get MAC of TDLS connected peer

### DIFF
--- a/src/Tizen.Network.WiFi/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Network.WiFi/Interop/Interop.Libraries.cs
@@ -20,5 +20,6 @@ internal static partial class Interop
     {
         public const string WiFi = "libcapi-network-wifi-manager.so.1";
         public const string Glib = "libglib-2.0.so.0";
+        public const string Libc = "libc.so.6";
     }
 }

--- a/src/Tizen.Network.WiFi/Interop/Interop.WiFi.cs
+++ b/src/Tizen.Network.WiFi/Interop/Interop.WiFi.cs
@@ -132,6 +132,8 @@ internal static partial class Interop
         internal static extern int SetScanStateChangedCallback(SafeWiFiManagerHandle wifi, ScanStateChangedCallback callback, IntPtr userData);
         [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_unset_scan_state_changed_cb")]
         internal static extern int UnsetScanStateChangedCallback(SafeWiFiManagerHandle wifi);
+        [DllImport(Libraries.WiFi, EntryPoint = "wifi_manager_tdls_get_connected_peer")]
+        internal static extern int GetTdlsConnectedPeer(SafeWiFiManagerHandle wifi, out IntPtr peerMacAddress);
 
         internal static class AP
         {
@@ -371,6 +373,12 @@ internal static partial class Interop
     internal static partial class Glib
     {
         [DllImport(Libraries.Glib, EntryPoint = "g_free", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void Free(IntPtr userData);
+    }
+
+    internal static partial class Libc
+    {
+        [DllImport(Libraries.Libc, EntryPoint = "free")]
         public static extern void Free(IntPtr userData);
     }
 }

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManager.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManager.cs
@@ -536,5 +536,20 @@ namespace Tizen.Network.WiFi
             WiFiManagerImpl.Instance.SetSpecificScanFreq(frequency);
             return WiFiManagerImpl.Instance.StartMultiScan();
         }
+
+        /// <summary>
+        /// Gets MAC address of peer connected through TDLS.
+        /// </summary>
+        /// <since_tizen> 11 </since_tizen>
+        /// <returns>MAC address of the TDLS peer if connected on success or an empty string.</returns>
+        /// <privilege>http://tizen.org/privilege/network.get</privilege>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        static public string TDLSConnectedPeer
+        {
+            get
+            {
+                return WiFiManagerImpl.Instance.TDLSConnectedPeer;
+            }
+        }
     }
 }

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -57,6 +57,7 @@ namespace Tizen.Network.WiFi
 
         private int _requestId = 0;
         private string _macAddress;
+        private string _tdlsMacAddress;
         private IntPtr _specificScanHandle;
 
         //private string PrivilegeNetworkSet = "http://tizen.org/privilege/network.set";
@@ -722,6 +723,28 @@ namespace Tizen.Network.WiFi
             }, null);
 
             return task.Task;
+        }
+
+        internal string TDLSConnectedPeer
+        {
+            get
+            {
+                IntPtr strPtr;
+                int ret = Interop.WiFi.GetTdlsConnectedPeer(GetSafeHandle(), out strPtr);
+                if (ret != (int)WiFiError.None)
+                {
+                    _tdlsMacAddress = "";
+                    Log.Error(Globals.LogTag, "Failed to get mac address, Error - " + (WiFiError)ret);
+                }
+                else
+                {
+                    _tdlsMacAddress = Marshal.PtrToStringAnsi(strPtr);
+                    Interop.Libc.Free(strPtr);
+                }
+
+                Log.Info(Globals.LogTag, "Tdls Mac address: " + _tdlsMacAddress);
+                return _tdlsMacAddress;
+            }
         }
 
         private void CheckReturnValue(int ret, string method, string privilege)


### PR DESCRIPTION
### Description of Change ###
Implement API for getting MAC address of connect. This API implements C# api for CAPI _wifi_manager_tdls_get_connected_peer_


### API Changes ###
 - ACR: NA
 Its an internal API

- Added:
Property
static public string TDLSConnectedPeer

### Related PRs:
#6472 
#6481 