### PR TITLE
[NUI] Add Minimum/Maximum Width/Height to View markup methods

### DIFF
--- a/src/Tizen.NUI.Extension/Markup/ViewExtensions.cs
+++ b/src/Tizen.NUI.Extension/Markup/ViewExtensions.cs
@@ -731,5 +731,61 @@ namespace Tizen.NUI.Extension
             view.LayoutHeight = layoutHeight;
             return view;
         }
+
+        /// <summary>
+        /// Sets the minimum width of the view used to size the view within its parent layout container.
+        /// </summary>
+        /// <typeparam name="T">The type of the view.</typeparam>
+        /// <param name="view">The extension target.</param>
+        /// <param name="minimumWidth">The minimum width value.</param>
+        /// <returns>The view itself.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T MinimumWidth<T>(this T view, float minimumWidth) where T : View
+        {
+            view.SetMinimumWidth(minimumWidth, true);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the minimum height of the view used to size the view within its parent layout container.
+        /// </summary>
+        /// <typeparam name="T">The type of the view.</typeparam>
+        /// <param name="view">The extension target.</param>
+        /// <param name="minimumHeight">The minimum height value.</param>
+        /// <returns>The view itself.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T MinimumHeight<T>(this T view, float minimumHeight) where T : View
+        {
+            view.SetMinimumHeight(minimumHeight, true);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the maximum width of the view used to size the view within its parent layout container.
+        /// </summary>
+        /// <typeparam name="T">The type of the view.</typeparam>
+        /// <param name="view">The extension target.</param>
+        /// <param name="maximumWidth">The maximum width value.</param>
+        /// <returns>The view itself.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T MaximumWidth<T>(this T view, float maximumWidth) where T : View
+        {
+            view.SetMaximumWidth(maximumWidth, true);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the maximum height of the view used to size the view within its parent layout container.
+        /// </summary>
+        /// <typeparam name="T">The type of the view.</typeparam>
+        /// <param name="view">The extension target.</param>
+        /// <param name="maximumHeight">The maximum height value.</param>
+        /// <returns>The view itself.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T MaximumHeight<T>(this T view, float maximumHeight) where T : View
+        {
+            view.SetMaximumHeight(maximumHeight, true);
+            return view;
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -4196,6 +4196,12 @@ namespace Tizen.NUI.BaseComponents
                 {
                     throw new ArgumentNullException(nameof(value));
                 }
+
+                if (HasMinimumWidth())
+                    SetMinimumWidth(value.Width, false);
+                if (HasMinimumHeight())
+                    SetMinimumHeight(value.Height, false);
+
                 if (layoutExtraData?.Layout is LayoutItem layout)
                 {
                     // Note: it only works if minimum size is >= than natural size.
@@ -4246,6 +4252,11 @@ namespace Tizen.NUI.BaseComponents
             }
             set
             {
+                if (HasMaximumWidth())
+                    SetMaximumWidth(value.Width, false);
+                if (HasMaximumHeight())
+                    SetMaximumHeight(value.Height, false);
+
                 // We don't have Layout.Maximum(Width|Height) so we cannot apply it to layout.
                 // MATCH_PARENT spec + parent container size can be used to limit
                 RequestLayout();
@@ -5155,6 +5166,15 @@ namespace Tizen.NUI.BaseComponents
                     SetLayoutWidth(widthPolicy);
                 if (!hasLayoutHeight)
                     SetLayoutHeight(heightPolicy);
+
+                if (!HasMinimumWidth())
+                    SetMinimumWidth(MinimumSize.Width, false);
+                if (!HasMinimumHeight())
+                    SetMinimumHeight(MinimumSize.Height, false);
+                if (!HasMaximumWidth())
+                    SetMaximumWidth(MaximumSize.Width, false);
+                if (!HasMaximumHeight())
+                    SetMaximumHeight(MaximumSize.Height, false);
 
                 // Do nothing if layout provided is already set on this View.
                 if (value == layoutExtraData.Layout)
@@ -6107,6 +6127,146 @@ namespace Tizen.NUI.BaseComponents
         internal bool HasLayoutHeight()
         {
             return layoutExtraData?.Height == null ? false : true;
+        }
+
+        internal void SetMinimumWidth(float minimumWidth, bool updateMinimumSize)
+        {
+            if (float.IsNaN(minimumWidth))
+            {
+                return;
+            }
+
+            var layoutExtraData = EnsureLayoutExtraData();
+            if (layoutExtraData.MinimumWidth != minimumWidth)
+            {
+                if (updateMinimumSize)
+                {
+                    if (minimumWidth >= int.MaxValue)
+                    {
+                        MinimumSize.Width = int.MaxValue;
+                    }
+                    else if (minimumWidth <= int.MinValue)
+                    {
+                        MinimumSize.Width = int.MinValue;
+                    }
+                    else
+                    {
+                        MinimumSize.Width = (int)minimumWidth;
+                    }
+                }
+                layoutExtraData.MinimumWidth = minimumWidth;
+                layoutExtraData.Layout?.RequestLayout();
+            }
+        }
+
+        internal void SetMinimumHeight(float minimumHeight, bool updateMinimumSize)
+        {
+            if (float.IsNaN(minimumHeight))
+            {
+                return;
+            }
+
+            var layoutExtraData = EnsureLayoutExtraData();
+            if (layoutExtraData.MinimumHeight != minimumHeight)
+            {
+                if (updateMinimumSize)
+                {
+                    if (minimumHeight >= int.MaxValue)
+                    {
+                        MinimumSize.Height = int.MaxValue;
+                    }
+                    else if (minimumHeight <= int.MinValue)
+                    {
+                        MinimumSize.Height = int.MinValue;
+                    }
+                    else
+                    {
+                        MinimumSize.Height = (int)minimumHeight;
+                    }
+                }
+                layoutExtraData.MinimumHeight = minimumHeight;
+                layoutExtraData.Layout?.RequestLayout();
+            }
+        }
+
+        internal void SetMaximumWidth(float maximumWidth, bool updateMaximumSize)
+        {
+            if (float.IsNaN(maximumWidth))
+            {
+                return;
+            }
+
+            var layoutExtraData = EnsureLayoutExtraData();
+            if (layoutExtraData.MaximumWidth != maximumWidth)
+            {
+                if (updateMaximumSize)
+                {
+                    if (maximumWidth >= int.MaxValue)
+                    {
+                        MaximumSize.Width = int.MaxValue;
+                    }
+                    else if (maximumWidth <= int.MinValue)
+                    {
+                        MaximumSize.Width = int.MinValue;
+                    }
+                    else
+                    {
+                        MaximumSize.Width = (int)maximumWidth;
+                    }
+                }
+                layoutExtraData.MaximumWidth = maximumWidth;
+                layoutExtraData.Layout?.RequestLayout();
+            }
+        }
+
+        internal void SetMaximumHeight(float maximumHeight, bool updateMaximumSize)
+        {
+            if (float.IsNaN(maximumHeight))
+            {
+                return;
+            }
+
+            var layoutExtraData = EnsureLayoutExtraData();
+            if (layoutExtraData.MaximumHeight != maximumHeight)
+            {
+                if (updateMaximumSize)
+                {
+                    if (maximumHeight >= int.MaxValue)
+                    {
+                        MaximumSize.Height = int.MaxValue;
+                    }
+                    else if (maximumHeight <= int.MinValue)
+                    {
+                        MaximumSize.Height = int.MinValue;
+                    }
+                    else
+                    {
+                        MaximumSize.Height = (int)maximumHeight;
+                    }
+                }
+                layoutExtraData.MaximumHeight = maximumHeight;
+                layoutExtraData.Layout?.RequestLayout();
+            }
+        }
+
+        internal bool HasMinimumWidth()
+        {
+            return layoutExtraData?.MinimumWidth == null ? false : true;
+        }
+
+        internal bool HasMinimumHeight()
+        {
+            return layoutExtraData?.MinimumHeight == null ? false : true;
+        }
+
+        internal bool HasMaximumWidth()
+        {
+            return layoutExtraData?.MaximumWidth == null ? false : true;
+        }
+
+        internal bool HasMaximumHeight()
+        {
+            return layoutExtraData?.MaximumHeight == null ? false : true;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
@@ -57,6 +57,26 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         public LayoutDimension Height { get; set; } = LayoutDimensionMode.WrapContent;
 
+        /// <summary>
+        /// Gets or sets the minimum width of the view.
+        /// </summary>
+        public float MinimumWidth { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets the minimum height of the view.
+        /// </summary>
+        public float MinimumHeight { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets the maximum width of the view.
+        /// </summary>
+        public float MaximumWidth { get; set; } = int.MaxValue;
+
+        /// <summary>
+        /// Gets or sets the maximum height of the view.
+        /// </summary>
+        public float MaximumHeight { get; set; } = int.MaxValue;
+
         ~LayoutExtraData() => Dispose(false);
 
         public void Dispose()


### PR DESCRIPTION
Minimum/Maximum Width/Height are added to View markup methods to be used by the layout to size the view within its parent layout container. Unlike existing Minimum/MaximumSize, the newly added markup methods provide float.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
