### PR TITLE
[NUI] Access managed fields only when explicit view disposal

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1469,13 +1469,13 @@ namespace Tizen.NUI.BaseComponents
                     heightConstraint.Remove();
                     heightConstraint.Dispose();
                 }
+
+                DisConnectFromSignals();
             }
 
             //Release your own unmanaged resources here.
             //You should not access any managed member here except static instance.
             //because the execution order of Finalizes is non-deterministic.
-
-            DisConnectFromSignals();
 
             backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
 


### PR DESCRIPTION
### Description of Change ###
Ref : https://github.sec.samsung.net/NUI/OneUIComponents/issues/5
Ref : https://github.com/Samsung/TizenFX/pull/6502

When a View becomes a target for GC and enters the dispose queue, the signal reference it had as a member may not be valid anymore.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
