### PR TITLE
[NUI] Reduce build warnings at VisualObjects

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualObject.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualObject.cs
@@ -55,22 +55,22 @@ namespace Tizen.NUI
             public static extern void Detach(global::System.Runtime.InteropServices.HandleRef visualObject);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_Raise")]
-            public static extern uint Raise(global::System.Runtime.InteropServices.HandleRef visualObject);
+            public static extern void Raise(global::System.Runtime.InteropServices.HandleRef visualObject);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_Lower")]
-            public static extern uint Lower(global::System.Runtime.InteropServices.HandleRef visualObject);
+            public static extern void Lower(global::System.Runtime.InteropServices.HandleRef visualObject);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RaiseToTop")]
-            public static extern uint RaiseToTop(global::System.Runtime.InteropServices.HandleRef visualObject);
+            public static extern void RaiseToTop(global::System.Runtime.InteropServices.HandleRef visualObject);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_LowerToBottom")]
-            public static extern uint LowerToBottom(global::System.Runtime.InteropServices.HandleRef visualObject);
+            public static extern void LowerToBottom(global::System.Runtime.InteropServices.HandleRef visualObject);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_RaiseAbove")]
-            public static extern uint RaiseAbove(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef target);
+            public static extern void RaiseAbove(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef target);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualObject_LowerBelow")]
-            public static extern uint LowerBelow(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef target);
+            public static extern void LowerBelow(global::System.Runtime.InteropServices.HandleRef visualObject, global::System.Runtime.InteropServices.HandleRef target);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Tizen.NUI.Binding;
@@ -380,6 +381,7 @@ namespace Tizen.NUI.BaseComponents
         /// Once a raise or lower API is used, that view will then have an exclusive sibling order independent of insertion.
         /// </remarks>
         /// <since_tizen> 3 </since_tizen>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Method used to raise the object, not event")]
         public void RaiseToTop()
         {
             var parentChildren = GetParent()?.Children;
@@ -798,6 +800,7 @@ namespace Tizen.NUI.BaseComponents
         /// Raise view above the next sibling view.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Method used to raise the object, not event")]
         public void Raise()
         {
             var parentChildren = GetParent()?.Children;
@@ -855,6 +858,7 @@ namespace Tizen.NUI.BaseComponents
         /// </remarks>
         /// <param name="target">Will be raised above this view.</param>
         /// <since_tizen> 9 </since_tizen>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Method used to raise the object, not event")]
         public void RaiseAbove(View target)
         {
             var parentChildren = GetParent()?.Children;

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -17,6 +17,7 @@
 using System;
 using Tizen.NUI.BaseComponents;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Tizen.NUI
@@ -476,6 +477,7 @@ namespace Tizen.NUI
         /// Increments the depth of the layer.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Method used to raise the object, not event")]
         public void Raise()
         {
             var parentChildren = window?.LayersChildren;
@@ -515,6 +517,7 @@ namespace Tizen.NUI
         /// Raises the layer to the top.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Method used to raise the object, not event")]
         public void RaiseToTop()
         {
             var parentChildren = window?.LayersChildren;

--- a/src/Tizen.NUI/src/public/Common/PropertyMap.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyMap.cs
@@ -500,7 +500,9 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public PropertyValue GetValue(uint position)
         {
+#pragma warning disable CA2000 // Dispose objects before losing scope
             PropertyValue ret = new PropertyValue(Interop.PropertyMap.GetValue(SwigCPtr, position), false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -513,7 +515,9 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public PropertyKey GetKeyAt(uint position)
         {
+#pragma warning disable CA2000 // Dispose objects before losing scope
             PropertyKey ret = new PropertyKey(Interop.PropertyMap.GetKeyAt(SwigCPtr, position), true);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -527,7 +531,9 @@ namespace Tizen.NUI
         public PropertyValue Find(string stringKey)
         {
             global::System.IntPtr cPtr = Interop.PropertyMap.Find(SwigCPtr, stringKey);
+#pragma warning disable CA2000 // Dispose objects before losing scope
             PropertyValue ret = (cPtr == global::System.IntPtr.Zero) ? null : new PropertyValue(cPtr, false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -541,7 +547,9 @@ namespace Tizen.NUI
         public PropertyValue Find(int key)
         {
             global::System.IntPtr cPtr = Interop.PropertyMap.Find(SwigCPtr, key);
+#pragma warning disable CA2000 // Dispose objects before losing scope
             PropertyValue ret = (cPtr == global::System.IntPtr.Zero) ? null : new PropertyValue(cPtr, false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -556,7 +564,9 @@ namespace Tizen.NUI
         public PropertyValue Find(int indexKey, string stringKey)
         {
             global::System.IntPtr cPtr = Interop.PropertyMap.Find(SwigCPtr, indexKey, stringKey);
+#pragma warning disable CA2000 // Dispose objects before losing scope
             PropertyValue ret = (cPtr == global::System.IntPtr.Zero) ? null : new PropertyValue(cPtr, false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -595,7 +605,9 @@ namespace Tizen.NUI
         /// <returns>The value for the element with the specified key.</returns>
         internal PropertyValue ValueOfIndex(string key)
         {
+#pragma warning disable CA2000 // Dispose objects before losing scope
             PropertyValue ret = new PropertyValue(Interop.PropertyMap.ValueOfIndex(SwigCPtr, key), false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
@@ -607,7 +619,9 @@ namespace Tizen.NUI
         /// <returns>The value for the element with the specified key.</returns>
         internal PropertyValue ValueOfIndex(int key)
         {
+#pragma warning disable CA2000 // Dispose objects before losing scope
             PropertyValue ret = new PropertyValue(Interop.PropertyMap.ValueOfIndex(SwigCPtr, key), false);
+#pragma warning restore CA2000 // Dispose objects before losing scope
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Window/GLWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/GLWindow.cs
@@ -20,6 +20,7 @@ extern alias TizenSystemInformation;
 using System;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Tizen.NUI
@@ -173,6 +174,7 @@ namespace Tizen.NUI
         /// Raises the window to the top of the window stack.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Method used to raise the object, not event")]
         public void Raise()
         {
             Interop.GLWindow.GlWindowRaise(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -21,6 +21,7 @@ using TizenSystemInformation.Tizen.System;
 using System;
 using System.ComponentModel;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Tizen.NUI.BaseComponents;
 using Tizen.Common;
@@ -990,6 +991,7 @@ namespace Tizen.NUI
         /// Raises the window to the top of the window stack.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Method used to raise the object, not event")]
         public void Raise()
         {
             Interop.Window.Raise(SwigCPtr);


### PR DESCRIPTION
Reduce some build warnings at VisualObjects

    - Remove CA1030
    - Disable warning for CA2000 for several codes
    - Fix unmatched binding function
    - Remove CA1001 : Make VisualTransformInfo as disposable

Total the number of build warnings : 1851 -> 1818

Build command : dotnet build /p:NuiRoslynAnalysis=true