### PR TITLE
[NUI] Apply Margin to LinearLayout cases in NUILayout

### DIFF
--- a/test/NUILayout/Examples/LinearLayoutTest/LinearHMatchMargin.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearHMatchMargin.cs
@@ -38,6 +38,8 @@ namespace NUILayout
                 BackgroundColor = Color.DarkGray,
                 Margin = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];

--- a/test/NUILayout/Examples/LinearLayoutTest/LinearHMatchMarginPadding.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearHMatchMarginPadding.cs
@@ -39,6 +39,8 @@ namespace NUILayout
                 Margin = 50,
                 Padding = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];

--- a/test/NUILayout/Examples/LinearLayoutTest/LinearHSizeMargin.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearHSizeMargin.cs
@@ -40,6 +40,8 @@ namespace NUILayout
                 BackgroundColor = Color.DarkGray,
                 Margin = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];

--- a/test/NUILayout/Examples/LinearLayoutTest/LinearHSizeMarginPadding.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearHSizeMarginPadding.cs
@@ -41,6 +41,8 @@ namespace NUILayout
                 Margin = 50,
                 Padding = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];

--- a/test/NUILayout/Examples/LinearLayoutTest/LinearVMatchMargin.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearVMatchMargin.cs
@@ -41,6 +41,8 @@ namespace NUILayout
                 BackgroundColor = Color.DarkGray,
                 Margin = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];

--- a/test/NUILayout/Examples/LinearLayoutTest/LinearVMatchMarginPadding.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearVMatchMarginPadding.cs
@@ -42,6 +42,8 @@ namespace NUILayout
                 Margin = 50,
                 Padding = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];

--- a/test/NUILayout/Examples/LinearLayoutTest/LinearVSizeMargin.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearVSizeMargin.cs
@@ -43,6 +43,8 @@ namespace NUILayout
                 BackgroundColor = Color.DarkGray,
                 Margin = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];

--- a/test/NUILayout/Examples/LinearLayoutTest/LinearVSizeMarginPadding.cs
+++ b/test/NUILayout/Examples/LinearLayoutTest/LinearVSizeMarginPadding.cs
@@ -44,6 +44,8 @@ namespace NUILayout
                 Margin = 50,
                 Padding = 50,
             };
+            // This allows AbsoluteLayout to apply margin of its child view.
+            AbsoluteLayout.SetLayoutBounds(linearLayout, new UIRect(0, 0, AbsoluteLayout.LayoutBoundsAutoSized, AbsoluteLayout.LayoutBoundsAutoSized));
             Add(linearLayout);
 
             var views = new View[LayoutChildren.Count];


### PR DESCRIPTION
### Description of Change ###
In LinearLayout cases of NUILayout, LinearLayout is a child of AbsoluteLayout.
To apply Margin of LinearLayout as a child of AbsoluteLayout, AbsoluteLayout.SetLayoutBounds is added.


### API Changes ###
nothing