### PR TITLE
[NUI] Do not re-create visual if we change only transform

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisualTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VisualTest.cs
@@ -125,6 +125,24 @@ namespace Tizen.NUI.Samples
                         }
                     }
                 }
+                else if (e.Key.KeyPressedName == "8")
+                {
+                    // Toggle some transform infomations
+                    if (shadowVisual1 != null)
+                    {
+                        shadowVisual1.ExtraWidth = 20.0f - shadowVisual1.ExtraWidth;
+                        shadowVisual1.ExtraHeight = 20.0f - shadowVisual1.ExtraHeight;
+
+                        shadowVisual1.OffsetX = 100.0f - shadowVisual1.OffsetX;
+                    }
+                    if (shadowVisual2 != null)
+                    {
+                        shadowVisual2.ExtraWidth = 10.0f - shadowVisual2.ExtraWidth;
+                        shadowVisual2.ExtraHeight = 10.0f - shadowVisual2.ExtraHeight;
+
+                        shadowVisual2.OffsetY = 100.0f - shadowVisual2.OffsetY;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Since transform data is kind of renderer property internally, we don't need to re-create them.

Let we use UpdateProperty action for this case.

Required dali patch (merged) :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/316868/4/dali-toolkit/internal/visuals/visual-base-impl.cpp
