### PR TITLE
[NUI] Handles null argument ControlState.Equals

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
@@ -149,7 +149,13 @@ namespace Tizen.NUI.BaseComponents
 
         ///  <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Equals(ControlState other) => value.Equals(other.value);
+        public bool Equals(ControlState other)
+        {
+            if (other is null)
+                return false;
+
+            return value.Equals(other.value);
+        }
 
         ///  <inheritdoc/>
         /// <since_tizen> 9 </since_tizen>


### PR DESCRIPTION
### Description of Change ###
Fix null reference error when calling `Equals` method for `ControlState`


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
