### PR TITLE
[NUI] Extract View variables for Layout to remove wasted memory

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2019-2022 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2019-2025 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -798,12 +798,13 @@ namespace Tizen.NUI.BaseComponents
                 }
                 if (relayoutRequired)
                 {
-                    view.layout?.RequestLayout();
+                    view.RequestLayout();
                 }
 
                 Object.InternalSetPropertyVector2ActualVector3(view.SwigCPtr, View.Property.SIZE, ((Size2D)newValue).SwigCPtr);
             }
         }
+
         internal static object GetInternalSize2DProperty(BindableObject bindable)
         {
             var view = (View)bindable;
@@ -1577,7 +1578,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 if (relayoutRequired)
                 {
-                    view.layout?.RequestLayout();
+                    view.RequestLayout();
                 }
 
                 view.SetSize(width, height, depth);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -192,9 +192,9 @@ namespace Tizen.NUI.BaseComponents
         {
             LayoutCount++;
 
-            this.layout = layout;
-            this.layout?.AttachToOwner(this);
-            this.layout?.RequestLayout();
+            EnsureLayoutExtraData().Layout = layout;
+            layout?.AttachToOwner(this);
+            layout?.RequestLayout();
         }
 
         internal void AttachTransitionsToChildren(LayoutTransition transition)
@@ -1172,7 +1172,7 @@ namespace Tizen.NUI.BaseComponents
         {
             LayoutCount--;
 
-            layout = null;
+            EnsureLayoutExtraData().Layout = null;
         }
 
         internal ResourceLoadingStatusType GetBackgroundResourceStatus()

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -127,8 +127,6 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 4 </since_tizen>
         public override void Add(View child)
         {
-            bool hasLayout = (layout != null);
-
             if (null == child)
             {
                 Tizen.Log.Fatal("NUI", "Child is null");
@@ -186,14 +184,12 @@ namespace Tizen.NUI.BaseComponents
                 return;
             }
 
-            bool hasLayout = (layout != null);
-
             // If View has a layout then do a deferred child removal
             // Actual child removal is performed by the layouting system so
             // transitions can be completed.
-            if (hasLayout)
+            if (Layout != null)
             {
-                (layout as LayoutGroup)?.RemoveChildFromLayoutGroup(child);
+                (Layout as LayoutGroup)?.RemoveChildFromLayoutGroup(child);
             }
 
             RemoveChild(child);

--- a/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
@@ -1,0 +1,73 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.BaseComponents
+{
+    /// <summary>
+    /// The class storing Layout properties.
+    /// </summary>
+    internal sealed class LayoutExtraData : IDisposable
+    {
+        private bool disposed;
+
+        // Indicates whether the layout has been set by user or not.
+        public bool LayoutSet { get; set; }
+
+        // Exclusive layout assigned to this View.
+        public LayoutItem Layout { get; set; }
+
+        // The List of transitions for this View.
+        public Dictionary<TransitionCondition, TransitionList> LayoutTransitions { get; set; }
+
+        // Layout transitions for this View.
+        public LayoutTransition LayoutTransition { get; set; }
+
+        // TransitionOptions for the page transition.
+        public TransitionOptions TransitionOptions { get; set; }
+
+        // The weight of the View, used to share available space in a layout with siblings.
+        public float Weight { get; set; }
+
+        // The status of whether the view is excluded from its parent's layouting or not.
+        public bool ExcludeLayouting { get; set; }
+
+        ~LayoutExtraData() => Dispose(false);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+            if (disposing)
+            {
+                TransitionOptions?.Dispose();
+            }
+            disposed = true;
+        }
+    }
+}
+
+


### PR DESCRIPTION
If an application does not use Layout, then View's variables used for Layout waste memory.
To remove those wasted memory, those variables are moved to the new internal class LayoutExtraData and it is not allocated if Layout is not used.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
