### PR TITLE
[NUI] Fix AbsoluteLayout typo in calculating Padding size

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -214,7 +214,7 @@ namespace Tizen.NUI
                             new MeasureSpecification(
                                 new LayoutLength(heightMeasureSpec.Size) - (childMargin.Top + childMargin.Bottom),
                                 heightMeasureSpec.Mode),
-                            new LayoutLength(Padding.Top + Padding.End),
+                            new LayoutLength(Padding.Top + Padding.Bottom),
                             new LayoutLength(CalculateChildSpecSizeHeight(childLayout.Owner)));
                     }
 


### PR DESCRIPTION
Typo of padding top + end is fixed to top + bottom.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
