### PR TITLE
[NUI] Add UIColor constructor without alpha value

### DIFF
--- a/src/Tizen.NUI/src/devel/Lite/UIColor.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIColor.cs
@@ -106,6 +106,19 @@ namespace Tizen.NUI
         /// <summary>
         /// Initializes a new instance of the <see cref="UIColor"/> struct.
         /// </summary>
+        /// <param name="value">The value of 0xRRGGBB format.</param>
+        /// <example>
+        /// <code>
+        ///     new UIColor(0xFF0000); // Solid red
+        /// </code>
+        /// </example>
+        public UIColor(uint value) : this(value, 1f)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UIColor"/> struct.
+        /// </summary>
         /// <param name="tokenId">The unique identifier of the token.</param>
         /// <param name="multiplyAlpha">The alpha value to multiply by.</param>
         /// <param name="fixedAlpha">The fixed alpha value.</param>


### PR DESCRIPTION
### Description of Change ###
Add a new constructor of `UIColor` which allows alphs value omission for hex expression.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
