### PR TITLE
[NUI] Fix GridLocations to preserve empty space for Stretch Expand

### DIFF
--- a/test/NUITizenGallery/Examples/GridTest/GridTest5.cs
+++ b/test/NUITizenGallery/Examples/GridTest/GridTest5.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using Tizen.NUI;
+using Tizen.NUI.Components;
+
+namespace NUITizenGallery
+{
+    internal class GridTest5 : IExample
+    {
+        private Window window;
+        public void Activate()
+        {
+            window = NUIApplication.GetDefaultWindow();
+            window.GetDefaultNavigator().Push(new GridTest5Page());
+        }
+        public void Deactivate()
+        {
+            window.GetDefaultNavigator().Pop();
+        }
+    }
+}
+

--- a/test/NUITizenGallery/Examples/GridTest/GridTest5Page.xaml
+++ b/test/NUITizenGallery/Examples/GridTest/GridTest5Page.xaml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage x:Class="NUITizenGallery.GridTest5Page"
+  xmlns="http://tizen.org/Tizen.NUI/2018/XAML"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  WidthSpecification="{Static LayoutParamPolicies.MatchParent}"
+  HeightSpecification="{Static LayoutParamPolicies.MatchParent}">
+
+    <!-- AppBar is top-side bar with navigation content, title, and action. If you not set any contents, back button is automatically added. -->
+    <ContentPage.AppBar>
+        <AppBar x:Name="appBar" Title="GridTest5Page"/>
+    </ContentPage.AppBar>
+
+    <!-- Content is main placeholder of ContentPage. Add your content into this view. -->
+    <ContentPage.Content>
+		<View x:Name="gridView"
+                HeightSpecification="{Static LayoutParamPolicies.MatchParent}"
+				WidthSpecification="{Static LayoutParamPolicies.MatchParent}">
+
+			<View.Layout >
+				<GridLayout Columns="2" Rows="2" ColumnSpacing="10" RowSpacing="10" />
+			</View.Layout>
+
+            <!-- Row 0 -->
+			<View x:Name="child1"
+					GridLayout.Column="0"
+					GridLayout.Row="0"
+                    GridLayout.ColumnSpan="2"
+                    GridLayout.VerticalStretch="ExpandAndFill"
+                    GridLayout.HorizontalStretch="ExpandAndFill" BackgroundColor="Red"/>
+            <!-- Row 0 Column 1 is expanded by span -->
+            <!-- Row 1 -->
+			<View x:Name="child2"
+                    SizeWidth="300"
+					GridLayout.Column="1"
+					GridLayout.Row="1"
+                    GridLayout.VerticalStretch="ExpandAndFill" BackgroundColor="Green"/>
+            <!-- Row 1 Column 0 is empty space by span -->
+		</View>
+	</ContentPage.Content>
+</ContentPage>

--- a/test/NUITizenGallery/Examples/GridTest/GridTest5Page.xaml.cs
+++ b/test/NUITizenGallery/Examples/GridTest/GridTest5Page.xaml.cs
@@ -1,0 +1,79 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUITizenGallery
+{
+    public partial class GridTest5Page : ContentPage
+    {
+        public GridTest5Page()
+        {
+            InitializeComponent();
+
+            GridLayout.SetColumnSpan(child1, 2);
+        }
+
+        protected override void Dispose(DisposeTypes type)
+        {
+            if (Disposed)
+            {
+                return;
+            }
+
+            if (type == DisposeTypes.Explicit)
+            {
+                RemoveAllChildren(true);
+            }
+
+            base.Dispose(type);
+        }
+
+        private void RemoveAllChildren(bool dispose = false)
+        {
+            RecursiveRemoveChildren(this, dispose);
+        }
+
+        private void RecursiveRemoveChildren(View parent, bool dispose)
+        {
+            if (parent == null)
+            {
+                return;
+            }
+
+            int maxChild = (int)parent.ChildCount;
+            for (int i = maxChild - 1; i >= 0; --i)
+            {
+                View child = parent.GetChildAt((uint)i);
+                if (child == null)
+                {
+                    continue;
+                }
+
+                RecursiveRemoveChildren(child, dispose);
+                parent.Remove(child);
+                if (dispose)
+                {
+                    child.Dispose();
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Previously, if a cell has multiple ColumnSpacing or RowSpacing with Stretch Expand, its column or row does not occupy Expand space if the column or row is empty.

e.g. Child2 begins the beginning of the GridLayout without preserving the empty space for Row 1, Column 0.
GridLayout Width 400.
Child1 Row 0, Column 0, ColumnSpan 2, HorizontalStretch Expand
Child2 Row 1, Column 1, ColumnSpan 1, HorizontalStretch None, Width 100

\-------------------------------------
|||||||||||||||Child1||||||||||||||||
\-------------------------------------
||Child2||                          |
\-------------------------------------

Now, it has been fixed to make the column or row occupy Expand space even though the column or row is empty.
To do so, virtual edges for the column or row have Stretch Expand. It works the same way as CSS grid.
e.g. Child2 begins after the empty space for Row 1, Column 0.
\-------------------------------------
|||||||||||||||Child1||||||||||||||||
\-------------------------------------
|                 ||Child2||        |
\-------------------------------------

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
