### PR TITLE
[NUI] Reduce managed PropertyValue creation for VisualObject

### DIFF
--- a/src/Tizen.NUI/src/public/Common/PropertyValue.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyValue.cs
@@ -443,6 +443,14 @@ namespace Tizen.NUI
             {
                 value = new PropertyValue((Rectangle)obj);
             }
+            else if (type.Equals(typeof(PropertyArray)))
+            {
+                value = new PropertyValue((PropertyArray)obj);
+            }
+            else if (type.Equals(typeof(PropertyMap)))
+            {
+                value = new PropertyValue((PropertyMap)obj);
+            }
             else
             {
                 throw new global::System.InvalidOperationException("Unimplemented type for Property Value :" + type.Name);
@@ -547,6 +555,14 @@ namespace Tizen.NUI
             else if (type.Equals(typeof(Rectangle)))
             {
                 value = Interop.PropertyValue.NewPropertyValueRect(Rectangle.getCPtr((Rectangle)obj));
+            }
+            else if (type.Equals(typeof(PropertyArray)))
+            {
+                value = Interop.PropertyValue.NewPropertyValueArray(PropertyArray.getCPtr((PropertyArray)(obj)));
+            }
+            else if (type.Equals(typeof(PropertyMap)))
+            {
+                value = Interop.PropertyValue.NewPropertyValueMap(PropertyMap.getCPtr((PropertyMap)(obj)));
             }
             else
             {

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
@@ -92,12 +92,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameDelay, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameDelay, value);
             }
             get
             {
                 int ret = 100;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameDelay);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameDelay);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -112,12 +112,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoopCount, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoopCount, value);
             }
             get
             {
                 int ret = -1;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoopCount);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoopCount);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -131,12 +131,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.StopBehavior, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.StopBehavior, value);
             }
             get
             {
                 int ret = (int)Tizen.NUI.BaseComponents.AnimatedImageView.StopBehaviorType.CurrentFrame;
-                var propertyValue = GetVisualProperty((int)Tizen.NUI.ImageVisualProperty.StopBehavior);
+                using var propertyValue = GetVisualProperty((int)Tizen.NUI.ImageVisualProperty.StopBehavior);
                 propertyValue?.Get(out ret);
                 return (Tizen.NUI.BaseComponents.AnimatedImageView.StopBehaviorType)ret;
             }
@@ -153,12 +153,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameSpeedFactor, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameSpeedFactor, value);
             }
             get
             {
                 float ret = 1.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameSpeedFactor);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.FrameSpeedFactor);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -177,7 +177,7 @@ namespace Tizen.NUI.Visuals
                 UpdateVisualPropertyMap();
 
                 int ret = -1;
-                var propertyValue = GetCurrentVisualProperty((int)Tizen.NUI.ImageVisualProperty.TotalFrameNumber);
+                using var propertyValue = GetCurrentVisualProperty((int)Tizen.NUI.ImageVisualProperty.TotalFrameNumber);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -205,7 +205,7 @@ namespace Tizen.NUI.Visuals
                 UpdateVisualPropertyMap();
 
                 int ret = -1;
-                var propertyValue = GetCurrentVisualProperty((int)Tizen.NUI.ImageVisualProperty.CurrentFrameNumber);
+                using var propertyValue = GetCurrentVisualProperty((int)Tizen.NUI.ImageVisualProperty.CurrentFrameNumber);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -219,12 +219,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.BatchSize, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.BatchSize, value);
             }
             get
             {
                 int ret = 1;
-                var propertyValue = GetVisualProperty((int)Tizen.NUI.ImageVisualProperty.BatchSize);
+                using var propertyValue = GetVisualProperty((int)Tizen.NUI.ImageVisualProperty.BatchSize);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -238,12 +238,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.CacheSize, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.CacheSize, value);
             }
             get
             {
                 int ret = 1;
-                var propertyValue = GetVisualProperty((int)Tizen.NUI.ImageVisualProperty.CacheSize);
+                using var propertyValue = GetVisualProperty((int)Tizen.NUI.ImageVisualProperty.CacheSize);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -296,7 +296,8 @@ namespace Tizen.NUI.Visuals
                 using var urlArray = new PropertyArray();
                 foreach (var url in resourceUrls)
                 {
-                    urlArray.Add(new PropertyValue(url));
+                    using var urlValue = new PropertyValue(url);
+                    urlArray.Add(urlValue);
                 }
                 using var urlArrayValue = new PropertyValue(urlArray);
 

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/BorderVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/BorderVisual.cs
@@ -55,12 +55,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.BorderVisualProperty.Color, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.BorderVisualProperty.Color, value);
             }
             get
             {
                 Tizen.NUI.Color ret = new Tizen.NUI.Color();
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.BorderVisualProperty.Color);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.BorderVisualProperty.Color);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -74,12 +74,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.BorderVisualProperty.Size, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.BorderVisualProperty.Size, value);
             }
             get
             {
                 float ret = 0.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.BorderVisualProperty.Size);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.BorderVisualProperty.Size);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -93,12 +93,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.BorderVisualProperty.AntiAliasing, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.BorderVisualProperty.AntiAliasing, value);
             }
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.BorderVisualProperty.AntiAliasing);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.BorderVisualProperty.AntiAliasing);
                 propertyValue?.Get(out ret);
                 return ret;
             }

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/ColorVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/ColorVisual.cs
@@ -58,12 +58,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ColorVisualProperty.BlurRadius, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.ColorVisualProperty.BlurRadius, value, false);
             }
             get
             {
                 float ret = 0.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ColorVisualProperty.BlurRadius);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ColorVisualProperty.BlurRadius);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -77,12 +77,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ColorVisualProperty.CutoutPolicy, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ColorVisualProperty.CutoutPolicy, value);
             }
             get
             {
                 int ret = (int)ColorVisualCutoutPolicyType.None;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ColorVisualProperty.CutoutPolicy);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ColorVisualProperty.CutoutPolicy);
                 propertyValue?.Get(out ret);
                 return (ColorVisualCutoutPolicyType)ret;
             }
@@ -100,12 +100,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius, value, false);
             }
             get
             {
                 Vector4 ret = new Vector4();
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -121,12 +121,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy, new PropertyValue((int)value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy, value, false);
             }
             get
             {
                 int ret = (int)VisualTransformPolicyType.Absolute;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy);
                 propertyValue?.Get(out ret);
                 return (VisualTransformPolicyType)ret;
             }
@@ -142,12 +142,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness, value, false);
             }
             get
             {
                 Vector4 ret = new Vector4();
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -161,12 +161,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth, value, false);
             }
             get
             {
                 float ret = 0.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -181,12 +181,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor, value, false);
             }
             get
             {
                 Color ret = new Color(0.0f, 0.0f, 0.0f, 1.0f);
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -205,12 +205,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset, value, false);
             }
             get
             {
                 float ret = 0.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset);
                 propertyValue?.Get(out ret);
                 return ret;
             }

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
@@ -73,7 +73,7 @@ namespace Tizen.NUI.Visuals
                 {
                     isResourceUrlValid = true;
 
-                    UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.URL, new PropertyValue(value));
+                    UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.URL, value);
 
                     if (SynchronousVisualCreationRequired())
                     {
@@ -84,7 +84,7 @@ namespace Tizen.NUI.Visuals
             get
             {
                 string ret = "";
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.URL);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.URL);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -103,12 +103,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.PixelArea, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.PixelArea, value, false);
             }
             get
             {
                 Vector4 ret = new Vector4(0.0f, 0.0f, 1.0f, 1.0f);
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.PixelArea);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.PixelArea);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -123,12 +123,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.PremultipliedAlpha, new PropertyValue(value), true);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.PremultipliedAlpha, value, true);
             }
             get
             {
                 bool ret = true;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.PremultipliedAlpha);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.PremultipliedAlpha);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -143,12 +143,12 @@ namespace Tizen.NUI.Visuals
             set
             {
                 // Note : We need to create new visual if previous visual was async, and now we set value as sync.
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousLoading, new PropertyValue(value), value);
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousLoading, value, value);
             }
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousLoading);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousLoading);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -162,12 +162,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.OrientationCorrection, new PropertyValue(value), true);
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.OrientationCorrection, value, true);
             }
             get
             {
                 bool ret = true;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.OrientationCorrection);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.OrientationCorrection);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -185,12 +185,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousSizing, new PropertyValue(value), true);
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousSizing, value, true);
             }
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousSizing);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.SynchronousSizing);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -205,15 +205,14 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.AlphaMaskURL, string.IsNullOrEmpty(value) ? null : new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.AlphaMaskURL, string.IsNullOrEmpty(value) ? null : value);
 
                 // When we never set CropToMask property before, we should set default value as true.
                 using (PropertyValue cropToMask = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask))
                 {
                     if (cropToMask == null)
                     {
-                        using PropertyValue setCropValue = new PropertyValue(true);
-                        UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask, setCropValue);
+                        UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask, true);
                     }
                 }
 
@@ -225,7 +224,7 @@ namespace Tizen.NUI.Visuals
             get
             {
                 string ret = "";
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.AlphaMaskURL);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.AlphaMaskURL);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -239,12 +238,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskContentScale, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskContentScale, value);
             }
             get
             {
                 float ret = 1.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskContentScale);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskContentScale);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -258,12 +257,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask, value);
             }
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.CropToMask);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -277,12 +276,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskingMode, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskingMode, value);
             }
             get
             {
                 int ret = (int)Tizen.NUI.BaseComponents.ImageView.MaskingModeType.MaskingOnLoading;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskingMode);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.MaskingMode);
                 propertyValue?.Get(out ret);
                 return (Tizen.NUI.BaseComponents.ImageView.MaskingModeType)ret;
             }
@@ -308,7 +307,7 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FastTrackUploading, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.FastTrackUploading, value);
 
                 if (value && isResourceUrlValid)
                 {
@@ -320,7 +319,7 @@ namespace Tizen.NUI.Visuals
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.FastTrackUploading);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.FastTrackUploading);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -335,12 +334,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.ReleasePolicy, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.ReleasePolicy, value);
             }
             get
             {
                 int ret = (int)ReleasePolicyType.Detached;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.ReleasePolicy);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.ReleasePolicy);
                 propertyValue?.Get(out ret);
                 return (ReleasePolicyType)ret;
             }
@@ -357,12 +356,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.SamplingMode, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.SamplingMode, value);
             }
             get
             {
                 int ret = (int)SamplingModeType.BoxThenLinear;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.SamplingMode);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.SamplingMode);
                 propertyValue?.Get(out ret);
                 return (SamplingModeType)ret;
             }
@@ -379,12 +378,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredWidth, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredWidth, value);
             }
             get
             {
                 int ret = -1;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredWidth);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredWidth);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -401,12 +400,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredHeight, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredHeight, value);
             }
             get
             {
                 int ret = -1;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredHeight);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.DesiredHeight);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -421,12 +420,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoadPolicy, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoadPolicy, value);
             }
             get
             {
                 int ret = (int)LoadPolicyType.Attached;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoadPolicy);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.LoadPolicy);
                 propertyValue?.Get(out ret);
                 return (LoadPolicyType)ret;
             }
@@ -444,12 +443,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeU, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeU, value);
             }
             get
             {
                 int ret = (int)WrapModeType.Default;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeU);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeU);
                 propertyValue?.Get(out ret);
                 return (WrapModeType)ret;
             }
@@ -468,12 +467,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeV, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeV, value);
             }
             get
             {
                 int ret = (int)WrapModeType.Default;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeV);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.WrapModeV);
                 propertyValue?.Get(out ret);
                 return (WrapModeType)ret;
             }
@@ -491,12 +490,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius, value, false);
             }
             get
             {
                 Vector4 ret = new Vector4();
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadius);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -512,12 +511,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy, new PropertyValue((int)value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy, value, false);
             }
             get
             {
                 int ret = (int)VisualTransformPolicyType.Absolute;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerRadiusPolicy);
                 propertyValue?.Get(out ret);
                 return (VisualTransformPolicyType)ret;
             }
@@ -533,12 +532,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness, value, false);
             }
             get
             {
                 Vector4 ret = new Vector4();
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.CornerSquareness);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -552,12 +551,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth, value, false);
             }
             get
             {
                 float ret = 0.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineWidth);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -572,12 +571,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor, value, false);
             }
             get
             {
                 Color ret = new Color(0.0f, 0.0f, 0.0f, 1.0f);
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineColor);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -596,12 +595,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset, new PropertyValue(value), false);
+                UpdateVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset, value, false);
             }
             get
             {
                 float ret = 0.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.Visual.Property.BorderlineOffset);
                 propertyValue?.Get(out ret);
                 return ret;
             }

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/NPatchVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/NPatchVisual.cs
@@ -66,12 +66,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.BorderOnly, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.BorderOnly, value);
             }
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.BorderOnly);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.BorderOnly);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -88,12 +88,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.Border, (value == null) ? null : new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.Border, (value == null) ? null : value);
             }
             get
             {
                 Rectangle ret = new Rectangle();
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.Border);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.NpatchImageVisualProperty.Border);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -108,12 +108,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageURL, string.IsNullOrEmpty(value) ? null : new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageURL, string.IsNullOrEmpty(value) ? null : value);
             }
             get
             {
                 string ret = "";
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageURL);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageURL);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -127,12 +127,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageAlpha, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageAlpha, value);
             }
             get
             {
                 float ret = 1.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageAlpha);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.ImageVisualProperty.AuxiliaryImageAlpha);
                 propertyValue?.Get(out ret);
                 return ret;
             }

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/TextVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/TextVisual.cs
@@ -56,12 +56,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.Text, new PropertyValue(string.IsNullOrEmpty(value) ? "" : value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.Text, string.IsNullOrEmpty(value) ? "" : value);
             }
             get
             {
                 string ret = "";
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.Text);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.Text);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -75,12 +75,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.FontFamily, new PropertyValue(string.IsNullOrEmpty(value) ? "" : value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.FontFamily, string.IsNullOrEmpty(value) ? "" : value);
             }
             get
             {
                 string ret = "";
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.FontFamily);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.FontFamily);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -94,12 +94,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.PointSize, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.PointSize, value);
             }
             get
             {
                 float ret = 0.0f;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.PointSize);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.PointSize);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -113,12 +113,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.MultiLine, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.MultiLine, value);
             }
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.MultiLine);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.MultiLine);
                 propertyValue?.Get(out ret);
                 return ret;
             }
@@ -132,12 +132,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.HorizontalAlignment, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.HorizontalAlignment, value);
             }
             get
             {
                 int ret = (int)Tizen.NUI.HorizontalAlignment.Begin;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.HorizontalAlignment);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.HorizontalAlignment);
                 propertyValue?.Get(out ret);
                 return (Tizen.NUI.HorizontalAlignment)ret;
             }
@@ -151,12 +151,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.VerticalAlignment, new PropertyValue((int)value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.VerticalAlignment, value);
             }
             get
             {
                 int ret = (int)Tizen.NUI.VerticalAlignment.Top;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.VerticalAlignment);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.VerticalAlignment);
                 propertyValue?.Get(out ret);
                 return (Tizen.NUI.VerticalAlignment)ret;
             }
@@ -170,12 +170,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.TextColor, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.TextColor, value);
             }
             get
             {
                 Tizen.NUI.Color ret = new Color(0.0f, 0.0f, 0.0f, 1.0f);
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.TextColor);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.TextColor);
                 propertyValue?.Get(ret);
                 return ret;
             }
@@ -189,12 +189,12 @@ namespace Tizen.NUI.Visuals
         {
             set
             {
-                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.EnableMarkup, new PropertyValue(value));
+                UpdateVisualProperty((int)Tizen.NUI.TextVisualProperty.EnableMarkup, value);
             }
             get
             {
                 bool ret = false;
-                var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.EnableMarkup);
+                using var propertyValue = GetCachedVisualProperty((int)Tizen.NUI.TextVisualProperty.EnableMarkup);
                 propertyValue?.Get(out ret);
                 return ret;
             }


### PR DESCRIPTION
Let we add 'using' mark for temperally used `PropertyValue`.

Optimize PropertyMap.Add() API if it is prepared

It is kind of next-step. So current PR could be keep going on.