### PR TITLE
[NUI] Make FrameUpdateCallback could use UIVector2 and UIColor

### DIFF
--- a/src/Tizen.NUI/src/devel/Common/DevelFrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/devel/Common/DevelFrameUpdateCallbackInterface.cs
@@ -1,0 +1,143 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    public partial class FrameUpdateCallbackInterface
+    {
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool GetPosition(uint id, out UIVector2 position)
+        {
+            float x = 0.0f;
+            float y = 0.0f;
+            bool ret = false;
+            if (proxyIntPtr != IntPtr.Zero)
+            {
+                ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceGetPositionVector2Componentwise(proxyIntPtr, id, ref x, ref y);
+            }
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            position = new UIVector2(x, y);
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool BakePosition(uint id, UIVector2 position)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceBakePositionVector2Componentwise(proxyIntPtr, id, position.X, position.Y);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool GetSize(uint id, out UIVector2 size)
+        {
+            float x = 0.0f;
+            float y = 0.0f;
+            bool ret = false;
+            if (proxyIntPtr != IntPtr.Zero)
+            {
+                ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceGetSizeVector2Componentwise(proxyIntPtr, id, ref x, ref y);
+            }
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            size = new UIVector2(x, y);
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool BakeSize(uint id, UIVector2 size)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceBakeSizeVector2Componentwise(proxyIntPtr, id, size.X, size.Y);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool GetScale(uint id, out UIVector2 scale)
+        {
+            float x = 0.0f;
+            float y = 0.0f;
+            bool ret = false;
+            if (proxyIntPtr != IntPtr.Zero)
+            {
+                ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceGetScaleVector2Componentwise(proxyIntPtr, id, ref x, ref y);
+            }
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            scale = new UIVector2(x, y);
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool BakeScale(uint id, UIVector2 scale)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceBakeScaleVector2Componentwise(proxyIntPtr, id, scale.X, scale.Y);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool GetColor(uint id, out UIColor color)
+        {
+            float r = 0.0f;
+            float g = 0.0f;
+            float b = 0.0f;
+            float a = 0.0f;
+            bool ret = false;
+            if (proxyIntPtr != IntPtr.Zero)
+            {
+                ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceGetColorVector4Componentwise(proxyIntPtr, id, ref r, ref g, ref b, ref a);
+            }
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            color = new UIColor(r, g, b, a);
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool BakeColor(uint id, UIColor color)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceBakeColorVector4Componentwise(proxyIntPtr, id, color.R, color.G, color.B, color.A);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
@@ -107,6 +107,40 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_RemoveFrameCallback")]
             public static extern void FrameCallbackInterfaceRemoveFrameUpdateCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
+
+            // UIVector2 and UIColor
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetPositionVector2Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceGetPositionVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakePositionVector2Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceBakePositionVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetSizeVector2Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceGetSizeVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeSizeVector2Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceBakeSizeVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetScaleVector2Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceGetScaleVector2Componentwise(global::System.IntPtr proxy, uint id, ref float x, ref float y);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeScaleVector2Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceBakeScaleVector2Componentwise(global::System.IntPtr proxy, uint id, float x, float y);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_GetColorVector4Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceGetColorVector4Componentwise(global::System.IntPtr proxy, uint id, ref float r, ref float g, ref float b, ref float a);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_BakeColorVector4Componentwise")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceBakeColorVector4Componentwise(global::System.IntPtr proxy, uint id, float r, float g, float b, float a);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI
 
     /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class FrameUpdateCallbackInterface : Disposable
+    public partial class FrameUpdateCallbackInterface : Disposable
     {
         private uint onUpdateCallbackVersion = 0u;
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackTest.cs
@@ -1,3 +1,4 @@
+using System.Drawing;
 using System;
 using System.Threading.Tasks;
 using Tizen.NUI;
@@ -20,43 +21,43 @@ namespace Tizen.NUI.Samples
 
         private static string resourcePath = Tizen.Applications.Application.Current.DirectoryInfo.Resource;
         private static string[] BACKGROUND_IMAGE_PATH = {
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_02_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_03_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_04_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_05_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_06_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_apps_nor.png"
-    };
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_02_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_03_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_04_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_05_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_06_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_bg_apps_nor.png"
+        };
 
         private static string[] APPS_IMAGE_PATH = {
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_culinary_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_family_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_ent_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_homecare_nor.png"
-    };
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_culinary_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_family_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_ent_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_homecare_nor.png"
+        };
 
         private static string[] APPS_ICON_NAME = {
-      "Culinary",
-      "Family",
-      "Entertainment",
-      "Homecare"
-    };
+            "Culinary",
+            "Family",
+            "Entertainment",
+            "Homecare"
+        };
 
         private static string[] CONTROL_IMAGE_PATH = {
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_apps_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_settings_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_viewinside_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_timer_nor.png",
-      resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_internet_nor.png"
-    };
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_apps_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_settings_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_viewinside_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_timer_nor.png",
+            resourcePath + "/images/FrameUpdateCallbackTest/launcher_ic_internet_nor.png"
+        };
 
         private static string[] CONTROL_ICON_NAME = {
-      "Apps",
-      "Settings",
-      "ViewInside",
-      "Timer",
-      "Internet"
-    };
+            "Apps",
+            "Settings",
+            "ViewInside",
+            "Timer",
+            "Internet"
+        };
 
         private const int FRAME_RATE = 60;
         private const int OBJECT_DELAY = 30;
@@ -66,6 +67,8 @@ namespace Tizen.NUI.Samples
         private const int DEVIDE_BAR_SIZE = 4;
 
         private const float DEGREE_PER_POSITION = 0.05f;
+        private const float HEIGHT_PER_POSITION = 0.5f;
+        private const float OPACITY_PER_POSITION = 0.01f;
 
         private const uint FRAME_UPDATE_CALLBACK_VERSION = 1u;
 
@@ -225,6 +228,18 @@ namespace Tizen.NUI.Samples
                 bool isStillMoving = true;
                 for (int i = 0; i < viewId.Count; ++i)
                 {
+                    // Reset size and color
+                    {
+                        if(GetSize(viewId[i], out UIVector2 size))
+                        {
+                            BakeSize(viewId[i], new UIVector2(size.X, OBJECT_SIZE));
+                        }
+                        if(GetColor(viewId[i], out UIColor color))
+                        {
+                            BakeColor(viewId[i], new UIColor(color.R, color.G, color.B, 1.0f));
+                        }
+                    }
+
                     if (i == touchedViewIndex)
                     {
                         continue;
@@ -273,8 +288,7 @@ namespace Tizen.NUI.Samples
                     float positionDiff = 0.0f;
                     if (i >= leftIndex && i <= rightIndex)
                     {
-                        Vector3 previousPosition = new Vector3();
-                        GetPosition(viewId[i], previousPosition);
+                        GetPosition(viewId[i], out UIVector2 previousPosition);
                         positionDiff = newPosition - previousPosition.X;
                         if (Math.Abs(positionDiff) >= 1.0f)
                         {
@@ -282,7 +296,20 @@ namespace Tizen.NUI.Samples
                         }
                     }
                     // update new position and rotiation
-                    SetPosition(viewId[i], new Vector3(newPosition, 0.0f, 0.0f));
+                    //BakePosition(viewId[i], new Vector3(newPosition, 0.0f, 0.0f));
+                    BakePosition(viewId[i], new UIVector2(newPosition, 0.0f)); // We can use UIVector2 instead of Vector3.
+
+                    {
+                        if(GetSize(viewId[i], out UIVector2 size))
+                        {
+                            BakeSize(viewId[i], new UIVector2(size.X, OBJECT_SIZE + Math.Abs(positionDiff * HEIGHT_PER_POSITION)));
+                        }
+                        if(GetColor(viewId[i], out UIColor color))
+                        {
+                            BakeColor(viewId[i], new UIColor(color.R, color.G, color.B, 1.0f - Math.Abs(positionDiff * OPACITY_PER_POSITION)));
+                        }
+                    }
+
                     SetOrientation(viewId[i], new Rotation(new Radian(new Degree(positionDiff * DEGREE_PER_POSITION)), Vector3.ZAxis));
                     positionChanged = true;
                 }
@@ -302,8 +329,7 @@ namespace Tizen.NUI.Samples
                 // second -> millisecond
                 totalAnimationTime += elapsedSeconds * 1000.0f;
 
-                Vector3 currentPosition = new Vector3();
-                GetPosition(containerId, currentPosition);
+                GetPosition(containerId, out UIVector2 currentPosition);
 
                 // Add new Movement, if there is change in position.
                 // 1. if dirty(there is reserved event)


### PR DESCRIPTION
Let we allow to use FrameUpdateCallbackInterface could use UIVector2 and UIColor so we can reduce GC call at render thread.

Require dali patch :

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/318520