### PR TITLE
[NUI.Devel.Tests] Fix mis-implements for NativeImageSource TCT

### DIFF
--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Images/TSNativeImageSource.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/public/Images/TSNativeImageSource.cs
@@ -88,6 +88,7 @@ namespace Tizen.NUI.Devel.Tests
             try
             {
                 testingTarget.AcquireBuffer(ref width, ref height, ref stride);
+                testingTarget.ReleaseBuffer(); ///< Must call after AcquireBuffer
             }
             catch (Exception e)
             {
@@ -114,6 +115,7 @@ namespace Tizen.NUI.Devel.Tests
             Assert.IsNotNull(testingTarget, "Can't create success object NativeImageSource");
             Assert.IsInstanceOf<NativeImageSource>(testingTarget, "Should be an instance of NativeImageSource type.");
 
+            testingTarget.AcquireBuffer(ref width, ref height, ref stride); ///< Must call before ReleaseBuffer
             try
             {
                 testingTarget.ReleaseBuffer();


### PR DESCRIPTION
- We MUST call ReleaseBuffer after call AcquireBuffer
- We MUST call AcquireBUffer before call ReleaseBuffer

If not, exception or deadlock will occured.
