### PR TITLE
[NUI] Add View.OffScreenRendering property

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
@@ -92,6 +92,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_AUTOMATION_ID_get")]
             public static extern int AutomationIdGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_OFFSCREEN_RENDERING_get")]
+            public static extern int OffScreenRenderingGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -429,7 +429,6 @@ namespace Tizen.NUI.BaseComponents
                 DispatchHoverMotionProperty = BindableProperty.Create(nameof(DispatchHoverMotion), typeof(bool), typeof(View), false,
                     propertyChanged: SetInternalDispatchHoverMotionProperty, defaultValueCreator: GetInternalDispatchHoverMotionProperty);
 
-
                 RegisterPropertyGroup(PositionProperty, positionPropertyGroup);
                 RegisterPropertyGroup(Position2DProperty, positionPropertyGroup);
                 RegisterPropertyGroup(PositionXProperty, positionPropertyGroup);
@@ -5988,6 +5987,38 @@ namespace Tizen.NUI.BaseComponents
             get
             {
                 return AutomationId;
+            }
+        }
+
+        /// <summary>
+        /// Gets of sets the current offscreen rendering type of the view.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public OffScreenRenderingType OffScreenRendering
+        {
+            get
+            {
+                return GetInternalOffScreenRendering();
+            }
+            set
+            {
+                SetInternalOffScreenRendering(value);
+                NotifyPropertyChanged();
+            }
+        }
+        private void SetInternalOffScreenRendering(OffScreenRenderingType value)
+        {
+            Object.InternalSetPropertyInt(SwigCPtr, Property.OffScreenRendering, (int)value);
+        }
+        private OffScreenRenderingType GetInternalOffScreenRendering()
+        {
+            int temp = Object.InternalGetPropertyInt(SwigCPtr, Property.OffScreenRendering);
+            switch (temp)
+            {
+                case 0: return OffScreenRenderingType.None;
+                case 1: return OffScreenRenderingType.RefreshOnce;
+                case 2: return OffScreenRenderingType.RefreshAlways;
+                default: return OffScreenRenderingType.None;
             }
         }
     }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -164,6 +164,32 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Describes offscreen rendering types.
+        /// View with this property enabled renders at offscreen buffer, with all its children.
+        /// The property expects to reduce many repetitive render calls.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum OffScreenRenderingType
+        {
+          /// <summary>
+          /// No offscreen rendering.
+          /// </summary>
+          [EditorBrowsable(EditorBrowsableState.Never)]
+          None,
+          /// <summary>
+          /// Draw offscreen only once.
+          /// </summary>
+          [EditorBrowsable(EditorBrowsableState.Never)]
+          RefreshOnce,
+          /// <summary>
+          /// Draw offscreen every frame.
+          /// </summary>
+          [EditorBrowsable(EditorBrowsableState.Never)]
+          RefreshAlways,
+        };
+
+
+        /// <summary>
         /// Actions property value to update visual property.
         /// Note : Only few kind of properies can be update. Update with invalid property action is undefined.
         /// </summary>
@@ -266,6 +292,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int UpdateAreaHint = Interop.ActorProperty.UpdateAreaHintGet();
             internal static readonly int DispatchTouchMotion = Interop.ActorProperty.DispatchTouchMotionGet();
             internal static readonly int DispatchHoverMotion = Interop.ActorProperty.DispatchHoverMotionGet();
+            internal static readonly int OffScreenRendering = Interop.ViewProperty.OffScreenRenderingGet();
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
Adding View property that enables/disables offscreen rendering.
The view draws at offscreen buffer as itself a root node(subtree). The cached result may reduce repetitive render calls by occasion.
User can define the draw's refresh rate(RefreshAlways or RefrashOnce), or disable offscreen rendering(None).

### API Changes ###
The new property can be used as follows:
`View.OffScreenRendering = View.OffScreenRenderingType.RefreshOnce`