### PR TITLE
[NUI] Notify background change with magic keyword

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -944,6 +944,7 @@ namespace Tizen.NUI.BaseComponents
                     SetInternalBackgroundColorProperty(this, null, value);
                 }
                 NotifyPropertyChanged();
+                NotifyBackgroundChanged();
             }
         }
 
@@ -975,6 +976,7 @@ namespace Tizen.NUI.BaseComponents
                     SetInternalBackgroundImageProperty(this, null, value);
                 }
                 NotifyPropertyChanged();
+                NotifyBackgroundChanged();
             }
         }
 
@@ -1039,6 +1041,7 @@ namespace Tizen.NUI.BaseComponents
                     SetInternalBackgroundProperty(this, null, value);
                 }
                 NotifyPropertyChanged();
+                NotifyBackgroundChanged();
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1942,5 +1942,12 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        private void NotifyBackgroundChanged()
+        {
+            // NOTE
+            // Notify background modifications caused by one of BackgroundColor, BackgroundImage, Background and ClearBackground()
+            // By using reserved keyword "_background", user may get notified all background modifications.
+            NotifyPropertyChanged("_background");
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -310,6 +310,8 @@ namespace Tizen.NUI.BaseComponents
         {
             Interop.View.ClearBackground(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            NotifyBackgroundChanged();
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
NUI 외부 라이브러리에서 백그라운드를 토큰 형식으로 지원하기 위해 아래와 같은 기능을 추가했습니다.

<ins>설명</ins>

백그라운드를 토큰으로 지원하려면 백그라운드 변경에 대한 노티를 받을 수 있어야 함.
`View`는 bindable object를 상속하는 구조로 `PropertySet` 이벤트를 제공하고 있어 토큰 구현에 사용할 수 있음.

그런데 백그라운드는 서로 다른 프로퍼티간 상호 수정이 일어나는 구조임.
* BackgroundColor
* BackgroundImage
* Background
* ClearBackground()

이런 구조에서, 기존에 제공하던 `PropertySet` 이벤트는 아래의 이유로 사용하기 어려움이 있음
* BackgroundColor가 설정된 경우 BackgroundImage가 리셋되지만 BackgroundImage가 변경되었다는 노티를 받을 수 없음
* Clear의 경우엔 백그라운드 속성이 리셋됨에도 불구하고 변경 노티를 받을 수 없음


이를 해결하기 위해 `_background`라는 매직 키워드를 사용하여 백그라운드가 어떤 식으로든지 변경되었다는 노티 줄 수 있도록 조치하여 internal 구현에서 활용할 수 있게 함


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
