### PR TITLE
[NUI][API10] Remove DynamicProperty callback if URL changed + Make more thread safe enough

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LottieAnimationViewDynamicPropertyTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/LottieAnimationViewDynamicPropertyTest.cs
@@ -15,6 +15,7 @@ namespace Tizen.NUI.Samples
         Window win;
         View root;
         Timer timer;
+        List<LottieAnimationView> lavList = new List<LottieAnimationView>();
         public void Activate()
         {
             win = NUIApplication.GetDefaultWindow();
@@ -39,9 +40,11 @@ namespace Tizen.NUI.Samples
         bool OnTick(object sender, Timer.TickEventArgs e)
         {
             bool ret = false;
-            //ret = Test1();
-            //ret = Test2();
+            // ret = Test1();
+            // ret = Test2();
             ret = Test3();
+            // ret = Test4();
+            // ret = Test5();
             return ret;
         }
 
@@ -92,8 +95,55 @@ namespace Tizen.NUI.Samples
             return true;
         }
 
-        global::System.Random rand = new global::System.Random();
+        //create objects with same as before. Let's check whether leak occured or not.
         bool Test3()
+        {
+            if (timer.Interval == TIMER_INTERVAL)
+            {
+                // Change the interval more tight, to check memory leak
+                timer.Interval = TIMER_INTERVAL / 10;
+            }
+
+            MakeAll();
+            if (cnt % 2 == 0)
+            {
+                ForceFullGC();
+            }
+            cnt++;
+            return true;
+        }
+
+        //create objects first, and change ImageView property what might give effort to lottie images.
+        //Let's check whether dynamic callback still called or not.
+        bool Test4()
+        {
+            if (cnt == 0)
+            {
+                MakeAll();
+            }
+            else
+            {
+                LottieAnimationView lav = null;
+                if (lavList?.Count > 0)
+                {
+                    lav = lavList[0];
+                }
+                if (lav != null)
+                {
+                    // TODO : It will not affect to lottie image, but will create new visual.
+                    //        Let's make this sample works well in future.
+                    tlog.Debug(tag, $"non-Lottie relative property change start");
+                    lav.OrientationCorrection = true;
+                    lav.Play();
+                    tlog.Debug(tag, $"non-Lottie relative property change done");
+                }
+            }
+            cnt++;
+            return cnt < 2;
+        }
+
+        global::System.Random rand = new global::System.Random();
+        bool Test5()
         {
             var lav = new LottieAnimationView();
             lav.Size2D = new Size2D(300, 300);
@@ -108,7 +158,7 @@ namespace Tizen.NUI.Samples
             }
             lav.LoopCount = -1;
             lav.BackgroundColor = Color.White;
-            win.Add(lav);
+            root.Add(lav);
             lav.Play();
 
             var ret = lav.GetContentInfo();
@@ -135,12 +185,21 @@ namespace Tizen.NUI.Samples
             int width = (int)(root.Size.Width / NUM_OF_VIEW);
             for (int i = 0; i < NUM_OF_VIEW; i++)
             {
-                var lav = new LottieAnimationView();
+                LottieAnimationView lav;
+                if (lavList?.Count > i)
+                {
+                    lav = lavList[i];
+                }
+                else
+                {
+                    lav = new LottieAnimationView();
+                    lavList?.Add(lav);
+                    root.Add(lav);
+                }
                 lav.Size2D = new Size2D(width, width);
                 lav.URL = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "done.json";
                 lav.LoopCount = -1;
                 lav.BackgroundColor = Color.White;
-                root.Add(lav);
 
                 LottieAnimationViewDynamicProperty pro = new LottieAnimationViewDynamicProperty
                 {
@@ -185,6 +244,7 @@ namespace Tizen.NUI.Samples
         void DisposeAll()
         {
             tlog.Debug(tag, $"DisposeAll() start");
+            lavList?.Clear();
             int childNum = (int)root.ChildCount;
             for (int i = childNum - 1; i >= 0; i--)
             {
@@ -201,6 +261,7 @@ namespace Tizen.NUI.Samples
         void ImplicitDispose()
         {
             tlog.Debug(tag, $"ImplicitDispose() start");
+            lavList?.Clear();
             int childNum = (int)root.ChildCount;
             for (int i = childNum - 1; i >= 0; i--)
             {
@@ -266,6 +327,8 @@ namespace Tizen.NUI.Samples
             timer.Stop();
             DisposeAll();
             root.Dispose();
+            lavList?.Clear();
+            lavList = null;
         }
     }
 }


### PR DESCRIPTION
This PR is cherry-pick of #6504

Let us remove DynamicProperty callbacks if URL changes. So far, we discard the callbacks if visual was changed. But, the callbacks, which NUI stored, were not removed and remained alive whenever we changed the URL.

Let us ensure their removal when URL changed (~= Visual Changed)

+

To avoid race condition, let we add lock feature before change `InternalSavedDynamicPropertyCallbacks` (Since we can access this dictionary from various threads.) and make `weakReferencesOfLottie` as `ConcurrentDictionary` type.

Note : Since we need to iterate by `InternalSavedDynamicPropertyCallbacks.Keys` we need to use lock, instead of `ConcurrentDictionary`.

TODO : There are some cases where we don't want to destroy registered callbacks. They will remain active in the future. We make relative sample at `LottieAnimationViewDynamicPropertyTest.cs`. Let we pass `Test4` case show dynmaic property well.
