### PR TITLE
[NUI] Minimize system LocaleLanguage API calls in Text

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/SystemFontSizeChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemFontSizeChangedManager.cs
@@ -28,6 +28,9 @@ namespace Tizen.NUI
     /// </summary>
     internal static class SystemFontSizeChangedManager
     {
+        private static SystemSettingsFontSize? fontSize = null;
+        private static WeakEvent<EventHandler<FontSizeChangedEventArgs>> proxy = new WeakEvent<EventHandler<FontSizeChangedEventArgs>>();
+
         static SystemFontSizeChangedManager()
         {
             SystemSettings.FontSizeChanged += SystemFontSizeChanged;
@@ -74,8 +77,5 @@ namespace Tizen.NUI
                 return fontSize ?? SystemSettingsFontSize.Normal;
             }
         }
-
-        private static SystemSettingsFontSize? fontSize = null;
-        private static WeakEvent<EventHandler<FontSizeChangedEventArgs>> proxy = new WeakEvent<EventHandler<FontSizeChangedEventArgs>>();
     }
 }

--- a/src/Tizen.NUI/src/internal/Common/SystemFontTypeChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemFontTypeChangedManager.cs
@@ -28,6 +28,9 @@ namespace Tizen.NUI
     /// </summary>
     internal static class SystemFontTypeChangedManager
     {
+        private static string fontType = string.Empty;
+        private static WeakEvent<EventHandler<FontTypeChangedEventArgs>> proxy = new WeakEvent<EventHandler<FontTypeChangedEventArgs>>();
+
         static SystemFontTypeChangedManager()
         {
             SystemSettings.FontTypeChanged += SystemFontTypeChanged;
@@ -74,8 +77,5 @@ namespace Tizen.NUI
                 return fontType;
             }
         }
-
-        private static string fontType = string.Empty;
-        private static WeakEvent<EventHandler<FontTypeChangedEventArgs>> proxy = new WeakEvent<EventHandler<FontTypeChangedEventArgs>>();
     }
 }

--- a/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
@@ -28,6 +28,9 @@ namespace Tizen.NUI
     /// </summary>
     internal static class SystemLocaleLanguageChangedManager
     {
+        private static string localeLanguage = string.Empty;
+        private static WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>> proxy = new WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>>();
+
         static SystemLocaleLanguageChangedManager()
         {
             SystemSettings.LocaleLanguageChanged += SystemLocaleLanguageChanged;
@@ -74,8 +77,5 @@ namespace Tizen.NUI
                 return localeLanguage;
             }
         }
-
-        private static string localeLanguage = string.Empty;
-        private static WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>> proxy = new WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>>();
     }
 }

--- a/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+extern alias TizenSystemSettings;
+using TizenSystemSettings.Tizen.System;
+
+using System;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// A static class which adds user handler to the SystemSettings.LocaleLanguageChanged event.
+    /// This class also adds user handler to the last of the SystemSettings.LocaleLanguageChanged event.
+    /// </summary>
+    internal static class SystemLocaleLanguageChangedManager
+    {
+        static SystemLocaleLanguageChangedManager()
+        {
+            SystemSettings.LocaleLanguageChanged += SystemLocaleLanguageChanged;
+        }
+
+        /// <summary>
+        /// The handler invoked last after all handlers added to the SystemSettings.LocaleLanguageChanged event are invoked.
+        /// </summary>
+        public static event EventHandler<LocaleLanguageChangedEventArgs> Finished;
+
+        /// <summary>
+        /// Adds the given handler to the SystemSettings.LocaleLanguageChanged event.
+        /// </summary>
+        /// <param name="handler">A handler to be added to the event</param>
+        public static void Add(EventHandler<LocaleLanguageChangedEventArgs> handler)
+        {
+            proxy.Add(handler);
+        }
+
+        /// <summary>
+        /// Removes the given handler from the SystemSettings.LocaleLanguageChanged event.
+        /// </summary>
+        /// <param name="handler">A handler to be added to the event</param>
+        public static void Remove(EventHandler<LocaleLanguageChangedEventArgs> handler)
+        {
+            proxy.Remove(handler);
+        }
+
+        private static void SystemLocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs args)
+        {
+            localeLanguage = args.Value;
+            proxy.Invoke(sender, args);
+            Finished?.Invoke(sender, args);
+        }
+
+        public static string LocaleLanguage
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(localeLanguage))
+                {
+                    localeLanguage = SystemSettings.LocaleLanguage;
+                }
+                return localeLanguage;
+            }
+        }
+
+        private static string localeLanguage = string.Empty;
+        private static WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>> proxy = new WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>>();
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -487,7 +487,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("{0} Exception caught.", e);
+                        Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                         newFontFamily = defaultFontFamily;
                     }
                     AddSystemSettingsFontTypeChanged();
@@ -3344,7 +3344,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("{0} Exception caught.", e);
+                        Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                         systemSettingsFontSize = SystemSettingsFontSize.Normal;
                     }
                     newFontSizeScale = TextUtils.GetFontSizeScale(systemSettingsFontSize);
@@ -3849,8 +3849,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemLanguageChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3866,8 +3865,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemLanguageChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3880,7 +3878,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void AddSystemSettingsFontSizeChanged()
         {
-            if (hasSystemFontSizeChanged != true)
+            if (!hasSystemFontSizeChanged)
             {
                 try
                 {
@@ -3889,15 +3887,14 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontSizeChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
 
         private void RemoveSystemSettingsFontSizeChanged()
         {
-            if (hasSystemFontSizeChanged == true)
+            if (hasSystemFontSizeChanged)
             {
                 try
                 {
@@ -3906,8 +3903,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontSizeChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3928,8 +3924,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontTypeChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3945,8 +3940,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontTypeChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -34,7 +34,6 @@ namespace Tizen.NUI.BaseComponents
     {
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextEditor";
         static private string defaultFontFamily = "TizenSans";
-        private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
         private string textEditorTextSid = null;
         private string textEditorPlaceHolderTextSid = null;
         private InputMethodContext inputMethodContext = null;
@@ -3744,11 +3743,7 @@ namespace Tizen.NUI.BaseComponents
             internalTextColor?.Dispose();
             internalGrabHandleColor?.Dispose();
 
-            if (hasSystemLanguageChanged)
-            {
-                systemLocaleLanguageChanged.Remove(SystemSettings_LocaleLanguageChanged);
-            }
-
+            RemoveSystemSettingsLocaleLanguageChanged();
             RemoveSystemSettingsFontTypeChanged();
             RemoveSystemSettingsFontSizeChanged();
 
@@ -3817,24 +3812,21 @@ namespace Tizen.NUI.BaseComponents
         private string SetTranslatable(string textEditorSid)
         {
             string translatableText = null;
-            translatableText = NUIApplication.MultilingualResourceManager?.GetString(textEditorSid, new CultureInfo(SystemSettings.LocaleLanguage.Replace("_", "-")));
+            translatableText = NUIApplication.MultilingualResourceManager?.GetString(textEditorSid, new CultureInfo(SystemLocaleLanguageChangedManager.LocaleLanguage.Replace("_", "-")));
             if (translatableText != null)
             {
-                if (hasSystemLanguageChanged == false)
-                {
-                    systemLocaleLanguageChanged.Add(SystemSettings_LocaleLanguageChanged);
-                    hasSystemLanguageChanged = true;
-                }
+                AddSystemSettingsLocaleLanguageChanged();
                 return translatableText;
             }
             else
             {
                 translatableText = "";
+                RemoveSystemSettingsLocaleLanguageChanged();
                 return translatableText;
             }
         }
 
-        private void SystemSettings_LocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
+        private void SystemSettingsLocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
         {
             if (textEditorTextSid != null)
             {
@@ -3843,6 +3835,40 @@ namespace Tizen.NUI.BaseComponents
             if (textEditorPlaceHolderTextSid != null)
             {
                 PlaceholderText = NUIApplication.MultilingualResourceManager?.GetString(textEditorPlaceHolderTextSid, new CultureInfo(e.Value.Replace("_", "-")));
+            }
+        }
+
+        private void AddSystemSettingsLocaleLanguageChanged()
+        {
+            if (!hasSystemLanguageChanged)
+            {
+                try
+                {
+                    SystemLocaleLanguageChangedManager.Add(SystemSettingsLocaleLanguageChanged);
+                    hasSystemLanguageChanged = true;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemLanguageChanged = false;
+                }
+            }
+        }
+        
+        private void RemoveSystemSettingsLocaleLanguageChanged()
+        {
+            if (hasSystemLanguageChanged)
+            {
+                try
+                {
+                    SystemLocaleLanguageChangedManager.Remove(SystemSettingsLocaleLanguageChanged);
+                    hasSystemLanguageChanged = false;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemLanguageChanged = true;
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -33,7 +33,6 @@ namespace Tizen.NUI.BaseComponents
     {
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextField";
         static private string defaultFontFamily = "TizenSans";
-        private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
         private string textFieldTextSid = null;
         private string textFieldPlaceHolderTextSid = null;
         private string textFieldPlaceHolderTextFocusedSid = null;
@@ -3711,11 +3710,7 @@ namespace Tizen.NUI.BaseComponents
             internalTextColor?.Dispose();
             internalGrabHandleColor?.Dispose();
 
-            if (hasSystemLanguageChanged)
-            {
-                systemLocaleLanguageChanged.Remove(SystemSettingsLocaleLanguageChanged);
-            }
-
+            RemoveSystemSettingsLocaleLanguageChanged();
             RemoveSystemSettingsFontTypeChanged();
             RemoveSystemSettingsFontSizeChanged();
 
@@ -3790,19 +3785,16 @@ namespace Tizen.NUI.BaseComponents
         private string SetTranslatable(string textFieldSid)
         {
             string translatableText = null;
-            translatableText = NUIApplication.MultilingualResourceManager?.GetString(textFieldSid, new CultureInfo(SystemSettings.LocaleLanguage.Replace("_", "-")));
+            translatableText = NUIApplication.MultilingualResourceManager?.GetString(textFieldSid, new CultureInfo(SystemLocaleLanguageChangedManager.LocaleLanguage.Replace("_", "-")));
             if (translatableText != null)
             {
-                if (hasSystemLanguageChanged == false)
-                {
-                    systemLocaleLanguageChanged.Add(SystemSettingsLocaleLanguageChanged);
-                    hasSystemLanguageChanged = true;
-                }
+                AddSystemSettingsLocaleLanguageChanged();
                 return translatableText;
             }
             else
             {
                 translatableText = "";
+                RemoveSystemSettingsLocaleLanguageChanged();
                 return translatableText;
             }
         }
@@ -3820,6 +3812,40 @@ namespace Tizen.NUI.BaseComponents
             if (textFieldPlaceHolderTextFocusedSid != null)
             {
                 PlaceholderTextFocused = NUIApplication.MultilingualResourceManager?.GetString(textFieldPlaceHolderTextFocusedSid, new CultureInfo(e.Value.Replace("_", "-")));
+            }
+        }
+
+        private void AddSystemSettingsLocaleLanguageChanged()
+        {
+            if (!hasSystemLanguageChanged)
+            {
+                try
+                {
+                    SystemLocaleLanguageChangedManager.Add(SystemSettingsLocaleLanguageChanged);
+                    hasSystemLanguageChanged = true;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemLanguageChanged = false;
+                }
+            }
+        }
+        
+        private void RemoveSystemSettingsLocaleLanguageChanged()
+        {
+            if (hasSystemLanguageChanged)
+            {
+                try
+                {
+                    SystemLocaleLanguageChangedManager.Remove(SystemSettingsLocaleLanguageChanged);
+                    hasSystemLanguageChanged = false;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemLanguageChanged = true;
+                }
             }
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -638,7 +638,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("{0} Exception caught.", e);
+                        Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                         newFontFamily = defaultFontFamily;
                     }
                     AddSystemSettingsFontTypeChanged();
@@ -3502,7 +3502,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("{0} Exception caught.", e);
+                        Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                         systemSettingsFontSize = SystemSettingsFontSize.Normal;
                     }
                     newFontSizeScale = TextUtils.GetFontSizeScale(systemSettingsFontSize);
@@ -3826,8 +3826,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemLanguageChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3843,8 +3842,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemLanguageChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3857,7 +3855,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void AddSystemSettingsFontSizeChanged()
         {
-            if (hasSystemFontSizeChanged != true)
+            if (!hasSystemFontSizeChanged)
             {
                 try
                 {
@@ -3866,15 +3864,14 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontSizeChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
 
         private void RemoveSystemSettingsFontSizeChanged()
         {
-            if (hasSystemFontSizeChanged == true)
+            if (hasSystemFontSizeChanged)
             {
                 try
                 {
@@ -3883,8 +3880,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontSizeChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3905,8 +3901,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontTypeChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -3922,8 +3917,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontTypeChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -228,7 +228,6 @@ namespace Tizen.NUI.BaseComponents
             // Do nothing. Just call for load static values.
         }
 
-        private static SystemLocaleLanguageChanged systemLocaleLanguageChanged = new SystemLocaleLanguageChanged();
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextLabel";
         static private string defaultFontFamily = "BreezeSans";
         private string textLabelSid = null;
@@ -366,19 +365,16 @@ namespace Tizen.NUI.BaseComponents
                 }
                 string translatableText = null;
                 textLabelSid = value;
-                translatableText = NUIApplication.MultilingualResourceManager?.GetString(textLabelSid, new CultureInfo(SystemSettings.LocaleLanguage.Replace("_", "-")));
+                translatableText = NUIApplication.MultilingualResourceManager?.GetString(textLabelSid, new CultureInfo(SystemLocaleLanguageChangedManager.LocaleLanguage.Replace("_", "-")));
                 if (translatableText != null)
                 {
                     Text = translatableText;
-                    if (hasSystemLanguageChanged == false)
-                    {
-                        systemLocaleLanguageChanged.Add(SystemSettingsLocaleLanguageChanged);
-                        hasSystemLanguageChanged = true;
-                    }
+                    AddSystemSettingsLocaleLanguageChanged();
                 }
                 else
                 {
                     Text = "";
+                    RemoveSystemSettingsLocaleLanguageChanged();
                 }
                 NotifyPropertyChanged();
             }
@@ -2534,11 +2530,7 @@ namespace Tizen.NUI.BaseComponents
             internalAnchorColor?.Dispose();
             internalAnchorClickedColor?.Dispose();
 
-            if (hasSystemLanguageChanged)
-            {
-                systemLocaleLanguageChanged.Remove(SystemSettingsLocaleLanguageChanged);
-            }
-
+            RemoveSystemSettingsLocaleLanguageChanged();
             RemoveSystemSettingsFontTypeChanged();
             RemoveSystemSettingsFontSizeChanged();
 
@@ -2593,6 +2585,40 @@ namespace Tizen.NUI.BaseComponents
         private void SystemSettingsLocaleLanguageChanged(object sender, LocaleLanguageChangedEventArgs e)
         {
             Text = NUIApplication.MultilingualResourceManager?.GetString(textLabelSid, new CultureInfo(e.Value.Replace("_", "-")));
+        }
+
+        private void AddSystemSettingsLocaleLanguageChanged()
+        {
+            if (!hasSystemLanguageChanged)
+            {
+                try
+                {
+                    SystemLocaleLanguageChangedManager.Add(SystemSettingsLocaleLanguageChanged);
+                    hasSystemLanguageChanged = true;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemLanguageChanged = false;
+                }
+            }
+        }
+        
+        private void RemoveSystemSettingsLocaleLanguageChanged()
+        {
+            if (hasSystemLanguageChanged)
+            {
+                try
+                {
+                    SystemLocaleLanguageChangedManager.Remove(SystemSettingsLocaleLanguageChanged);
+                    hasSystemLanguageChanged = false;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("{0} Exception caught.", e);
+                    hasSystemLanguageChanged = true;
+                }
+            }
         }
 
         private void SystemSettingsFontSizeChanged(object sender, FontSizeChangedEventArgs e)

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -468,7 +468,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("{0} Exception caught.", e);
+                        Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                         newFontFamily = defaultFontFamily;
                     }
                     AddSystemSettingsFontTypeChanged();
@@ -2404,7 +2404,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("{0} Exception caught.", e);
+                        Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                         systemSettingsFontSize = SystemSettingsFontSize.Normal;
                     }
                     newFontSizeScale = TextUtils.GetFontSizeScale(systemSettingsFontSize);
@@ -2598,8 +2598,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemLanguageChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -2615,8 +2614,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemLanguageChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -2629,7 +2627,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void AddSystemSettingsFontSizeChanged()
         {
-            if (hasSystemFontSizeChanged != true)
+            if (!hasSystemFontSizeChanged)
             {
                 try
                 {
@@ -2638,15 +2636,14 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontSizeChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
 
         private void RemoveSystemSettingsFontSizeChanged()
         {
-            if (hasSystemFontSizeChanged == true)
+            if (hasSystemFontSizeChanged)
             {
                 try
                 {
@@ -2655,8 +2652,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontSizeChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -2677,8 +2673,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontTypeChanged = false;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }
@@ -2694,8 +2689,7 @@ namespace Tizen.NUI.BaseComponents
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("{0} Exception caught.", e);
-                    hasSystemFontTypeChanged = true;
+                    Tizen.Log.Info("NUI", $"{e} Exception caught.\n");
                 }
             }
         }


### PR DESCRIPTION
Every time we set Translatable text,
system LocaleLanguage API is called, which creates overhead.
This patch updates through static classes only when a specific value is needed.