### PR TITLE
Restore AbsoluteLayout not to apply margin/padding without bounds

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -147,12 +147,14 @@ namespace Tizen.NUI
                     continue;
                 }
 
+                var isBoundsSet = childLayout.Owner.GetAttached<LayoutParams>() != null;
+
                 Extents childMargin = childLayout.Margin;
                 var rect = GetLayoutBounds(childLayout.Owner);
                 var flags = GetLayoutFlags(childLayout.Owner);
 
-                // If child view positions with using pivot point, then padding and margin are not used.
-                if (childLayout.Owner.PositionUsesPivotPoint)
+                // If child view does not use bounds, then padding and margin are not used.
+                if (!isBoundsSet)
                 {
                     MeasureChildWithoutPadding(childLayout, widthMeasureSpec, heightMeasureSpec);
                 }
@@ -206,8 +208,8 @@ namespace Tizen.NUI
                 float childRight;
                 float childBottom;
 
-                // If child view positions with using pivot point, then padding and margin are not used.
-                if (childLayout.Owner.PositionUsesPivotPoint)
+                // If child view does not use bounds, then padding and margin are not used.
+                if (!isBoundsSet)
                 {
                     childRight = childLayout.MeasuredWidth.Size.AsDecimal() + childLayout.Owner.PositionX;
                     childBottom = childLayout.MeasuredHeight.Size.AsDecimal() + childLayout.Owner.PositionY;
@@ -267,6 +269,8 @@ namespace Tizen.NUI
                     continue;
                 }
 
+                var isBoundsSet = childLayout.Owner.GetAttached<LayoutParams>() != null;
+
                 Extents childMargin = childLayout.Margin;
 
                 LayoutLength childWidth = childLayout.MeasuredWidth.Size;
@@ -275,8 +279,8 @@ namespace Tizen.NUI
                 LayoutLength childLeft;
                 LayoutLength childTop;
 
-                // If child view positions with using pivot point, then padding and margin are not used.
-                if (childLayout.Owner.PositionUsesPivotPoint)
+                // If child view does not use bounds, then padding and margin are not used.
+                if (!isBoundsSet)
                 {
                     childLeft = new LayoutLength(childLayout.Owner.PositionX);
                     childTop = new LayoutLength(childLayout.Owner.PositionY);
@@ -284,18 +288,17 @@ namespace Tizen.NUI
                 }
                 else
                 {
-                    var isBoundsSet = childLayout.Owner.GetAttached<LayoutParams>() != null;
                     var rect = GetLayoutBounds(childLayout.Owner);
                     var flags = GetLayoutFlags(childLayout.Owner);
                     var isXProportional = flags.HasFlag(AbsoluteLayoutFlags.XProportional);
                     var isYProportional = flags.HasFlag(AbsoluteLayoutFlags.YProportional);
 
-                    var childX = MeasurePosition(isBoundsSet, childLayout.Owner.PositionX, rect.X, isXProportional,
+                    var childX = MeasureBoundsPosition(rect.X, isXProportional,
                                 MeasuredWidth.Size.AsDecimal() - (Padding.Start + Padding.End),
                                 childWidth.AsDecimal() + (childMargin.Start + childMargin.End),
                                 Padding.Start, childMargin.Start);
 
-                    var childY = MeasurePosition(isBoundsSet, childLayout.Owner.PositionY, rect.Y, isYProportional,
+                    var childY = MeasureBoundsPosition(rect.Y, isYProportional,
                                 MeasuredHeight.Size.AsDecimal() - (Padding.Top + Padding.Bottom),
                                 childHeight.AsDecimal() + (childMargin.Top + childMargin.Bottom),
                                 Padding.Top, childMargin.Bottom);
@@ -334,19 +337,6 @@ namespace Tizen.NUI
             else
             {
                 return paddingBegin + boundsValue + marginBegin;
-            }
-        }
-
-        private float MeasurePosition(bool isBoundsSet, float position, float boundsValue, bool proportional, float constraint, float sizeWithMargin, float paddingBegin, float marginBegin)
-        {
-            // If user sets LayoutBounds, use LayoutBounds. Otherwise, use Position property.
-            if (isBoundsSet)
-            {
-                return MeasureBoundsPosition(boundsValue, proportional, constraint, sizeWithMargin, paddingBegin, marginBegin);
-            }
-            else
-            {
-                return paddingBegin + position + marginBegin;
             }
         }
 

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBounds.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBounds.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -45,7 +45,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -53,7 +53,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBounds.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBounds.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBounds : View, IExample
+    {
+        public AbsoluteBounds()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsMargin.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -55,7 +55,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsMargin.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsMargin : View, IExample
+    {
+        public AbsoluteBoundsMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -54,7 +54,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMargin.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPMargin : View, IExample
+    {
+        public AbsoluteBoundsPMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 100;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds ParentMargin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginMargin.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPMarginMargin : View, IExample
+    {
+        public AbsoluteBoundsPMarginMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 100;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds ParentMargin Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -56,7 +56,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPadding.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
+                Padding = 100,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -55,7 +55,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPadding.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPMarginPadding : View, IExample
+    {
+        public AbsoluteBoundsPMarginPadding()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 100;
+            Padding = 100;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds ParentMargin Padding", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPaddingMargin.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
+                Padding = 100,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -57,7 +57,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPMarginPaddingMargin.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPMarginPaddingMargin : View, IExample
+    {
+        public AbsoluteBoundsPMarginPaddingMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 100;
+            Padding = 100;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds ParentMargin Padding Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPadding.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -54,7 +54,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPadding.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPadding : View, IExample
+    {
+        public AbsoluteBoundsPadding()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Padding = 100;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds Padding", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPaddingMargin.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPaddingMargin : View, IExample
+    {
+        public AbsoluteBoundsPaddingMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Padding = 100;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 100,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "Bounds Padding Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPaddingMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 100, 100));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -56,7 +56,7 @@ namespace NUILayout
                 Margin = 100,
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(100, 100, 100, 100));
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsProp.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsProp.cs
@@ -1,0 +1,88 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsProp : View, IExample
+    {
+        public AbsoluteBoundsProp()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsProp.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsProp.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -45,7 +45,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -54,7 +54,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMargin.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 Margin = 50,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -56,7 +56,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMargin.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPropMargin : View, IExample
+    {
+        public AbsoluteBoundsPropMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 50,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 50,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMargin.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPropPMargin : View, IExample
+    {
+        public AbsoluteBoundsPropPMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 50;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp ParentMargin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 50;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 50,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -55,7 +55,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 50;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 50,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 Margin = 50
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -57,7 +57,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginMargin.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPropPMarginMargin : View, IExample
+    {
+        public AbsoluteBoundsPropPMarginMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 50;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 50
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 50,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp ParentMargin Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPadding.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPropPMarginPadding : View, IExample
+    {
+        public AbsoluteBoundsPropPMarginPadding()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 50;
+            Padding = 50;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp ParentMargin Padding", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPadding.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 50;
-            Padding = 50;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 50,
+                Padding = 50,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -56,7 +56,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPaddingMargin.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPropPMarginPaddingMargin : View, IExample
+    {
+        public AbsoluteBoundsPropPMarginPaddingMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Margin = 50;
+            Padding = 50;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 50,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 50,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp ParentMargin Padding Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPMarginPaddingMargin.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 50;
-            Padding = 50;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = LayoutParamPolicies.MatchParent,
-                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 50,
+                Padding = 50,
             };
-            Add(background);
+            AbsoluteLayout.SetLayoutBounds(absoluteLayout, new UIRect(0, 0, 1, 1));
+            AbsoluteLayout.SetLayoutFlags(absoluteLayout, AbsoluteLayoutFlags.All);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 Margin = 50,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -58,7 +58,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPadding.cs
@@ -1,0 +1,89 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPropPadding : View, IExample
+    {
+        public AbsoluteBoundsPropPadding()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Padding = 50;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp Padding", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPadding.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 50;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 50,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -55,7 +55,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPaddingMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 50;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 50,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 Margin = 50,
             };
             AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -57,7 +57,7 @@ namespace NUILayout
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropPaddingMargin.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using Tizen.NUI.Components;
+
+namespace NUILayout
+{
+    internal class AbsoluteBoundsPropPaddingMargin : View, IExample
+    {
+        public AbsoluteBoundsPropPaddingMargin()
+        {
+            Layout = new AbsoluteLayout();
+            WidthSpecification = LayoutParamPolicies.MatchParent;
+            HeightSpecification = LayoutParamPolicies.MatchParent;
+            BackgroundColor = Color.Gray;
+            Padding = 50;
+
+            var background = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.DarkGray,
+            };
+            Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.LightBlue,
+                Margin = 50,
+            };
+            AbsoluteLayout.SetLayoutBounds(origin, new UIRect(0, 0, 50, 50));
+            Add(origin);
+
+            var view = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                BackgroundColor = Color.Blue,
+                Margin = 50,
+            };
+            AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
+            AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);
+            Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
+        }
+
+        public void Activate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Activate()");
+
+            var contentPage = new ContentPage()
+            {
+                AppBar = new AppBar() { Title = "BoundsProp Padding Margin", BackgroundColor = Color.White },
+                Content = this,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
+                BackgroundColor = Color.LightGray,
+            };
+            Window.Default.GetDefaultNavigator().Push(contentPage);
+        }
+        public void Deactivate()
+        {
+            Console.WriteLine($"@@@ this.GetType().Name={this.GetType().Name}, Deactivate()");
+            Window.Default.GetDefaultNavigator().Pop();
+        }
+    }
+}

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatch.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatch.cs
@@ -47,6 +47,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatch.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatch.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatch.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatch.cs
@@ -21,15 +21,14 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsoluteMatch : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsoluteMatch()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
             var background = new View()
             {
@@ -43,12 +42,9 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
             };
             Add(view);
         }
@@ -59,7 +55,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchMargin.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchMargin.cs
@@ -21,15 +21,14 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsoluteMatchMargin : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsoluteMatchMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
             var background = new View()
             {
@@ -43,12 +42,10 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
+                Margin = 100,
             };
             Add(view);
         }
@@ -59,7 +56,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchMargin.cs
@@ -48,6 +48,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMargin.cs
@@ -21,15 +21,14 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePMarginPaddingMarginPos : View, IExample
+    internal class AbsoluteMatchPMargin : View, IExample
     {
-        public AbsolutePMarginPaddingMarginPos()
+        public AbsoluteMatchPMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
             Margin = 100;
 
             var background = new View()
@@ -44,11 +43,9 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
-                Position = new Position(100, 100),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
-                Margin = 100,
             };
             Add(view);
         }
@@ -59,7 +56,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "ParentMargin Padding Margin Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent ParentMargin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMargin.cs
@@ -48,6 +48,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginMargin.cs
@@ -21,9 +21,9 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsoluteMatchPMarginMargin : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsoluteMatchPMarginMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
@@ -43,12 +43,10 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
+                Margin = 100,
             };
             Add(view);
         }
@@ -59,7 +57,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent ParentMargin Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginMargin.cs
@@ -49,6 +49,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPadding.cs
@@ -49,6 +49,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPadding.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPadding.cs
@@ -21,14 +21,15 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePaddingPos : View, IExample
+    internal class AbsoluteMatchPMarginPadding : View, IExample
     {
-        public AbsolutePaddingPos()
+        public AbsoluteMatchPMarginPadding()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
+            Margin = 100;
             Padding = 100;
 
             var background = new View()
@@ -43,9 +44,8 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
-                Position = new Position(100, 100),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
             };
             Add(view);
@@ -57,7 +57,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "Padding Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent ParentMargin Padding", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPaddingMargin.cs
@@ -21,15 +21,16 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsoluteMatchPMarginPaddingMargin : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsoluteMatchPMarginPaddingMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
             Margin = 100;
+            Padding = 100;
 
             var background = new View()
             {
@@ -43,12 +44,10 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
+                Margin = 100,
             };
             Add(view);
         }
@@ -59,7 +58,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent ParentMargin Padding Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPaddingMargin.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -49,7 +49,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPMarginPaddingMargin.cs
@@ -50,6 +50,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPadding.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPadding.cs
@@ -21,15 +21,15 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePMarginPos : View, IExample
+    internal class AbsoluteMatchPadding : View, IExample
     {
-        public AbsolutePMarginPos()
+        public AbsoluteMatchPadding()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
+            Padding = 100;
 
             var background = new View()
             {
@@ -43,9 +43,8 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
-                Position = new Position(100, 100),
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
             };
             Add(view);
@@ -57,7 +56,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "ParentMargin Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent Padding", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPadding.cs
@@ -48,6 +48,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPaddingMargin.cs
@@ -21,15 +21,15 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsoluteMatchPaddingMargin : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsoluteMatchPaddingMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
+            Padding = 100;
 
             var background = new View()
             {
@@ -43,12 +43,10 @@ namespace NUILayout
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
-                WidthSpecification = 100,
-                HeightSpecification = 100,
+                WidthSpecification = LayoutParamPolicies.MatchParent,
+                HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
+                Margin = 100,
             };
             Add(view);
         }
@@ -59,7 +57,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "MatchParent Padding Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPaddingMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteMatchPaddingMargin.cs
@@ -49,6 +49,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEnd.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEnd.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -49,7 +49,7 @@ namespace NUILayout
                 PivotPoint = new Position(1.0f, 1.0f),
                 ParentOrigin = new Position(1.0f, 1.0f),
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEnd.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEnd.cs
@@ -50,6 +50,14 @@ namespace NUILayout
                 ParentOrigin = new Position(1.0f, 1.0f),
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPMargin.cs
@@ -51,6 +51,14 @@ namespace NUILayout
                 ParentOrigin = new Position(1.0f, 1.0f),
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPMargin.cs
@@ -59,7 +59,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotBottomEnd PMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "PivotBottomEnd ParentMargin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -50,7 +50,7 @@ namespace NUILayout
                 PivotPoint = new Position(1.0f, 1.0f),
                 ParentOrigin = new Position(1.0f, 1.0f),
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPaddingMargin.cs
@@ -52,6 +52,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotBottomEndPaddingMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -51,7 +51,7 @@ namespace NUILayout
                 ParentOrigin = new Position(1.0f, 1.0f),
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenter.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenter.cs
@@ -50,6 +50,14 @@ namespace NUILayout
                 ParentOrigin = new Position(0.5f, 0.5f),
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenter.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenter.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -49,7 +49,7 @@ namespace NUILayout
                 PivotPoint = new Position(0.5f, 0.5f),
                 ParentOrigin = new Position(0.5f, 0.5f),
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -50,7 +50,7 @@ namespace NUILayout
                 PivotPoint = new Position(0.5f, 0.5f),
                 ParentOrigin = new Position(0.5f, 0.5f),
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPMargin.cs
@@ -51,6 +51,14 @@ namespace NUILayout
                 ParentOrigin = new Position(0.5f, 0.5f),
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPaddingMargin.cs
@@ -52,6 +52,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotCenterPaddingMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -51,7 +51,7 @@ namespace NUILayout
                 ParentOrigin = new Position(0.5f, 0.5f),
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStart.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStart.cs
@@ -50,6 +50,14 @@ namespace NUILayout
                 ParentOrigin = new Position(0.0f, 0.0f),
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStart.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStart.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -49,7 +49,7 @@ namespace NUILayout
                 PivotPoint = new Position(0.0f, 0.0f),
                 ParentOrigin = new Position(0.0f, 0.0f),
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPMargin.cs
@@ -51,6 +51,14 @@ namespace NUILayout
                 ParentOrigin = new Position(0.0f, 0.0f),
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -50,7 +50,7 @@ namespace NUILayout
                 PivotPoint = new Position(0.0f, 0.0f),
                 ParentOrigin = new Position(0.0f, 0.0f),
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPMargin.cs
@@ -59,7 +59,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotTopStart PMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "PivotTopStart ParentMargin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPaddingMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var view = new View()
             {
@@ -51,7 +51,7 @@ namespace NUILayout
                 ParentOrigin = new Position(0.0f, 0.0f),
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePivotTopStartPaddingMargin.cs
@@ -52,6 +52,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePos.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePos.cs
@@ -57,6 +57,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePos.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePos.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -46,7 +46,7 @@ namespace NUILayout
                 HeightSpecification = 100,
                 BackgroundColor = Color.LightBlue,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -56,7 +56,7 @@ namespace NUILayout
                 Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePos.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePos.cs
@@ -39,6 +39,15 @@ namespace NUILayout
             };
             Add(background);
 
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+            };
+            Add(origin);
+
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
@@ -56,7 +65,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosMargin.cs
@@ -21,15 +21,14 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsolutePosMargin : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsolutePosMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
             var background = new View()
             {
@@ -40,15 +39,24 @@ namespace NUILayout
             };
             Add(background);
 
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            Add(origin);
+
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = 100,
                 HeightSpecification = 100,
+                Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
+                Margin = 100,
             };
             Add(view);
         }
@@ -59,7 +67,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosMargin.cs
@@ -30,14 +30,14 @@ namespace NUILayout
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
                 Margin = 100,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -58,7 +58,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosMargin.cs
@@ -59,6 +59,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 HeightSpecification = 100,
                 BackgroundColor = Color.LightBlue,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -57,7 +57,7 @@ namespace NUILayout
                 Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMargin.cs
@@ -21,15 +21,15 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePaddingMarginPos : View, IExample
+    internal class AbsolutePosPMargin : View, IExample
     {
-        public AbsolutePaddingMarginPos()
+        public AbsolutePosPMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
+            Margin = 100;
 
             var background = new View()
             {
@@ -40,6 +40,15 @@ namespace NUILayout
             };
             Add(background);
 
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+            };
+            Add(origin);
+
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
@@ -47,7 +56,6 @@ namespace NUILayout
                 HeightSpecification = 100,
                 Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
-                Margin = 100,
             };
             Add(view);
         }
@@ -58,7 +66,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "Padding Margin Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position ParentMargin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMargin.cs
@@ -58,6 +58,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginMargin.cs
@@ -21,9 +21,9 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsolutePosPMarginMargin : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsolutePosPMarginMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
@@ -40,15 +40,24 @@ namespace NUILayout
             };
             Add(background);
 
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            Add(origin);
+
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = 100,
                 HeightSpecification = 100,
+                Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
+                Margin = 100,
             };
             Add(view);
         }
@@ -59,7 +68,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position ParentMargin Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginMargin.cs
@@ -60,6 +60,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
                 Margin = 100,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -59,7 +59,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPadding.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 HeightSpecification = 100,
                 BackgroundColor = Color.LightBlue,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -58,7 +58,7 @@ namespace NUILayout
                 Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPadding.cs
@@ -21,14 +21,15 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePivotCenterPMargin : View, IExample
+    internal class AbsolutePosPMarginPadding : View, IExample
     {
-        public AbsolutePivotCenterPMargin()
+        public AbsolutePosPMarginPadding()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
+            Padding = 100;
             Margin = 100;
 
             var background = new View()
@@ -40,15 +41,22 @@ namespace NUILayout
             };
             Add(background);
 
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+            };
+            Add(origin);
+
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = 100,
                 HeightSpecification = 100,
+                Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
-                PositionUsesPivotPoint = true,
-                PivotPoint = new Position(0.5f, 0.5f),
-                ParentOrigin = new Position(0.5f, 0.5f),
             };
             Add(view);
         }
@@ -59,7 +67,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "PivotCenter ParentMargin", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position ParentMargin Padding", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPadding.cs
@@ -59,6 +59,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPaddingMargin.cs
@@ -21,9 +21,9 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePMarginPaddingPos : View, IExample
+    internal class AbsolutePosPMarginPaddingMargin : View, IExample
     {
-        public AbsolutePMarginPaddingPos()
+        public AbsolutePosPMarginPaddingMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
@@ -41,6 +41,16 @@ namespace NUILayout
             };
             Add(background);
 
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            Add(origin);
+
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
@@ -48,6 +58,7 @@ namespace NUILayout
                 HeightSpecification = 100,
                 Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
+                Margin = 100,
             };
             Add(view);
         }
@@ -58,7 +69,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "ParentMargin Padding Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position ParentMargin Padding Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPaddingMargin.cs
@@ -61,6 +61,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPMarginPaddingMargin.cs
@@ -29,17 +29,17 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
-            Margin = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Margin = 100,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -49,7 +49,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
                 Margin = 100,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -60,7 +60,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPadding.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -47,7 +47,7 @@ namespace NUILayout
                 HeightSpecification = 100,
                 BackgroundColor = Color.LightBlue,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -57,7 +57,7 @@ namespace NUILayout
                 Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPadding.cs
@@ -21,14 +21,15 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsoluteMarginPos : View, IExample
+    internal class AbsolutePosPadding : View, IExample
     {
-        public AbsoluteMarginPos()
+        public AbsolutePosPadding()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
+            Padding = 100;
 
             var background = new View()
             {
@@ -39,6 +40,15 @@ namespace NUILayout
             };
             Add(background);
 
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+            };
+            Add(origin);
+
             var view = new View()
             {
                 Layout = new AbsoluteLayout(),
@@ -46,7 +56,6 @@ namespace NUILayout
                 HeightSpecification = 100,
                 Position = new Position(100, 100),
                 BackgroundColor = Color.Blue,
-                Margin = 100,
             };
             Add(view);
         }
@@ -57,7 +66,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "Margin Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position Padding", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPadding.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPadding.cs
@@ -58,6 +58,14 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPaddingMargin.cs
@@ -60,6 +60,14 @@ namespace NUILayout
                 Margin = 100,
             };
             Add(view);
+
+            var timer = new Tizen.NUI.Timer(1000);
+            timer.Tick += (o, e) =>
+            {
+                view.Layout.RequestLayout(); // Test if AbsoluteLayout position is updated unexpectedly.
+                return true;
+            };
+            timer.Start();
         }
 
         public void Activate()

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPaddingMargin.cs
@@ -29,16 +29,16 @@ namespace NUILayout
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Padding = 100;
 
-            var background = new View()
+            var absoluteLayout = new View()
             {
                 Layout = new AbsoluteLayout(),
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,
                 BackgroundColor = Color.DarkGray,
+                Padding = 100,
             };
-            Add(background);
+            Add(absoluteLayout);
 
             var origin = new View()
             {
@@ -48,7 +48,7 @@ namespace NUILayout
                 BackgroundColor = Color.LightBlue,
                 Margin = 100,
             };
-            Add(origin);
+            absoluteLayout.Add(origin);
 
             var view = new View()
             {
@@ -59,7 +59,7 @@ namespace NUILayout
                 BackgroundColor = Color.Blue,
                 Margin = 100,
             };
-            Add(view);
+            absoluteLayout.Add(view);
 
             var timer = new Tizen.NUI.Timer(1000);
             timer.Tick += (o, e) =>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPaddingMargin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsolutePosPaddingMargin.cs
@@ -21,15 +21,15 @@ using Tizen.NUI.Components;
 
 namespace NUILayout
 {
-    internal class AbsolutePMarginMarginPos : View, IExample
+    internal class AbsolutePosPaddingMargin : View, IExample
     {
-        public AbsolutePMarginMarginPos()
+        public AbsolutePosPaddingMargin()
         {
             Layout = new AbsoluteLayout();
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = Color.Gray;
-            Margin = 100;
+            Padding = 100;
 
             var background = new View()
             {
@@ -39,6 +39,16 @@ namespace NUILayout
                 BackgroundColor = Color.DarkGray,
             };
             Add(background);
+
+            var origin = new View()
+            {
+                Layout = new AbsoluteLayout(),
+                WidthSpecification = 100,
+                HeightSpecification = 100,
+                BackgroundColor = Color.LightBlue,
+                Margin = 100,
+            };
+            Add(origin);
 
             var view = new View()
             {
@@ -58,7 +68,7 @@ namespace NUILayout
 
             var contentPage = new ContentPage()
             {
-                AppBar = new AppBar() { Title = "ParentMargin Margin Pos", BackgroundColor = Color.White },
+                AppBar = new AppBar() { Title = "Position Padding Margin", BackgroundColor = Color.White },
                 Content = this,
                 WidthSpecification = LayoutParamPolicies.MatchParent,
                 HeightSpecification = LayoutParamPolicies.MatchParent,


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
