### PR TITLE
[NUI] Create ImageVisual synchronously if AlphaMaskURL use generated ImageUrl

### DIFF
--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
@@ -75,8 +75,7 @@ namespace Tizen.NUI.Visuals
 
                     UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.URL, new PropertyValue(value));
 
-                    // Special case. If set GeneratedUrl, or FastTrackUploading, Create ImageVisual synchronously.
-                    if (value.StartsWith("dali://") || value.StartsWith("enbuf://") || FastTrackUploading)
+                    if (SynchronousVisualCreationRequired())
                     {
                         UpdateVisualPropertyMap();
                     }
@@ -202,11 +201,26 @@ namespace Tizen.NUI.Visuals
         /// Optional.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public string AlphaMaskURL
+        public string AlphaMaskUrl
         {
             set
             {
                 UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.AlphaMaskURL, string.IsNullOrEmpty(value) ? null : new PropertyValue(value));
+
+                // When we never set CropToMask property before, we should set default value as true.
+                using (PropertyValue cropToMask = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask))
+                {
+                    if (cropToMask == null)
+                    {
+                        using PropertyValue setCropValue = new PropertyValue(true);
+                        UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask, setCropValue);
+                    }
+                }
+
+                if (SynchronousVisualCreationRequired())
+                {
+                    UpdateVisualPropertyMap();
+                }
             }
             get
             {
@@ -284,6 +298,7 @@ namespace Tizen.NUI.Visuals
         ///  - Seamless visual change didn't supported.<br />
         ///  - Alpha masking didn't supported. If you try, It will load as normal case.<br />
         ///  - Synchronous loading didn't supported. If you try, It will load as normal case.<br />
+        ///  - Synchronous sizing didn't supported. If you try, It will load as normal case.<br />
         ///  - Reload action didn't supported. If you try, It will load as normal case.<br />
         ///  - Atlas loading didn't supported. If you try, It will load as normal case.<br />
         ///  - Custom shader didn't supported. If you try, It will load as normal case.
@@ -295,7 +310,7 @@ namespace Tizen.NUI.Visuals
             {
                 UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FastTrackUploading, new PropertyValue(value));
 
-                if (value && !string.IsNullOrEmpty(ResourceUrl))
+                if (value && isResourceUrlValid)
                 {
                     // Special case. If user set FastTrackUploading mean, user want to upload image As-Soon-As-Possible.
                     // Create ImageVisual synchronously.
@@ -622,6 +637,27 @@ namespace Tizen.NUI.Visuals
                 cachedVisualPropertyMap = temperalStoredPropertyMap;
                 temperalStoredPropertyMap = null;
             }
+        }
+
+        private bool SynchronousVisualCreationRequired()
+        {
+            // Special case. If we set GeneratedUrl, or FastTrackUploading, Create ImageVisual synchronously.
+            if (isResourceUrlValid)
+            {
+                if (FastTrackUploading)
+                {
+                    return true;
+                }
+                if (ResourceUrl.StartsWith("dali://") || ResourceUrl.StartsWith("enbuf://"))
+                {
+                    return true;
+                }
+                if (!string.IsNullOrEmpty(AlphaMaskUrl) && (AlphaMaskUrl.StartsWith("dali://") || AlphaMaskUrl.StartsWith("enbuf://")))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
         #endregion
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/EncodedImageSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/EncodedImageSample.cs
@@ -24,6 +24,8 @@ namespace Tizen.NUI.Samples
             (DEMO_IMAGE_DIR + "../a.json", EncodedImageBuffer.ImageTypes.AnimatedVectorImage),
         };
 
+        string TestMaskImage = DEMO_IMAGE_DIR + "Dali/DaliDemo/shape-circle.png";
+
         public void Activate()
         {
             win = NUIApplication.GetDefaultWindow();
@@ -66,7 +68,18 @@ namespace Tizen.NUI.Samples
 
             imageUrl = buffer?.GenerateUrl();
             imageView.ResourceUrl = imageUrl?.ToString();
-            imageView.Play();
+
+            if (TestImages[index].Item2 == EncodedImageBuffer.ImageTypes.RegularImage)
+            {
+                var encodedMaskTask = CreateEncodedImageBufferAsync(TestMaskImage, EncodedImageBuffer.ImageTypes.RegularImage);
+                using var maskBuffer = await encodedMaskTask;
+                using var maskImageUrl = maskBuffer?.GenerateUrl();
+                imageView.AlphaMaskURL = maskImageUrl?.ToString();
+            }
+            else if (TestImages[index].Item2 == EncodedImageBuffer.ImageTypes.AnimatedVectorImage)
+            {
+                imageView.Play();
+            }
 
             imageUrl?.Dispose();
             buffer?.Dispose();

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisualTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisualTest.cs
@@ -19,6 +19,7 @@ namespace Tizen.NUI.Samples
             DEMO_IMAGE_DIR + "Dali/ContactCard/gallery-small-4.jpg",
             DEMO_IMAGE_DIR + "Dali/ContactCard/gallery-small-5.jpg",
         };
+        string MaskImageUrl = DEMO_IMAGE_DIR + "Dali/DaliDemo/shape-circle.png";
 
         const float viewSizeWidth = 320.0f;
         const float viewSizeHeight = 280.0f;
@@ -54,6 +55,7 @@ namespace Tizen.NUI.Samples
         {
             if (e.Key.State == Key.StateType.Down)
             {
+                Tizen.Log.Error("NUI", $"Key pressed. {e.Key.KeyPressedName}\n");
                 if (e.Key.KeyPressedName == "1")
                 {
                     Tizen.Log.Error("NUI", $"Reset scene\n");
@@ -101,6 +103,25 @@ namespace Tizen.NUI.Samples
                         if(thumbnailVisual != null)
                         {
                             thumbnailVisual.SamplingMode = GetNextSamplingModeType(thumbnailVisual.SamplingMode);
+                        }
+                    }
+                }
+                else if(e.Key.KeyPressedName == "7")
+                {
+                    View focusedView = FocusManager.Instance.GetCurrentFocusView();
+                    if(focusedView != null)
+                    {
+                        var mainVisual = focusedView.FindVisualByName("mainImage") as Visuals.ImageVisual;
+                        if(mainVisual != null)
+                        {
+                            if(string.IsNullOrEmpty(mainVisual.AlphaMaskUrl))
+                            {
+                                mainVisual.AlphaMaskUrl = MaskImageUrl;
+                            }
+                            else
+                            {
+                                mainVisual.AlphaMaskUrl = null;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Since ImageUrl's reference should be hold on image visual, we should generate image visual synchronously, not on Processor time.

+

Minor code clean up applied


Relative dali patch :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/315535