### PR TITLE
[NUI] Bind corner radius properties

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -842,24 +842,24 @@ namespace Tizen.NUI.Scene3D
         {
             base.ApplyCornerRadius();
 
+            {
+                using var setValue = new Tizen.NUI.PropertyValue(CornerRadius);
+                SetProperty(Interop.SceneView.CornerRadiusGet(), setValue);
+            }
+            {
+                using var setValue = new Tizen.NUI.PropertyValue((int)CornerRadiusPolicy);
+                SetProperty(Interop.SceneView.CornerRadiusPolicyGet(), setValue);
+            }
+
             if (backgroundExtraData == null) return;
 
             // Update corner radius properties to image by ActionUpdateProperty
             if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.ContentsCornerRadius))
             {
-                if (backgroundExtraData.CornerRadius != null)
-                {
-                    using var setValue = new Tizen.NUI.PropertyValue(backgroundExtraData.CornerRadius);
-                    SetProperty(Interop.SceneView.CornerRadiusGet(), setValue);
-                }
                 if (backgroundExtraData.CornerSquareness != null)
                 {
                     using var setValue = new Tizen.NUI.PropertyValue(backgroundExtraData.CornerSquareness);
                     SetProperty(Interop.SceneView.CornerSquarenessGet(), setValue);
-                }
-                {
-                    using var setValue = new Tizen.NUI.PropertyValue((int)backgroundExtraData.CornerRadiusPolicy);
-                    SetProperty(Interop.SceneView.CornerRadiusPolicyGet(), setValue);
                 }
             }
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
@@ -95,6 +95,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_OFFSCREEN_RENDERING_get")]
             public static extern int OffScreenRenderingGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_RADIUS_POLICY_get")]
+            public static extern int CornerRadiusPolicyGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_RADIUS_get")]
+            public static extern int CornerRadiusGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -2241,15 +2241,10 @@ namespace Tizen.NUI.BaseComponents
             // Update corner radius properties to image by ActionUpdateProperty
             if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.ContentsCornerRadius))
             {
-                if (backgroundExtraData.CornerRadius != null)
-                {
-                    _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.CornerRadius, Vector4.getCPtr(backgroundExtraData.CornerRadius));
-                }
                 if (backgroundExtraData.CornerSquareness != null)
                 {
                     _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.CornerSquareness, Vector4.getCPtr(backgroundExtraData.CornerSquareness));
                 }
-                _ = Interop.View.InternalUpdateVisualPropertyInt(this.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.CornerRadiusPolicy, (int)backgroundExtraData.CornerRadiusPolicy);
             }
         }
 
@@ -2562,11 +2557,8 @@ namespace Tizen.NUI.BaseComponents
                 }
             }
 
-            if (backgroundExtraData != null && backgroundExtraData.CornerRadius != null)
+            if (backgroundExtraData != null)
             {
-                cachedImagePropertyMap.Set(Visual.Property.CornerRadius, backgroundExtraData.CornerRadius);
-                cachedImagePropertyMap.Set(Visual.Property.CornerRadiusPolicy, (int)backgroundExtraData.CornerRadiusPolicy);
-
                 if (backgroundExtraData.CornerSquareness != null)
                 {
                     cachedImagePropertyMap.Set(Visual.Property.CornerSquareness, backgroundExtraData.CornerSquareness);

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -242,7 +242,7 @@ namespace Tizen.NUI.BaseComponents
 
                 if (backgroundExtraData != null)
                 {
-                    if (backgroundExtraData.CornerRadius != null || backgroundExtraData.CornerSquareness != null)
+                    if (backgroundExtraData.CornerSquareness != null)
                     {
                         UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.ContentsCornerRadius);
                     }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1452,13 +1452,14 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalCornerRadius(Vector4 newValue)
         {
-            (backgroundExtraData ?? (backgroundExtraData = new BackgroundExtraData())).CornerRadius = newValue;
-            UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.CornerRadius);
+            Object.InternalSetPropertyVector4(SwigCPtr, Property.CornerRadius, newValue.SwigCPtr);
         }
 
         private Vector4 GetInternalCornerRadius()
         {
-            return backgroundExtraData == null ? Vector4.Zero : backgroundExtraData.CornerRadius;
+            Vector4 value = new Vector4();
+            Object.InternalRetrievingPropertyVector4(SwigCPtr, Property.CornerRadius, value.SwigCPtr);
+            return value;
         }
 
         /// <summary>
@@ -1495,17 +1496,12 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalCornerRadiusPolicy(VisualTransformPolicyType value)
         {
-            (backgroundExtraData ?? (backgroundExtraData = new BackgroundExtraData())).CornerRadiusPolicy = value;
-
-            if (backgroundExtraData.CornerRadius != null)
-            {
-                UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.CornerRadius);
-            }
+            Object.InternalSetPropertyInt(SwigCPtr, Property.CornerRadiusPolicy, (int)value);
         }
 
         private VisualTransformPolicyType GetInternalCornerRadiusPolicy()
         {
-            return backgroundExtraData == null ? VisualTransformPolicyType.Absolute : backgroundExtraData.CornerRadiusPolicy;
+            return (VisualTransformPolicyType)(Object.InternalGetPropertyInt(SwigCPtr, Property.CornerRadiusPolicy));
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2219,9 +2219,7 @@ namespace Tizen.NUI.BaseComponents
 
             if (backgroundExtraData != null)
             {
-                map.Add(Visual.Property.CornerRadius, backgroundExtraData.CornerRadius)
-                   .Add(Visual.Property.CornerSquareness, backgroundExtraData.CornerSquareness)
-                   .Add(Visual.Property.CornerRadiusPolicy, (int)backgroundExtraData.CornerRadiusPolicy)
+                map.Add(Visual.Property.CornerSquareness, backgroundExtraData.CornerSquareness)
                    .Add(Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth)
                    .Add(Visual.Property.BorderlineColor, backgroundExtraData.BorderlineColor == null ? Color.Black : backgroundExtraData.BorderlineColor)
                    .Add(Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);
@@ -2302,9 +2300,7 @@ namespace Tizen.NUI.BaseComponents
 
             map.Add(Visual.Property.Type, (int)Visual.Type.Color)
                .Add(ColorVisualProperty.MixColor, value)
-               .Add(Visual.Property.CornerRadius, backgroundExtraData.CornerRadius)
                .Add(Visual.Property.CornerSquareness, backgroundExtraData.CornerSquareness)
-               .Add(Visual.Property.CornerRadiusPolicy, (int)(backgroundExtraData.CornerRadiusPolicy))
                .Add(Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth)
                .Add(Visual.Property.BorderlineColor, backgroundExtraData.BorderlineColor == null ? Color.Black : backgroundExtraData.BorderlineColor)
                .Add(Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -293,6 +293,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int DispatchTouchMotion = Interop.ActorProperty.DispatchTouchMotionGet();
             internal static readonly int DispatchHoverMotion = Interop.ActorProperty.DispatchHoverMotionGet();
             internal static readonly int OffScreenRendering = Interop.ViewProperty.OffScreenRenderingGet();
+            internal static readonly int CornerRadiusPolicy = Interop.ViewProperty.CornerRadiusPolicyGet();
+            internal static readonly int CornerRadius = Interop.ViewProperty.CornerRadiusGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1255,27 +1255,17 @@ namespace Tizen.NUI.BaseComponents
             // Update corner radius properties to background and shadow by ActionUpdateProperty
             if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.BackgroundCornerRadius))
             {
-                if (backgroundExtraData.CornerRadius != null)
-                {
-                    _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, View.Property.BACKGROUND, Visual.Property.CornerRadius, Vector4.getCPtr(backgroundExtraData.CornerRadius));
-                }
                 if (backgroundExtraData.CornerSquareness != null)
                 {
                     _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, View.Property.BACKGROUND, Visual.Property.CornerSquareness, Vector4.getCPtr(backgroundExtraData.CornerSquareness));
                 }
-                _ = Interop.View.InternalUpdateVisualPropertyInt(this.SwigCPtr, View.Property.BACKGROUND, Visual.Property.CornerRadiusPolicy, (int)backgroundExtraData.CornerRadiusPolicy);
             }
             if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.ShadowCornerRadius))
             {
-                if (backgroundExtraData.CornerRadius != null)
-                {
-                    _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, View.Property.SHADOW, Visual.Property.CornerRadius, Vector4.getCPtr(backgroundExtraData.CornerRadius));
-                }
                 if (backgroundExtraData.CornerSquareness != null)
                 {
                     _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, View.Property.SHADOW, Visual.Property.CornerSquareness, Vector4.getCPtr(backgroundExtraData.CornerSquareness));
                 }
-                _ = Interop.View.InternalUpdateVisualPropertyInt(this.SwigCPtr, View.Property.SHADOW, Visual.Property.CornerRadiusPolicy, (int)backgroundExtraData.CornerRadiusPolicy);
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
@@ -36,9 +36,7 @@ namespace Tizen.NUI.BaseComponents
                 using var map = new PropertyMap()
                     .Append(Visual.Property.Type, (int)Visual.Type.Color)
                     .Append(ColorVisualProperty.MixColor, color)
-                    .Append(Visual.Property.CornerRadius, backgroundExtraData.CornerRadius)
                     .Append(Visual.Property.CornerSquareness, backgroundExtraData.CornerSquareness)
-                    .Append(Visual.Property.CornerRadiusPolicy, (int)backgroundExtraData.CornerRadiusPolicy)
                     .Append(Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth)
                     .Append(Visual.Property.BorderlineColor, backgroundExtraData.BorderlineColor ?? Color.Black)
                     .Append(Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);

--- a/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
@@ -33,9 +33,7 @@ namespace Tizen.NUI
         internal BackgroundExtraData(BackgroundExtraData other)
         {
             BackgroundImageBorder = other.BackgroundImageBorder;
-            CornerRadius = other.CornerRadius;
             CornerSquareness = other.CornerSquareness;
-            CornerRadiusPolicy = other.CornerRadiusPolicy;
             BorderlineWidth = other.BorderlineWidth;
             BorderlineColor = other.BorderlineColor;
             BorderlineOffset = other.BorderlineOffset;
@@ -51,15 +49,7 @@ namespace Tizen.NUI
         }
 
         /// <summary></summary>
-        internal Vector4 CornerRadius { get; set; }
-
-        /// <summary></summary>
         internal Vector4 CornerSquareness { get; set; }
-
-        /// <summary>
-        /// Whether the CornerRadius value is relative (percentage [0.0f to 0.5f] of the view size) or absolute (in world units).
-        /// </summary>
-        internal VisualTransformPolicyType CornerRadiusPolicy { get; set; } = VisualTransformPolicyType.Absolute;
 
         /// <summary></summary>
         internal float BorderlineWidth { get; set; }
@@ -80,7 +70,6 @@ namespace Tizen.NUI
             if (disposing)
             {
                 backgroundImageBorder?.Dispose();
-                CornerRadius?.Dispose();
                 CornerSquareness?.Dispose();
                 BorderlineColor?.Dispose();
             }

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -3023,15 +3023,10 @@ namespace Tizen.NUI.BaseComponents
             }
 
             // Update corner radius properties to webView by ActionUpdateProperty
-            if (backgroundExtraData.CornerRadius != null)
-            {
-                _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, WebView.Property.Url, Visual.Property.CornerRadius, Vector4.getCPtr(backgroundExtraData.CornerRadius));
-            }
             if (backgroundExtraData.CornerSquareness != null)
             {
                 _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, WebView.Property.Url, Visual.Property.CornerSquareness, Vector4.getCPtr(backgroundExtraData.CornerSquareness));
             }
-            _ = Interop.View.InternalUpdateVisualPropertyInt(this.SwigCPtr, WebView.Property.Url, Visual.Property.CornerRadiusPolicy, (int)backgroundExtraData.CornerRadiusPolicy);
         }
 
         private void OnPageLoadStarted(string pageUrl)


### PR DESCRIPTION
Binds DALi's new feature(Animatable corner radius(and corner radius policy) on Dali::Toolkit::Control) to NUI View.
The value is synchronized with:
- Control's background, shadow, image visuals
- Control's render effect
- Control's Offscreen rendered result


Needs to be merged after:
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/320793
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/320794