### PR TITLE
[NUI] Remove build warnings

### DIFF
--- a/src/Tizen.NUI/src/devel/Lite/UIVector3.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIVector3.cs
@@ -105,7 +105,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Converts the UIVector3 to Vector3 class implicitly.
         /// </summary>
-        /// <param name="uiVector2">A UIVector3 to be converted to Vector3</param>
+        /// <param name="uiVector3">A UIVector3 to be converted to Vector3</param>
         public static implicit operator Vector3(UIVector3 uiVector3)
         {
             return new Vector3(uiVector3.X, uiVector3.Y, uiVector3.Z);

--- a/src/Tizen.NUI/src/internal/Common/Alignment.cs
+++ b/src/Tizen.NUI/src/internal/Common/Alignment.cs
@@ -166,13 +166,13 @@ namespace Tizen.NUI
             return ret;
         }
 
-        public void SetPadding(Alignment.Padding padding)
+        public void SetAlignmentPadding(Alignment.Padding padding)
         {
             Interop.Alignment.SetPadding(SwigCPtr, Alignment.Padding.getCPtr(padding));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        public Alignment.Padding GetPadding()
+        public Alignment.Padding GetAlignmentPadding()
         {
             Alignment.Padding ret = new Alignment.Padding(Interop.Alignment.GetPadding(SwigCPtr), false);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Common/TSAlignment.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Common/TSAlignment.cs
@@ -194,29 +194,29 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("Alignment SetPadding.")]
-        [Property("SPEC", "Tizen.NUI.Alignment.SetPadding M")]
+        [Description("Alignment SetAlignmentPadding.")]
+        [Property("SPEC", "Tizen.NUI.Alignment.SetAlignmentPadding M")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "MR")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void AlignmentSetPadding()
+        public void AlignmentSetAlignmentPadding()
         {
-            tlog.Debug(tag, $"AlignmentSetPadding START");
+            tlog.Debug(tag, $"AlignmentSetAlignmentPadding START");
 
             var testingTarget = new Alignment(Alignment.Type.HorizontalCenter);
             Assert.IsNotNull(testingTarget, "Can't create success object Alignment");
             Assert.IsInstanceOf<Alignment>(testingTarget, "Should be an instance of Alignment type.");
 
-            tlog.Debug(tag, "Alignment.Padding : " + testingTarget.GetPadding());
+            tlog.Debug(tag, "Alignment.Padding : " + testingTarget.GetAlignmentPadding());
 
             using (Alignment.Padding padding = new Alignment.Padding(1.0f, 2.0f, 3.0f, 4.0f))
             {
-                testingTarget.SetPadding(padding);
-                tlog.Debug(tag, "Alignment.Padding : " + testingTarget.GetPadding());
+                testingTarget.SetAlignmentPadding(padding);
+                tlog.Debug(tag, "Alignment.Padding : " + testingTarget.GetAlignmentPadding());
             }
 
             testingTarget.Dispose();
-            tlog.Debug(tag, $"AlignmentSetPadding END (OK)");
+            tlog.Debug(tag, $"AlignmentSetAlignmentPadding END (OK)");
         }
 
         [Test]


### PR DESCRIPTION
- Fix comments error at UIVector3
- Make Alignment's Padding getter and setter name as `GetAlignmentPaddng()` / `SetAlignmentPadding()`. (It was same name with `UIExtents GetPadding()`