### PR TITLE
[NUI] Fix AppControlReceived key duplicated error

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -523,7 +523,6 @@ namespace Tizen.NUI
             Backend.AddEventHandler(EventType.PreCreated, OnPreCreate);
             Backend.AddEventHandler(EventType.Resumed, OnResume);
             Backend.AddEventHandler(EventType.Paused, OnPause);
-            Backend.AddEventHandler<AppControlReceivedEventArgs>(EventType.AppControlReceived, OnAppControlReceived);
             base.Run(args);
         }
 

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -1142,7 +1142,7 @@ namespace Tizen.NUI.BaseComponents
                 if (deviceConnectionChangedEventHandler == null)
                 {
                     IntPtr ip = IntPtr.Zero;
-                    Interop.WebView.RegisterUserMediaPermissionRequestCallback(SwigCPtr, new HandleRef(this, ip));
+                    Interop.WebView.RegisterDeviceConnectionChangedCallback(SwigCPtr, new HandleRef(this, ip));
                 }
             }
         }
@@ -1151,9 +1151,7 @@ namespace Tizen.NUI.BaseComponents
         public void SetDeviceListGetCallback(WebViewDeviceListGetCallback callback)
         {
             deviceListGetCallbackForUser = callback;
-
-            internalWebViewDeviceListGetCallback cb = deviceListGet;
-            IntPtr ip = Marshal.GetFunctionPointerForDelegate(cb);
+            IntPtr ip = Marshal.GetFunctionPointerForDelegate((internalWebViewDeviceListGetCallback)deviceListGet);
             Interop.WebView.RegisterDeviceListGetCallback(SwigCPtr, new HandleRef(this, ip));
         }
 


### PR DESCRIPTION
### Description of Change ###
- Fix AppControlReceived key duplicated error: DF250107-00093 =>
```
Exception !!! : [com.samsung.tv.csfs] [608] EXCEPTION [031mException !!!:System.ArgumentException: An item with the same key has already been added. Key: AppControlReceived
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior) in System.Private.CoreLib.dll:token 0x6006ada+0x1a0
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value) in System.Private.CoreLib.dll:token 0x6006acd+0x0
   at Tizen.NUI.NUICoreBackend.AddEventHandler[TEventArgs](EventType evType, Action`1 handler) in Tizen.NUI.dll:token 0x6000102+0x0
   at Tizen.Applications.CoreApplication.Run(String[] args) in Tizen.Applications.Common.dll:token 0x60000c4+0x59
   at Tizen.NUI.NUIApplication.Run(String[] args) in Tizen.NUI.dll:token 0x6000d1d+0x74
   at Tizen.TV.FLUX.FluxApplication.Run(String[] args) in /home/abuild/rpmbuild/BUILD/csapi-tv-flux-1.0.157/Tizen.TV.FLUX/Tizen.TV.FLUX/FluxApplication.cs:line 330
   at Tizen.Tv.App.CoBA.Edenview.NUI.NUIApp.Main(String[] args) in /home/abuild/rpmbuild/BUILD/com.samsung.tv.csfs-3.3.25011/Main/NUIApp.cs:line 1170[0m
```
- Fix WebView DeviceConnectionChangedCallback bug

### API Changes ###
nothing