### PR TITLE
[NUI] Support PropertyValue set/get without create new Vector2/3/4

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyValue.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyValue.cs
@@ -152,6 +152,28 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get__SWIG_15")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool GetExtents(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            // For internal managed memory optimization
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector2_Componentwise")]
+            public static extern global::System.IntPtr NewPropertyValueVector2Componentwise(float jarg1, float jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector3_Componentwise")]
+            public static extern global::System.IntPtr NewPropertyValueVector3Componentwise(float jarg1, float jarg2, float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Property_Value_Vector4_Componentwise")]
+            public static extern global::System.IntPtr NewPropertyValueVector4Componentwise(float jarg1, float jarg2, float jarg3, float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector2_Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool PropertyValueGetVector2Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2, out float jarg3);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector3_Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool PropertyValueGetVector3Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2, out float jarg3, out float jarg4);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Property_Value_Get_Vector4_Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool PropertyValueGetVector4Componentwise(global::System.Runtime.InteropServices.HandleRef jarg1, out float jarg2, out float jarg3, out float jarg4, out float jarg5);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -1535,26 +1535,33 @@ namespace Tizen.NUI.BaseComponents
             {
                 case (int)(VectorProperty.FillColor):
                 case (int)(VectorProperty.StrokeColor):
-                    Vector3 tmpVector3 = new Vector3(-1, -1, -1);
-                    if ((ret != null) && ret.Get(tmpVector3))
+                {
+                    float tmpVal1 = -1;
+                    float tmpVal2 = -1;
+                    float tmpVal3 = -1;
+                    if ((ret != null) && ret.GetVector3Component(out tmpVal1, out tmpVal2, out tmpVal3))
                     {
-                        val1 = tmpVector3.X;
-                        val2 = tmpVector3.Y;
-                        val3 = tmpVector3.Z;
+                        val1 = tmpVal1;
+                        val2 = tmpVal2;
+                        val3 = tmpVal3;
                     }
                     break;
+                }
 
                 case (int)(VectorProperty.TransformAnchor):
                 case (int)(VectorProperty.TransformPosition):
                 case (int)(VectorProperty.TransformScale):
                 case (int)(VectorProperty.TrimEnd):
-                    Vector2 tmpVector2 = new Vector2(-1, -1);
-                    if ((ret != null) && ret.Get(tmpVector2))
+                {
+                    float tmpVal1 = -1;
+                    float tmpVal2 = -1;
+                    if ((ret != null) && ret.GetVector2Component(out tmpVal1, out tmpVal2))
                     {
-                        val1 = tmpVector2.X;
-                        val2 = tmpVector2.Y;
+                        val1 = tmpVal1;
+                        val2 = tmpVal2;
                     }
                     break;
+                }
 
                 case (int)(VectorProperty.FillOpacity):
                 case (int)(VectorProperty.StrokeOpacity):
@@ -1562,12 +1569,14 @@ namespace Tizen.NUI.BaseComponents
                 case (int)(VectorProperty.TransformRotation):
                 case (int)(VectorProperty.TransformOpacity):
                 case (int)(VectorProperty.TrimStart):
-                    float tmpFloat = -1;
-                    if ((ret != null) && ret.Get(out tmpFloat))
+                {
+                    float tmpVal1 = -1;
+                    if ((ret != null) && ret.Get(out tmpVal1))
                     {
-                        val1 = tmpFloat;
+                        val1 = tmpVal1;
                     }
                     break;
+                }
                 default:
                     //do nothing
                     break;

--- a/src/Tizen.NUI/src/public/Common/PropertyValue.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyValue.cs
@@ -244,6 +244,39 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Creates a Vector2 property value componentwise.
+        /// </summary>
+        /// <param name="xValue">X value of Vector2.</param>
+        /// <param name="yValue">Y value of Vector2.</param>
+        internal PropertyValue(float xValue, float yValue) : this(Interop.PropertyValue.NewPropertyValueVector2Componentwise(xValue, yValue), true)
+        {
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
+        /// <summary>
+        /// Creates a Vector3 property value componentwise.
+        /// </summary>
+        /// <param name="xValue">X value of Vector3.</param>
+        /// <param name="yValue">Y value of Vector3.</param>
+        /// <param name="zValue">Z value of Vector3.</param>
+        internal PropertyValue(float xValue, float yValue, float zValue) : this(Interop.PropertyValue.NewPropertyValueVector3Componentwise(xValue, yValue, zValue), true)
+        {
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
+        /// <summary>
+        /// Creates a Vector4 property value componentwise.
+        /// </summary>
+        /// <param name="xValue">X value of Vector4.</param>
+        /// <param name="yValue">Y value of Vector4.</param>
+        /// <param name="zValue">Z value of Vector4.</param>
+        /// <param name="wValue">W value of Vector4.</param>
+        internal PropertyValue(float xValue, float yValue, float zValue, float wValue) : this(Interop.PropertyValue.NewPropertyValueVector4Componentwise(xValue, yValue, zValue, wValue), true)
+        {
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
+        /// <summary>
         /// Determines whether the ProperyValue has equal value with the current ProperyValue.
         /// </summary>
         /// <remarks>
@@ -831,6 +864,48 @@ namespace Tizen.NUI
         {
             bool ret = Interop.PropertyValue.GetAngleAxis(SwigCPtr, AngleAxis.getCPtr(angleAxisValue));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Get each components of Vector2. It will be failed if the type is not Vector2.
+        /// </summary>
+        /// <param name="xValue">X value of Vector2 component</param>
+        /// <param name="yValue">Y value of Vector2 component</param>
+        /// <returns>Returns true if the value is successfully retrieved, false if the type is not convertible.</returns>
+        internal bool GetVector2Component(out float xValue, out float yValue)
+        {
+            bool ret = Interop.PropertyValue.PropertyValueGetVector2Componentwise(SwigCPtr, out xValue, out yValue);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            return ret;
+        }
+
+        /// <summary>
+        /// Get each components of Vector3. It will be failed if the type is not Vector3.
+        /// </summary>
+        /// <param name="xValue">X value of Vector3 component</param>
+        /// <param name="yValue">Y value of Vector3 component</param>
+        /// <param name="zValue">Z value of Vector3 component</param>
+        /// <returns>Returns true if the value is successfully retrieved, false if the type is not convertible.</returns>
+        internal bool GetVector3Component(out float xValue, out float yValue, out float zValue)
+        {
+            bool ret = Interop.PropertyValue.PropertyValueGetVector3Componentwise(SwigCPtr, out xValue, out yValue, out zValue);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            return ret;
+        }
+
+        /// <summary>
+        /// Get each components of Vector4. It will be failed if the type is not Vector4.
+        /// </summary>
+        /// <param name="xValue">X value of Vector4 component</param>
+        /// <param name="yValue">Y value of Vector4 component</param>
+        /// <param name="zValue">Z value of Vector4 component</param>
+        /// <param name="wValue">W value of Vector4 component</param>
+        /// <returns>Returns true if the value is successfully retrieved, false if the type is not convertible.</returns>
+        internal bool GetVector4Component(out float xValue, out float yValue, out float zValue, out float wValue)
+        {
+            bool ret = Interop.PropertyValue.PropertyValueGetVector4Componentwise(SwigCPtr, out xValue, out yValue, out zValue, out wValue);
+            NDalicPINVOKE.ThrowExceptionIfExists();
             return ret;
         }
 


### PR DESCRIPTION
Since NUI Vector2 / Vector3 / Vector4 are managed classes, create and dispose them might give overhead sightly.

If some memory/performance critical path don't want to create useless temperal Vector234 classes when we get/set PropertyValue, we need to support it.

Relative dali patch:

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/316151
