### PR TITLE
[NUI] Fix dictionary variables to support non UsingXaml case

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -136,7 +136,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return flexAlignmentSelfMap[view];
+                if (flexAlignmentSelfMap.TryGetValue(view, out var flexAlignmentSelf))
+                {
+                    return flexAlignmentSelf;
+                }
+                else
+                {
+                    return AlignmentType.Auto;
+                }
             }
         }
 
@@ -176,7 +183,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return flexAspectRatioMap[view];
+                if (flexAspectRatioMap.TryGetValue(view, out var flexAspectRatio))
+                {
+                    return flexAspectRatio;
+                }
+                else
+                {
+                    return FlexUndefined;
+                }
             }
         }
 
@@ -196,7 +210,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return flexBasisMap[view];
+                if (flexBasisMap.TryGetValue(view, out var flexBasis))
+                {
+                    return flexBasis;
+                }
+                else
+                {
+                    return FlexUndefined;
+                }
             }
         }
 
@@ -216,7 +237,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return flexShrinkMap[view];
+                if (flexShrinkMap.TryGetValue(view, out var flexShrink))
+                {
+                    return flexShrink;
+                }
+                else
+                {
+                    return 1.0f;
+                }
             }
         }
 
@@ -236,7 +264,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return flexGrowMap[view];
+                if (flexGrowMap.TryGetValue(view, out var flexGrow))
+                {
+                    return flexGrow;
+                }
+                else
+                {
+                    return FlexUndefined;
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -127,7 +127,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return columnMap[view];
+                if (columnMap.TryGetValue(view, out var column))
+                {
+                    return column;
+                }
+                else
+                {
+                    return AutoColumn;
+                }
             }
         }
 
@@ -146,7 +153,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return columnSpanMap[view] != 0 ? columnSpanMap[view] : 1;
+                if (columnSpanMap.TryGetValue(view, out var columnSpan))
+                {
+                    return columnSpan;
+                }
+                else
+                {
+                    return 1;
+                }
             }
         }
 
@@ -165,7 +179,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return rowMap[view];
+                if (rowMap.TryGetValue(view, out var row))
+                {
+                    return row;
+                }
+                else
+                {
+                    return AutoRow;
+                }
             }
         }
 
@@ -184,7 +205,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return rowSpanMap[view] != 0 ? rowSpanMap[view] : 1;
+                if (rowSpanMap.TryGetValue(view, out var rowSpan))
+                {
+                    return rowSpan;
+                }
+                else
+                {
+                    return 1;
+                }
             }
         }
 
@@ -203,7 +231,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return horizontalStretchMap[view];
+                if (horizontalStretchMap.TryGetValue(view, out var horizontalStretch))
+                {
+                    return horizontalStretch;
+                }
+                else
+                {
+                    return StretchFlags.None;
+                }
             }
         }
 
@@ -222,7 +257,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return verticalStretchMap[view];
+                if (verticalStretchMap.TryGetValue(view, out var verticalStretch))
+                {
+                    return verticalStretch;
+                }
+                else
+                {
+                    return StretchFlags.None;
+                }
             }
         }
 
@@ -241,7 +283,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return horizontalAlignmentMap[view];
+                if (horizontalAlignmentMap.TryGetValue(view, out var horizontalAlignment))
+                {
+                    return horizontalAlignment;
+                }
+                else
+                {
+                    return Alignment.Start;
+                }
             }
         }
 
@@ -260,7 +309,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return verticalAlignmentMap[view];
+                if (verticalAlignmentMap.TryGetValue(view, out var verticalAlignment))
+                {
+                    return verticalAlignment;
+                }
+                else
+                {
+                    return Alignment.Start;
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
@@ -168,7 +168,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return leftTargetMap[(View)view];
+                if (leftTargetMap.TryGetValue((View)view, out var leftTarget))
+                {
+                    return leftTarget;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -188,7 +195,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return rightTargetMap[(View)view];
+                if (rightTargetMap.TryGetValue((View)view, out var rightTarget))
+                {
+                    return rightTarget;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -208,7 +222,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return topTargetMap[(View)view];
+                if (topTargetMap.TryGetValue((View)view, out var topTarget))
+                {
+                    return topTarget;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -228,7 +249,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return bottomTargetMap[(View)view];
+                if (bottomTargetMap.TryGetValue((View)view, out var bottomTarget))
+                {
+                    return bottomTarget;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -247,7 +275,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return leftRelativeOffsetMap[view];
+                if (leftRelativeOffsetMap.TryGetValue(view, out var leftRelativeOffset))
+                {
+                    return leftRelativeOffset;
+                }
+                else
+                {
+                    return 0.0f;
+                }
             }
         }
 
@@ -266,7 +301,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return rightRelativeOffsetMap[view];
+                if (rightRelativeOffsetMap.TryGetValue(view, out var rightRelativeOffset))
+                {
+                    return rightRelativeOffset;
+                }
+                else
+                {
+                    return 1.0f;
+                }
             }
         }
 
@@ -285,7 +327,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return topRelativeOffsetMap[view];
+                if (topRelativeOffsetMap.TryGetValue(view, out var topRelativeOffset))
+                {
+                    return topRelativeOffset;
+                }
+                else
+                {
+                    return 0.0f;
+                }
             }
         }
 
@@ -304,7 +353,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return bottomRelativeOffsetMap[view];
+                if (bottomRelativeOffsetMap.TryGetValue(view, out var bottomRelativeOffset))
+                {
+                    return bottomRelativeOffset;
+                }
+                else
+                {
+                    return 1.0f;
+                }
             }
         }
 
@@ -323,7 +379,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return horizontalAlignmentMap[view];
+                if (horizontalAlignmentMap.TryGetValue(view, out var horizontalAlignment))
+                {
+                    return horizontalAlignment;
+                }
+                else
+                {
+                    return Alignment.Start;
+                }
             }
         }
 
@@ -342,7 +405,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return verticalAlignmentMap[view];
+                if (verticalAlignmentMap.TryGetValue(view, out var verticalAlignment))
+                {
+                    return verticalAlignment;
+                }
+                else
+                {
+                    return Alignment.Start;
+                }
             }
         }
 
@@ -361,7 +431,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return fillHorizontalMap[view];
+                if (fillHorizontalMap.TryGetValue(view, out var fillHorizontal))
+                {
+                    return fillHorizontal;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
 
@@ -380,7 +457,14 @@ namespace Tizen.NUI
             }
             else
             {
-                return fillVerticalMap[view];
+                if (fillVerticalMap.TryGetValue(view, out var fillVertical))
+                {
+                    return fillVertical;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
In some codes, dictionary variables' getter does not check if the key exists in the dictionary.
This causes an exception by accessing key's value which does not exist.

This PR resolves the above cases.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
