### PR TITLE
[Tizen.Network.WiFi] Remove thread local support

### DIFF
--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi.csproj
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Tizen.Network.Connection\Tizen.Network.Connection.csproj" />
-    <ProjectReference Include="..\Tizen.Applications.Common\Tizen.Applications.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
-using Tizen.Applications;
 
 namespace Tizen.Network.WiFi
 {
@@ -49,8 +48,6 @@ namespace Tizen.Network.WiFi
     {
         private static readonly Lazy<WiFiManagerImpl> _instance =
             new Lazy<WiFiManagerImpl>(() => new WiFiManagerImpl());
-
-        private TizenSynchronizationContext context = new TizenSynchronizationContext();
 
         private Dictionary<IntPtr, Interop.WiFi.VoidCallback> _callback_map =
             new Dictionary<IntPtr, Interop.WiFi.VoidCallback>();
@@ -330,24 +327,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.ActivateAsync");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.ActivateAsync");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.Activate(GetSafeHandle(), _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "Activate", "");
+                    ret = Interop.WiFi.Activate(GetSafeHandle(), _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on ActivateAsync\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "Activate", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on ActivateAsync\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }
@@ -379,24 +373,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.ActivateWithWiFiPickerTestedAsync");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.ActivateWithWiFiPickerTestedAsync");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.ActivateWithWiFiPickerTested(GetSafeHandle(), _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "ActivateWithWiFiPickerTested", "");
+                    ret = Interop.WiFi.ActivateWithWiFiPickerTested(GetSafeHandle(), _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on ActivateWithWiFiPickerTestedAsync\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "ActivateWithWiFiPickerTested", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on ActivateWithWiFiPickerTestedAsync\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }
@@ -428,24 +419,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.Deactivate");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.Deactivate");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.Deactivate(GetSafeHandle(), _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "Deactivate", "");
+                    ret = Interop.WiFi.Deactivate(GetSafeHandle(), _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on Deactivate\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "Deactivate", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on Deactivate\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }
@@ -477,24 +465,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.Scan");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.Scan");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.Scan(GetSafeHandle(), _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "Scan", "");
+                    ret = Interop.WiFi.Scan(GetSafeHandle(), _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on Scan\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "Scan", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on Scan\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }
@@ -526,24 +511,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.ScanSpecificAPAsync");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.ScanSpecificAPAsync");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.ScanSpecificAP(GetSafeHandle(), essid, _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "ScanSpecificAP", "");
+                    ret = Interop.WiFi.ScanSpecificAP(GetSafeHandle(), essid, _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on ScanSpecificAPAsync\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "ScanSpecificAP", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on ScanSpecificAPAsync\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }
@@ -575,24 +557,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.BssidScan");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.BssidScan");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.BssidScan(GetSafeHandle(), _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "BssidScan", "");
+                    ret = Interop.WiFi.BssidScan(GetSafeHandle(), _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on BssidScan\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "BssidScan", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on BssidScan\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }
@@ -631,24 +610,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.HiddenAPConnect");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.HiddenAPConnect");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.ConnectHiddenAP(GetSafeHandle(), essid, secType, passphrase, _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "HiddenAPConnect", "");
+                    ret = Interop.WiFi.ConnectHiddenAP(GetSafeHandle(), essid, secType, passphrase, _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on HiddenAPConnect\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "HiddenAPConnect", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on HiddenAPConnect\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }
@@ -702,24 +678,21 @@ namespace Tizen.Network.WiFi
                 };
             }
 
-            context.Post((x) =>
+            Log.Info(Globals.LogTag, "Interop.WiFi.SpecificApStartMultiScan");
+            try
             {
-                Log.Info(Globals.LogTag, "Interop.WiFi.SpecificApStartMultiScan");
-                try
+                int ret = (int)WiFiError.None;
+                lock (_callback_map)
                 {
-                    int ret = (int)WiFiError.None;
-                    lock (_callback_map)
-                    {
-                        ret = Interop.WiFi.SpecificApStartMultiScan(GetSafeHandle(), _specificScanHandle, _callback_map[id], id);
-                    }
-                    CheckReturnValue(ret, "MultiScan", "");
+                    ret = Interop.WiFi.SpecificApStartMultiScan(GetSafeHandle(), _specificScanHandle, _callback_map[id], id);
                 }
-                catch (Exception e)
-                {
-                    Log.Error(Globals.LogTag, "Exception on Multi Scan\n" + e);
-                    task.SetException(e);
-                }
-            }, null);
+                CheckReturnValue(ret, "MultiScan", "");
+            }
+            catch (Exception e)
+            {
+                Log.Error(Globals.LogTag, "Exception on Multi Scan\n" + e);
+                task.SetException(e);
+            }
 
             return task.Task;
         }

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiManagerImpl.cs
@@ -149,11 +149,7 @@ namespace Tizen.Network.WiFi
             }
         }
 
-        private static ThreadLocal<HandleHolder> s_threadName = new ThreadLocal<HandleHolder>(() =>
-        {
-            Log.Info(Globals.LogTag, "In threadlocal delegate");
-            return new HandleHolder();
-        });
+        private static HandleHolder _handle = new HandleHolder();
 
         private WiFiManagerImpl()
         {
@@ -162,7 +158,7 @@ namespace Tizen.Network.WiFi
 
         internal SafeWiFiManagerHandle GetSafeHandle()
         {
-            return s_threadName.Value.GetSafeHandle();
+            return _handle.GetSafeHandle();
         }
 
         internal SafeWiFiManagerHandle Initialize()

--- a/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiNetworkChange.cs
+++ b/src/Tizen.Network.WiFi/Tizen.Network.WiFi/WiFiNetworkChange.cs
@@ -59,39 +59,34 @@ namespace Tizen.Network.WiFi
         {
             add
             {
-                context.Post((x) =>
+                if (_deviceStateChanged == null)
                 {
-                    if (_deviceStateChanged == null)
+                    try
                     {
-                        try
-                        {
-                            RegisterDeviceStateChangedEvent();
-                        } catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on adding DeviceStateChanged\n" + e);
-                            return;
-                        }
+                        RegisterDeviceStateChangedEvent();
                     }
-                    _deviceStateChanged += value;
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on adding DeviceStateChanged\n" + e);
+                        return;
+                    }
+                }
+                _deviceStateChanged += value;
             }
             remove
             {
-                context.Post((x) =>
+                _deviceStateChanged -= value;
+                if (_deviceStateChanged == null)
                 {
-                    _deviceStateChanged -= value;
-                    if (_deviceStateChanged == null)
+                    try
                     {
-                        try
-                        {
-                            UnregisterDeviceStateChangedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on removing DeviceStateChanged\n" + e);
-                        }
+                        UnregisterDeviceStateChangedEvent();
                     }
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on removing DeviceStateChanged\n" + e);
+                    }
+                }
             }
         }
 
@@ -99,40 +94,34 @@ namespace Tizen.Network.WiFi
         {
             add
             {
-                context.Post((x) =>
+                if (_connectionStateChanged == null)
                 {
-                    if (_connectionStateChanged == null)
+                    try
                     {
-                        try
-                        {
-                            RegisterConnectionStateChangedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on adding ConnectionStateChanged\n" + e);
-                            return;
-                        }
+                        RegisterConnectionStateChangedEvent();
                     }
-                    _connectionStateChanged += value;
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on adding ConnectionStateChanged\n" + e);
+                        return;
+                    }
+                }
+                _connectionStateChanged += value;
             }
             remove
             {
-                context.Post((x) =>
+                _connectionStateChanged -= value;
+                if (_connectionStateChanged == null)
                 {
-                    _connectionStateChanged -= value;
-                    if (_connectionStateChanged == null)
+                    try
                     {
-                        try
-                        {
-                            UnregisterConnectionStateChangedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on removing ConnectionStateChanged\n" + e);
-                        }
+                        UnregisterConnectionStateChangedEvent();
                     }
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on removing ConnectionStateChanged\n" + e);
+                    }
+                }
             }
         }
 
@@ -140,40 +129,34 @@ namespace Tizen.Network.WiFi
         {
             add
             {
-                context.Post((x) =>
+                if (_rssiLevelChanged == null)
                 {
-                    if (_rssiLevelChanged == null)
+                    try
                     {
-                        try
-                        {
-                            RegisterRssiLevelChangedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on adding RssiLevelChanged\n" + e);
-                            return;
-                        }
+                        RegisterRssiLevelChangedEvent();
                     }
-                    _rssiLevelChanged += value;
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on adding RssiLevelChanged\n" + e);
+                        return;
+                    }
+                }
+                _rssiLevelChanged += value;
             }
             remove
             {
-                context.Post((x) =>
+                _rssiLevelChanged -= value;
+                if (_rssiLevelChanged == null)
                 {
-                    _rssiLevelChanged -= value;
-                    if (_rssiLevelChanged == null)
+                    try
                     {
-                        try
-                        {
-                            UnregisterRssiLevelChangedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on removing RssiLevelChanged\n" + e);
-                        }
+                        UnregisterRssiLevelChangedEvent();
                     }
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on removing RssiLevelChanged\n" + e);
+                    }
+                }
             }
         }
 
@@ -181,40 +164,34 @@ namespace Tizen.Network.WiFi
         {
             add
             {
-                context.Post((x) =>
+                if (_scanStateChanged == null)
                 {
-                    if (_scanStateChanged == null)
+                    try
                     {
-                        try
-                        {
-                            RegisterScanStateChangedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on adding ScanStateChanged\n" + e);
-                            return;
-                        }
+                        RegisterScanStateChangedEvent();
                     }
-                    _scanStateChanged += value;
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on adding ScanStateChanged\n" + e);
+                        return;
+                    }
+                }
+                _scanStateChanged += value;
             }
             remove
             {
-                context.Post((x) =>
+                _scanStateChanged -= value;
+                if (_scanStateChanged == null)
                 {
-                    _scanStateChanged -= value;
-                    if (_scanStateChanged == null)
+                    try
                     {
-                        try
-                        {
-                            UnregisterScanStateChangedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on removing ScanStateChanged\n" + e);
-                        }
+                        UnregisterScanStateChangedEvent();
                     }
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on removing ScanStateChanged\n" + e);
+                    }
+                }
             }
         }
 
@@ -222,40 +199,34 @@ namespace Tizen.Network.WiFi
         {
             add
             {
-                context.Post((x) =>
+                if (_backgroundScanFinished == null)
                 {
-                    if (_backgroundScanFinished == null)
+                    try
                     {
-                        try
-                        {
-                            RegisterBackgroundScanFinishedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on adding BackgroundScanFinished\n" + e);
-                            return;
-                        }
+                        RegisterBackgroundScanFinishedEvent();
                     }
-                    _backgroundScanFinished += value;
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on adding BackgroundScanFinished\n" + e);
+                        return;
+                    }
+                }
+                _backgroundScanFinished += value;
             }
             remove
             {
-                context.Post((x) =>
+                _backgroundScanFinished -= value;
+                if (_backgroundScanFinished == null)
                 {
-                    _backgroundScanFinished -= value;
-                    if (_backgroundScanFinished == null)
+                    try
                     {
-                        try
-                        {
-                            UnregisterBackgroundScanFinishedEvent();
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(Globals.LogTag, "Exception on removing BackgroundScanFinished\n" + e);
-                        }
+                        UnregisterBackgroundScanFinishedEvent();
                     }
-                }, null);
+                    catch (Exception e)
+                    {
+                        Log.Error(Globals.LogTag, "Exception on removing BackgroundScanFinished\n" + e);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
**Description of Change:**
Remove thread local support in Tizen.Network.WiFi

**Reason of change:**
Until Tizen 5.0, wifi-manager handles were supported only as thread locals, so the WiFi C# API was implemented so.
However, starting from Tizen 6.0, wifi-manager was modified to remove this restriction, so there is no longer need to use Post().
So, this is being removed.

**API Changes:**
ACR: None

**Related:**
https://github.com/Samsung/TizenFX/pull/6659
