### PR TITLE
[NUI] Provide implicit conversion to Color from UIColor

### DIFF
--- a/src/Tizen.NUI/src/devel/Lite/UIColor.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIColor.cs
@@ -156,6 +156,13 @@ namespace Tizen.NUI
         /// <returns>A new color object with the specified alpha value.</returns>
         public readonly UIColor WithAlpha(float alpha) => new (R, G, B, alpha);
 
+        /// <summary>
+        /// Provides an implicit conversion between <see cref="UIColor"/> and <see cref="Color"/>.
+        /// </summary>
+        /// <param name="uiColor">The <see cref="UIColor"/> to convert.</param>
+        /// <returns>The converted <see cref="Color"/>.</returns>
+        public static implicit operator Color(UIColor uiColor) => uiColor.ToReferenceType();
+
         internal readonly NUI.Color ToReferenceType() => new NUI.Color(R, G, B, A);
     }
 }


### PR DESCRIPTION
### Description of Change ###
Provide implicit conversion to `Color` from `UIColor` for users who want to use UIColor for Color type API.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
