### PR TITLE
[NUI.Gadget] Modify NUIGadgetAssembly unload logic

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetAssembly.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetAssembly.cs
@@ -104,6 +104,7 @@ namespace Tizen.NUI
                     (_assemblyRef.Target as NUIGadgetAssemblyLoadContext).Unload();
                 }
 
+                _assembly = null;
                 _loaded = false;
                 Log.Warn("Unload(): " + _assemblyPath + " --");
             }


### PR DESCRIPTION


### Description of Change ###
`_assembly` must be reset to null after calling `Unload()`.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
