### PR TITLE
[NUI] Remove UIColor constructor with vector4 and etc.

### DIFF
--- a/src/Tizen.NUI.Extension/Markup/TextEditorExtensions.cs
+++ b/src/Tizen.NUI.Extension/Markup/TextEditorExtensions.cs
@@ -894,7 +894,7 @@ namespace Tizen.NUI.Extension
         public static UIColor TextColor(this TextEditor view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.TextColor);
+            return UIColor.From(view.TextColor);
         }
 
         /// <summary>
@@ -905,7 +905,7 @@ namespace Tizen.NUI.Extension
         public static UIColor PlaceholderTextColor(this TextEditor view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.PlaceholderTextColor);
+            return UIColor.From(view.PlaceholderTextColor);
         }
 
         /// <summary>
@@ -916,7 +916,7 @@ namespace Tizen.NUI.Extension
         public static UIColor PrimaryCursorColor(this TextEditor view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.PrimaryCursorColor);
+            return UIColor.From(view.PrimaryCursorColor);
         }
 
         /// <summary>
@@ -927,7 +927,7 @@ namespace Tizen.NUI.Extension
         public static UIColor SecondaryCursorColor(this TextEditor view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.SecondaryCursorColor);
+            return UIColor.From(view.SecondaryCursorColor);
         }
 
         /// <summary>
@@ -938,7 +938,7 @@ namespace Tizen.NUI.Extension
         public static UIColor SelectionHighlightColor(this TextEditor view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.SelectionHighlightColor);
+            return UIColor.From(view.SelectionHighlightColor);
         }
 
         /// <summary>
@@ -949,7 +949,7 @@ namespace Tizen.NUI.Extension
         public static UIColor InputColor(this TextEditor view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.InputColor);
+            return UIColor.From(view.InputColor);
         }
     }
 }

--- a/src/Tizen.NUI.Extension/Markup/TextFieldExtensions.cs
+++ b/src/Tizen.NUI.Extension/Markup/TextFieldExtensions.cs
@@ -867,7 +867,7 @@ namespace Tizen.NUI.Extension
         public static UIColor TextColor(this TextField view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.TextColor);
+            return UIColor.From(view.TextColor);
         }
 
         /// <summary>
@@ -878,7 +878,7 @@ namespace Tizen.NUI.Extension
         public static UIColor PlaceholderTextColor(this TextField view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.PlaceholderTextColor);
+            return UIColor.From(view.PlaceholderTextColor);
         }
 
         /// <summary>
@@ -889,7 +889,7 @@ namespace Tizen.NUI.Extension
         public static UIColor PrimaryCursorColor(this TextField view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.PrimaryCursorColor);
+            return UIColor.From(view.PrimaryCursorColor);
         }
 
         /// <summary>
@@ -900,7 +900,7 @@ namespace Tizen.NUI.Extension
         public static UIColor SecondaryCursorColor(this TextField view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.SecondaryCursorColor);
+            return UIColor.From(view.SecondaryCursorColor);
         }
 
         /// <summary>
@@ -911,7 +911,7 @@ namespace Tizen.NUI.Extension
         public static UIColor SelectionHighlightColor(this TextField view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.SelectionHighlightColor);
+            return UIColor.From(view.SelectionHighlightColor);
         }
 
         /// <summary>
@@ -922,7 +922,7 @@ namespace Tizen.NUI.Extension
         public static UIColor InputColor(this TextField view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.InputColor);
+            return UIColor.From(view.InputColor);
         }
     }
 }

--- a/src/Tizen.NUI.Extension/Markup/TextLabelExtensions.cs
+++ b/src/Tizen.NUI.Extension/Markup/TextLabelExtensions.cs
@@ -504,7 +504,7 @@ namespace Tizen.NUI.Extension
         public static UIColor TextColor(this TextLabel view)
         {
             //FIXME: we need to set UI value type directly without converting reference value.
-            return new UIColor(view.TextColor);
+            return UIColor.From(view.TextColor);
         }
     }
 }

--- a/src/Tizen.NUI.Extension/Markup/ViewExtensions.cs
+++ b/src/Tizen.NUI.Extension/Markup/ViewExtensions.cs
@@ -648,7 +648,7 @@ namespace Tizen.NUI.Extension
             var color = view.Color;
 
             //FIXME: we need to set UI value type directly without converting reference value.
-            return color != null ? new UIColor(color) : UIColor.Transparent;
+            return color != null ? UIColor.From(color) : UIColor.Transparent;
         }
 
         /// <summary>
@@ -693,7 +693,7 @@ namespace Tizen.NUI.Extension
             var color = view.BorderlineColor;
 
             //FIXME: we need to set UI value type directly without converting reference value.
-            return color != null ? new UIColor(color) : UIColor.Transparent;
+            return color != null ? UIColor.From(color) : UIColor.Transparent;
         }
     }
 }

--- a/src/Tizen.NUI/src/devel/Lite/UIColor.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIColor.cs
@@ -47,6 +47,11 @@ namespace Tizen.NUI
         public static readonly UIColor White = new (1, 1, 1, 1);
 
         /// <summary>
+        /// The gray color.
+        /// </summary>
+        public static readonly UIColor Gray = new (0.5f, 0.5f, 0.5f, 1);
+
+        /// <summary>
         /// The red color.
         /// </summary>
         public static readonly UIColor Red = new (1, 0, 0, 1);
@@ -60,6 +65,21 @@ namespace Tizen.NUI
         /// The blue color.
         /// </summary>
         public static readonly UIColor Blue = new (0, 0, 1, 1);
+
+        /// <summary>
+        /// The yellow color.
+        /// </summary>
+        public static readonly UIColor Yellow = new (1, 1, 0, 1);
+
+        /// <summary>
+        /// The cyan color.
+        /// </summary>
+        public static readonly UIColor Cyan = new (0, 1, 1, 1);
+
+        /// <summary>
+        /// The magenta color.
+        /// </summary>
+        public static readonly UIColor Magenta = new (1, 0, 1, 1);
 
         private float _r; // multiply alpha for token
         private float _g; // fixed alpha for token
@@ -121,10 +141,6 @@ namespace Tizen.NUI
             _b = 0f;
             _a = 0f;
             _tokenId = tokenId;
-        }
-
-        internal UIColor(NUI.Vector4 vector4) : this(vector4.X, vector4.Y, vector4.Z, vector4.W)
-        {
         }
 
         /// <summary>
@@ -230,6 +246,8 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="id">The unique identifier of the token.</param>
         public static UIColor Token(string id) => new (id, 1f);
+
+        internal static UIColor From(NUI.Vector4 vector4) => new UIColor(vector4.X, vector4.Y, vector4.Z, vector4.W);
 
         /// <summary>
         /// Compares two UIColor for equality.

--- a/src/Tizen.NUI/src/internal/Common/Object.cs
+++ b/src/Tizen.NUI/src/internal/Common/Object.cs
@@ -361,7 +361,7 @@ namespace Tizen.NUI
                 vector4.Reset();
                 _ = Interop.View.InternalRetrievingVisualPropertyVector4(actor, visualIndex, visualPropertyIndex, vector4.SwigCPtr);
                 NDalicPINVOKE.ThrowExceptionIfExists();
-                return new UIColor(vector4);
+                return UIColor.From(vector4);
             }, actor, visualIndex, visualPropertyIndex);
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
@@ -80,7 +80,7 @@ namespace Tizen.NUI.BaseComponents
                     var shadow = new Shadow(map);
                     return new UIShadow()
                     {
-                        Color = new UIColor(shadow.Color),
+                        Color = UIColor.From(shadow.Color),
                         BlurRadius = shadow.BlurRadius,
                         OffsetX = shadow.Offset.X,
                         OffsetY = shadow.Offset.Y,


### PR DESCRIPTION
### Description of Change ###
* Remove internal UIColor constructor with vector4 type. (It caused wrong use of `new UIColor(0xFFFFFF)`)
* Add predefined colors: Yellow, Cyan, Magenta, Gray


<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
