### PR TITLE
[NUI] Fix the issue that Style Property Getter does not work.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -647,6 +647,10 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual T GetOrCreateValue<T>(IStyleProperty styleProperty)
         {
+            if (values.TryGetValue(styleProperty, out var value))
+            {
+                return (T)value;
+            }
             T newValue = (T)Activator.CreateInstance(typeof(T));
             values[styleProperty] = newValue;
             return newValue;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -69,6 +69,10 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public Animation AnimateColor(string targetVisual, object destinationColor, int startTime, int endTime, AlphaFunction.BuiltinFunctions? alphaFunction = null, object initialColor = null)
         {
+            if (targetVisual == null)
+            {
+                throw new ArgumentNullException(nameof(targetVisual), "targetVisual is null.");
+            }
             Animation animation = null;
             using (PropertyMap animator = new PropertyMap())
             using (PropertyMap timePeriod = new PropertyMap())


### PR DESCRIPTION
This patch is to fix failed TC in TCT.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: None

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
