### PR TITLE
[NUI] Remove code about boxing/unboxing in Layouting.

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -105,8 +105,6 @@ namespace Tizen.NUI
         private MeasureSpecification parentMeasureSpecificationWidth;
         private MeasureSpecification parentMeasureSpecificationHeight;
 
-        private IntPtr _rootFlex;  // Pointer to the unmanaged flex layout class.
-
         internal const float FlexUndefined = 10E20F; // Auto setting which is equivalent to WrapContent.
 
         internal struct MeasuredSize
@@ -163,7 +161,11 @@ namespace Tizen.NUI
             }
             else
             {
-                return (PositionType)GetInternalFlexPositionTypeProperty(view);
+                _ = view ?? throw new ArgumentNullException(nameof(view));
+                if (view.ExcludeLayouting)
+                    return PositionType.Absolute;
+
+                return PositionType.Relative;
             }
         }
 
@@ -294,10 +296,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= AlignmentType.Auto && value <= AlignmentType.Stretch)
                 {
                     flexAlignmentSelfMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -323,9 +326,10 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= PositionType.Relative && value <= PositionType.Absolute)
                 {
-                    SetInternalFlexPositionTypeProperty(view, null, value);
+                    view.ExcludeLayouting = value == PositionType.Absolute;
                 }
             }
         }
@@ -349,10 +353,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value > 0)
                 {
                     flexAspectRatioMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -377,10 +382,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= 0)
                 {
                     flexBasisMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -405,10 +411,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= 0)
                 {
                     flexShrinkMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -433,10 +440,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= 0)
                 {
                     flexGrowMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -478,7 +486,6 @@ namespace Tizen.NUI
         {
             swigCMemOwn = cMemoryOwn;
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
-            _rootFlex = Interop.FlexLayout.New();
             measureChildDelegate = new ChildMeasureCallback(measureChild);
             if (!NUIApplication.IsUsingXaml)
             {

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -337,10 +337,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= 0)
                 {
                     columnMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -361,10 +362,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= 1)
                 {
                     columnSpanMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -386,10 +388,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= 0)
                 {
                     rowMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -410,10 +413,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= 1)
                 {
                     rowSpanMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -434,10 +438,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= StretchFlags.None && value <= StretchFlags.ExpandAndFill)
                 {
                     horizontalStretchMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -458,10 +463,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= StretchFlags.None && value <= StretchFlags.ExpandAndFill)
                 {
                     verticalStretchMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -482,10 +488,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= Alignment.Start && value <= Alignment.End)
                 {
                     horizontalAlignmentMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -506,10 +513,11 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 if (value >= Alignment.Start && value <= Alignment.End)
                 {
                     verticalAlignmentMap[view] = value;
-                    OnChildPropertyChanged(view, null, value);
+                    view.Layout?.RequestLayout();
                 }
             }
         }
@@ -748,7 +756,7 @@ namespace Tizen.NUI
                     // because the grand children's Measure() is called with the mode type AtMost.
                     var layoutWidth = child.LayoutItem.Owner.LayoutWidth;
                     var layoutHeight = child.LayoutItem.Owner.LayoutHeight;
-                    Size2D origSize = new Size2D(child.LayoutItem.Owner.Size2D.Width, child.LayoutItem.Owner.Size2D.Height);
+                    using Size2D origSize = new Size2D(child.LayoutItem.Owner.Size2D.Width, child.LayoutItem.Owner.Size2D.Height);
 
                     if (needMeasuredWidth)
                     {

--- a/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
@@ -484,8 +484,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 leftTargetMap[view] = reference;
-                OnChildPropertyChanged(view, null, reference);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -505,8 +506,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 rightTargetMap[view] = reference;
-                OnChildPropertyChanged(view, null, reference);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -526,8 +528,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 topTargetMap[view] = reference;
-                OnChildPropertyChanged(view, null, reference);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -547,8 +550,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 bottomTargetMap[view] = reference;
-                OnChildPropertyChanged(view, null, reference);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -569,8 +573,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 leftRelativeOffsetMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -591,8 +596,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 rightRelativeOffsetMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -613,8 +619,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 topRelativeOffsetMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -635,8 +642,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 bottomRelativeOffsetMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -655,8 +663,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 horizontalAlignmentMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -675,8 +684,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 verticalAlignmentMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -695,8 +705,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 fillHorizontalMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -715,8 +726,9 @@ namespace Tizen.NUI
             }
             else
             {
+                _ = view ?? throw new ArgumentNullException(nameof(view));
                 fillVerticalMap[view] = value;
-                OnChildPropertyChanged(view, null, value);
+                view.Layout?.RequestLayout();
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
After Xaml is disabled, there are boxing/unboxing objects in Getter/Setter in Layouting, these could be removed.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
