### PR TITLE
[NUI] Prepare extra space to View to attach objects from external

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -48,6 +48,7 @@ namespace Tizen.NUI.BaseComponents
         private LayoutTransition layoutTransition;
         private TransitionOptions transitionOptions = null;
         private ThemeData themeData;
+        private Dictionary<Type, object> attached;
         private bool isThemeChanged = false;
 
         // Collection of image-sensitive properties, and need to update C# side cache value.

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Collections.Generic;
 using global::System.Diagnostics;
 using Tizen.NUI;
 
@@ -1342,6 +1343,24 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        internal T GetAttached<T>()
+        {
+            if (attached != null && attached.ContainsKey(typeof(T)))
+                return (T)attached[typeof(T)];
+            return default;
+        }
+
+        internal void ClearAttached<T>()
+        {
+            attached?.Remove(typeof(T));
+        }
+
+        internal void SetAttached<T>(T value)
+        {
+            attached ??= new Dictionary<Type, object>();
+            attached[typeof(T)] = value;
+        }
+
         /// <summary>
         /// you can override it to clean-up your own resources.
         /// </summary>
@@ -1469,6 +1488,9 @@ namespace Tizen.NUI.BaseComponents
                     heightConstraint.Remove();
                     heightConstraint.Dispose();
                 }
+
+                attached?.Clear();
+                attached = null;
             }
 
             //Release your own unmanaged resources here.


### PR DESCRIPTION
### Description of Change ###
View provides methods to attach extra data (that is not bindable property) from the outside.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
