### PR TITLE
[Optimization] Remove redundant PInvoke call for NUI constants.

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTask.cs
@@ -93,9 +93,8 @@ namespace Tizen.NUI
         {
             get
             {
-                bool ret = Interop.RenderTask.DefaultExclusiveGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::RenderTask::DEFAULT_EXCLUSIVE
+                return false;
             }
         }
 
@@ -103,20 +102,24 @@ namespace Tizen.NUI
         {
             get
             {
-                bool ret = Interop.RenderTask.DefaultInputEnabledGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::RenderTask::DEFAULT_INPUT_ENABLED
+                return true;
             }
         }
+
+        private static Vector4 defaultClearColor;
 
         public static Vector4 DEFAULT_CLEAR_COLOR
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.RenderTask.DefaultClearColorGet();
-                Vector4 ret = (cPtr == global::System.IntPtr.Zero) ? null : new Vector4(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::RenderTask::DEFAULT_CLEAR_COLOR
+                if (null == defaultClearColor)
+                {
+                    defaultClearColor = new Vector4(0.0f, 0.0f, 0.0f, 1.0f);
+                }    
+
+                return defaultClearColor;
             }
         }
 
@@ -124,9 +127,8 @@ namespace Tizen.NUI
         {
             get
             {
-                bool ret = Interop.RenderTask.DefaultClearEnabledGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::RenderTask::DEFAULT_CLEAR_ENABLED
+                return false;
             }
         }
 
@@ -134,9 +136,8 @@ namespace Tizen.NUI
         {
             get
             {
-                bool ret = Interop.RenderTask.DefaultCullModeGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::RenderTask::DEFAULT_CULL_MODE
+                return true;
             }
         }
 
@@ -144,9 +145,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.RenderTask.DefaultRefreshRateGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::RenderTask::DEFAULT_REFRESH_RATE
+                return 1;
             }
         }
 #pragma warning restore CA1707

--- a/src/Tizen.NUI/src/internal/NativeBinding/NDalic.cs
+++ b/src/Tizen.NUI/src/internal/NativeBinding/NDalic.cs
@@ -1911,9 +1911,8 @@ namespace Tizen.NUI
         {
             get
             {
-                PixelFormat ret = (PixelFormat)Interop.NDalic.FirstValidPixelFormatGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to FIRST_VALID_PIXEL_FORMAT = A8
+                return PixelFormat.A8;
             }
         }
 
@@ -1921,9 +1920,8 @@ namespace Tizen.NUI
         {
             get
             {
-                PixelFormat ret = (PixelFormat)Interop.NDalic.LastValidPixelFormatGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to LAST_VALID_PIXEL_FORMAT = CHROMINANCE_V
+                return (PixelFormat)62;
             }
         }
 
@@ -1951,9 +1949,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.NDalicXYZ.PositiveXGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to Dali::CubeMapLayer::POSITIVE_X = 0u
+                return 0;
             }
         }
 
@@ -1961,9 +1958,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.NDalicXYZ.NegativeXGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to Dali::CubeMapLayer::NEGATIVE_X = 1u
+                return 1;
             }
         }
 
@@ -1971,9 +1967,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.NDalicXYZ.PositiveYGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to Dali::CubeMapLayer::POSITIVE_Y = 2u
+                return 2;
             }
         }
 
@@ -1981,9 +1976,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.NDalicXYZ.NegativeYGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to Dali::CubeMapLayer::NEGATIVE_Y = 3u
+                return 3;
             }
         }
 
@@ -1991,9 +1985,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.NDalicXYZ.PositiveZGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to Dali::CubeMapLayer::POSITIVE_Z = 4u
+                return 4;
             }
         }
 
@@ -2001,9 +1994,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.NDalicXYZ.NegativeZGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to Dali::CubeMapLayer::NEGATIVE_Z = 5u
+                return 5;
             }
         }
 

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -98,6 +98,7 @@ namespace Tizen.NUI
             }
         }
 
+        private static Radian directionLeft;
         /// <summary>
         /// For a left pan (-PI Radians).
         /// </summary>
@@ -107,13 +108,16 @@ namespace Tizen.NUI
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.PanGestureDetector.DirectionLeftGet();
-                Radian ret = (cPtr == global::System.IntPtr.Zero) ? null : new Radian(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::PanGestureDetector::DIRECTION_LEFT(-Math::PI)
+                if (null == directionLeft)
+                {
+                    directionLeft = new Radian((float)-Math.PI);
+                }
+                return directionLeft;
             }
         }
 
+        private static Radian directionRight;
         /// <summary>
         /// For a right pan (0 Radians).
         /// </summary>
@@ -123,13 +127,16 @@ namespace Tizen.NUI
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.PanGestureDetector.DirectionRightGet();
-                Radian ret = (cPtr == global::System.IntPtr.Zero) ? null : new Radian(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::PanGestureDetector::DIRECTION_RIGHT(0.0f)
+                if (null == directionRight)
+                {
+                    directionRight = new Radian(0);
+                }
+                return directionRight;
             }
         }
 
+        private static Radian directionUp;
         /// <summary>
         /// For an up pan (-0.5 * PI Radians).
         /// </summary>
@@ -139,13 +146,16 @@ namespace Tizen.NUI
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.PanGestureDetector.DirectionUpGet();
-                Radian ret = (cPtr == global::System.IntPtr.Zero) ? null : new Radian(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::PanGestureDetector::DIRECTION_UP(-0.5f * Math::PI)
+                if (null == directionUp)
+                {
+                    directionUp = new Radian(-0.5f * (float)Math.PI);
+                }
+                return directionUp;
             }
         }
 
+        private static Radian directionDown;
         /// <summary>
         /// For a down pan (0.5 * PI Radians).
         /// </summary>
@@ -155,13 +165,16 @@ namespace Tizen.NUI
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.PanGestureDetector.DirectionDownGet();
-                Radian ret = (cPtr == global::System.IntPtr.Zero) ? null : new Radian(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::PanGestureDetector::DIRECTION_DOWN(0.5f * Math::PI)
+                if (null == directionDown)
+                {
+                    directionDown = new Radian(0.5f * (float)Math.PI);
+                }
+                return directionDown;
             }
         }
 
+        private static Radian directionHorizontal;
         /// <summary>
         /// For a left and right pan (PI Radians). Useful for AddDirection().
         /// </summary>
@@ -171,13 +184,16 @@ namespace Tizen.NUI
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.PanGestureDetector.DirectionHorizontalGet();
-                Radian ret = (cPtr == global::System.IntPtr.Zero) ? null : new Radian(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::PanGestureDetector::DIRECTION_HORIZONTAL(-Math::PI)
+                if (null == directionHorizontal)
+                {
+                    directionHorizontal = new Radian((float)-Math.PI);
+                }
+                return directionHorizontal;
             }
         }
 
+        private static Radian directionVertical;
         /// <summary>
         /// For an up and down pan (-0.5 * PI Radians). Useful for AddDirection().
         /// </summary>
@@ -187,13 +203,16 @@ namespace Tizen.NUI
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.PanGestureDetector.DirectionVerticalGet();
-                Radian ret = (cPtr == global::System.IntPtr.Zero) ? null : new Radian(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::PanGestureDetector::DIRECTION_VERTICAL(-0.5f * Math::PI)
+                if (null == directionVertical)
+                {
+                    directionVertical = new Radian(-0.5f * (float)Math.PI);
+                }
+                return directionVertical;
             }
         }
 
+        private static Radian defaultThreshold;
         /// <summary>
         /// The default threshold is PI * 0.25 radians (or 45 degrees).
         /// </summary>
@@ -203,10 +222,12 @@ namespace Tizen.NUI
         {
             get
             {
-                global::System.IntPtr cPtr = Interop.PanGestureDetector.DefaultThresholdGet();
-                Radian ret = (cPtr == global::System.IntPtr.Zero) ? null : new Radian(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
-                return ret;
+                //this originates to Dali::PanGestureDetector::DEFAULT_THRESHOLD(0.25f * Math::PI)
+                if (null == defaultThreshold)
+                {
+                    defaultThreshold = new Radian(0.25f * (float)Math.PI);
+                }
+                return defaultThreshold;
             }
         }
 

--- a/src/Tizen.NUI/src/public/Utility/FontClient.cs
+++ b/src/Tizen.NUI/src/public/Utility/FontClient.cs
@@ -42,9 +42,8 @@ namespace Tizen.NUI
         {
             get
             {
-                uint ret = Interop.FontClient.DefaultPointSizeGet();
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
+                //this originates to Dali::TextAbstraction::FontClient::DEFAULT_POINT_SIZE   = 768u;
+                return 768;
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
