### PR TITLE
[NUI] Fix SetSize of ExcludeLayouting with LayoutWidth/Height

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -601,7 +601,10 @@ namespace Tizen.NUI
                     {
                         // If height or width specification is not explicitly defined,
                         // the size of the owner view must be reset even the ExcludeLayouting is true.
-                        if (!Owner.LayoutWidth.IsFixedValue || !Owner.LayoutHeight.IsFixedValue)
+                        // Unlike Width/HeightSpecification, LayoutWidth/Height does not set view size automatically.
+                        // Therefore, view size should be checked if it is same with LayoutWidth/Height.
+                        if (!Owner.LayoutWidth.IsFixedValue || Owner.LayoutWidth != Owner.SizeWidth ||
+                            !Owner.LayoutHeight.IsFixedValue || Owner.LayoutHeight != Owner.SizeHeight)
                         {
                             Owner.SetSize(right - left, bottom - top);
                             Owner.NotifyLayoutUpdated(false);


### PR DESCRIPTION
Previously, ExcludeLayouting case sets layout size only if Width/HeightSpecification is negative value.
If Width/HeightSpecification is negative value, then it is either MatchParent or WrapContent instead of fixed size value. Therefore, calculated layout size should be set to view size.

Now, LayoutWidth/Height is used instead of Width/HeightSpecification. Width/HeightSpecification sets view size if it is fixed size value. Unlike Width/HeightSpecification, LayoutWidth/Height does not set view size although it is fixed size value. View size is set by Layout.

Therefore, the condition that LayoutWidth/Height is not fixed size value is not the same with the condition that Width/HeightSpecification is not fixed size value since view size may not be set.

To make the condition same as before, additional condition is added.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
