### PR TITLE
[NUI] Add IsAutoRotationEnabled, IsLetterBoxEnabled

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
@@ -66,6 +66,20 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_Backward")]
             public static extern void Backward(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetAutoRotationEnabled")]
+            public static extern void SetAutoRotationEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_IsAutoRotationEnabled")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsAutoRotationEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetLetterBoxEnabled")]
+            public static extern void SetLetterBoxEnabled(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_IsLetterBoxEnabled")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsLetterBoxEnabled(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_FinishedSignal")]
             public static extern global::System.IntPtr FinishedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -448,6 +448,52 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Enables auto rotation of the video based on the orientation of the video contents.
+        /// </summary>
+        /// <note>
+        /// This feature is supported only when underlay is false.
+        /// So This property will not be set to true unless you first set underlay to false.
+        /// </note>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsAutoRotationEnabled
+        {
+            get
+            {
+                bool ret = (bool)Interop.VideoView.IsAutoRotationEnabled(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+            set
+            {
+                Interop.VideoView.SetAutoRotationEnabled(SwigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Enables letter box of the video based on the aspect of the video contents.
+        /// </summary>
+        /// <note>
+        /// This property is supported only when underlay is false.
+        /// So This property will not be set to true unless you first set underlay to false.
+        /// </note>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsLetterBoxEnabled
+        {
+            get
+            {
+                bool ret = (bool)Interop.VideoView.IsLetterBoxEnabled(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+            set
+            {
+                Interop.VideoView.SetLetterBoxEnabled(SwigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
         /// Starts the video playback.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

If Underlay=false is set, the tbm buffer of the media packet is displayed on the screen as is.
So, if the video content is rotated, it is displayed on the screen as rotated.

1. Setting IsAutoRotationEnabled to true automatically rotates video content.
2. If you set IsLetterBoxEnabled to true, it will display the video content proportionally on the screen.





https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/317900
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/317901
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/317903
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-extension/+/317902

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
Added =>
(property) public bool IsAutoRotationEnabled
(property) public bool IsLetterBoxEnabled

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
