### PR TITLE
[NUI] Adds version tag or Hides deprecated APIs

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/CustomView.cs
@@ -197,6 +197,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="depth">The depth in the hierarchy for the view.</param>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated since API8 and will be removed in API10. Use OnSceneConnection instead.")]
         public virtual void OnStageConnection(int depth)
         {
@@ -208,6 +209,7 @@ namespace Tizen.NUI.BaseComponents
         /// When the parent of a set of views is disconnected to the stage, then all of the children will receive this callback, starting with the leaf views.<br />
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated since API8 and will be removed in API10. Use OnSceneDisconnection instead.")]
         public virtual void OnStageDisconnection()
         {
@@ -382,6 +384,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="width">Width to use</param>
         /// <returns>The height based on the width</returns>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API9 and will be removed in API11. Use HeightForWidth property instead.")]
         public new virtual float GetHeightForWidth(float width)
         {
@@ -395,6 +398,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="height">Height to use</param>
         /// <returns>The width based on the width</returns>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated since API9 and will be removed in API11. Use WidthForHeight property instead.")]
         public new virtual float GetWidthForHeight(float height)
         {
@@ -448,6 +452,7 @@ namespace Tizen.NUI.BaseComponents
         /// <param name="styleManager">The StyleManager object.</param>
         /// <param name="change">Information denoting what has changed.</param>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Deprecated in API9, Will be removed in API11.")]
         public virtual void OnStyleChange(StyleManager styleManager, StyleChangeType change)
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/FlexContainer.cs
@@ -28,6 +28,7 @@ namespace Tizen.NUI.BaseComponents
     /// FlexContainer can expand items to fill available free space, or shrink them to prevent overflow.<br />
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
     public class FlexContainer : View
     {
@@ -175,6 +176,7 @@ namespace Tizen.NUI.BaseComponents
         /// Calling member functions with an uninitialized handle is not allowed.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public FlexContainer() : this(Interop.FlexContainer.New(), true)
         {
@@ -190,6 +192,7 @@ namespace Tizen.NUI.BaseComponents
         /// the direction that flex items are laid out in the flex container.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public enum FlexDirectionType
         {
@@ -197,24 +200,28 @@ namespace Tizen.NUI.BaseComponents
             /// The flexible items are displayed vertically as a column.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             Column,
             /// <summary>
             /// The flexible items are displayed vertically as a column, but in reverse order.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             ColumnReverse,
             /// <summary>
             /// The flexible items are displayed horizontally as a row.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             Row,
             /// <summary>
             /// The flexible items are displayed horizontally as a row.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             RowReverse
         }
@@ -224,6 +231,7 @@ namespace Tizen.NUI.BaseComponents
         /// and on which sides the ?�start??and ?�end??are.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public enum ContentDirectionType
         {
@@ -231,18 +239,21 @@ namespace Tizen.NUI.BaseComponents
             /// Inherits the same direction from the parent.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             Inherit,
             /// <summary>
             /// From left to right.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             LTR,
             /// <summary>
             /// From right to left.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             RTL
         }
@@ -252,6 +263,7 @@ namespace Tizen.NUI.BaseComponents
         /// space on the main axis.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public enum Justification
         {
@@ -259,30 +271,35 @@ namespace Tizen.NUI.BaseComponents
             /// Items are positioned at the beginning of the container.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             JustifyFlexStart,
             /// <summary>
             /// Items are positioned at the center of the container.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             JustifyCenter,
             /// <summary>
             /// Items are positioned at the end of the container.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             JustifyFlexEnd,
             /// <summary>
             /// Items are positioned with equal space between the lines.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             JustifySpaceBetween,
             /// <summary>
             /// Items are positioned with equal space before, between, and after the lines.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             JustifySpaceAround
         }
@@ -292,6 +309,7 @@ namespace Tizen.NUI.BaseComponents
         /// use all the available space on the cross axis.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public enum Alignment
         {
@@ -299,30 +317,35 @@ namespace Tizen.NUI.BaseComponents
             /// Inherits the same alignment from the parent (only valid for "alignSelf" property).
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             AlignAuto,
             /// <summary>
             /// At the beginning of the container.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             AlignFlexStart,
             /// <summary>
             /// At the center of the container.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             AlignCenter,
             /// <summary>
             /// At the end of the container.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             AlignFlexEnd,
             /// <summary>
             /// Stretch to fit the container.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             AlignStretch
         }
@@ -332,6 +355,7 @@ namespace Tizen.NUI.BaseComponents
         /// all the items on one flex line.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public enum WrapType
         {
@@ -339,12 +363,14 @@ namespace Tizen.NUI.BaseComponents
             /// Flex items laid out in single line (shrunk to fit the flex container along the main axis).
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             NoWrap,
             /// <summary>
             /// Flex items laid out in multiple lines if needed.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [EditorBrowsable(EditorBrowsableState.Never)]
             [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
             Wrap
         }
@@ -353,6 +379,7 @@ namespace Tizen.NUI.BaseComponents
         /// The primary direction in which content is ordered.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public ContentDirectionType ContentDirection
         {
@@ -385,6 +412,7 @@ namespace Tizen.NUI.BaseComponents
         /// The direction of the main axis which determines the direction that flex items are laid out.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public FlexDirectionType FlexDirection
         {
@@ -417,6 +445,7 @@ namespace Tizen.NUI.BaseComponents
         /// Whether the flex items should wrap or not if there is no enough room for them on one flex line.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public WrapType FlexWrap
         {
@@ -449,6 +478,7 @@ namespace Tizen.NUI.BaseComponents
         /// The alignment of flex items when the items do not use all available space on the main axis.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public Justification JustifyContent
         {
@@ -481,6 +511,7 @@ namespace Tizen.NUI.BaseComponents
         /// The alignment of flex items when the items do not use all available space on the cross axis.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public Alignment AlignItems
         {
@@ -513,6 +544,7 @@ namespace Tizen.NUI.BaseComponents
         /// Similar to "alignItems", but it aligns flex lines; so only works when there are multiple lines.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API8 and will be removed in API10. Use FlexLayout instead.")]
         public Alignment AlignContent
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -698,6 +698,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         [Obsolete("This has been deprecated since API9 and will be removed in API11. Use SynchronousLoading instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool SynchronosLoading
         {
             get

--- a/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Scrollable.cs
@@ -27,12 +27,13 @@ namespace Tizen.NUI.BaseComponents
     /// (via touch) or automatically.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This has been deprecated in API12")]
     public class Scrollable : View
     {
         static Scrollable()
         {
-            if(NUIApplication.IsUsingXaml)
+            if (NUIApplication.IsUsingXaml)
             {
                 OvershootEffectColorProperty = BindableProperty.Create(nameof(OvershootEffectColor), typeof(Vector4), typeof(Scrollable), null, propertyChanged: SetInternalOvershootEffectColorProperty, defaultValueCreator: GetInternalOvershootEffectColorProperty);
 
@@ -40,7 +41,7 @@ namespace Tizen.NUI.BaseComponents
 
                 OvershootEnabledProperty = BindableProperty.Create(nameof(OvershootEnabled), typeof(bool), typeof(Scrollable), false, propertyChanged: SetInternalOvershootEnabledProperty, defaultValueCreator: GetInternalOvershootEnabledProperty);
 
-                OvershootSizeProperty = BindableProperty.Create(nameof(OvershootSize), typeof(Vector2), typeof(Scrollable), null, propertyChanged: SetInternalOvershootSizeProperty, defaultValueCreator: GetInternalOvershootSizeProperty );
+                OvershootSizeProperty = BindableProperty.Create(nameof(OvershootSize), typeof(Vector2), typeof(Scrollable), null, propertyChanged: SetInternalOvershootSizeProperty, defaultValueCreator: GetInternalOvershootSizeProperty);
 
                 ScrollToAlphaFunctionProperty = BindableProperty.Create(nameof(ScrollToAlphaFunction), typeof(int), typeof(Scrollable), default(int), propertyChanged: SetInternalScrollToAlphaFunctionProperty, defaultValueCreator: GetInternalScrollToAlphaFunctionProperty);
 
@@ -114,7 +115,7 @@ namespace Tizen.NUI.BaseComponents
                 Tizen.NUI.Object.SetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.OvershootEnabled, new Tizen.NUI.PropertyValue((bool)newValue));
             }
         }
-        
+
         internal static object GetInternalOvershootEnabledProperty(BindableObject bindable)
         {
             var scrollable = (Scrollable)bindable;
@@ -136,7 +137,7 @@ namespace Tizen.NUI.BaseComponents
                 Tizen.NUI.Object.SetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.OvershootSize, new Tizen.NUI.PropertyValue((Vector2)newValue));
             }
         }
-        
+
         internal static object GetInternalOvershootSizeProperty(BindableObject bindable)
         {
             var scrollable = (Scrollable)bindable;
@@ -150,7 +151,7 @@ namespace Tizen.NUI.BaseComponents
         [Obsolete("This has been deprecated in API12")]
         public static readonly BindableProperty ScrollToAlphaFunctionProperty = null;
 
-        internal static void SetInternalScrollToAlphaFunctionProperty(BindableObject bindable, object oldValue, object newValue) 
+        internal static void SetInternalScrollToAlphaFunctionProperty(BindableObject bindable, object oldValue, object newValue)
         {
             var scrollable = (Scrollable)bindable;
             if (newValue != null)
@@ -158,7 +159,7 @@ namespace Tizen.NUI.BaseComponents
                 Tizen.NUI.Object.SetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollToAlphaFunction, new Tizen.NUI.PropertyValue((int)newValue));
             }
         }
-        
+
         internal static object GetInternalScrollToAlphaFunctionProperty(BindableObject bindable)
         {
             var scrollable = (Scrollable)bindable;
@@ -180,7 +181,7 @@ namespace Tizen.NUI.BaseComponents
                 Tizen.NUI.Object.SetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollRelativePosition, new Tizen.NUI.PropertyValue((Vector2)newValue));
             }
         }
-        
+
         internal static object GetInternalScrollRelativePositionProperty(BindableObject bindable)
         {
             var scrollable = (Scrollable)bindable;
@@ -202,7 +203,7 @@ namespace Tizen.NUI.BaseComponents
                 Tizen.NUI.Object.SetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollPositionMin, new Tizen.NUI.PropertyValue((Vector2)newValue));
             }
         }
-        
+
         internal static object GetInternalScrollPositionMinProperty(BindableObject bindable)
         {
             var scrollable = (Scrollable)bindable;
@@ -224,7 +225,7 @@ namespace Tizen.NUI.BaseComponents
                 Tizen.NUI.Object.SetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.ScrollPositionMax, new Tizen.NUI.PropertyValue((Vector2)newValue));
             }
         }
-        
+
         internal static object GetInternalScrollPositionMaxProperty(BindableObject bindable)
         {
             var scrollable = (Scrollable)bindable;
@@ -268,7 +269,7 @@ namespace Tizen.NUI.BaseComponents
                 Tizen.NUI.Object.SetProperty((HandleRef)scrollable.SwigCPtr, Scrollable.Property.CanScrollHorizontal, new Tizen.NUI.PropertyValue((bool)newValue));
             }
         }
-        
+
         internal static object GetInternalCanScrollHorizontalProperty(BindableObject bindable)
         {
             var scrollable = (Scrollable)bindable;
@@ -288,6 +289,7 @@ namespace Tizen.NUI.BaseComponents
         /// Create an instance of scrollable.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public Scrollable() : this(Interop.Scrollable.NewScrollable(), true)
         {
@@ -311,6 +313,7 @@ namespace Tizen.NUI.BaseComponents
         /// The ScrollStarted event emitted when the Scrollable has moved (whether by touch or animation).
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public event DaliEventHandler<object, StartedEventArgs> ScrollStarted
         {
@@ -341,6 +344,7 @@ namespace Tizen.NUI.BaseComponents
         /// The ScrollUpdated event emitted when the Scrollable has moved (whether by touch or animation).
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public event DaliEventHandler<object, UpdatedEventArgs> ScrollUpdated
         {
@@ -372,6 +376,7 @@ namespace Tizen.NUI.BaseComponents
         /// (whether by touch or animation).
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public event DaliEventHandler<object, CompletedEventArgs> ScrollCompleted
         {
@@ -402,6 +407,7 @@ namespace Tizen.NUI.BaseComponents
         /// Sets and Gets the color of the overshoot effect.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public Vector4 OvershootEffectColor
         {
@@ -434,6 +440,7 @@ namespace Tizen.NUI.BaseComponents
         /// Sets and Gets the speed of overshoot animation in pixels per second.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public float OvershootAnimationSpeed
         {
@@ -466,6 +473,7 @@ namespace Tizen.NUI.BaseComponents
         /// Checks if scroll overshoot has been enabled or not.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public bool OvershootEnabled
         {
@@ -498,6 +506,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets and Sets OvershootSize property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public Vector2 OvershootSize
         {
@@ -530,6 +539,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets and Sets ScrollToAlphaFunction property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public int ScrollToAlphaFunction
         {
@@ -562,6 +572,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets and Sets ScrollRelativePosition property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public Vector2 ScrollRelativePosition
         {
@@ -594,6 +605,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets and Sets ScrollPositionMin property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public Vector2 ScrollPositionMin
         {
@@ -626,6 +638,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets and Sets ScrollPositionMax property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public Vector2 ScrollPositionMax
         {
@@ -658,6 +671,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets and Sets CanScrollVertical property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public bool CanScrollVertical
         {
@@ -690,6 +704,7 @@ namespace Tizen.NUI.BaseComponents
         /// Gets and Sets CanScrollHorizontal property.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public bool CanScrollHorizontal
         {
@@ -744,6 +759,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="type">DisposeTypes</param>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         protected override void Dispose(DisposeTypes type)
         {
@@ -880,6 +896,7 @@ namespace Tizen.NUI.BaseComponents
         /// The scroll animation started event arguments.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public class StartedEventArgs : EventArgs
         {
@@ -906,6 +923,7 @@ namespace Tizen.NUI.BaseComponents
         /// The scrollable updated event arguments.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public class UpdatedEventArgs : EventArgs
         {
@@ -932,6 +950,7 @@ namespace Tizen.NUI.BaseComponents
         /// The scroll animation completed event arguments.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API12")]
         public class CompletedEventArgs : EventArgs
         {

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -499,6 +499,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <param name="padding">Width and height.</param>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API9 and will be removed in API11. Use CellPadding property instead.")]
         public void SetCellPadding(Size2D padding)
         {
@@ -511,6 +512,7 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         /// <returns>The current padding as width and height.</returns>
         /// <since_tizen> 3 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("This has been deprecated in API9 and will be removed in API11. Use CellPadding property instead.")]
         public Vector2 GetCellPadding()
         {


### PR DESCRIPTION
### Description of Change ###

Some of APIs are already deprecated but showed in API guilde.
This PR make the deprecated APIs to hidden.

The APIs are deprecated by follow items:
CustomView : https://jira.sec.samsung.net/browse/TCSACR-370, https://jira.sec.samsung.net/browse/TCSACR-402
FlexContainer : https://jira.sec.samsung.net/browse/TCSACR-324
ImageView : https://jira.sec.samsung.net/browse/TCSACR-464
Scrollable : https://jira.sec.samsung.net/browse/TCSACR-588, https://jira.sec.samsung.net/browse/TCSACR-397
TableView : https://jira.sec.samsung.net/browse/TCSACR-402


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
