### PR TITLE
Revert "[NUI] add asynchronous tasked animation play"

### DIFF
--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -25,8 +25,6 @@ namespace Tizen.NUI
     using System.Reflection;
     using System.Globalization;
     using System.Diagnostics.CodeAnalysis;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     using Tizen.NUI.BaseComponents;
 
@@ -63,7 +61,6 @@ namespace Tizen.NUI
         private System.IntPtr finishedCallbackOfNative;
 
         private AnimationProgressReachedEventCallbackType animationProgressReachedEventCallback;
-        private TaskCompletionSource animationTaskCompletionSource;
 
         private string[] properties = null;
         private string[] destValue = null;
@@ -1351,13 +1348,6 @@ namespace Tizen.NUI
         {
             Interop.Animation.Clear(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
-            if (animationTaskCompletionSource != null)
-            {
-                animationTaskCompletionSource.SetCanceled();
-                animationTaskCompletionSource = null;
-            }
-
         }
 
         internal object ConvertTo(object value, Type toType)
@@ -1373,33 +1363,6 @@ namespace Tizen.NUI
             };
 
             return ConvertTo(value, toType, getConverter);
-        }
-
-        /// <summary>
-        /// Plays the animation asynchronously.
-        /// </summary>
-        /// <returns>A Task that completes when the animation finishes.</returns>
-        internal Task PlayAsync()
-        {
-            if (DisableAnimation)
-            {
-                return Task.FromCanceled(CancellationToken.None);
-            }
-
-            if (animationTaskCompletionSource != null)
-            {
-                animationTaskCompletionSource.SetCanceled();
-            }
-            animationTaskCompletionSource = new TaskCompletionSource();
-            void finished(object sender, EventArgs e)
-            {
-                Finished -= finished;
-                animationTaskCompletionSource.SetResult();
-                animationTaskCompletionSource = null;
-            }
-            Finished += finished;
-            Play();
-            return animationTaskCompletionSource.Task;
         }
 
         internal object ConvertTo(object value, Type toType, Func<object> getConverter)


### PR DESCRIPTION
This reverts commit c9cb5922a4eb67ea5b632ee3285256b9e66bd1ea.
OneUI have their own TypedAnimation so this animation is not neceesary.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
