### PR TITLE
[NUI] Fix AbsoluteLayout to consider Margin and Padding

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -52,8 +52,7 @@ namespace Tizen.NUI
                     continue;
                 }
 
-                // Get size of child with no padding, no margin. we won't support margin, padding for AbsolutLayout.
-                MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
+                MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
 
                 // Determine the width and height needed by the children using their given position and size.
                 // Children could overlap so find the right most child.
@@ -100,13 +99,15 @@ namespace Tizen.NUI
                     continue;
                 }
 
+                Extents childMargin = childLayout.Margin;
+
                 LayoutLength childWidth = childLayout.MeasuredWidth.Size;
                 LayoutLength childHeight = childLayout.MeasuredHeight.Size;
 
-                LayoutLength childLeft = new LayoutLength(childLayout.Owner.PositionX);
-                LayoutLength childTop = new LayoutLength(childLayout.Owner.PositionY);
+                LayoutLength childLeft = new LayoutLength(Padding.Start + childLayout.Owner.PositionX + childMargin.Start);
+                LayoutLength childTop = new LayoutLength(Padding.Top + childLayout.Owner.PositionY + childMargin.Top);
 
-                childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight, true);
+                childLayout.Layout(childLeft, childTop, childLeft + childWidth, childTop + childHeight);
             }
         }
     }


### PR DESCRIPTION
AbsoluteLayout is fixed to consider Margin and Padding when it measures and layouts.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
