### PR TITLE
[NUI] Fix LayoutLength not to take invalid float values

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutLength.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutLength.cs
@@ -41,9 +41,20 @@ namespace Tizen.NUI
         /// Constructor from a float
         /// </summary>
         /// <param name="value">Float to initialize with.</param>
+        /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
         /// <since_tizen> 6 </since_tizen>
         public LayoutLength(float value)
         {
+            if (!float.IsFinite(value))
+            {
+                throw new ArgumentException("LayoutLength cannot take non-finite values.");
+            }
+
+            if (value == float.MinValue || value == float.MaxValue)
+            {
+                throw new ArgumentException("LayoutLength cannot take float.MinValue or float.MaxValue. Please use int.MinValue or int.MaxValue.");
+            }
+
             this.value = value;
         }
 
@@ -61,9 +72,20 @@ namespace Tizen.NUI
         /// Constructor from a LayoutDimension
         /// </summary>
         /// <param name="layoutDimension">LayoutSize to initialize with.</param>
+        /// <exception cref="ArgumentException">Thrown when the argument is invalid.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public LayoutLength(LayoutDimension layoutDimension)
         {
+            if (!float.IsFinite(layoutDimension))
+            {
+                throw new ArgumentException("LayoutLength cannot take non-finite values.");
+            }
+
+            if (layoutDimension == float.MinValue || layoutDimension == float.MaxValue)
+            {
+                throw new ArgumentException("LayoutLength cannot take float.MinValue or float.MaxValue. Please use int.MinValue or int.MaxValue.");
+            }
+
             this.value = layoutDimension;
         }
 


### PR DESCRIPTION
### Description of Change ###
LayoutLength is fixed not to take invalid float values such as non-finite values, float.MinValue, float.MaxValue. If user wants to use float.MinValue or float.MaxValue, then int.MinValue or int.MaxValue are suggested.


### API Changes ###
nothing