### PR TITLE
[NUI] Fix Layout to respect MinimumSize and MaximumSize

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -2844,15 +2844,16 @@ namespace Tizen.NUI.BaseComponents
                 float specHeight = heightMeasureSpec.Size.AsDecimal();
                 float naturalWidth = Owner.NaturalSize.Width;
                 float naturalHeight = Owner.NaturalSize.Height;
-                float minWidth = Owner.MinimumSize.Width;
-                float maxWidth = Owner.MaximumSize.Width;
-                float minHeight = Owner.MinimumSize.Height;
-                float maxHeight = Owner.MaximumSize.Height;
+                var minWidth = Owner.GetMinimumWidth();
+                var minHeight = Owner.GetMinimumHeight();
+                var maxWidth = Owner.GetMaximumWidth();
+                var maxHeight = Owner.GetMaximumHeight();
                 float aspectRatio = (naturalWidth > 0) ? (naturalHeight / naturalWidth) : 0;
 
                 // Assume that the new width and height are given from the view's suggested size by default.
-                float newWidth = Math.Min(Math.Max(naturalWidth, minWidth), (maxWidth < 0 ? Int32.MaxValue : maxWidth));
-                float newHeight = Math.Min(Math.Max(naturalHeight, minHeight), (maxHeight < 0 ? Int32.MaxValue : maxHeight));
+                // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                float newWidth = Math.Max(Math.Min(naturalWidth, maxWidth < 0 ? Int32.MaxValue : maxWidth), minWidth);
+                float newHeight = Math.Max(Math.Min(naturalHeight, maxHeight < 0 ? Int32.MaxValue : maxHeight), minHeight);
 
                 // The width and height measure specs are going to be used to set measured size.
                 // Mark that the measure specs are changed by default to update measure specs later.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -5136,8 +5136,10 @@ namespace Tizen.NUI.BaseComponents
                 // Padding will be automatically applied by DALi TextEditor.
                 var totalWidth = widthMeasureSpec.Size.AsDecimal();
                 var totalHeight = heightMeasureSpec.Size.AsDecimal();
-                var minSize = Owner.MinimumSize;
-                var maxSize = Owner.MaximumSize;
+                var minWidth = Owner.GetMinimumWidth();
+                var minHeight = Owner.GetMinimumHeight();
+                var maxWidth = Owner.GetMaximumWidth();
+                var maxHeight = Owner.GetMaximumHeight();
                 var naturalSize = Owner.GetNaturalSize();
 
                 if (((TextEditor)Owner).Text.Length == 0)
@@ -5171,13 +5173,15 @@ namespace Tizen.NUI.BaseComponents
                 if (widthMeasureSpec.Mode != MeasureSpecification.ModeType.Exactly)
                 {
                     float width = naturalSize != null ? naturalSize.Width : 0;
-                    totalWidth = Math.Min(Math.Max(width, minSize.Width), maxSize.Width);
+                    // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                    totalWidth = Math.Max(Math.Min(width, maxWidth), minWidth);
                 }
 
                 if (heightMeasureSpec.Mode != MeasureSpecification.ModeType.Exactly)
                 {
                     float height = naturalSize != null ? naturalSize.Height : 0;
-                    totalHeight = Math.Min(Math.Max(height, minSize.Height), maxSize.Height);
+                    // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                    totalHeight = Math.Max(Math.Min(height, maxHeight), minHeight);
                 }
 
                 widthMeasureSpec = new MeasureSpecification(new LayoutLength(totalWidth), MeasureSpecification.ModeType.Exactly);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -5087,8 +5087,10 @@ namespace Tizen.NUI.BaseComponents
                 // Padding will be automatically applied by DALi TextField.
                 var totalWidth = widthMeasureSpec.Size.AsDecimal();
                 var totalHeight = heightMeasureSpec.Size.AsDecimal();
-                var minSize = Owner.MinimumSize;
-                var maxSize = Owner.MaximumSize;
+                var minWidth = Owner.GetMinimumWidth();
+                var minHeight = Owner.GetMinimumHeight();
+                var maxWidth = Owner.GetMaximumWidth();
+                var maxHeight = Owner.GetMaximumHeight();
                 var naturalSize = Owner.GetNaturalSize();
 
                 if (((TextField)Owner).Text.Length == 0)
@@ -5122,13 +5124,15 @@ namespace Tizen.NUI.BaseComponents
                 if (widthMeasureSpec.Mode != MeasureSpecification.ModeType.Exactly)
                 {
                     float width = naturalSize != null ? naturalSize.Width : 0;
-                    totalWidth = Math.Min(Math.Max(width, minSize.Width), maxSize.Width);
+                    // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                    totalWidth = Math.Max(Math.Min(width, maxWidth), minWidth);
                 }
 
                 if (heightMeasureSpec.Mode != MeasureSpecification.ModeType.Exactly)
                 {
                     float height = naturalSize != null ? naturalSize.Height : 0;
-                    totalHeight = Math.Min(Math.Max(height, minSize.Height), maxSize.Height);
+                    // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                    totalHeight = Math.Max(Math.Min(height, maxHeight), minHeight);
                 }
 
                 widthMeasureSpec = new MeasureSpecification(new LayoutLength(totalWidth), MeasureSpecification.ModeType.Exactly);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -51,23 +51,27 @@ namespace Tizen.NUI.BaseComponents
                 }
                 else
                 {
-                    var minSize = Owner.MinimumSize;
-                    var maxSize = Owner.MaximumSize;
+                    var minWidth = Owner.GetMinimumWidth();
+                    var minHeight = Owner.GetMinimumHeight();
+                    var maxWidth = Owner.GetMaximumWidth();
+                    var maxHeight = Owner.GetMaximumHeight();
                     var naturalSize = Owner.GetNaturalSize();
 
                     if (heightMeasureSpec.Mode == MeasureSpecification.ModeType.Exactly)
                     {
                         // GetWidthForHeight is not implemented.
                         float width = naturalSize != null ? naturalSize.Width : 0;
-                        totalWidth = Math.Min(Math.Max(width, minSize.Width), (maxSize.Width < 0 ? Int32.MaxValue : maxSize.Width));
+                        // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                        totalWidth = Math.Max(Math.Min(width, maxWidth < 0 ? Int32.MaxValue : maxWidth), minWidth);
                         widthMeasureSpec = new MeasureSpecification(new LayoutLength(totalWidth), MeasureSpecification.ModeType.Exactly);
                     }
                     else
                     {
                         float width = naturalSize != null ? naturalSize.Width : 0;
                         float height = naturalSize != null ? naturalSize.Height : 0;
-                        totalWidth = Math.Min(Math.Max(width, minSize.Width), (maxSize.Width < 0 ? Int32.MaxValue : maxSize.Width));
-                        totalHeight = Math.Min(Math.Max(height, minSize.Height), (maxSize.Height < 0 ? Int32.MaxValue : maxSize.Height));
+                        // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                        totalWidth = Math.Max(Math.Min(width, maxWidth < 0 ? Int32.MaxValue : maxWidth), minWidth);
+                        totalHeight = Math.Max(Math.Min(height, maxHeight < 0 ? Int32.MaxValue : maxHeight), minHeight);
 
                         heightMeasureSpec = new MeasureSpecification(new LayoutLength(totalHeight), MeasureSpecification.ModeType.Exactly);
                         widthMeasureSpec = new MeasureSpecification(new LayoutLength(totalWidth), MeasureSpecification.ModeType.Exactly);

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -571,12 +571,12 @@ namespace Tizen.NUI
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
                         new MeasureSpecification(new LayoutLength(parentWidthMeasureSpec.Size), parentWidthMeasureSpec.Mode),
                         new LayoutLength(Padding.Start + Padding.End),
-                        new LayoutLength(childOwner.LayoutWidth));
+                        new LayoutLength(CalculateChildSpecSizeWidth(childOwner)));
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                         new MeasureSpecification(new LayoutLength(parentHeightMeasureSpec.Size), parentHeightMeasureSpec.Mode),
                         new LayoutLength(Padding.Top + Padding.Bottom),
-                        new LayoutLength(childOwner.LayoutHeight));
+                        new LayoutLength(CalculateChildSpecSizeHeight(childOwner)));
 
             child.Measure(childWidthMeasureSpec, childHeightMeasureSpec);
         }
@@ -608,14 +608,14 @@ namespace Tizen.NUI
                             new LayoutLength(parentWidthMeasureSpec.Size + widthUsed - (margin.Start + margin.End)),
                             parentWidthMeasureSpec.Mode),
                         new LayoutLength(Padding.Start + Padding.End),
-                        new LayoutLength(childOwner.LayoutWidth));
+                        new LayoutLength(CalculateChildSpecSizeWidth(childOwner)));
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                         new MeasureSpecification(
                             new LayoutLength(parentHeightMeasureSpec.Size + heightUsed - (margin.Top + margin.Bottom)),
                             parentHeightMeasureSpec.Mode),
                         new LayoutLength(Padding.Top + Padding.Bottom),
-                        new LayoutLength(childOwner.LayoutHeight));
+                        new LayoutLength(CalculateChildSpecSizeHeight(childOwner)));
             child.Measure(childWidthMeasureSpec, childHeightMeasureSpec);
 
         }
@@ -642,14 +642,36 @@ namespace Tizen.NUI
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
                         new MeasureSpecification(new LayoutLength(parentWidthMeasureSpec.Size), parentWidthMeasureSpec.Mode),
                         new LayoutLength(0),
-                        new LayoutLength(childOwner.LayoutWidth));
+                        new LayoutLength(CalculateChildSpecSizeWidth(childOwner)));
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                         new MeasureSpecification(new LayoutLength(parentHeightMeasureSpec.Size), parentHeightMeasureSpec.Mode),
                         new LayoutLength(0),
-                        new LayoutLength(childOwner.LayoutHeight));
+                        new LayoutLength(CalculateChildSpecSizeHeight(childOwner)));
 
             child.Measure(childWidthMeasureSpec, childHeightMeasureSpec);
+        }
+
+        internal float CalculateChildSpecSizeWidth(View child)
+        {
+            if (child.LayoutWidth.IsFixedValue)
+            {
+                // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                return Math.Max(Math.Min(child.LayoutWidth, child.GetMaximumWidth()), child.GetMinimumWidth());
+            }
+
+            return child.LayoutWidth;
+        }
+
+        internal float CalculateChildSpecSizeHeight(View child)
+        {
+            if (child.LayoutHeight.IsFixedValue)
+            {
+                // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
+                return Math.Max(Math.Min(child.LayoutHeight, child.GetMaximumHeight()), child.GetMinimumHeight());
+            }
+
+            return child.LayoutHeight;
         }
 
         /// <summary>

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMin.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMin.cs
@@ -51,7 +51,7 @@ namespace NUILayout
             {
                 Layout = new AbsoluteLayout(),
                 BackgroundColor = Color.Blue,
-                MinimumSize = new Size2D(800, 800),
+                MinimumSize = new Size2D(600, 600),
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));
             AbsoluteLayout.SetLayoutFlags(view, AbsoluteLayoutFlags.All);

--- a/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMinMax.cs
+++ b/test/NUILayout/Examples/AbsoluteLayoutTest/AbsoluteBoundsPropMinMax.cs
@@ -51,7 +51,7 @@ namespace NUILayout
             {
                 Layout = new AbsoluteLayout(),
                 BackgroundColor = Color.Blue,
-                MinimumSize = new Size2D(800, 800),
+                MinimumSize = new Size2D(600, 600),
                 MaximumSize = new Size2D(50, 50),
             };
             AbsoluteLayout.SetLayoutBounds(view, new UIRect(0, 0.5f, 1.0f, 0.5f));


### PR DESCRIPTION
Previously, MinimumSize and MaximumSize were not respected by Layout.
e.g. AbsoluteLayout, LinearLayout, RelativeLayout, etc.

Now, MinimumSize and MaximumSize are respected by Layout.

Since the priority of MinimumSize is higher than MaximumSize in DALi,
Layout also follows it.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
