### PR TITLE
[NUI] Introduce new binding style.

### DIFF
--- a/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
+++ b/src/Tizen.NUI.Components/Controls/RecyclerView/Item/RecyclerViewItem.Internal.cs
@@ -227,6 +227,7 @@ namespace Tizen.NUI.Components
         protected override void OnBindingContextChanged()
         {
             PropagateBindingContext(this);
+            base.OnBindingContextChanged();
         }
 
         private void PropagateBindingContext(View parent)

--- a/src/Tizen.NUI/src/devel/Binding/BindingExtensions.cs
+++ b/src/Tizen.NUI/src/devel/Binding/BindingExtensions.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reflection;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Binding
+{
+    /// <summary>
+    /// Provides extension methods for binding properties of a view model to a view.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class BindingExtensions
+    {
+        /// <summary>
+        /// Sets the binding for the specified view model property.
+        /// </summary>
+        /// <typeparam name="T">The type of the view model.</typeparam>
+        /// <typeparam name="TView">The type of the view.</typeparam>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="vm">The view model to bind from.</param>
+        /// <param name="set">The action to set the view property.</param>
+        /// <param name="path">The path of the view model property.</param>
+        /// <returns>The view.</returns>
+        public static TView SetBinding<T, TView>(this TView view, BindingSession<T> vm, Action<T, TView> set, string path) where TView : View
+        {
+            _ = view ?? throw new ArgumentNullException(nameof(view));
+
+            var setter = new Action<T>(vm =>
+            {
+                set.Invoke(vm, view);
+            });
+            vm.AddBinding(setter, path);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the binding for the specified view model property.
+        /// </summary>
+        /// <typeparam name="T">The type of the view model.</typeparam>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="vm">The view model to bind from.</param>
+        /// <param name="set">The action to set the view property.</param>
+        /// <param name="path">The path of the view model property.</param>
+        /// <returns>The view.</returns>
+        public static View SetBinding<T>(this View view, BindingSession<T> vm, Action<T> set, string path)
+        {
+            vm.AddBinding(set, path);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the binding for the specified view model property.
+        /// </summary>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="session">The binding session.</param>
+        /// <param name="targetPath">The path of the view property.</param>
+        /// <param name="srcPath">The path of the view model property.</param>
+        /// <returns>The view.</returns>
+        public static View SetBinding<TViewModel>(this View view, BindingSession<TViewModel> session, string targetPath, string srcPath)
+        {
+            var setter = new Action<TViewModel>(model =>
+            {
+                if (view.Disposed)
+                {
+                    return;
+                }
+                var prop = view.GetType().GetProperty(targetPath, BindingFlags.Public | BindingFlags.Instance);
+                prop.SetValue(view, session.GetValue(srcPath));
+            });
+            session.AddBinding(setter, srcPath);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the binding for the specified view model property.
+        /// </summary>
+        /// <typeparam name="TView">The type of the view.</typeparam>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <typeparam name="TProperty">The type of the view property.</typeparam>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="session">The binding session.</param>
+        /// <param name="property">The view property.</param>
+        /// <param name="path">The path of the view model property.</param>
+        /// <returns>The view.</returns>
+        public static TView SetBinding<TView, TViewModel, TProperty>(this TView view, BindingSession<TViewModel> session, BindingProperty<TView, TProperty> property, string path) where TView : View
+        {
+            var setter = new Action<TViewModel>(model =>
+            {
+                if (view.Disposed)
+                {
+                    return;
+                }
+
+                var value = session.GetValue(path);
+                // need to apply convertor if type was not mached
+                if (value != null && !typeof(TProperty).IsAssignableFrom(value.GetType()))
+                {
+                    // only string type convert with ToString()
+                    if (typeof(TProperty) == typeof(string))
+                    {
+                        value = value.ToString();
+                    }
+                    else
+                    {
+                        throw new InvalidCastException($"Cannot cast {value.GetType()} to {typeof(TProperty)}");
+                    }
+                }
+                property.Setter(view, (TProperty)value);
+            });
+            session.AddBinding(setter, path);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the two-way binding for the specified view model property.
+        /// </summary>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <typeparam name="TProperty">The type of the view property.</typeparam>
+        /// <param name="view">The view to bind to.</param>
+        /// <param name="session">The binding session.</param>
+        /// <param name="property">The view property.</param>
+        /// <param name="path">The path of the view model property.</param>
+        /// <returns>The view.</returns>
+        public static View SetTwoWayBinding<TViewModel, TProperty>(this View view, BindingSession<TViewModel> session, TwoWayBindingProperty<View, TProperty> property, string path)
+        {
+            var regit = new Action<Action>(act =>
+            {
+                property.AddObserver(view, act);
+            });
+            var unregit = new Action<Action>(act =>
+            {
+                property.RemoveObserver(view, act);
+            });
+            var setter = new Action<TViewModel>(model =>
+            {
+                if (view.Disposed)
+                {
+                    return;
+                }
+                property.Setter(view, (TProperty)session.GetValue(path));
+            });
+            var getter = new Func<TProperty>(() => property.Getter(view));
+            session.AddTwoWayBinding(regit, unregit, setter, getter, path);
+            return view;
+        }
+
+        /// <summary>
+        /// Sets the two-way binding for the specified view model property.
+        /// </summary>
+        /// <typeparam name="TView">The type of the view.</typeparam>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <typeparam name="TProperty">The type of the view property.</typeparam>
+        /// <param name="view">The to.</param>
+        /// <param name="session">The binding session.</param>
+        /// <param name="property">The view property.</param>
+        /// <param name="path">The path of the view model property.</param>
+        /// <returns>The view.</returns>
+        public static TView SetTwoWayBinding<TView, TViewModel, TProperty>(this TView view, BindingSession<TViewModel> session, TwoWayBindingProperty<TView, TProperty> property, string path) where TView : View
+        {
+            var regit = new Action<Action>(act =>
+            {
+                property.AddObserver(view, act);
+            });
+            var unregit = new Action<Action>(act =>
+            {
+                property.RemoveObserver(view, act);
+            });
+            var setter = new Action<TViewModel>(model =>
+            {
+                if (view.Disposed)
+                {
+                    return;
+                }
+                property.Setter(view, (TProperty)session.GetValue(path));
+            });
+            var getter = new Func<TProperty>(() => property.Getter(view));
+            session.AddTwoWayBinding(regit, unregit, setter, getter, path);
+            return view;
+        }
+
+        /// <summary>
+        /// Gets the binding session for the specified view.
+        /// </summary>
+        /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+        /// <param name="view">The view.</param>
+        /// <returns>The binding session.</returns>
+        public static BindingSession<TViewModel> BindingSession<TViewModel>(this View view)
+        {
+            return view.GetAttached<BindingSession<TViewModel>>();
+        }
+
+        /// <summary>
+        /// Sets the binding session for the specified view.
+        /// </summary>
+        /// <typeparam name="T">The type of the view model.</typeparam>
+        /// <typeparam name="TViewModel">The type of the view.</typeparam>
+        /// <param name="view">The view.</param>
+        /// <param name="session">The binding session.</param>
+        /// <returns>The view.</returns>
+        public static T BindingSession<T, TViewModel>(this T view, BindingSession<TViewModel> session) where T : View
+        {
+            view.SetAttached(session);
+            return view;
+        }
+    }
+}

--- a/src/Tizen.NUI/src/devel/Binding/BindingProperty.cs
+++ b/src/Tizen.NUI/src/devel/Binding/BindingProperty.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Binding
+{
+    /// <summary>
+    /// The BindingProperty class represents a binding property for a view.
+    /// </summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BindingProperty<TView, TValue>
+    {
+        /// <summary>
+        /// Gets or sets the setter action for the binding property.
+        /// </summary>
+        public Action<TView, TValue> Setter { get; set; }
+    }
+}

--- a/src/Tizen.NUI/src/devel/Binding/BindingSession.cs
+++ b/src/Tizen.NUI/src/devel/Binding/BindingSession.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Binding
+{
+    /// <summary>
+    /// BindingSession class provides a mechanism for binding properties of a view model to a view.
+    /// </summary>
+    /// <typeparam name="TViewModel">The type of the view model.</typeparam>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BindingSession<TViewModel> : INotifyPropertyChanged, IDisposable
+    {
+        private List<Action> _bindingActions = new List<Action>();
+        private List<PropertyChangedEventHandler> _changedAction = new List<PropertyChangedEventHandler>();
+        private Dictionary<Action, Action<Action>> _observers = new Dictionary<Action, Action<Action>>();
+        private TViewModel _viewmodel;
+        private bool _disposed;
+
+        /// <summary>
+        /// Represents an event that is raised when a property value changes.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Gets or sets the view model.
+        /// </summary>
+        public TViewModel ViewModel
+        {
+            get => _viewmodel;
+            set
+            {
+                if (_viewmodel != null && _viewmodel is INotifyPropertyChanged noti)
+                {
+                    noti.PropertyChanged -= OnPropertyChanged;
+                }
+                _viewmodel = value;
+
+                if (_viewmodel != null && _viewmodel is INotifyPropertyChanged newobj)
+                {
+                    newobj.PropertyChanged += OnPropertyChanged;
+                }
+
+                UpdateViewModel();
+            }
+        }
+
+        /// <summary>
+        /// Updates the view model.
+        /// </summary>
+        /// <param name="vm">The view model to update.</param>
+        public void UpdateViewModel(TViewModel vm)
+        {
+            ViewModel = vm;
+        }
+
+        /// <summary>
+        /// Updates the view model.
+        /// </summary>
+        public void UpdateViewModel()
+        {
+            foreach (var action in _bindingActions)
+            {
+                action.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Adds a binding between a property of the view model and a property of the view.
+        /// </summary>
+        /// <param name="setter">The setter method of the view.</param>
+        /// <param name="path">The path of the property to bind.</param>
+        public void AddBinding(Action<TViewModel> setter, string path)
+        {
+            var action = new Action(() =>
+            {
+                if (ViewModel != null)
+                    setter(ViewModel);
+            });
+            _bindingActions.Add(action);
+            PropertyChangedEventHandler handler = (s, e) =>
+            {
+                if (path == "*" || e.PropertyName == path || e.PropertyName == "*")
+                {
+                    action();
+                }
+            };
+            _changedAction.Add(handler);
+            PropertyChanged += handler;
+            action.Invoke();
+        }
+
+        /// <summary>
+        /// Adds a two-way binding between a property of the view model and a property of the view.
+        /// </summary>
+        /// <typeparam name="T">The type of the property to bind.</typeparam>
+        /// <param name="register">The registration method of the observer.</param>
+        /// <param name="unregister">The unregistration method of the observer.</param>
+        /// <param name="setter">The setter method of the view.</param>
+        /// <param name="getter">The getter method of the view.</param>
+        /// <param name="path">The path of the property to bind.</param>
+        public void AddTwoWayBinding<T>(Action<Action> register, Action<Action> unregister, Action<TViewModel> setter, Func<T> getter, string path)
+        {
+            var action = new Action(() =>
+            {
+                if (ViewModel != null)
+                    SetValue(getter(), path);
+            });
+            _observers[action] = unregister;
+            register(action);
+            AddBinding(setter, path);
+        }
+
+        /// <summary>
+        /// Clears all bindings.
+        /// </summary>
+        public void ClearBinding()
+        {
+            foreach (var evtHandler in _changedAction)
+            {
+                PropertyChanged -= evtHandler;
+            }
+            foreach (var observer in _observers)
+            {
+                observer.Value.Invoke(observer.Key);
+            }
+            _observers.Clear();
+            _changedAction.Clear();
+            _bindingActions.Clear();
+        }
+
+        /// <summary>
+        /// Gets the value of a property of the view model.
+        /// </summary>
+        /// <param name="name">The name of the property.</param>
+        /// <returns>The value of the property.</returns>
+        public object GetValue(string name)
+        {
+            if (name == ".")
+                return ViewModel;
+
+            var prop = ViewModel.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+            if (prop == null)
+            {
+                Log.Error("NUI", $"Binding : Property {name} not found");
+            }
+            return prop?.GetValue(ViewModel) ?? null;
+        }
+
+        /// <summary>
+        /// Sets the value of a property of the view model.
+        /// </summary>
+        /// <param name="obj">The value to set.</param>
+        /// <param name="name">The name of the property.</param>
+        public void SetValue(object obj, string name)
+        {
+            var prop = ViewModel.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public);
+            prop?.SetValue(ViewModel, obj);
+        }
+
+        /// <summary>
+        /// Releases all resources used by the current instance of the BindingSession class.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Provides a mechanism for releasing unmanaged resources used by the BindingSession class.
+        /// </summary>
+        /// <param name="disposing">True if the method is called from Dispose, false if it is called from the finalizer.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    ClearBinding();
+                }
+                _disposed = true;
+            }
+        }
+
+        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            PropertyChanged?.Invoke(this, e);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/devel/Binding/TwoWayBindingProperty.cs
+++ b/src/Tizen.NUI/src/devel/Binding/TwoWayBindingProperty.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI.Binding
+{
+    /// <summary>
+    /// This class represents a two-way binding property between a view and its value.
+    /// </summary>
+    /// <typeparam name="TView">The type of the view.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class TwoWayBindingProperty<TView, TValue> : BindingProperty<TView, TValue>
+    {
+        /// <summary>
+        /// Gets or sets the function that retrieves the value from the view.
+        /// </summary>
+        public Func<TView, TValue> Getter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action that adds an observer to the view.
+        /// </summary>
+        public Action<TView, Action> AddObserver { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action that removes an observer from the view.
+        /// </summary>
+        public Action<TView, Action> RemoveObserver { get; set; }
+    }
+}

--- a/src/Tizen.NUI/src/devel/Binding/ViewBindings.cs
+++ b/src/Tizen.NUI/src/devel/Binding/ViewBindings.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Binding
+{
+    /// <summary>
+    /// Provides a set of static properties that represent the binding properties of the <see cref="View"/> class.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ViewBindings
+    {
+        /// <summary>
+        /// Gets the binding property for the width of a <see cref="View"/>.
+        /// </summary>
+        public static BindingProperty<View, float> WidthProperty { get; } = new BindingProperty<View, float>
+        {
+            Setter = (v, value) => v.SizeWidth = value,
+        };
+
+        /// <summary>
+        /// Gets the binding property for the height of a <see cref="View"/>.
+        /// </summary>
+        public static BindingProperty<View, float> HeightProperty { get; } = new BindingProperty<View, float>
+        {
+            Setter = (v, value) => v.SizeHeight = value,
+        };
+
+        /// <summary>
+        /// Gets the binding property for the background color of a <see cref="View"/>.
+        /// </summary>
+        public static BindingProperty<View, UIColor> BackgroundColorProperty { get; } = new BindingProperty<View, UIColor>
+        {
+            Setter = (v, value) => v.SetBackgroundColor(value),
+        };
+    }
+
+    /// <summary>
+    /// Provides a set of static properties that represent the data-binding capabilities of the <see cref="TextLabel"/> class.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class TextLabelBindings
+    {
+        /// <summary>
+        /// Gets the binding property for the <see cref="TextLabel.Text"/> property.
+        /// </summary>
+        public static BindingProperty<TextLabel, string> TextProperty { get; } = new BindingProperty<TextLabel, string>
+        {
+            Setter = (v, value) =>
+            {
+                v.Text = value;
+            }
+        };
+
+        /// <summary>
+        /// Gets the binding property for the <see cref="TextLabel.TextColor"/> property.
+        /// </summary>
+        public static BindingProperty<TextLabel, UIColor> TextColorProperty { get; } = new BindingProperty<TextLabel, UIColor>
+        {
+            Setter = (v, value) => v.TextColor = value.ToReferenceType(),
+        };
+
+        /// <summary>
+        /// Gets the binding property for the <see cref="TextLabel.PointSize"/> property.
+        /// </summary>
+        public static BindingProperty<TextLabel, float> FontSizeProperty { get; } = new BindingProperty<TextLabel, float>
+        {
+            Setter = (v, value) => v.PointSize = value,
+        };
+    }
+
+    /// <summary>
+    /// This class provides a set of static properties for binding with <see cref="TextField"/> control.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class TextFieldBindings
+    {
+        /// <summary>
+        /// The TextColorProperty is a bindable property that indicates the color of the text in the <see cref="TextField"/> control.
+        /// </summary>
+        public static BindingProperty<TextField, UIColor> TextColorProperty { get; } = new BindingProperty<TextField, UIColor>
+        {
+            Setter = (v, value) => v.TextColor = value.ToReferenceType(),
+        };
+
+        /// <summary>
+        /// The FontSizeProperty is a bindable property that indicates the size of the font used to display the text in the <see cref="TextField"/> control.
+        /// </summary>
+        public static BindingProperty<TextField, float> FontSizeProperty { get; } = new BindingProperty<TextField, float>
+        {
+            Setter = (v, value) => v.PointSize = value,
+        };
+
+        /// <summary>
+        /// The TextProperty is a two-way bindable property that indicates the text displayed in the <see cref="TextField"/> control.
+        /// </summary>
+        public static TwoWayBindingProperty<TextField, string> TextProperty { get; } = new TwoWayBindingProperty<TextField, string>
+        {
+            Setter = (v, value) => v.Text = value,
+            Getter = v => v.Text,
+            AddObserver = (v, action) => v.TextChanged += EventHandlerHelper.Set<EventHandler<TextField.TextChangedEventArgs>>((s, e) => { action.Invoke(); }, action),
+            RemoveObserver = (v, action) => v.TextChanged -= EventHandlerHelper.Get<EventHandler<TextField.TextChangedEventArgs>>(action),
+        };
+    }
+
+    /// <summary>
+    /// Provides a set of static properties for binding TextEditor controls.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class TextEditorBindings
+    {
+        /// <summary>
+        /// The TextColorProperty is a bindable property that indicates the color of the text in the TextEditor control.
+        /// </summary>
+        public static BindingProperty<TextEditor, UIColor> TextColorProperty { get; } = new BindingProperty<TextEditor, UIColor>
+        {
+            Setter = (v, value) => v.TextColor = value.ToReferenceType(),
+        };
+
+        /// <summary>
+        /// The FontSizeProperty is a bindable property that indicates the size of the font used to display the text in the TextEditor control.
+        /// </summary>
+        public static BindingProperty<TextEditor, float> FontSizeProperty { get; } = new BindingProperty<TextEditor, float>
+        {
+            Setter = (v, value) => v.PointSize = value,
+        };
+
+        /// <summary>
+        /// The TextProperty is a two-way bindable property that indicates the text displayed in the TextEditor control.
+        /// </summary>
+        public static TwoWayBindingProperty<TextEditor, string> TextProperty { get; } = new TwoWayBindingProperty<TextEditor, string>
+        {
+            Setter = (v, value) => v.Text = value,
+            Getter = v => v.Text,
+            AddObserver = (v, action) => v.TextChanged += EventHandlerHelper.Set<EventHandler<TextEditor.TextChangedEventArgs>>((s, e) => { action.Invoke(); }, action),
+            RemoveObserver = (v, action) => v.TextChanged -= EventHandlerHelper.Get<EventHandler<TextEditor.TextChangedEventArgs>>(action),
+        };
+    }
+
+    /// <summary>
+    /// Provides a set of static properties that represent the bindable properties of the <see cref="ImageView"/> class.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class ImageViewBindings
+    {
+        /// <summary>
+        /// Represents the bindable property for the <see cref="ImageView.ResourceUrl"/> property.
+        /// </summary>
+        public static BindingProperty<ImageView, string> ResourceUrlProperty { get; } = new BindingProperty<ImageView, string>
+        {
+            Setter = (v, value) => v.ResourceUrl = value,
+        };
+    }
+
+    /// <summary>
+    /// EventHandlerHelper class provides a helper method to set and get event handlers using actions.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class EventHandlerHelper
+    {
+        private static Dictionary<Action, Delegate> s_actionHandlerMap = new Dictionary<Action, Delegate>();
+
+        /// <summary>
+        /// Sets the event handler for the given action.
+        /// </summary>
+        /// <typeparam name="TEventHandler">The type of the event handler.</typeparam>
+        /// <param name="handler">The event handler to set.</param>
+        /// <param name="action">The action to associate with the event handler.</param>
+        /// <returns>The event handler that was set.</returns>
+        public static TEventHandler Set<TEventHandler>(TEventHandler handler, Action action) where TEventHandler : Delegate
+        {
+            s_actionHandlerMap[action] = handler;
+            return handler;
+        }
+
+        /// <summary>
+        /// Gets the event handler associated with the given action and removes the association.
+        /// </summary>
+        /// <typeparam name="TEventHandler">The type of the event handler.</typeparam>
+        /// <param name="action">The action to get the event handler for.</param>
+        /// <returns>The event handler associated with the given action, or null if no association exists.</returns>
+        public static TEventHandler Get<TEventHandler>(Action action) where TEventHandler : Delegate
+        {
+            if (!s_actionHandlerMap.ContainsKey(action))
+                return null;
+
+            var handler = (TEventHandler)s_actionHandlerMap[action];
+            s_actionHandlerMap.Remove(action);
+            return handler;
+        }
+    }
+}

--- a/test/Tizen.NUI.StyleGuide/Tizen.NUI.StyleGuide.cs
+++ b/test/Tizen.NUI.StyleGuide/Tizen.NUI.StyleGuide.cs
@@ -22,6 +22,7 @@ using Tizen.NUI;
 using Tizen.NUI.Components;
 using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Binding;
+//using Tizen.NUI.Bindings;
 using System.Reflection;
 
 namespace Tizen.NUI.StyleGuide
@@ -307,11 +308,16 @@ namespace Tizen.NUI.StyleGuide
                 ItemsLayouter = new LinearLayouter(),
                 ItemTemplate = new DataTemplate(() =>
                 {
+                    var session = new BindingSession<ControlMenu>();
                     DefaultLinearItem item = new DefaultLinearItem()
                     {
                         WidthSpecification = LayoutParamPolicies.MatchParent,
                     };
-                    item.Label.SetBinding(TextLabel.TextProperty, "ViewLabel");
+                    item.BindingContextChanged += (sender, e) =>
+                    {
+                        session.ViewModel = (ControlMenu)item.BindingContext;
+                    };
+                    item.Label.SetBinding(session, TextLabelBindings.TextProperty, "ViewLabel");
                     item.Label.HorizontalAlignment = HorizontalAlignment.Begin;
                     item.Focusable = true; //BaseComponents' Focusable is false as a default value, true should be set to navigate key focus.
                     return item;


### PR DESCRIPTION
The binding in NUI cause performance and memory issue, so we plan to deprecate them by setting IsUsingXaml disable.

This patch is aim to introduce new style of binding, which do not causing performance and memory seriously, and user can add binding property on existing view class, so that we do not need to add every property to bindable.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
