### PR TITLE
[NUI] Remove LayoutDimensionMode from LayoutDimension

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -263,12 +263,12 @@ namespace Tizen.NUI
         private float GetLengthSize(float size, LayoutDimension layoutDimension)
         {
             // exact size provided so match width exactly
-            return layoutDimension.IsFixedValue ? layoutDimension.GetValue() : size;
+            return layoutDimension.IsFixedValue ? layoutDimension : size;
         }
 
         private MeasureSpecification.ModeType GetMode(LayoutDimension layoutDimension)
         {
-            if (layoutDimension.IsFixedValue || layoutDimension == LayoutDimensionMode.MatchParent)
+            if (layoutDimension.IsFixedValue || layoutDimension == LayoutDimension.MatchParent)
             {
                 return MeasureSpecification.ModeType.Exactly;
             }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2905,9 +2905,9 @@ namespace Tizen.NUI.BaseComponents
             userSizeHeight = (float)height;
 
             if (HasLayoutWidth())
-                SetLayoutWidth(width);
+                LayoutWidth = width;
             if (HasLayoutHeight())
-                SetLayoutHeight(height);
+                LayoutHeight = height;
 
             bool relayoutRequired = false;
             // To avoid duplicated size setup, change internal policy directly.
@@ -3531,7 +3531,7 @@ namespace Tizen.NUI.BaseComponents
             userSizeWidth = width;
 
             if (HasLayoutWidth())
-                SetLayoutWidth(width);
+                LayoutWidth = width;
 
             // To avoid duplicated size setup, change internal policy directly.
             // change temporary value's name as widthPolicyCeiling
@@ -3599,7 +3599,7 @@ namespace Tizen.NUI.BaseComponents
             userSizeHeight = height;
 
             if (HasLayoutHeight())
-                SetLayoutHeight(height);
+                LayoutHeight = height;
 
             // To avoid duplicated size setup, change internal policy directly.
             // change temporary value's name as heightPolicyCeiling
@@ -5342,9 +5342,9 @@ namespace Tizen.NUI.BaseComponents
                 userSizeHeight = height;
 
                 if (HasLayoutWidth())
-                    SetLayoutWidth(width);
+                    LayoutWidth = width;
                 if (HasLayoutHeight())
-                    SetLayoutHeight(height);
+                    LayoutHeight = height;
 
                 // Set Specification so when layouts measure this View it matches the value set here.
                 // All Views are currently Layouts.
@@ -5678,7 +5678,7 @@ namespace Tizen.NUI.BaseComponents
                 }
 
                 if (HasLayoutWidth())
-                    SetLayoutWidth(widthPolicy);
+                    LayoutWidth = widthPolicy;
 
                 RequestLayout();
             }
@@ -5759,7 +5759,7 @@ namespace Tizen.NUI.BaseComponents
                 }
 
                 if (HasLayoutHeight())
-                    SetLayoutHeight(heightPolicy);
+                    LayoutHeight = heightPolicy;
 
                 RequestLayout();
             }
@@ -6202,9 +6202,9 @@ namespace Tizen.NUI.BaseComponents
                 // Copy from width/heightPolicy only if LayoutWidth/Height has not been set before
                 // not to overwrite LayoutWidth/Height value set by user.
                 if (!hasLayoutWidth)
-                    SetLayoutWidth(widthPolicy);
+                    LayoutWidth = widthPolicy;
                 if (!hasLayoutHeight)
-                    SetLayoutHeight(heightPolicy);
+                    LayoutHeight = heightPolicy;
 
                 if (!HasMinimumWidth())
                     SetMinimumWidth(MinimumSize.Width, false);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
@@ -117,11 +117,11 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         internal LayoutDimension LayoutWidth
         {
-            get => layoutExtraData?.Width ?? LayoutDimensionMode.WrapContent;
+            get => layoutExtraData?.Width ?? LayoutDimension.WrapContent;
             set
             {
                 var layoutExtraData = EnsureLayoutExtraData();
-                if (float.IsNaN(layoutExtraData.Width.GetValue()) || layoutExtraData.Width != value)
+                if (!layoutExtraData.Width.IsFixedValue || layoutExtraData.Width != value)
                 {
                     layoutExtraData.Width = value;
                     layoutExtraData.Layout?.RequestLayout();
@@ -134,47 +134,15 @@ namespace Tizen.NUI.BaseComponents
         /// </summary>
         internal LayoutDimension LayoutHeight
         {
-            get => layoutExtraData?.Height ?? LayoutDimensionMode.WrapContent;
+            get => layoutExtraData?.Height ?? LayoutDimension.WrapContent;
             set
             {
                 var layoutExtraData = EnsureLayoutExtraData();
-                if (float.IsNaN(layoutExtraData.Height.GetValue()) || layoutExtraData.Height != value)
+                if (!layoutExtraData.Height.IsFixedValue || layoutExtraData.Height != value)
                 {
                     layoutExtraData.Height = value;
                     layoutExtraData.Layout?.RequestLayout();
                 }
-            }
-        }
-
-        internal void SetLayoutWidth(float size)
-        {
-            if (size >= 0)
-            {
-                LayoutWidth = size;
-            }
-            else if ((int)size == LayoutParamPolicies.WrapContent)
-            {
-                LayoutWidth = LayoutDimensionMode.WrapContent;
-            }
-            else if ((int)size == LayoutParamPolicies.MatchParent)
-            {
-                LayoutWidth = LayoutDimensionMode.MatchParent;
-            }
-        }
-
-        internal void SetLayoutHeight(float size)
-        {
-            if (size >= 0)
-            {
-                LayoutHeight = size;
-            }
-            else if ((int)size == LayoutParamPolicies.WrapContent)
-            {
-                LayoutHeight = LayoutDimensionMode.WrapContent;
-            }
-            else if ((int)size == LayoutParamPolicies.MatchParent)
-            {
-                LayoutHeight = LayoutDimensionMode.MatchParent;
             }
         }
 

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -752,11 +752,11 @@ namespace Tizen.NUI
 
                     if (needMeasuredWidth)
                     {
-                        child.LayoutItem.Owner.LayoutWidth = LayoutDimensionMode.MatchParent;
+                        child.LayoutItem.Owner.LayoutWidth = LayoutDimension.MatchParent;
                     }
                     if (needMeasuredHeight)
                     {
-                        child.LayoutItem.Owner.LayoutHeight = LayoutDimensionMode.MatchParent;
+                        child.LayoutItem.Owner.LayoutHeight = LayoutDimension.MatchParent;
                     }
 
                     MeasureSpecification widthSpec = new MeasureSpecification(new LayoutLength(width), MeasureSpecification.ModeType.Exactly);

--- a/src/Tizen.NUI/src/public/Layouting/LayoutDimension.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutDimension.cs
@@ -14,6 +14,7 @@
  *
  */
 using System.ComponentModel;
+using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
 {
@@ -24,56 +25,27 @@ namespace Tizen.NUI
     public struct LayoutDimension
     {
         private bool isFixedValue;
-        private LayoutDimensionMode mode;
         private float value;
-
-        private LayoutDimension(LayoutDimensionMode mode)
-        {
-            isFixedValue = false;
-            this.mode = mode;
-            value = float.NaN;
-        }
 
         private LayoutDimension(float value)
         {
-            isFixedValue = true;
-            this.mode = LayoutDimensionMode.FixedValue;
+            if (value == LayoutParamPolicies.WrapContent || value == LayoutParamPolicies.MatchParent)
+            {
+                isFixedValue = false;
+            }
+            else
+            {
+                isFixedValue = true;
+            }
             this.value = value;
         }
 
         /// <summary>
-        /// Gets whether the size is fixed value or not. If it's fixed value, then the value is valid. Otherwise, the mode is valid.
+        /// Gets whether the size is fixed value or not. If it's fixed value, then the value is valid.
         /// </summary>
         public bool IsFixedValue
         {
             get => isFixedValue;
-        }
-
-        /// <summary>
-        /// Gets the mode of the size. If size is fixed value, then the mode is set to <see cref="LayoutDimensionMode.FixedValue"/>.
-        /// </summary>
-        /// <returns>The mode of the size.</returns>
-        public LayoutDimensionMode GetMode()
-        {
-            return mode;
-        }
-
-        /// <summary>
-        /// Gets the value of the size. This value is valid only when the size is fixed value. Otherwise, it returns NaN.
-        /// </summary>
-        /// <returns>The fixed value of the size.</returns>
-        public float GetValue()
-        {
-            return value;
-        }
-
-        /// <summary>
-        /// Creates a LayoutDimension from a LayoutDimensionMode. It's used implicitly. For example, LayoutDimension layoutWidth = LayoutDimensionMode.MatchParent;
-        /// </summary>
-        /// <param name="mode">The mode of the size.</param>
-        public static implicit operator LayoutDimension(LayoutDimensionMode mode)
-        {
-            return new LayoutDimension(mode);
         }
 
         /// <summary>
@@ -97,7 +69,7 @@ namespace Tizen.NUI
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return isFixedValue ? value.GetHashCode() : mode.GetHashCode();
+            return value.GetHashCode();
         }
 
         /// <inheritdoc/>
@@ -112,9 +84,9 @@ namespace Tizen.NUI
             }
             else
             {
-                if (obj is LayoutDimension ls)
+                if (obj is LayoutDimension ld)
                 {
-                    return mode == ls.mode;
+                    return value == ld.value;
                 }
             }
 
@@ -122,7 +94,7 @@ namespace Tizen.NUI
         }
 
         /// <summary>
-        /// Equality operator for LayoutDimension. It compares two LayoutDimensions. If both are fixed values, then it compares their values. Otherwise, it compares their modes.
+        /// Equality operator for LayoutDimension. It compares two LayoutDimensions. If both are fixed values, then it compares their values.
         /// </summary>
         /// <param name="a">A <see cref="LayoutDimension"/> on the left hand side.</param>
         /// <param name="b">A <see cref="LayoutDimension"/> on the right hand side.</param>
@@ -131,14 +103,14 @@ namespace Tizen.NUI
         {
             if (a.isFixedValue == b.isFixedValue)
             {
-                return a.isFixedValue ? a.value == b.value : a.mode == b.mode;
+                return a.value == b.value;
             }
 
             return false;
         }
 
         /// <summary>
-        /// Inequality operator for LayoutDimension. It compares two LayoutDimensions. If both are fixed values, then it compares their values. Otherwise, it compares their modes.
+        /// Inequality operator for LayoutDimension. It compares two LayoutDimensions. If both are fixed values, then it compares their values.
         /// </summary>
         /// <param name="a">A <see cref="LayoutDimension"/> on the left hand side.</param>
         /// <param name="b">A <see cref="LayoutDimension"/> on the right hand side.</param>
@@ -147,7 +119,7 @@ namespace Tizen.NUI
         {
             if (a.isFixedValue == b.isFixedValue)
             {
-                return a.isFixedValue ? a.value != b.value : a.mode != b.mode;
+                return a.value != b.value;
             }
 
             return false;
@@ -344,27 +316,15 @@ namespace Tizen.NUI
 
             return a;
         }
-    }
-
-    /// <summary>
-    /// The LayoutDimensionMode enum defines the mode of a LayoutDimension. It can be wrap content, match parent, or fixed value.
-    /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public enum LayoutDimensionMode
-    {
-        /// <summary>
-        /// Wrap content means that the size fits the child's content.
-        /// </summary>
-        WrapContent = BaseComponents.LayoutParamPolicies.WrapContent,
 
         /// <summary>
-        /// Match parent means that the size fills the available space in parent.
+        /// Constant value that indicates WrapContent for LayoutDimension. For example, LayoutDimension layoutWidth = LayoutDimension.WrapContent;
         /// </summary>
-        MatchParent = BaseComponents.LayoutParamPolicies.MatchParent,
+        public const float WrapContent = LayoutParamPolicies.WrapContent;
 
         /// <summary>
-        /// Fixed value means that the size is fixed value. This is used when the size is explicitly specified.
+        /// Constant value that indicates MatchParent for LayoutDimension. For example, LayoutDimension layoutWidth = LayoutDimension.MatchParent;
         /// </summary>
-        FixedValue = 0,
+        public const float MatchParent = LayoutParamPolicies.MatchParent;
     }
 }

--- a/src/Tizen.NUI/src/public/Layouting/LayoutLength.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutLength.cs
@@ -64,7 +64,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public LayoutLength(LayoutDimension layoutDimension)
         {
-            this.value = layoutDimension.IsFixedValue ? layoutDimension.GetValue() : (int)layoutDimension.GetMode();
+            this.value = layoutDimension;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -315,7 +315,7 @@ namespace Tizen.NUI
             int childrenCount = IterateLayoutChildren().Count();
 
             // Child layout, which wants to match its width to its parent's remaining width, is either following 1 or 2.
-            // 1. Child layout whose Owner.LayoutWidth is LayoutDimensionMode.MatchParent.
+            // 1. Child layout whose Owner.LayoutWidth is LayoutDimension.MatchParent.
             // 2. Child layout whose Owner.LayoutWidth is 0 and Owner.Weight is greater than 0.
             // The number of child layout which wants to match its width to its parent's remaining width.
             int childrenMatchParentCount = 0;
@@ -344,7 +344,7 @@ namespace Tizen.NUI
                 float childMarginWidth = childMargin.Start + childMargin.End;
                 bool useRemainingWidth = (childDesiredWidth == 0) && (childWeight > 0);
 
-                if ((childDesiredWidth == LayoutDimensionMode.MatchParent) || (useRemainingWidth))
+                if ((childDesiredWidth == LayoutDimension.MatchParent) || (useRemainingWidth))
                 {
                     totalWeight += childWeight;
                     childrenMatchParentCount++;
@@ -358,7 +358,7 @@ namespace Tizen.NUI
                 // Child layout1 is MatchParent and its margin is 20. (This margin is not ad
                 // Child layout2 is MatchParent and its margin is 0.
                 // Then, child layout1's size is 30 and child layout2's size is 50.
-                if ((childDesiredWidth == LayoutDimensionMode.WrapContent) || ((childDesiredWidth >= 0) && (!useRemainingWidth)))
+                if ((childDesiredWidth == LayoutDimension.WrapContent) || ((childDesiredWidth >= 0) && (!useRemainingWidth)))
                 {
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
 
@@ -418,7 +418,7 @@ namespace Tizen.NUI
                 bool useRemainingWidth = (childDesiredWidth == 0) && (childWeight > 0);
                 bool needToMeasure = false;
 
-                if ((childDesiredHeight == LayoutDimensionMode.MatchParent) || (useRemainingWidth))
+                if ((childDesiredHeight == LayoutDimension.MatchParent) || (useRemainingWidth))
                 {
                     if (isHeightExactly)
                     {
@@ -429,9 +429,9 @@ namespace Tizen.NUI
                     // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
                     //
                     // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
-                    else if (Owner.LayoutHeight == LayoutDimensionMode.WrapContent)
+                    else if (Owner.LayoutHeight == LayoutDimension.WrapContent)
                     {
-                        if (childDesiredHeight == LayoutDimensionMode.MatchParent)
+                        if (childDesiredHeight == LayoutDimension.MatchParent)
                         {
                             Tizen.Log.Error("NUI", "There is a recursive reference! Parent layout(Owner: " + Owner + ")'s LayoutHeight is WrapContent and child layout(Owner: " + childLayout.Owner + ")'s LayoutHeight is MatchParent!");
                         }
@@ -444,7 +444,7 @@ namespace Tizen.NUI
 
                 if (remainingWidth > 0)
                 {
-                    if ((childDesiredWidth == LayoutDimensionMode.MatchParent) || (useRemainingWidth))
+                    if ((childDesiredWidth == LayoutDimension.MatchParent) || (useRemainingWidth))
                     {
                         if (isWidthExactly)
                         {
@@ -458,9 +458,9 @@ namespace Tizen.NUI
                         // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
                         //
                         // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
-                        else if (Owner.LayoutWidth == LayoutDimensionMode.WrapContent)
+                        else if (Owner.LayoutWidth == LayoutDimension.WrapContent)
                         {
-                            if (childDesiredWidth == LayoutDimensionMode.MatchParent)
+                            if (childDesiredWidth == LayoutDimension.MatchParent)
                             {
                                 Tizen.Log.Error("NUI", "There is a recursive reference! Parent layout(Owner: " + Owner + ")'s LayoutWidth is WrapContent and child layout(Owner: " + childLayout.Owner + ")'s LayoutWidth is MatchParent!");
                             }
@@ -477,7 +477,7 @@ namespace Tizen.NUI
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
                 }
 
-                if ((childWeight > 0) && ((childDesiredWidth == LayoutDimensionMode.MatchParent) || (childDesiredWidth == 0)))
+                if ((childWeight > 0) && ((childDesiredWidth == LayoutDimension.MatchParent) || (childDesiredWidth == 0)))
                 {
                     float childMeasuredWidth = childLayout.MeasuredWidth.Size.AsDecimal();
 
@@ -508,7 +508,7 @@ namespace Tizen.NUI
                     var childDesiredWidth = childLayout.Owner.LayoutWidth;
                     float childWeight = childLayout.Owner.Weight;
 
-                    if ((childWeight > 0) && ((childDesiredWidth == LayoutDimensionMode.MatchParent) || (childDesiredWidth == 0)))
+                    if ((childWeight > 0) && ((childDesiredWidth == LayoutDimension.MatchParent) || (childDesiredWidth == 0)))
                     {
                         if (isWidthExactly)
                         {
@@ -521,9 +521,9 @@ namespace Tizen.NUI
                         // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
                         //
                         // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
-                        else if (Owner.LayoutWidth == LayoutDimensionMode.WrapContent)
+                        else if (Owner.LayoutWidth == LayoutDimension.WrapContent)
                         {
-                            if (childDesiredWidth == LayoutDimensionMode.MatchParent)
+                            if (childDesiredWidth == LayoutDimension.MatchParent)
                             {
                                 Tizen.Log.Error("NUI", "There is a recursive reference! Parent layout(Owner: " + Owner + ")'s LayoutWidth is WrapContent and child layout(Owner: " + childLayout.Owner + ")'s LayoutWidth is MatchParent!");
                             }
@@ -580,7 +580,7 @@ namespace Tizen.NUI
             int childrenCount = IterateLayoutChildren().Count();
 
             // Child layout, which wants to match its height to its parent's remaining height, is either following 1 or 2.
-            // 1. Child layout whose Owner.LayoutHeight is LayoutDimensionMode.MatchParent.
+            // 1. Child layout whose Owner.LayoutHeight is LayoutDimension.MatchParent.
             // 2. Child layout whose Owner.LayoutHeight is 0 and Owner.Weight is greater than 0.
             // The number of child layout which wants to match its height to its parent's remaining height.
             int childrenMatchParentCount = 0;
@@ -609,7 +609,7 @@ namespace Tizen.NUI
                 float childMarginHeight = childMargin.Top + childMargin.Bottom;
                 bool useRemainingHeight = (childDesiredHeight == 0) && (childWeight > 0);
 
-                if ((childDesiredHeight == LayoutDimensionMode.MatchParent) || (useRemainingHeight))
+                if ((childDesiredHeight == LayoutDimension.MatchParent) || (useRemainingHeight))
                 {
                     totalWeight += childWeight;
                     childrenMatchParentCount++;
@@ -623,7 +623,7 @@ namespace Tizen.NUI
                 // Child layout1 is MatchParent and its margin is 20. (This margin is not ad
                 // Child layout2 is MatchParent and its margin is 0.
                 // Then, child layout1's size is 30 and child layout2's size is 50.
-                if ((childDesiredHeight == LayoutDimensionMode.WrapContent) || ((childDesiredHeight >= 0) && (!useRemainingHeight)))
+                if ((childDesiredHeight == LayoutDimension.WrapContent) || ((childDesiredHeight >= 0) && (!useRemainingHeight)))
                 {
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
 
@@ -683,7 +683,7 @@ namespace Tizen.NUI
                 bool useRemainingHeight = (childDesiredHeight == 0) && (childWeight > 0);
                 bool needToMeasure = false;
 
-                if ((childDesiredWidth == LayoutDimensionMode.MatchParent) || (useRemainingHeight))
+                if ((childDesiredWidth == LayoutDimension.MatchParent) || (useRemainingHeight))
                 {
                     if (isWidthExactly)
                     {
@@ -694,9 +694,9 @@ namespace Tizen.NUI
                     // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
                     //
                     // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
-                    else if (Owner.LayoutWidth == LayoutDimensionMode.WrapContent)
+                    else if (Owner.LayoutWidth == LayoutDimension.WrapContent)
                     {
-                        if (childDesiredWidth == LayoutDimensionMode.MatchParent)
+                        if (childDesiredWidth == LayoutDimension.MatchParent)
                         {
                             Tizen.Log.Error("NUI", "There is a recursive reference! Parent layout(Owner: " + Owner + ")'s LayoutWidth is WrapContent and child layout(Owner: " + childLayout.Owner + ")'s LayoutWidth is MatchParent!");
                         }
@@ -709,7 +709,7 @@ namespace Tizen.NUI
 
                 if (remainingHeight > 0)
                 {
-                    if ((childDesiredHeight == LayoutDimensionMode.MatchParent) || (useRemainingHeight))
+                    if ((childDesiredHeight == LayoutDimension.MatchParent) || (useRemainingHeight))
                     {
                         if (isHeightExactly)
                         {
@@ -723,9 +723,9 @@ namespace Tizen.NUI
                         // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
                         //
                         // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
-                        else if (Owner.LayoutHeight == LayoutDimensionMode.WrapContent)
+                        else if (Owner.LayoutHeight == LayoutDimension.WrapContent)
                         {
-                            if (childDesiredHeight == LayoutDimensionMode.MatchParent)
+                            if (childDesiredHeight == LayoutDimension.MatchParent)
                             {
                                 Tizen.Log.Error("NUI", "There is a recursive reference! Parent layout(Owner: " + Owner + ")'s LayoutHeight is WrapContent and child layout(Owner: " + childLayout.Owner + ")'s LayoutHeight is MatchParent!");
                             }
@@ -742,7 +742,7 @@ namespace Tizen.NUI
                     MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0));
                 }
 
-                if ((childWeight > 0) && ((childDesiredHeight == LayoutDimensionMode.MatchParent) || (childDesiredHeight == 0)))
+                if ((childWeight > 0) && ((childDesiredHeight == LayoutDimension.MatchParent) || (childDesiredHeight == 0)))
                 {
                     float childMeasuredHeight = childLayout.MeasuredHeight.Size.AsDecimal();
 
@@ -773,7 +773,7 @@ namespace Tizen.NUI
                     var childDesiredHeight = childLayout.Owner.LayoutHeight;
                     float childWeight = childLayout.Owner.Weight;
 
-                    if ((childWeight > 0) && ((childDesiredHeight == LayoutDimensionMode.MatchParent) || (childDesiredHeight == 0)))
+                    if ((childWeight > 0) && ((childDesiredHeight == LayoutDimension.MatchParent) || (childDesiredHeight == 0)))
                     {
                         if (isHeightExactly)
                         {
@@ -786,9 +786,9 @@ namespace Tizen.NUI
                         // Therefore, not to fill the RelativeLayout, the mode is changed from Exactly to AtMost.
                         //
                         // Not to print the recursive reference error message for this case, Specification is checked if it is WrapContent.
-                        else if (Owner.LayoutHeight == LayoutDimensionMode.WrapContent)
+                        else if (Owner.LayoutHeight == LayoutDimension.WrapContent)
                         {
-                            if (childDesiredHeight == LayoutDimensionMode.MatchParent)
+                            if (childDesiredHeight == LayoutDimension.MatchParent)
                             {
                                 Tizen.Log.Error("NUI", "There is a recursive reference! Parent layout(Owner: " + Owner + ")'s LayoutHeight is WrapContent and child layout(Owner: " + childLayout.Owner + ")'s LayoutHeight is MatchParent!");
                             }
@@ -1000,7 +1000,7 @@ namespace Tizen.NUI
                 var desiredChildHeight = childLayout.Owner.LayoutHeight;
                 var desiredChildWidth = childLayout.Owner.LayoutWidth;
 
-                if (desiredChildHeight == LayoutDimensionMode.MatchParent)
+                if (desiredChildHeight == LayoutDimension.MatchParent)
                 {
                     // Temporarily force children to reuse their original measured width
                     var originalWidth = desiredChildWidth;

--- a/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
@@ -870,12 +870,12 @@ namespace Tizen.NUI
                     if (ellipsisTextWidth || needMeasuredWidth)
                     {
                         origLayoutParamsWidth = childLayout.Owner.LayoutWidth;
-                        childLayout.Owner.LayoutWidth = LayoutDimensionMode.MatchParent;
+                        childLayout.Owner.LayoutWidth = LayoutDimension.MatchParent;
                     }
                     if (ellipsisTextHeight || needMeasuredHeight)
                     {
                         origLayoutParamsHeight = childLayout.Owner.LayoutHeight;
-                        childLayout.Owner.LayoutHeight = LayoutDimensionMode.MatchParent;
+                        childLayout.Owner.LayoutHeight = LayoutDimension.MatchParent;
                     }
 
                     MeasureChild(childLayout, childWidthMeasureSpec, childHeightMeasureSpec);

--- a/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
@@ -50,12 +50,12 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets or sets the width of the view. It can be set to a fixed value, wrap content, or match parent.
         /// </summary>
-        public LayoutDimension Width { get; set; } = LayoutDimensionMode.WrapContent;
+        public LayoutDimension Width { get; set; } = LayoutDimension.WrapContent;
 
         /// <summary>
         /// Gets or sets the height of the view. It can be set to a fixed value, wrap content, or match parent.
         /// </summary>
-        public LayoutDimension Height { get; set; } = LayoutDimensionMode.WrapContent;
+        public LayoutDimension Height { get; set; } = LayoutDimension.WrapContent;
 
         /// <summary>
         /// Gets or sets the minimum width of the view.


### PR DESCRIPTION
Since IsFixedValue and comparing operators are provided, LayoutDimensionMode is not necessary. So it is removed. Instead, const float WrapContent and MatchParent are added to be used for assigning or comparing WrapContent and MatchParent.

e.g. value assignment
LayoutDimension layoutWidth = LayoutDimension.MatchParent;

e.g. value comparison
if (layoutWidth == LayoutDimension.WrapContent)

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
