### PR TITLE
[NUI][API12] Match property name of ImageVisual.AlphaMaskUrl with latest version

### DIFF
--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
@@ -202,7 +202,7 @@ namespace Tizen.NUI.Visuals
         /// Optional.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public string AlphaMaskURL
+        public string AlphaMaskUrl
         {
             set
             {


### PR DESCRIPTION
Latest version use AlphaMaskUrl, instead of AlphaMaskURL.

Let we match the name of property so application don't be confused.
