### PR TITLE
[NUI] Fix the issue where the AppControlReceived event handler is not being called

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -523,6 +523,7 @@ namespace Tizen.NUI
             Backend.AddEventHandler(EventType.PreCreated, OnPreCreate);
             Backend.AddEventHandler(EventType.Resumed, OnResume);
             Backend.AddEventHandler(EventType.Paused, OnPause);
+            Backend.AddEventHandler<AppControlReceivedEventArgs>(EventType.AppControlReceived, OnAppControlReceived);
             base.Run(args);
         }
 


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix the issue where the AppControlReceived event handler is not being called
- GBM issue: DF250104-00684
- comments: 

1. OnAppControlReceived() 동작 검토 부탁드립니다. 

2. NUICoreBackend의 OnAppControl()까지 호출된걸로 봐서 저희 쪽 동작은 제대로 진행되었습니다. OnAppControlReceived()는 Backend의 OnAppControl()안에서 호출해주고 있습니다. NUIApplication안에서 AddEventHandler()를 호출하지 않으면 호출되지 않는 구조로 되어있는것으로 보입니다.

3. Hello, OnAppControl was called but OnAppControlReceived wasn't called,
could you please check?
[LN: 1110218] [04-01-2025 03.45.55.594]    18420.908 W/AMD     (P  602, T  602): launch_manager.cc: StartApp(42) > StartApp: appid=com.samsung.tv.mycontents caller_pid=1433 caller_uid=5001
[LN: 1110506] [04-01-2025 03.45.55.612]    18420.926 I/APP_CORE(P 2555, T 2555): appcore-ui-plugin.c: __raise_win(786) > appid(com.samsung.tv.mycontents)
[LN: 1110535] [04-01-2025 03.45.55.612]    18420.928 I/E20     (P  261, T  261): <e>      e_policy_wl.c:1242  POL_VIS|w:0x022110c8|ec:0x2584030|SEND     |win:0x022110c8|res_tzvis:0x22cfdc8|ver:13|sent_vis:3|pid:2555|cdata:0x2588778|title:/usr/apps/com.samsung.tv.mycontents/bin/MyContent.dll, name:(null)
[LN: 1110576] [04-01-2025 03.45.55.612]    18420.934 I/APP_CORE(P 2555, T 2555): appcore-ui-plugin.c: __on_control(1287) > start appid(com.samsung.tv.mycontents)
[LN: 1110627] [04-01-2025 03.45.55.626]    18420.940 I/DALI    (P 2555, T 2555): application-impl.cpp: OnAppControl(501) > Application::OnAppControl
[LN: 1110631] [04-01-2025 03.45.55.626]    18420.940 I/NUI     (P 2555, T 2555): NUICoreBackend.cs: OnAppControl(467) > NUICorebackend OnAppControl Called

### API Changes ###
nothing