### PR TITLE
[NUI] Rename State to ViewState

### DIFF
--- a/src/Tizen.NUI/src/devel/Base/ViewState.cs
+++ b/src/Tizen.NUI/src/devel/Base/ViewState.cs
@@ -23,84 +23,84 @@ using Tizen.NUI.BaseComponents;
 namespace Tizen.NUI
 {
     /// <summary>
-    /// Defines a value type of control state.
+    /// Defines a value type of view state.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public readonly struct State
+    public readonly struct ViewState
     {
         /// <summary>
         /// The All state is used in a selector class. It represents all states, so if this state is defined in a selector, the other states are ignored.
         /// </summary>
-        public static readonly State All = new (ControlStateUtility.FullMask);
+        public static readonly ViewState All = new (ControlStateUtility.FullMask);
 
         /// <summary>
         /// Normal State.
         /// </summary>
-        public static readonly State Normal = new (0UL);
+        public static readonly ViewState Normal = new (0UL);
 
         /// <summary>
         /// Focused State.
         /// </summary>
-        public static readonly State Focused =  new (nameof(Focused));
+        public static readonly ViewState Focused =  new (nameof(Focused));
 
         /// <summary>
         /// Pressed State.
         /// </summary>
-        public static readonly State Pressed = new (nameof(Pressed));
+        public static readonly ViewState Pressed = new (nameof(Pressed));
 
         /// <summary>
         /// Disabled State.
         /// </summary>
-        public static readonly State Disabled = new (nameof(Disabled));
+        public static readonly ViewState Disabled = new (nameof(Disabled));
 
         /// <summary>
         /// Selected State.
         /// </summary>
-        public static readonly State Selected = new (nameof(Selected));
+        public static readonly ViewState Selected = new (nameof(Selected));
 
         /// <summary>
         /// Pressed caused by key state.
         /// </summary>
-        public static readonly State PressedByKey = Pressed + new State(nameof(PressedByKey));
+        public static readonly ViewState PressedByKey = Pressed + new ViewState(nameof(PressedByKey));
 
         /// <summary>
         /// Pressed caused by touch state.
         /// </summary>
-        public static readonly State PressedByTouch = Pressed + new State(nameof(PressedByTouch));
+        public static readonly ViewState PressedByTouch = Pressed + new ViewState(nameof(PressedByTouch));
 
         /// <summary>
         /// SelectedPressed State.
         /// </summary>
-        public static readonly State SelectedPressed = Selected + Pressed;
+        public static readonly ViewState SelectedPressed = Selected + Pressed;
 
         /// <summary>
         /// DisabledSelected State.
         /// </summary>
-        public static readonly State DisabledSelected = Disabled + Selected;
+        public static readonly ViewState DisabledSelected = Disabled + Selected;
 
         /// <summary>
         /// DisabledFocused State.
         /// </summary>
-        public static readonly State DisabledFocused = Disabled + Focused;
+        public static readonly ViewState DisabledFocused = Disabled + Focused;
 
         /// <summary>
         /// SelectedFocused State.
         /// </summary>
-        public static readonly State SelectedFocused = Selected + Focused;
+        public static readonly ViewState SelectedFocused = Selected + Focused;
 
         /// <summary>
         /// This is used in a selector class. It represents all other states except for states that are already defined in a selector.
         /// </summary>
-        public static readonly State Other = new State(nameof(Other));
+        public static readonly ViewState Other = new ViewState(nameof(Other));
 
         private readonly ulong bitFlags;
 
-        private State(ulong bitMask)
+        private ViewState(ulong bitMask)
         {
             bitFlags = bitMask;
         }
 
-        private State(string name) : this(ControlStateUtility.Register(name))
+        private ViewState(string name) : this(ControlStateUtility.Register(name))
         {
         }
 
@@ -110,15 +110,15 @@ namespace Tizen.NUI
         internal bool IsCombined => (bitFlags != 0UL) && ((bitFlags & (bitFlags - 1UL)) != 0UL);
 
         /// <summary>
-        /// Create an instance of the <see cref="State"/> with state name.
+        /// Create an instance of the <see cref="ViewState"/> with state name.
         /// </summary>
         /// <param name="name">The state name.</param>
-        /// <returns>The <see cref="State"/> instance which has single state.</returns>
+        /// <returns>The <see cref="ViewState"/> instance which has single state.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the given name is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the given name is invalid.</exception>
-        public static State Create(string name)
+        public static ViewState Create(string name)
         {
-            return new State(name);
+            return new ViewState(name);
         }
 
         /// <summary>
@@ -126,14 +126,14 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="state">The state to search for</param>
         /// <returns>true if the state contain a specified state, otherwise, false.</returns>
-        public bool Contains(State state) => (bitFlags & state.bitFlags) == state.bitFlags;
+        public bool Contains(ViewState state) => (bitFlags & state.bitFlags) == state.bitFlags;
 
         /// <summary>
         /// Checks if there is a intersection part between this and the other.
         /// </summary>
         /// <param name="other">The other state to check.</param>
         /// <returns>True if an intersection exists, otherwise false.</returns>
-        public bool HasIntersectionWith(State other) => (bitFlags & other.bitFlags) != 0L;
+        public bool HasIntersectionWith(ViewState other) => (bitFlags & other.bitFlags) != 0L;
 
         ///  <inheritdoc/>
         public override string ToString()
@@ -165,41 +165,41 @@ namespace Tizen.NUI
         /// <summary>
         /// Compares whether the two ControlStates are same or not.
         /// </summary>
-        /// <param name="lhs">A <see cref="State"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="State"/> on the right hand side.</param>
+        /// <param name="lhs">A <see cref="ViewState"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ViewState"/> on the right hand side.</param>
         /// <returns>true if the ControlStates are equal; otherwise, false.</returns>
-        public static bool operator ==(State lhs, State rhs) => lhs.Equals(rhs);
+        public static bool operator ==(ViewState lhs, ViewState rhs) => lhs.Equals(rhs);
 
         /// <summary>
         /// Compares whether the two ControlStates are different or not.
         /// </summary>
-        /// <param name="lhs">A <see cref="State"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="State"/> on the right hand side.</param>
+        /// <param name="lhs">A <see cref="ViewState"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ViewState"/> on the right hand side.</param>
         /// <returns>true if the ControlStates are not equal; otherwise, false.</returns>
-        public static bool operator !=(State lhs, State rhs) => !lhs.Equals(rhs);
+        public static bool operator !=(ViewState lhs, ViewState rhs) => !lhs.Equals(rhs);
 
         /// <summary>
         /// The addition operator.
         /// </summary>
-        /// <param name="lhs">A <see cref="State"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="State"/> on the right hand side.</param>
-        /// <returns>The <see cref="State"/> containing the result of the addition.</returns>
-        public static State operator +(State lhs, State rhs) => new State(lhs.bitFlags | rhs.bitFlags);
+        /// <param name="lhs">A <see cref="ViewState"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ViewState"/> on the right hand side.</param>
+        /// <returns>The <see cref="ViewState"/> containing the result of the addition.</returns>
+        public static ViewState operator +(ViewState lhs, ViewState rhs) => new ViewState(lhs.bitFlags | rhs.bitFlags);
 
         /// <summary>
         /// The substraction operator.
         /// </summary>
-        /// <param name="lhs">A <see cref="State"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="State"/> on the right hand side.</param>
-        /// <returns>The <see cref="State"/> containing the result of the substraction.</returns>
-        public static State operator -(State lhs, State rhs) => new State(lhs.bitFlags & ~(rhs.bitFlags));
+        /// <param name="lhs">A <see cref="ViewState"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ViewState"/> on the right hand side.</param>
+        /// <returns>The <see cref="ViewState"/> containing the result of the substraction.</returns>
+        public static ViewState operator -(ViewState lhs, ViewState rhs) => new ViewState(lhs.bitFlags & ~(rhs.bitFlags));
 
-        public bool Equals(State other) => bitFlags == other.bitFlags;
+        public bool Equals(ViewState other) => bitFlags == other.bitFlags;
 
         ///  <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (obj is State otherState)
+            if (obj is ViewState otherState)
             {
                 return Equals(otherState);
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
@@ -35,59 +35,59 @@ namespace Tizen.NUI.BaseComponents
         /// The All state is used in a selector class. It represents all states, so if this state is defined in a selector, the other states are ignored.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState All = new ControlState(State.All);
+        public static readonly ControlState All = new ControlState(ViewState.All);
         /// <summary>
         /// Normal State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Normal = new ControlState(State.Normal);
+        public static readonly ControlState Normal = new ControlState(ViewState.Normal);
         /// <summary>
         /// Focused State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Focused =  new ControlState(State.Focused);
+        public static readonly ControlState Focused =  new ControlState(ViewState.Focused);
         /// <summary>
         /// Pressed State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Pressed = new ControlState(State.Pressed);
+        public static readonly ControlState Pressed = new ControlState(ViewState.Pressed);
         /// <summary>
         /// Disabled State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Disabled = new ControlState(State.Disabled);
+        public static readonly ControlState Disabled = new ControlState(ViewState.Disabled);
         /// <summary>
         /// Selected State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Selected = new ControlState(State.Selected);
+        public static readonly ControlState Selected = new ControlState(ViewState.Selected);
         /// <summary>
         /// SelectedPressed State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState SelectedPressed = new ControlState(State.SelectedPressed);
+        public static readonly ControlState SelectedPressed = new ControlState(ViewState.SelectedPressed);
         /// <summary>
         /// DisabledSelected State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState DisabledSelected = new ControlState(State.DisabledSelected);
+        public static readonly ControlState DisabledSelected = new ControlState(ViewState.DisabledSelected);
         /// <summary>
         /// DisabledFocused State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState DisabledFocused = new ControlState(State.DisabledFocused);
+        public static readonly ControlState DisabledFocused = new ControlState(ViewState.DisabledFocused);
         /// <summary>
         /// SelectedFocused State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState SelectedFocused = new ControlState(State.SelectedFocused);
+        public static readonly ControlState SelectedFocused = new ControlState(ViewState.SelectedFocused);
         /// <summary>
         /// This is used in a selector class. It represents all other states except for states that are already defined in a selector.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Other = new ControlState(State.Other);
+        public static readonly ControlState Other = new ControlState(ViewState.Other);
 
-        readonly State value;
+        readonly ViewState value;
 
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsCombined => value.IsCombined;
 
-        internal ControlState(State value)
+        internal ControlState(ViewState value)
         {
             this.value = value;
         }
@@ -111,7 +111,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public static ControlState Create(string name)
         {
-            return new ControlState(State.Create(name));
+            return new ControlState(ViewState.Create(name));
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ControlState Create(params ControlState[] states)
         {
-            State result = State.Normal;
+            ViewState result = ViewState.Normal;
 
             for (int i = 0; i < states.Length; i++)
             {


### PR DESCRIPTION
### Description of Change ###
Since `State` already preseved as property name of `View` so the struct class should be renamed : `ViewState`


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
