### PR TITLE
[NUI] Fix to apply text objects' padding after added to view

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -4918,7 +4918,7 @@ namespace Tizen.NUI.BaseComponents
                 if (layoutExtraData != null && extents is Extents newPadding)
                     SetPadding(new UIExtents(newPadding.Start, newPadding.End, newPadding.Top, newPadding.Bottom), false);
 
-                if (Layout != null)
+                if (Layout != null && !Layout.IsPaddingHandledByNative())
                 {
                     Layout.Padding = new Extents((Extents)extents);
                     if ((Padding.Start != 0) || (Padding.End != 0) || (Padding.Top != 0) || (Padding.Bottom != 0))


### PR DESCRIPTION
Previously, Padding of text objects such as TextLabel, TextField, TextEditor was not applied if Padding was set after those objects were added to Layout View.
e.g. The following did not work
var textLabel = new TextLabel();
absoluteLayoutView.Add(textLabel);
textLabel.Padding = padding;

Now, the above problem has been resolved by not clearing Padding of those text objects.
Padding of those text objects is managed by native.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
