### PR TITLE
[NUI] Add Tizen.NUI.OneUI as friend assembly

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/FriendAssembly.cs
+++ b/src/Tizen.NUI/src/internal/Common/FriendAssembly.cs
@@ -44,6 +44,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Tizen.NUI2, " + Tizen.NUI.PublicKey.TizenNUI2)]
 [assembly: InternalsVisibleTo("Tizen.NUI2.Compatibility, " + Tizen.NUI.PublicKey.TizenNUI2)]
 
+[assembly: InternalsVisibleTo("Tizen.NUI.OneUI, " + Tizen.NUI.PublicKey.TizenNUIOneUI)]
+
 namespace Tizen.NUI
 {
     internal static class PublicKey
@@ -71,5 +73,12 @@ namespace Tizen.NUI
             "99e5766f42eef33d89d1f67225db051f011abcfce47a4788875c39750a2e5695f1ec117f41d96610419811762" +
             "669f98131db30a6e64c6bb8fde3731f373f6cda4c0087d121f5108559f216dc015807dc46ec5a4d1b63f5deff" +
             "64c01754a0db0dc849bc300672572cbd2697432ab6c193ebf9fade6bf0f2aad";
+
+        internal const string TizenNUIOneUI =
+            "PublicKey=002400000480000094000000060200000024000052534131000400000100010027a569d80f8543" +
+            "114f08f0ac25b7ebfe9528865cdc4d49129cc393d42b043db596b7a701812252464c0493c54326" +
+            "cbcbd8f2d37eb91217120d199fe0b86e1bdfd955873558a630ee595bcca0ade643f1750b22a910" +
+            "60ea4e84639b40b346991f8271f18d4a6bd2802c41762846e13bf0ec0d82d4857be253ee8cbd7c" +
+            "9561c193";
     }
 }


### PR DESCRIPTION
### Description of Change ###
An experimental external NUI library Tizen.NUI.OneUI has been introduced and it needs to access NUI internals.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
