### PR TITLE
[NUI] Fix to check IsPaddingHandledByNative for Padding getter

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -4939,23 +4939,20 @@ namespace Tizen.NUI.BaseComponents
 
         private Extents GetInternalPadding()
         {
-            if ((internalPadding == null) || (Layout != null))
+            if (internalPadding == null || (Layout != null && !Layout.IsPaddingHandledByNative()))
             {
                 ushort start = 0, end = 0, top = 0, bottom = 0;
-                if (Layout != null)
+                if (Layout != null && !Layout.IsPaddingHandledByNative() && Layout.Padding != null)
                 {
-                    if (Layout.Padding != null)
-                    {
-                        start = Layout.Padding.Start;
-                        end = Layout.Padding.End;
-                        top = Layout.Padding.Top;
-                        bottom = Layout.Padding.Bottom;
-                    }
+                    start = Layout.Padding.Start;
+                    end = Layout.Padding.End;
+                    top = Layout.Padding.Top;
+                    bottom = Layout.Padding.Bottom;
                 }
                 internalPadding = new Extents(OnPaddingChanged, start, end, top, bottom);
             }
 
-            if (Layout == null)
+            if (Layout == null || Layout.IsPaddingHandledByNative())
             {
                 var tmp = Object.GetProperty(SwigCPtr, Property.PADDING);
                 tmp?.Get(internalPadding);


### PR DESCRIPTION
If a view.Layout.IsPaddingHandledByNative is true, then the view.Padding setter sets view.Padding instead of view.Layout.Padding. Because the padding is applied by DALi instead of NUI Layout.

In the same way, view.Padding getter gets view.Padding instead of view.Layout.Padding if view.Layout.IsPaddingHandledByNative is true.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
