### PR TITLE
[NUI] Add FullScreenMode to InputMethodContext

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodContext.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodContext.cs
@@ -188,6 +188,13 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsTextPredictionAllowed(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetFullScreenMode")]
+            public static extern void SetFullScreenMode(global::System.Runtime.InteropServices.HandleRef inputMethodContext, bool fullScreen);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_IsFullScreenMode")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool IsFullScreenMode(global::System.Runtime.InteropServices.HandleRef inputMethodContext);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodContext_SetInputPanelLanguage")]
             public static extern void SetInputPanelLanguage(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 

--- a/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
+++ b/src/Tizen.NUI/src/public/Input/InputMethodContext.cs
@@ -444,6 +444,22 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets or sets whether the input panel should be shown in fullscreen mode.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool FullScreenMode
+        {
+            get
+            {
+                return IsFullScreenMode();
+            }
+            set
+            {
+                SetFullScreenMode(value);
+            }
+        }
+
+        /// <summary>
         /// Destroys the context of the IMF.<br/>
         /// </summary>
         /// <since_tizen> 5 </since_tizen>
@@ -809,6 +825,19 @@ namespace Tizen.NUI
         internal bool IsTextPredictionAllowed()
         {
             bool ret = Interop.InputMethodContext.IsTextPredictionAllowed(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        internal void SetFullScreenMode(bool fullScreen)
+        {
+            Interop.InputMethodContext.SetFullScreenMode(SwigCPtr, fullScreen);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        internal bool IsFullScreenMode()
+        {
+            bool ret = Interop.InputMethodContext.IsFullScreenMode(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }


### PR DESCRIPTION
To support full screen mode of the input panal.

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/318558
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/318559

```
/**
 * @typedef Ecore_IMF_Input_Hints
 * @brief Enumeration for defining the types of Ecore_IMF Input Hints.
 * @since 1.12
 */

typedef enum
{
   ECORE_IMF_INPUT_HINT_NONE                = 0,        /**< No active hints @since 1.12 */
   ECORE_IMF_INPUT_HINT_AUTO_COMPLETE       = 1 << 0,   /**< Suggest word auto completion @since 1.12 */
   ECORE_IMF_INPUT_HINT_SENSITIVE_DATA      = 1 << 1,   /**< Typed text should not be stored. @since 1.12 */
   ECORE_IMF_INPUT_HINT_MULTILINE           = 1 << 2,   /**< Multiline text @since 1.18 */
+   ECORE_IMF_INPUT_HINT_FULLSCREEN_MODE     = 1 << 3,   /**< The input panel should be shown in fullscreen mode @since 1.28 */
...
} Ecore_IMF_Input_Hints;
```