### PR TITLE
[NUI] Block native callback if InputMethodContext is disposed

### DIFF
--- a/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
@@ -880,9 +880,39 @@ namespace Tizen.NUI
             //You should not access any managed member here except static instance
             //because the execution order of Finalizes is non-deterministic.
 
+            if (activatedEventCallback != null)
+            {
+                ActivatedSignal().Disconnect(activatedEventCallback);
+            }
+
+            if (eventReceivedEventCallback != null)
+            {
+                EventReceivedSignal().Disconnect(eventReceivedEventCallback);
+            }
+
+            if (statusChangedEventCallback != null)
+            {
+                StatusChangedSignal().Disconnect(statusChangedEventCallback);
+            }
+
+            if (resizedEventCallback != null)
+            {
+                ResizedSignal().Disconnect(resizedEventCallback);
+            }
+
+            if (languageChangedEventCallback != null)
+            {
+                LanguageChangedSignal().Disconnect(languageChangedEventCallback);
+            }
+
             if (keyboardTypeChangedEventCallback != null)
             {
                 KeyboardTypeChangedSignal().Disconnect(keyboardTypeChangedEventCallback);
+            }
+
+            if (contentReceivedEventCallback != null)
+            {
+                ContentReceivedSignal().Disconnect(contentReceivedEventCallback);
             }
 
             base.Dispose(type);
@@ -897,6 +927,12 @@ namespace Tizen.NUI
 
         private void OnActivated(IntPtr data)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             ActivatedEventArgs e = new ActivatedEventArgs();
 
             if (data != IntPtr.Zero)
@@ -912,6 +948,12 @@ namespace Tizen.NUI
 
         private IntPtr OnEventReceived(IntPtr inputMethodContext, IntPtr eventData)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return IntPtr.Zero;
+            }
+
             CallbackData callbackData = null;
 
             EventReceivedEventArgs e = new EventReceivedEventArgs();
@@ -941,6 +983,12 @@ namespace Tizen.NUI
 
         private void OnStatusChanged(bool statusChanged)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             StatusChangedEventArgs e = new StatusChangedEventArgs();
 
             e.StatusChanged = statusChanged;
@@ -953,6 +1001,12 @@ namespace Tizen.NUI
 
         private void OnResized(int resized)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             ResizedEventArgs e = new ResizedEventArgs();
             e.Resized = resized;
 
@@ -964,6 +1018,12 @@ namespace Tizen.NUI
 
         private void OnLanguageChanged(int languageChanged)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             LanguageChangedEventArgs e = new LanguageChangedEventArgs();
             e.LanguageChanged = languageChanged;
 
@@ -975,6 +1035,12 @@ namespace Tizen.NUI
 
         private void OnKeyboardTypeChanged(KeyboardType type)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             KeyboardTypeChangedEventArgs e = new KeyboardTypeChangedEventArgs();
 
             e.KeyboardType = type;
@@ -987,6 +1053,12 @@ namespace Tizen.NUI
 
         private void OnContentReceived(string content, string description, string mimeType)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             ContentReceivedEventArgs e = new ContentReceivedEventArgs();
             e.Content = content;
             e.Description = description;


### PR DESCRIPTION
Block native callback if InputMethodContext is disposed

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
