### PR TITLE
[NUI] Block native callback if InputMethodContext is disposed

### DIFF
--- a/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
@@ -879,9 +879,39 @@ namespace Tizen.NUI
             //You should not access any managed member here except static instance
             //because the execution order of Finalizes is non-deterministic.
 
+            if (activatedEventCallback != null)
+            {
+                ActivatedSignal().Disconnect(activatedEventCallback);
+            }
+
+            if (eventReceivedEventCallback != null)
+            {
+                EventReceivedSignal().Disconnect(eventReceivedEventCallback);
+            }
+
+            if (statusChangedEventCallback != null)
+            {
+                StatusChangedSignal().Disconnect(statusChangedEventCallback);
+            }
+
+            if (resizedEventCallback != null)
+            {
+                ResizedSignal().Disconnect(resizedEventCallback);
+            }
+
+            if (languageChangedEventCallback != null)
+            {
+                LanguageChangedSignal().Disconnect(languageChangedEventCallback);
+            }
+
             if (keyboardTypeChangedEventCallback != null)
             {
                 KeyboardTypeChangedSignal().Disconnect(keyboardTypeChangedEventCallback);
+            }
+
+            if (contentReceivedEventCallback != null)
+            {
+                ContentReceivedSignal().Disconnect(contentReceivedEventCallback);
             }
 
             base.Dispose(type);
@@ -896,6 +926,12 @@ namespace Tizen.NUI
 
         private void OnActivated(IntPtr data)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             ActivatedEventArgs e = new ActivatedEventArgs();
 
             if (data != IntPtr.Zero)
@@ -911,6 +947,12 @@ namespace Tizen.NUI
 
         private IntPtr OnEventReceived(IntPtr inputMethodContext, IntPtr eventData)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return IntPtr.Zero;
+            }
+
             CallbackData callbackData = null;
 
             EventReceivedEventArgs e = new EventReceivedEventArgs();
@@ -940,6 +982,12 @@ namespace Tizen.NUI
 
         private void OnStatusChanged(bool statusChanged)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             StatusChangedEventArgs e = new StatusChangedEventArgs();
 
             e.StatusChanged = statusChanged;
@@ -952,6 +1000,12 @@ namespace Tizen.NUI
 
         private void OnResized(int resized)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             ResizedEventArgs e = new ResizedEventArgs();
             e.Resized = resized;
 
@@ -963,6 +1017,12 @@ namespace Tizen.NUI
 
         private void OnLanguageChanged(int languageChanged)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             LanguageChangedEventArgs e = new LanguageChangedEventArgs();
             e.LanguageChanged = languageChanged;
 
@@ -974,6 +1034,12 @@ namespace Tizen.NUI
 
         private void OnKeyboardTypeChanged(KeyboardType type)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             KeyboardTypeChangedEventArgs e = new KeyboardTypeChangedEventArgs();
 
             e.KeyboardType = type;
@@ -986,6 +1052,12 @@ namespace Tizen.NUI
 
         private void OnContentReceived(string content, string description, string mimeType)
         {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if InputMethodContext is disposed or queued for disposal.
+                return;
+            }
+
             ContentReceivedEventArgs e = new ContentReceivedEventArgs();
             e.Content = content;
             e.Description = description;


### PR DESCRIPTION
Block native callback if InputMethodContext is disposed

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
