### PR TITLE
[NUI] Add Margin and Padding to View markup methods

### DIFF
--- a/src/Tizen.NUI.Extension/Markup/ViewExtensions.cs
+++ b/src/Tizen.NUI.Extension/Markup/ViewExtensions.cs
@@ -787,5 +787,35 @@ namespace Tizen.NUI.Extension
             view.SetMaximumHeight(maximumHeight, true);
             return view;
         }
+
+        /// <summary>
+        /// Sets the margin of the view used to size and position the view within its parent layout container.
+        /// </summary>
+        /// <typeparam name="T">The type of the view.</typeparam>
+        /// <param name="view">The extension target.</param>
+        /// <param name="margin">The margin value.</param>
+        /// <returns>The view itself.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T Margin<T>(this T view, UIExtents margin) where T : View
+        {
+            // FIXME: UIExtents is not supported yet. Instead, Extents is used internally.
+            view.SetMargin(margin, true);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the padding of the view used to size and position the child views within this layout container.
+        /// </summary>
+        /// <typeparam name="T">The type of the view.</typeparam>
+        /// <param name="view">The extension target.</param>
+        /// <param name="padding">The padding value.</param>
+        /// <returns>The view itself.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T Padding<T>(this T view, UIExtents padding) where T : View
+        {
+            // FIXME: UIExtents is not supported yet. Instead, Extents is used internally.
+            view.SetPadding(padding, true);
+            return view;
+        }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -5176,6 +5176,11 @@ namespace Tizen.NUI.BaseComponents
                 if (!HasMaximumHeight())
                     SetMaximumHeight(MaximumSize.Height, false);
 
+                if (!HasMargin())
+                    SetMargin(new UIExtents(Margin.Start, Margin.End, Margin.Top, Margin.End), false);
+                if (!HasPadding())
+                    SetPadding(new UIExtents(Padding.Start, Padding.End, Padding.Top, Padding.End), false);
+
                 // Do nothing if layout provided is already set on this View.
                 if (value == layoutExtraData.Layout)
                 {
@@ -6267,6 +6272,54 @@ namespace Tizen.NUI.BaseComponents
         internal bool HasMaximumHeight()
         {
             return layoutExtraData?.MaximumHeight == null ? false : true;
+        }
+
+        internal void SetMargin(UIExtents margin, bool updateMargin)
+        {
+            if (margin.IsNaN)
+            {
+                return;
+            }
+
+            var layoutExtraData = EnsureLayoutExtraData();
+            if (layoutExtraData.Margin != margin)
+            {
+                if (updateMargin)
+                {
+                    Margin = new Extents(margin);
+                }
+                layoutExtraData.Margin = margin;
+                layoutExtraData.Layout?.RequestLayout();
+            }
+        }
+
+        internal bool HasMargin()
+        {
+            return layoutExtraData?.Margin == null ? false : true;
+        }
+
+        internal void SetPadding(UIExtents padding, bool updatePadding)
+        {
+            if (padding.IsNaN)
+            {
+                return;
+            }
+
+            var layoutExtraData = EnsureLayoutExtraData();
+            if (layoutExtraData.Padding != padding)
+            {
+                if (updatePadding)
+                {
+                    Padding = new Extents(padding);
+                }
+                layoutExtraData.Padding = padding;
+                layoutExtraData.Layout?.RequestLayout();
+            }
+        }
+
+        internal bool HasPadding()
+        {
+            return layoutExtraData?.Padding == null ? false : true;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -1494,6 +1494,9 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (newValue != null)
             {
+                if (view.HasPadding() && newValue is Extents newPadding)
+                    view.SetPadding(new UIExtents(newPadding.Start, newPadding.End, newPadding.Top, newPadding.Bottom), false);
+
                 if (view.Layout != null)
                 {
                     view.Layout.Padding = new Extents((Extents)newValue);
@@ -1752,6 +1755,9 @@ namespace Tizen.NUI.BaseComponents
             var view = (View)bindable;
             if (newValue != null)
             {
+                if (view.HasMargin() && newValue is Extents newMargin)
+                    view.SetMargin(new UIExtents(newMargin.Start, newMargin.End, newMargin.Top, newMargin.Bottom), false);
+
                 if (view.Layout != null)
                 {
                     view.Layout.Margin = new Extents((Extents)newValue);

--- a/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
@@ -77,6 +77,16 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         public float MaximumHeight { get; set; } = int.MaxValue;
 
+        /// <summary>
+        /// Gets or sets the margin of the view.
+        /// </summary>
+        public UIExtents Margin { get; set; } = UIExtents.Zero;
+
+        /// <summary>
+        /// Gets or sets the padding of the view.
+        /// </summary>
+        public UIExtents Padding { get; set; } = UIExtents.Zero;
+
         ~LayoutExtraData() => Dispose(false);
 
         public void Dispose()


### PR DESCRIPTION
Margin is added to View markup method to be used by the layout to size and position the view within its parent layout container. Padding is added to View markup method to be used by the layout to size and position the child views within the layout container.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
