### PR TITLE
[NUI] BindableObject creates property dictionary on demand

### DIFF
--- a/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/BindableObject.cs
@@ -40,7 +40,7 @@ namespace Tizen.NUI.Binding
             BindableProperty.Create(nameof(BindingContext), typeof(object), typeof(BindableObject),  default(object), BindingMode.OneWay, null, BindingContextPropertyChanged,
             null, null, BindingContextPropertyBindingChanging);
 
-        readonly Dictionary<BindableProperty, BindablePropertyContext> properties = new Dictionary<BindableProperty, BindablePropertyContext>(4);
+        private Dictionary<BindableProperty, BindablePropertyContext> properties;
 
         bool applying;
         object inheritedContext;
@@ -110,18 +110,24 @@ namespace Tizen.NUI.Binding
                 return;
             }
 
-            foreach (var property in properties)
+            if (properties != null)
             {
-                RemoveBinding(property.Key);
+                foreach (var property in properties)
+                {
+                    RemoveBinding(property.Key);
+                }
             }
 
-            foreach (var property in other.properties)
+            if (other.properties != null)
             {
-                if (null != property.Value.Binding)
+                foreach (var property in other.properties)
                 {
-                    var binding = property.Value.Binding;
-                    other.RemoveBinding(property.Key);
-                    SetBinding(property.Key, binding);
+                    if (null != property.Value.Binding)
+                    {
+                        var binding = property.Value.Binding;
+                        other.RemoveBinding(property.Key);
+                        SetBinding(property.Key, binding);
+                    }
                 }
             }
         }
@@ -445,7 +451,7 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnPropertyChanging([CallerMemberName] string propertyName = null)
             => PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
-        
+
         /// <summary>
         /// Method that is called when a bound property is changed.
         /// </summary>
@@ -459,6 +465,11 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void UnapplyBindings()
         {
+            if (properties == null)
+            {
+                return;
+            }
+
             foreach (var context in properties.Values)
             {
                 if (context.Binding == null)
@@ -487,21 +498,24 @@ namespace Tizen.NUI.Binding
         {
             var values = new object[2];
 
-            foreach (var context in properties.Values)
+            if (properties != null)
             {
-                if (ReferenceEquals(context.Property, property0))
+                foreach (var context in properties.Values)
                 {
-                    values[0] = context.Value;
-                    property0 = null;
-                }
-                else if (ReferenceEquals(context.Property, property1))
-                {
-                    values[1] = context.Value;
-                    property1 = null;
-                }
+                    if (ReferenceEquals(context.Property, property0))
+                    {
+                        values[0] = context.Value;
+                        property0 = null;
+                    }
+                    else if (ReferenceEquals(context.Property, property1))
+                    {
+                        values[1] = context.Value;
+                        property1 = null;
+                    }
 
-                if (property0 == null && property1 == null)
-                    return values;
+                    if (property0 == null && property1 == null)
+                        return values;
+                }
             }
 
             if (!ReferenceEquals(property0, null))
@@ -522,6 +536,11 @@ namespace Tizen.NUI.Binding
         internal object[] GetValues(BindableProperty property0, BindableProperty property1, BindableProperty property2)
         {
             var values = new object[3];
+
+            if (properties == null)
+            {
+                return values;
+            }
 
             foreach (var context in properties.Values)
             {
@@ -756,6 +775,11 @@ namespace Tizen.NUI.Binding
 
         internal void ApplyBindings(bool skipBindingContext, bool fromBindingContextChanged)
         {
+            if (properties == null)
+            {
+                return;
+            }
+
             var prop = properties.Values.ToArray();
             for (int i = 0, propLength = prop.Length; i < propLength; i++)
             {
@@ -876,12 +900,19 @@ namespace Tizen.NUI.Binding
             else
                 context.Attributes = BindableContextAttributes.IsDefaultValueCreated;
 
-            properties.Add(property, context);
+            (properties ??= new Dictionary<BindableProperty, BindablePropertyContext>(4)).Add(property, context);
             return context;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        BindablePropertyContext GetContext(BindableProperty property) => properties.TryGetValue(property, out var result) ? result : null;
+        BindablePropertyContext GetContext(BindableProperty property)
+        {
+            if (properties != null && properties.TryGetValue(property, out var result))
+            {
+                return result;
+            }
+            return null;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         BindablePropertyContext GetOrCreateContext(BindableProperty property)
@@ -1066,19 +1097,22 @@ namespace Tizen.NUI.Binding
                 xElementToNameOfOld.Add(pair.Value, pair.Key);
             }
 
-            foreach (var property in properties)
+            if (properties != null)
             {
-                if (property.Value.Binding is Binding binding && null != binding.Source)
+                foreach (var property in properties)
                 {
-                    string xName;
-                    xElementToNameOfOld.TryGetValue(binding.Source, out xName);
-
-                    if (null != xName)
+                    if (property.Value.Binding is Binding binding && null != binding.Source)
                     {
-                        var newObject = newNameScope[xName];
-                        binding.Unapply();
-                        binding.Source = newObject;
-                        SetBinding(property.Key, binding);
+                        string xName;
+                        xElementToNameOfOld.TryGetValue(binding.Source, out xName);
+
+                        if (null != xName)
+                        {
+                            var newObject = newNameScope[xName];
+                            binding.Unapply();
+                            binding.Source = newObject;
+                            SetBinding(property.Key, binding);
+                        }
                     }
                 }
             }
@@ -1102,6 +1136,11 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ClearBinding()
         {
+            if (properties == null)
+            {
+                return;
+            }
+
             foreach (var property in properties)
             {
                 if (null != property.Value.Binding)


### PR DESCRIPTION
### Description of Change ###
BindableObject does not create property dictionary for Xaml disabled case.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
