### PR TITLE
[NUI] Reduce build warning CA1805: Do not initialize unnecessarily (Internal/Devel/some public)

### DIFF
--- a/src/Tizen.NUI/src/devel/Lite/UIRect.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIRect.cs
@@ -63,7 +63,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets a <see cref="UIRect"/> structure with all coordinates and sizes set to zero.
         /// </summary>
-        public static UIRect Zero = new UIRect();
+        public static readonly UIRect Zero;
 
         /// <summary>
         /// Gets the y-coordinate of the top edge of the rectangle.

--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -366,7 +366,7 @@ namespace Tizen.NUI
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void RootIdleCallbackType();
 
-        private RootIdleCallbackType rootIdleCallback = null;
+        private RootIdleCallbackType rootIdleCallback;
         private Dictionary<System.Delegate, bool> idleCallbackMap = new Dictionary<System.Delegate, bool>();
 
         private void RootIdleCallback()

--- a/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
+++ b/src/Tizen.NUI/src/internal/Application/NUICoreBackend.cs
@@ -32,10 +32,10 @@ namespace Tizen.NUI
         protected Application application;
         private string stylesheet = "";
         private NUIApplication.WindowMode windowMode = NUIApplication.WindowMode.Opaque;
-        private Rectangle windowRectangle = null;
+        private Rectangle windowRectangle;
         private WindowType defaultWindowType = WindowType.Normal;
         private ICoreTask coreTask;
-        private WindowData windowData = null;
+        private WindowData windowData;
 
         /// <summary>
         /// The Dictionary to contain each type of event callback.

--- a/src/Tizen.NUI/src/internal/Common/ControlStateUtility.cs
+++ b/src/Tizen.NUI/src/internal/Common/ControlStateUtility.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     {
         private const int MaxBitWidth = 62;
         private static readonly Dictionary<string, ulong> registeredStates = new Dictionary<string, ulong>();
-        private static int nextBitPosition = 0;
+        private static int nextBitPosition;
 
         /// <summary>
         /// </summary>

--- a/src/Tizen.NUI/src/internal/Common/Disposable.cs
+++ b/src/Tizen.NUI/src/internal/Common/Disposable.cs
@@ -40,7 +40,7 @@ namespace Tizen.NUI
 
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
         private bool swigCMemOwn { get; set; }
-        private bool isDisposeQueued = false;
+        private bool isDisposeQueued;
 
         /// <summary>
         /// Create an instance of Disposable.

--- a/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
+++ b/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
@@ -37,12 +37,12 @@ namespace Tizen.NUI
         private EventThreadCallback eventThreadCallback;
         private EventThreadCallback.CallbackDelegate disposeQueueProcessDisposablesDelegate;
 
-        private bool initialized = false;
-        private bool processorRegistered = false;
-        private bool eventThreadCallbackTriggered = false;
+        private bool initialized;
+        private bool processorRegistered;
+        private bool eventThreadCallbackTriggered;
 
-        private bool incrementalDisposeSupported = false;
-        private bool fullCollectRequested = false;
+        private bool incrementalDisposeSupported;
+        private bool fullCollectRequested;
 
         private DisposeQueue()
         {

--- a/src/Tizen.NUI/src/internal/Common/NUIWindowInfo.cs
+++ b/src/Tizen.NUI/src/internal/Common/NUIWindowInfo.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI
         private const string logTag = "Tizen.NUI";
         private Window window;
         private int resourceId;
-        private bool disposed = false;
+        private bool disposed;
 
         /// <summary>
         /// Initializes the NUI Window class.

--- a/src/Tizen.NUI/src/internal/Common/NUIWindowProxy.cs
+++ b/src/Tizen.NUI/src/internal/Common/NUIWindowProxy.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI
         private const string logTag = "Tizen.NUI";
         private Window window;
         private int resourceId;
-        private bool disposed = false;
+        private bool disposed;
 
         /// <summary>
         /// Initializes the NUI Window class.

--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -33,8 +33,8 @@ namespace Tizen.NUI
     /// </summary>
     internal sealed class ProcessorController : Disposable
     {
-        private static ProcessorController instance = null;
-        private static bool initialized = false;
+        private static ProcessorController instance;
+        private static bool initialized;
 
         private ProcessorController() : this(true)
         {
@@ -63,7 +63,7 @@ namespace Tizen.NUI
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate void ProcessorEventHandler();
 
-        private ProcessorEventHandler processorCallback = null;
+        private ProcessorEventHandler processorCallback;
 
         private uint onceEventIndex;
         // Double buffered once event processing

--- a/src/Tizen.NUI/src/internal/Common/SystemFontSizeChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemFontSizeChangedManager.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI
     /// </summary>
     internal static class SystemFontSizeChangedManager
     {
-        private static SystemSettingsFontSize? fontSize = null;
+        private static SystemSettingsFontSize? fontSize;
         private static WeakEvent<EventHandler<FontSizeChangedEventArgs>> proxy = new WeakEvent<EventHandler<FontSizeChangedEventArgs>>();
 
         static SystemFontSizeChangedManager()

--- a/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/FrameBrokerBase.cs
@@ -32,10 +32,10 @@ namespace Tizen.NUI
         private string logTag = "NUI";
         private readonly SafeFrameBrokerHandle handle;
         private Dictionary<int, Interop.FrameBroker.AppControlResultCallback> resultCallbackMaps = new Dictionary<int, Interop.FrameBroker.AppControlResultCallback>();
-        private int resultId = 0;
+        private int resultId;
         private Interop.FrameBroker.FrameContextLifecycleCallbacks callbacks;
         private IntPtr context = IntPtr.Zero;
-        private bool disposed = false;
+        private bool disposed;
 
         private Renderer renderer;
         private TextureSet textureSet;

--- a/src/Tizen.NUI/src/internal/FrameBroker/FrameData.cs
+++ b/src/Tizen.NUI/src/internal/FrameBroker/FrameData.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
         private const string logTag = "NUI";
         private readonly IntPtr frame;
         private int fd = -1;
-        private uint size = 0;
+        private uint size;
 
         internal FrameData(IntPtr frame)
         {

--- a/src/Tizen.NUI/src/internal/FrameProvider/FrameProvider.cs
+++ b/src/Tizen.NUI/src/internal/FrameProvider/FrameProvider.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
         private string logTag = "NUI";
         private readonly SafeFrameProviderHandle handle;
         private Interop.FrameProvider.FrameProviderEventCallbacks callbacks;
-        private bool disposed = false;
+        private bool disposed;
 
         /// <summary>
         /// Initializes the FrameProvider class.

--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -167,7 +167,7 @@ namespace Tizen.NUI
         {
             [global::System.ThreadStatic]
             private static global::System.Exception pendingException = null;
-            private static int numExceptionsPending = 0;
+            private static int numExceptionsPending;
             private static readonly object exceptionPendingLock = new object();
 
             /// <since_tizen> 3 </since_tizen>

--- a/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/GridLocations.cs
@@ -30,8 +30,8 @@ namespace Tizen.NUI
         private int maxColumnConut;
         private float[] hLocations;
         private float[] vLocations;
-        private int totalHorizontalExpand = 0;
-        private int totalVerticalExpand = 0;
+        private int totalHorizontalExpand;
+        private int totalVerticalExpand;
 
         private List<GridChild> gridChildren = new List<GridChild>();
 

--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI
         private float windowHeight;
         private LayoutTransitionManager transitionManager;
 
-        private int layoutCount = 0;
+        private int layoutCount;
 
         /// <summary>
         /// Constructs a LayoutController which controls the measuring and layouting.<br />

--- a/src/Tizen.NUI/src/internal/Layouting/LayoutTransitionManager.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutTransitionManager.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI
 {
     internal class LayoutTransitionManager : Disposable
     {
-        private bool overrideCoreAnimation = false;
+        private bool overrideCoreAnimation;
         private Animation coreAnimation;
         private List<LayoutData> layoutTransitionDataQueue;
         private List<LayoutItem> itemRemovalQueue;

--- a/src/Tizen.NUI/src/internal/Transition/TransitionGroupItem.cs
+++ b/src/Tizen.NUI/src/internal/Transition/TransitionGroupItem.cs
@@ -28,13 +28,13 @@ namespace Tizen.NUI
     /// </summary>
     internal class TransitionGroupItem : TransitionItemBase
     {
-        private List<TransitionItemBase> transitionItemList = null;
+        private List<TransitionItemBase> transitionItemList;
 
-        private bool useGroupTimePeriod = false;
-        private bool stepTransition = false;
-        private bool useGroupAlphaFunction = false;
+        private bool useGroupTimePeriod;
+        private bool stepTransition;
+        private bool useGroupAlphaFunction;
 
-        private View transitionView = null;
+        private View transitionView;
 
         /// <summary>
         /// Creates an initialized fade.<br />

--- a/src/Tizen.NUI/src/internal/Utility/ColorCutQuantizer.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ColorCutQuantizer.cs
@@ -261,7 +261,7 @@ namespace Tizen.NUI
             private const int minGrow = 1;
 
             private int capacity = initialcapacity;
-            private int tail = 0;
+            private int tail;
             private T[] heap = Array.Empty<T>();
 
             public CustomHeap(Comparer<T> comparer)

--- a/src/Tizen.NUI/src/internal/WebView/WebBackForwardList.cs
+++ b/src/Tizen.NUI/src/internal/WebView/WebBackForwardList.cs
@@ -78,8 +78,8 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class WebBackForwardList : Disposable
     {
-        private WebBackForwardSubList backwardItemList = null;
-        private WebBackForwardSubList forwardItemList = null;
+        private WebBackForwardSubList backwardItemList;
+        private WebBackForwardSubList forwardItemList;
 
         internal WebBackForwardList(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
         {

--- a/src/Tizen.NUI/src/internal/Xaml/TypeConversionExtensions.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/TypeConversionExtensions.cs
@@ -143,7 +143,7 @@ namespace Tizen.NUI.Xaml
 
         private delegate void ParseValueFunc(string s, IFormatProvider provider);
 
-        static private Dictionary<Type, ParseValueFunc> typeToParseValueFunc = null;
+        static private Dictionary<Type, ParseValueFunc> typeToParseValueFunc;
 
         static private void BuildParseValueFunc()
         {

--- a/src/Tizen.NUI/src/internal/Xaml/XmlName.cs
+++ b/src/Tizen.NUI/src/internal/Xaml/XmlName.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI.Xaml
         public static readonly XmlName xArguments = new XmlName("x", "Arguments");
         public static readonly XmlName xFactoryMethod = new XmlName("x", "FactoryMethod");
         public static readonly XmlName xDataType = new XmlName("x", "DataType");
-        public static readonly XmlName Empty = new XmlName();
+        public static readonly XmlName Empty;
 
         public string NamespaceURI { get; }
         public string LocalName { get; }

--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -320,13 +320,13 @@ namespace Tizen.NUI.Accessibility
         #endregion Event, Enum, Struct, ETC
 
         #region Private
-        private static Interop.Accessibility.EnabledDisabledSignalHandler enabledSignalHandler = null;
+        private static Interop.Accessibility.EnabledDisabledSignalHandler enabledSignalHandler;
 
-        private static Interop.Accessibility.EnabledDisabledSignalHandler disabledSignalHandler = null;
+        private static Interop.Accessibility.EnabledDisabledSignalHandler disabledSignalHandler;
 
-        private static Interop.Accessibility.EnabledDisabledSignalHandler screenReaderEnabledSignalHandler = null;
+        private static Interop.Accessibility.EnabledDisabledSignalHandler screenReaderEnabledSignalHandler;
 
-        private static Interop.Accessibility.EnabledDisabledSignalHandler screenReaderDisabledSignalHandler = null;
+        private static Interop.Accessibility.EnabledDisabledSignalHandler screenReaderDisabledSignalHandler;
 
         private static readonly IReadOnlyDictionary<string, SayFinishedState> sayFinishedStateDictionary = new Dictionary<string, SayFinishedState>
         {

--- a/src/Tizen.NUI/src/public/Animation/Animation.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animation.cs
@@ -55,24 +55,24 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class Animation : BaseHandle
     {
-        private static bool? disableAnimation = null;
+        private static bool? disableAnimation;
 
         private AnimationFinishedEventCallbackType animationFinishedEventCallback;
         private System.IntPtr finishedCallbackOfNative;
 
         private AnimationProgressReachedEventCallbackType animationProgressReachedEventCallback;
 
-        private string[] properties = null;
-        private string[] destValue = null;
-        private int[] startTime = null;
-        private int[] endTime = null;
+        private string[] properties;
+        private string[] destValue;
+        private int[] startTime;
+        private int[] endTime;
 
-        private List<string> propertyList = null;
-        private List<string> destValueList = null;
-        private List<int> startTimeList = null;
-        private List<int> endTimeList = null;
+        private List<string> propertyList;
+        private List<string> destValueList;
+        private List<int> startTimeList;
+        private List<int> endTimeList;
 
-        private List<System.Delegate> customAlphaFunctionDelegates = null;
+        private List<System.Delegate> customAlphaFunctionDelegates;
 
         /// <summary>
         /// Creates an initialized animation.<br />

--- a/src/Tizen.NUI/src/public/Animation/TransitionOptions.cs
+++ b/src/Tizen.NUI/src/public/Animation/TransitionOptions.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
     /// <since_tizen> 9 </since_tizen>
     public class TransitionOptions : IDisposable
     {
-        private bool disposed = false;
+        private bool disposed;
 
         /// <summary>
         /// Initializes the TransitionOptions class.
@@ -46,7 +46,7 @@ namespace Tizen.NUI
         /// This is property for Page Transition.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public string TransitionTag { set; get; } = null;
+        public string TransitionTag { set; get; }
 
         /// <summary>
         /// Property for Page transition.
@@ -54,7 +54,7 @@ namespace Tizen.NUI
         /// Default value is false
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public bool TransitionWithChild { set; get; } = false;
+        public bool TransitionWithChild { set; get; }
 
         /// <summary>
         /// Hidden API (Inhouse API).

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -47,14 +47,14 @@ namespace Tizen.NUI
         /// <summary>
         /// The instance of ResourceManager.
         /// </summary>
-        private static System.Resources.ResourceManager resourceManager = null;
-        private static string currentLoadedXaml = null;
+        private static System.Resources.ResourceManager resourceManager;
+        private static string currentLoadedXaml;
 
         /// <summary>
         /// The border window
         /// </summary>
-        private bool borderEnabled = false;
-        private IBorderInterface borderInterface = null;
+        private bool borderEnabled;
+        private IBorderInterface borderInterface;
 
         private States currentState = States.Invalid;
 

--- a/src/Tizen.NUI/src/public/Application/NUIFrameComponent.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIFrameComponent.cs
@@ -26,7 +26,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class NUIFrameComponent : FrameComponent
     {
-        private bool defaultWindowSet = false;
+        private bool defaultWindowSet;
         internal NUIWindowInfo NUIWindowInfo
         {
             get;

--- a/src/Tizen.NUI/src/public/Application/NUIWidgetComponent.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIWidgetComponent.cs
@@ -26,7 +26,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class NUIWidgetComponent : WidgetComponent
     {
-        private bool defaultWindowSet = false;
+        private bool defaultWindowSet;
         internal NUIWindowProxy NUIWindowProxy
         {
             get;

--- a/src/Tizen.NUI/src/public/Application/WindowData.cs
+++ b/src/Tizen.NUI/src/public/Application/WindowData.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class WindowData : Disposable
     {
-        private IBorderInterface borderInterface = null;
+        private IBorderInterface borderInterface;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public WindowData() : this(Interop.WindowData.New(), true)

--- a/src/Tizen.NUI/src/public/ApplicationAnimation/ApplicationTransitionManager.cs
+++ b/src/Tizen.NUI/src/public/ApplicationAnimation/ApplicationTransitionManager.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class ApplicationTransitionManager : IDisposable
     {
-        private bool disposed = false;
+        private bool disposed;
         private FrameProvider frameProvider;
         private DefaultFrameBroker frameBroker;
         private Window mainWindow;

--- a/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/Style/ViewStyle.cs
@@ -69,9 +69,9 @@ namespace Tizen.NUI.BaseComponents
         static readonly IStyleProperty IsEnabledProperty = new StyleProperty<View, bool>((v, o) => v.IsEnabled = o);
 
         private Dictionary<IStyleProperty, object> values = new Dictionary<IStyleProperty, object>();
-        private bool disposed = false;
+        private bool disposed;
 
-        private float? sizeDepth = null;
+        private float? sizeDepth;
 
         static ViewStyle() { }
 

--- a/src/Tizen.NUI/src/public/Clipboard/Clipboard.cs
+++ b/src/Tizen.NUI/src/public/Clipboard/Clipboard.cs
@@ -41,7 +41,7 @@ namespace Tizen.NUI
         /// </remarks>
         public delegate void ClipboardCallback(bool success, ClipEvent clipEvent);
 
-        internal bool hasClipboardDataReceived = false;
+        internal bool hasClipboardDataReceived;
         internal Dictionary<uint, ClipboardCallback> receivedCallbackDictionary = new Dictionary<uint, ClipboardCallback>();
 
         private Clipboard(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -61,7 +61,7 @@ namespace Tizen.NUI
         private bool registerMe;
 
         //The flag to check who called Dispose(). (By User or DisposeQueue)
-        private bool isDisposeQueued = false;
+        private bool isDisposeQueued;
 
         /// <summary>
         /// Create an instance of BaseHandle.

--- a/src/Tizen.NUI/src/public/Common/Container.cs
+++ b/src/Tizen.NUI/src/public/Common/Container.cs
@@ -46,7 +46,7 @@ namespace Tizen.NUI
 
         internal BaseHandle InternalParent;
         private List<View> childViews = new List<View>();
-        private MergedStyle mergedStyle = null;
+        private MergedStyle mergedStyle;
         ResourceDictionary _resources;
         bool IResourcesProvider.IsResourcesCreated => _resources != null;
 

--- a/src/Tizen.NUI/src/public/Common/Extents.cs
+++ b/src/Tizen.NUI/src/public/Common/Extents.cs
@@ -122,7 +122,7 @@ namespace Tizen.NUI
         /// <since_tizen> Only used by Tizen.NUI.Components, will not be opened </since_tizen>
 		[System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public delegate void ExtentsChangedCallback(ushort start, ushort end, ushort top, ushort bottom);
-        private ExtentsChangedCallback callback = null;
+        private ExtentsChangedCallback callback;
 
         /// <summary>
         /// The Start extent.

--- a/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
@@ -25,7 +25,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public partial class FrameUpdateCallbackInterface : Disposable
     {
-        private uint onUpdateCallbackVersion = 0u;
+        private uint onUpdateCallbackVersion;
 
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/Common/Layer.cs
+++ b/src/Tizen.NUI/src/public/Common/Layer.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
     public class Layer : Container
     {
         private Window window;
-        private int layoutCount = 0;
+        private int layoutCount;
 
         private EventHandler<VisibilityChangedEventArgs> visibilityChangedEventHandler;
         private VisibilityChangedEventCallbackType visibilityChangedEventCallback;

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -1799,7 +1799,7 @@ namespace Tizen.NUI
     /// </summary>
     internal struct FrameworkInformation
     {
-        public readonly static string ResourcePath = "/usr/share/dotnet.tizen/framework/res/";
+        public const string ResourcePath = "/usr/share/dotnet.tizen/framework/res/";
     }
 
     /// <summary>

--- a/src/Tizen.NUI/src/public/Common/Position.cs
+++ b/src/Tizen.NUI/src/public/Common/Position.cs
@@ -650,6 +650,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        private PositionChangedCallback callback = null;
+        private PositionChangedCallback callback;
     }
 }

--- a/src/Tizen.NUI/src/public/Common/Position2D.cs
+++ b/src/Tizen.NUI/src/public/Common/Position2D.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     [Tizen.NUI.Binding.TypeConverter(typeof(Position2DTypeConverter))]
     public class Position2D : Disposable, ICloneable
     {
-        private Position2DChangedCallback callback = null;
+        private Position2DChangedCallback callback;
 
         /// <summary>
         /// The constructor.

--- a/src/Tizen.NUI/src/public/Common/Rectangle.cs
+++ b/src/Tizen.NUI/src/public/Common/Rectangle.cs
@@ -86,7 +86,7 @@ namespace Tizen.NUI
         }
 
         internal delegate void RectangleChangedCallback(int x, int y, int width, int height);
-        private RectangleChangedCallback callback = null;
+        private RectangleChangedCallback callback;
 
         /// <summary>
         /// The x position of the rectangle.

--- a/src/Tizen.NUI/src/public/Common/RelativeVector4.cs
+++ b/src/Tizen.NUI/src/public/Common/RelativeVector4.cs
@@ -77,7 +77,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
         internal delegate void RelativeVector4ChangedCallback(float x, float y, float z, float w);
-        private RelativeVector4ChangedCallback callback = null;
+        private RelativeVector4ChangedCallback callback;
 
         /// <summary>
         /// The x component.

--- a/src/Tizen.NUI/src/public/Common/Size.cs
+++ b/src/Tizen.NUI/src/public/Common/Size.cs
@@ -547,6 +547,6 @@ namespace Tizen.NUI
             depth = d;
         }
 
-        private SizeChangedCallback callback = null;
+        private SizeChangedCallback callback;
     }
 }

--- a/src/Tizen.NUI/src/public/Common/Size2D.cs
+++ b/src/Tizen.NUI/src/public/Common/Size2D.cs
@@ -28,7 +28,7 @@ namespace Tizen.NUI
     public class Size2D : Disposable, ICloneable
     {
 
-        private Size2DChangedCallback callback = null;
+        private Size2DChangedCallback callback;
 
         /// <summary>
         /// The constructor.

--- a/src/Tizen.NUI/src/public/Common/Vector2.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector2.cs
@@ -115,7 +115,7 @@ namespace Tizen.NUI
         }
 
         internal delegate void Vector2ChangedCallback(float x, float y);
-        private Vector2ChangedCallback callback = null;
+        private Vector2ChangedCallback callback;
 
         /// <summary>
         /// Returns a Vector2 instance where both the x and y components are set to 1.0f.

--- a/src/Tizen.NUI/src/public/Common/Vector3.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector3.cs
@@ -103,7 +103,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
         internal delegate void Vector3ChangedCallback(float x, float y, float z);
-        private Vector3ChangedCallback callback = null;
+        private Vector3ChangedCallback callback;
 
         /// <summary>
         /// Returns a Vector2 instance where both the x and y components are set to 1.0f.

--- a/src/Tizen.NUI/src/public/Common/Vector4.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector4.cs
@@ -101,7 +101,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
         internal delegate void Vector4ChangedCallback(float x, float y, float z, float w);
-        private Vector4ChangedCallback callback = null;
+        private Vector4ChangedCallback callback;
 
         /// <summary>
         /// Returns a Vector2 instance where both the x and y components are set to 1.0f.

--- a/src/Tizen.NUI/src/public/Common/WeakEvent.cs
+++ b/src/Tizen.NUI/src/public/Common/WeakEvent.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
     {
         private const int addThreshold = 1000; // Experimetal constant
         private const int listLengthThreshold = 1000; // Experimetal constant
-        private int cleanUpAddCount = 0;
+        private int cleanUpAddCount;
         private List<WeakHandler<T>> handlers = new List<WeakHandler<T>>();
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
+++ b/src/Tizen.NUI/src/public/CustomView/CustomViewRegistry.cs
@@ -192,7 +192,7 @@ namespace Tizen.NUI
         /// <summary>
         /// ViewRegistry is a singleton.
         /// </summary>
-        private static CustomViewRegistry instance = null;
+        private static CustomViewRegistry instance;
 
         private CreateControlDelegate createCallback;
         private SetPropertyDelegate setPropertyCallback;

--- a/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
+++ b/src/Tizen.NUI/src/public/DragAndDrop/DragAndDrop.cs
@@ -55,8 +55,8 @@ namespace Tizen.NUI
         private Window mDragWindow;
         private int shadowWidth;
         private int shadowHeight;
-        private int dragWindowOffsetX = 0;
-        private int dragWindowOffsetY = 0;
+        private int dragWindowOffsetX;
+        private int dragWindowOffsetY;
 
         private const int MinDragWindowWidth = 100;
         private const int MinDragWindowHeight = 100;

--- a/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class EncodedImageBuffer : BaseHandle
     {
-        private VectorUnsignedChar mCachedBuffer = null; // cached encoded raw buffer
+        private VectorUnsignedChar mCachedBuffer; // cached encoded raw buffer
 
         /// <summary>
         /// The list of type of encoded image buffer.

--- a/src/Tizen.NUI/src/public/Input/FocusManager.cs
+++ b/src/Tizen.NUI/src/public/Input/FocusManager.cs
@@ -75,8 +75,8 @@ namespace Tizen.NUI
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void FocusedViewEnterKeyEventCallback2(IntPtr view);
 
-        private View internalFocusIndicator = null;
-        private View nullFocusIndicator = null;
+        private View internalFocusIndicator;
+        private View nullFocusIndicator;
 
         /// <summary>
         /// PreFocusChange will be triggered before the focus is going to be changed.<br />

--- a/src/Tizen.NUI/src/public/Input/InputMethod.cs
+++ b/src/Tizen.NUI/src/public/Input/InputMethod.cs
@@ -22,10 +22,10 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class InputMethod
     {
-        private PanelLayoutType? panelLayout = null;
-        private ActionButtonTitleType? actionButton = null;
-        private AutoCapitalType? autoCapital = null;
-        private int? variation = null;
+        private PanelLayoutType? panelLayout;
+        private ActionButtonTitleType? actionButton;
+        private AutoCapitalType? autoCapital;
+        private int? variation;
 
         /// <summary>
         /// The default constructor of InputMethod.

--- a/src/Tizen.NUI/src/public/Input/KeyValue.cs
+++ b/src/Tizen.NUI/src/public/Input/KeyValue.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     /// </summary>
     public class KeyValue : IDisposable
     {
-        private bool disposed = false;
+        private bool disposed;
         /// <summary>
         /// Int key.
         /// </summary>
@@ -52,9 +52,9 @@ namespace Tizen.NUI
         [SuppressMessage("Microsoft.Design", "CA1051:Do not declare visible instance fields")]
         public PropertyValue TrueValue = null;
 
-        private string key = null;
-        private object originalValue = null;
-        private object originalKey = null;
+        private string key;
+        private object originalValue;
+        private object originalKey;
 
         /// <summary>
         /// The default Constructor of KeyValue class.

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -89,18 +89,18 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FlexGrowProperty = null;
 
-        private static Dictionary<View, AlignmentType> flexAlignmentSelfMap = null;
-        private static Dictionary<View, float> flexAspectRatioMap = null;
-        private static Dictionary<View, float> flexBasisMap = null;
-        private static Dictionary<View, float> flexShrinkMap = null;
-        private static Dictionary<View, float> flexGrowMap = null;
+        private static Dictionary<View, AlignmentType> flexAlignmentSelfMap;
+        private static Dictionary<View, float> flexAspectRatioMap;
+        private static Dictionary<View, float> flexBasisMap;
+        private static Dictionary<View, float> flexShrinkMap;
+        private static Dictionary<View, float> flexGrowMap;
 
-        private Dictionary<View, HandleRef> childHandleRefMap = null;
+        private Dictionary<View, HandleRef> childHandleRefMap;
 
         private global::System.Runtime.InteropServices.HandleRef swigCPtr;
         private bool swigCMemOwn;
         private bool disposed;
-        private bool isDisposeQueued = false;
+        private bool isDisposeQueued;
 
         private MeasureSpecification parentMeasureSpecificationWidth;
         private MeasureSpecification parentMeasureSpecificationHeight;

--- a/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/GridLayout.cs
@@ -81,20 +81,20 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public const int AutoRow = int.MinValue;
 
-        private static Dictionary<View, int> columnMap = null;
-        private static Dictionary<View, int> columnSpanMap = null;
-        private static Dictionary<View, int> rowMap = null;
-        private static Dictionary<View, int> rowSpanMap = null;
-        private static Dictionary<View, StretchFlags> horizontalStretchMap = null;
-        private static Dictionary<View, StretchFlags> verticalStretchMap = null;
-        private static Dictionary<View, Alignment> horizontalAlignmentMap  = null;
-        private static Dictionary<View, Alignment> verticalAlignmentMap = null;
+        private static Dictionary<View, int> columnMap;
+        private static Dictionary<View, int> columnSpanMap;
+        private static Dictionary<View, int> rowMap;
+        private static Dictionary<View, int> rowSpanMap;
+        private static Dictionary<View, StretchFlags> horizontalStretchMap;
+        private static Dictionary<View, StretchFlags> verticalStretchMap;
+        private static Dictionary<View, Alignment> horizontalAlignmentMap;
+        private static Dictionary<View, Alignment> verticalAlignmentMap;
 
         private Orientation gridOrientation = Orientation.Horizontal;
         private int columns = 1;
         private int rows = 1;
-        private float columnSpacing = 0;
-        private float rowSpacing = 0;
+        private float columnSpacing;
+        private float rowSpacing;
 
         /// <summary>
         /// Enumeration for the direction in which the content is laid out

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -39,7 +39,7 @@ namespace Tizen.NUI
     /// </summary>
     public class LayoutItem : IDisposable
     {
-        private bool disposed = false;
+        private bool disposed;
         private MeasureSpecification oldWidthMeasureSpec; // Store measure specification to compare against later
         private MeasureSpecification oldHeightMeasureSpec; // Store measure specification to compare against later
 
@@ -52,7 +52,7 @@ namespace Tizen.NUI
         private Extents padding;
         private Extents margin;
 
-        private bool parentReplacement = false;
+        private bool parentReplacement;
         private bool setPositionByLayout = true;
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/LayoutTransition.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutTransition.cs
@@ -105,7 +105,7 @@ namespace Tizen.NUI
     /// <since_tizen> 6 </since_tizen>
     public class TransitionComponents : IDisposable
     {
-        private bool disposed = false;
+        private bool disposed;
         /// <summary>
         /// TransitionComponents default constructor.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LinearLayout.cs
@@ -197,7 +197,7 @@ namespace Tizen.NUI
         /// <since_tizen> 9 </since_tizen>
         public VerticalAlignment VerticalAlignment { get; set; } = VerticalAlignment.Top;
 
-        private float totalLength = 0.0f;
+        private float totalLength;
         private Size2D cellPadding = new Size2D(0, 0);
         private Orientation linearOrientation = Orientation.Horizontal;
 

--- a/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/RelativeLayout.cs
@@ -99,18 +99,18 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly BindableProperty FillVerticalProperty = null;
 
-        private static Dictionary<View, View> leftTargetMap = null;
-        private static Dictionary<View, View> rightTargetMap = null;
-        private static Dictionary<View, View> topTargetMap = null;
-        private static Dictionary<View, View> bottomTargetMap = null;
-        private static Dictionary<View, float> leftRelativeOffsetMap = null;
-        private static Dictionary<View, float> rightRelativeOffsetMap = null;
-        private static Dictionary<View, float> topRelativeOffsetMap = null;
-        private static Dictionary<View, float> bottomRelativeOffsetMap = null;
-        private static Dictionary<View, Alignment> horizontalAlignmentMap = null;
-        private static Dictionary<View, Alignment> verticalAlignmentMap = null;
-        private static Dictionary<View, bool> fillHorizontalMap = null;
-        private static Dictionary<View, bool> fillVerticalMap = null;
+        private static Dictionary<View, View> leftTargetMap;
+        private static Dictionary<View, View> rightTargetMap;
+        private static Dictionary<View, View> topTargetMap;
+        private static Dictionary<View, View> bottomTargetMap;
+        private static Dictionary<View, float> leftRelativeOffsetMap;
+        private static Dictionary<View, float> rightRelativeOffsetMap;
+        private static Dictionary<View, float> topRelativeOffsetMap;
+        private static Dictionary<View, float> bottomRelativeOffsetMap;
+        private static Dictionary<View, Alignment> horizontalAlignmentMap;
+        private static Dictionary<View, Alignment> verticalAlignmentMap;
+        private static Dictionary<View, bool> fillHorizontalMap;
+        private static Dictionary<View, bool> fillVerticalMap;
 
         static RelativeLayout()
         {

--- a/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
+++ b/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
@@ -367,7 +367,7 @@ namespace Tizen.NUI.ParticleSystem
 
         // Internal proxy object to be used on the update thread
         internal ParticleEmitterProxy EmitterProxy => mProxy;
-        private ParticleEmitterProxy mProxy = null;
+        private ParticleEmitterProxy mProxy;
     }
     
     /// <summary>

--- a/src/Tizen.NUI/src/public/ParticleSystem/ParticleModifier.cs
+++ b/src/Tizen.NUI/src/public/ParticleSystem/ParticleModifier.cs
@@ -169,7 +169,7 @@ namespace Tizen.NUI.ParticleSystem
         }
         
         private static Interop.ParticleModifier.ParticleModifierUpdateInvokerType mOnUpdateInvoker = OnUpdateInvoker;
-        private ParticleModifierInterface mInterface = null;
+        private ParticleModifierInterface mInterface;
         private static IntPtr gRefObjectPtr;
     }
 }

--- a/src/Tizen.NUI/src/public/ParticleSystem/ParticleSource.cs
+++ b/src/Tizen.NUI/src/public/ParticleSystem/ParticleSource.cs
@@ -209,7 +209,7 @@ namespace Tizen.NUI.ParticleSystem
         // private fields
         private static Interop.ParticleSource.ParticleSourceInitInvokerType mOnInitInvoker = OnInitInvoker;
         private static Interop.ParticleSource.ParticleSourceUpdateInvokerType mOnUpdateInvoker = OnUpdateInvoker;
-        private ParticleSourceInterface mInterface = null;
+        private ParticleSourceInterface mInterface;
         private static IntPtr gRefObjectPtr;
     }
 }

--- a/src/Tizen.NUI/src/public/Theme/Theme.cs
+++ b/src/Tizen.NUI/src/public/Theme/Theme.cs
@@ -41,7 +41,7 @@ namespace Tizen.NUI
     public class Theme : BindableObject, IResourcesProvider
     {
         private readonly Dictionary<string, ViewStyle> map;
-        private IEnumerable<KeyValuePair<string, string>> changedResources = null;
+        private IEnumerable<KeyValuePair<string, string>> changedResources;
         private string baseTheme;
         ResourceDictionary resources;
 
@@ -105,7 +105,7 @@ namespace Tizen.NUI
         /// The version of the Theme.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public string Version { get; set; } = null;
+        public string Version { get; set; }
 
         /// <summary>
         /// The url of small broken image
@@ -220,7 +220,7 @@ namespace Tizen.NUI
 
         internal int Count => map.Count;
 
-        internal int PackageCount { get; set; } = 0;
+        internal int PackageCount { get; set; }
 
         /// <summary>
         /// Get an enumerator of the theme.

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -59,9 +59,9 @@ namespace Tizen.NUI
         private static Theme themeForInitialize; // baseTheme + platformTheme + userTheme. It is used when the component is created.
         private static readonly List<Theme> cachedPlatformThemes = new List<Theme>(); // Themes provided by framework.
         private static readonly List<string> packages = new List<string>();// This is to store base theme creators by packages.
-        private static bool platformThemeEnabled = false;
-        private static bool isInEventProgress = false;
-        private static bool updateThemeDirty = false;
+        private static bool platformThemeEnabled;
+        private static bool isInEventProgress;
+        private static bool updateThemeDirty;
 
         static ThemeManager()
         {
@@ -171,7 +171,7 @@ namespace Tizen.NUI
             }
         }
 
-        internal static bool ApplicationThemeChangeSensitive { get; set; } = false;
+        internal static bool ApplicationThemeChangeSensitive { get; set; }
 
 #if PROFILE_TV
         internal const bool InitialThemeDisabled = true;

--- a/src/Tizen.NUI/src/public/Transition/FadeTransition.cs
+++ b/src/Tizen.NUI/src/public/Transition/FadeTransition.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     /// <since_tizen> 9 </since_tizen>
     public class FadeTransition : TransitionBase
     {
-        private float opacity = 0.0f;
+        private float opacity;
 
         /// <summary>
         /// Create a FadeTransition for the View pair.

--- a/src/Tizen.NUI/src/public/Transition/TransitionBase.cs
+++ b/src/Tizen.NUI/src/public/Transition/TransitionBase.cs
@@ -31,8 +31,8 @@ namespace Tizen.NUI
     /// <since_tizen> 9 </since_tizen>
     public class TransitionBase : Disposable
     {
-        private AlphaFunction alphaFunction = null;
-        private TimePeriod timePeriod = null;
+        private AlphaFunction alphaFunction;
+        private TimePeriod timePeriod;
 
         /// <summary>
         /// Default constructor to create a TransitionBase

--- a/src/Tizen.NUI/src/public/Transition/TransitionGroup.cs
+++ b/src/Tizen.NUI/src/public/Transition/TransitionGroup.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class TransitionGroup : TransitionBase
     {
-        private List<TransitionBase> transitionList = null;
+        private List<TransitionBase> transitionList;
 
         /// <summary>
         /// Create a FadeTransition for the View pair.

--- a/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
+++ b/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
@@ -48,8 +48,8 @@ namespace Tizen.NUI.Utility
 
         private const int mHistorySize = 20;
         private uint mMaximumTime;
-        private uint mLastEventTime = 0;
-        private float mLastPosition = 0;
+        private uint mLastEventTime;
+        private float mLastPosition;
         private uint mAssumePointerStoppedTime = 40; // 40ms
         protected SortedDictionary<int, List<Movement>> mMovements;
 

--- a/src/Tizen.NUI/src/public/Utility/Timer.cs
+++ b/src/Tizen.NUI/src/public/Utility/Timer.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class Timer : BaseHandle
     {
-        private bool played = false;
+        private bool played;
         private EventHandlerWithReturnType<object, TickEventArgs, bool> timerTickEventHandler;
         private TickCallbackDelegate timerTickCallbackDelegate;
 

--- a/src/Tizen.NUI/src/public/Utility/VelocityTracker.cs
+++ b/src/Tizen.NUI/src/public/Utility/VelocityTracker.cs
@@ -51,8 +51,8 @@ namespace Tizen.NUI.Utility
     {
         private struct Axis
         {
-            public static int X = 0;
-            public static int Y = 1;
+            public const int X = 0;
+            public const int Y = 1;
         }
 
         private struct ComputedVelocity
@@ -81,8 +81,8 @@ namespace Tizen.NUI.Utility
             }
         }
 
-        private int mPointerCount = 0;
-        private bool mIsComputed = false;
+        private int mPointerCount;
+        private bool mIsComputed;
         private ComputedVelocity mComputedVelocity;
         private VelocityTrackerStrategy[] mConfiguredStrategies;
 

--- a/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
@@ -24,7 +24,7 @@ namespace Tizen.NUI
     /// </summary>
     internal class BackgroundExtraData : IDisposable
     {
-        private bool disposed = false;
+        private bool disposed;
         internal BackgroundExtraData()
         {
             BorderlineColor = Tizen.NUI.Color.Black;

--- a/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/LayoutExtraData.cs
@@ -60,12 +60,12 @@ namespace Tizen.NUI.BaseComponents
         /// <summary>
         /// Gets or sets the minimum width of the view.
         /// </summary>
-        public float MinimumWidth { get; set; } = 0;
+        public float MinimumWidth { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum height of the view.
         /// </summary>
-        public float MinimumHeight { get; set; } = 0;
+        public float MinimumHeight { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum width of the view.

--- a/src/Tizen.NUI/src/public/ViewProperty/TextShadow.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/TextShadow.cs
@@ -26,8 +26,8 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class TextShadow : ICloneable, IDisposable
     {
-        private bool disposed = false;
-        private readonly PropertyMap propertyMap = null;
+        private bool disposed;
+        private readonly PropertyMap propertyMap;
 
         internal delegate void PropertyChangedCallback(TextShadow instance);
 

--- a/src/Tizen.NUI/src/public/Visuals/AnimatedImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/AnimatedImageVisual.cs
@@ -24,11 +24,11 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class AnimatedImageVisual : VisualMap
     {
-        private List<string> urls = null;
-        private int? batchSize = null;
-        private int? cacheSize = null;
-        private float? frameDelay = null;
-        private float? loopCount = null;
+        private List<string> urls;
+        private int? batchSize;
+        private int? cacheSize;
+        private float? frameDelay;
+        private float? loopCount;
 
         /// <summary>
         /// Default constructor of AnimatedImageVisual class.

--- a/src/Tizen.NUI/src/public/Visuals/BorderVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/BorderVisual.cs
@@ -23,9 +23,9 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class BorderVisual : VisualMap
     {
-        private Color color = null;
-        private float? size = null;
-        private bool? antiAliasing = null;
+        private Color color;
+        private float? size;
+        private bool? antiAliasing;
 
         /// <summary>
         /// Default constructor of BorderVisual class.

--- a/src/Tizen.NUI/src/public/Visuals/ColorVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/ColorVisual.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class ColorVisual : VisualMap
     {
-        private Color mixColorForColorVisual = null;
+        private Color mixColorForColorVisual;
         private bool? renderIfTransparent = false;
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
@@ -23,14 +23,14 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class GradientVisual : VisualMap
     {
-        private Vector2 _startPosition = null;
-        private Vector2 _endPosition = null;
-        private Vector2 _center = null;
-        private float? _radius = null;
-        private PropertyArray _stopOffset = null;
-        private PropertyArray _stopColor = null;
-        private GradientVisualUnitsType? _units = null;
-        private GradientVisualSpreadMethodType? _spreadMethod = null;
+        private Vector2 _startPosition;
+        private Vector2 _endPosition;
+        private Vector2 _center;
+        private float? _radius;
+        private PropertyArray _stopOffset;
+        private PropertyArray _stopColor;
+        private GradientVisualUnitsType? _units;
+        private GradientVisualSpreadMethodType? _spreadMethod;
 
         /// <summary>
         /// Default constructor of GradientVisual.

--- a/src/Tizen.NUI/src/public/Visuals/ImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/ImageVisual.cs
@@ -23,23 +23,23 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class ImageVisual : VisualMap
     {
-        private string url = null;
-        private string alphaMaskUrl = null;
-        private string auxiliaryImageUrl = null;
-        private FittingModeType? fittingMode = null;
-        private SamplingModeType? samplingMode = null;
-        private int? desiredWidth = null;
-        private int? desiredHeight = null;
+        private string url;
+        private string alphaMaskUrl;
+        private string auxiliaryImageUrl;
+        private FittingModeType? fittingMode;
+        private SamplingModeType? samplingMode;
+        private int? desiredWidth;
+        private int? desiredHeight;
         private bool? synchronousLoading = false;
-        private bool? borderOnly = null;
-        private Vector4 pixelArea = null;
-        private WrapModeType? wrapModeU = null;
-        private WrapModeType? wrapModeV = null;
-        private float? auxiliaryImageAlpha = null;
-        private float? maskContentScale = null;
-        private bool? cropToMask = null;
-        private ReleasePolicyType? releasePolicy = null;
-        private LoadPolicyType? loadPolicy = null;
+        private bool? borderOnly;
+        private Vector4 pixelArea;
+        private WrapModeType? wrapModeU;
+        private WrapModeType? wrapModeV;
+        private float? auxiliaryImageAlpha;
+        private float? maskContentScale;
+        private bool? cropToMask;
+        private ReleasePolicyType? releasePolicy;
+        private LoadPolicyType? loadPolicy;
         private bool? orientationCorrection = true;
         private bool? atlasing = false;
 

--- a/src/Tizen.NUI/src/public/Visuals/MeshVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/MeshVisual.cs
@@ -25,13 +25,13 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class MeshVisual : VisualMap
     {
-        private string objectURL = null;
-        private string materialURL = null;
-        private string texturesPath = null;
-        private MeshVisualShadingModeValue? shadingMode = null;
-        private bool? useMipmapping = null;
-        private bool? useSoftNormals = null;
-        private Vector3 lightPosition = null;
+        private string objectURL;
+        private string materialURL;
+        private string texturesPath;
+        private MeshVisualShadingModeValue? shadingMode;
+        private bool? useMipmapping;
+        private bool? useSoftNormals;
+        private Vector3 lightPosition;
 
         /// <summary>
         /// Default constructor of MeshVisual class.

--- a/src/Tizen.NUI/src/public/Visuals/NPatchVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/NPatchVisual.cs
@@ -23,9 +23,9 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class NPatchVisual : VisualMap
     {
-        private string url = null;
-        private bool? borderOnly = null;
-        private Rectangle border = null;
+        private string url;
+        private bool? borderOnly;
+        private Rectangle border;
 
         /// <summary>
         /// Default constructor of NPatchVisual class.

--- a/src/Tizen.NUI/src/public/Visuals/PrimitiveVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/PrimitiveVisual.cs
@@ -23,18 +23,18 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class PrimitiveVisual : VisualMap
     {
-        private PrimitiveVisualShapeType? _shape = null;
-        private Color _mixColorForPrimitiveVisual = null;
-        private int? _slices = null;
-        private int? _stacks = null;
-        private float? _scaleTopRadius = null;
-        private float? _scaleBottomRadius = null;
-        private float? _scaleHeight = null;
-        private float? _scaleRadius = null;
-        private Vector3 _scaleDimensions = null;
-        private float? _bevelPercentage = null;
-        private float? _bevelSmoothness = null;
-        private Vector3 _lightPosition = null;
+        private PrimitiveVisualShapeType? _shape;
+        private Color _mixColorForPrimitiveVisual;
+        private int? _slices;
+        private int? _stacks;
+        private float? _scaleTopRadius;
+        private float? _scaleBottomRadius;
+        private float? _scaleHeight;
+        private float? _scaleRadius;
+        private Vector3 _scaleDimensions;
+        private float? _bevelPercentage;
+        private float? _bevelSmoothness;
+        private Vector3 _lightPosition;
 
         /// <summary>
         /// Default constructor of PrimitiveVisual class.

--- a/src/Tizen.NUI/src/public/Visuals/SVGVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/SVGVisual.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class SVGVisual : VisualMap
     {
-        private string url = null;
+        private string url;
 
         /// <summary>
         /// Default constructor of SVGVisual class.

--- a/src/Tizen.NUI/src/public/Visuals/TextVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/TextVisual.cs
@@ -24,19 +24,19 @@ namespace Tizen.NUI
     public class TextVisual : VisualMap
     {
         static private float defaultPointSize = 18;
-        private string text = null;
-        private string fontFamily = null;
-        private PropertyMap fontStyle = null;
+        private string text;
+        private string fontFamily;
+        private PropertyMap fontStyle;
         private float pointSize = defaultPointSize;
-        private bool? multiLine = null;
-        private string horizontalAlignment = null;
-        private string verticalAlignment = null;
-        private Color textColor = null;
-        private bool? enableMarkup = null;
-        private PropertyMap shadow = null;
-        private PropertyMap underline = null;
-        private PropertyMap outline = null;
-        private PropertyMap background = null;
+        private bool? multiLine;
+        private string horizontalAlignment;
+        private string verticalAlignment;
+        private Color textColor;
+        private bool? enableMarkup;
+        private PropertyMap shadow;
+        private PropertyMap underline;
+        private PropertyMap outline;
+        private PropertyMap background;
 
         /// <summary>
         /// Default constructor of TextVisual class.

--- a/src/Tizen.NUI/src/public/Visuals/VisualAnimator.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualAnimator.cs
@@ -25,12 +25,12 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class VisualAnimator : VisualMap
     {
-        private string alphaFunction = null;
-        private int startTime = 0;
-        private int endTime = 0;
-        private string target = null;
-        private string propertyIndex = null;
-        private object destinationValue = null;
+        private string alphaFunction;
+        private int startTime;
+        private int endTime;
+        private string target;
+        private string propertyIndex;
+        private object destinationValue;
 
         /// <summary>
         /// Create VisualAnimator object.

--- a/src/Tizen.NUI/src/public/Visuals/VisualMaps.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualMaps.cs
@@ -26,7 +26,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class VisualMap : IDisposable
     {
-        private bool disposed = false;
+        private bool disposed;
         /// <summary>
         /// outputVisualMap.
         /// </summary>
@@ -76,11 +76,11 @@ namespace Tizen.NUI
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "<Pending>")]
         protected VisualFittingModeType? _visualFittingMode = null;
 
-        private Vector4 cornerRadius = null;
-        private VisualTransformPolicyType? cornerRadiusPolicy = null;
-        private float? borderlineWidth = null;
-        private Color borderlineColor = null;
-        private float? borderlineOffset = null;
+        private Vector4 cornerRadius;
+        private VisualTransformPolicyType? cornerRadiusPolicy;
+        private float? borderlineWidth;
+        private Color borderlineColor;
+        private float? borderlineOffset;
 
         /// <summary>
         /// The map for visual.
@@ -90,16 +90,16 @@ namespace Tizen.NUI
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1051:Do not declare visible instance fields", Justification = "<Pending>")]
         protected PropertyMap _commonlyUsedMap = null;
 
-        private Vector2 visualSize = null;
-        private Vector2 visualOffset = null;
-        private Vector2 visualOffsetPolicy = null;
-        private Vector2 visualSizePolicy = null;
-        private Visual.AlignType? visualOrigin = null;
-        private Visual.AlignType? visualAnchorPoint = null;
+        private Vector2 visualSize;
+        private Vector2 visualOffset;
+        private Vector2 visualOffsetPolicy;
+        private Vector2 visualSizePolicy;
+        private Visual.AlignType? visualOrigin;
+        private Visual.AlignType? visualAnchorPoint;
 
-        private PropertyMap visualTransformMap = null;
+        private PropertyMap visualTransformMap;
 
-        private int? depthIndex = null;
+        private int? depthIndex;
 
         /// <summary>
         /// Constructor.
@@ -717,7 +717,7 @@ namespace Tizen.NUI
         /// Suppress UpdateVisual() to update properties to Parent.
         /// If it is set to true, UpdateVisual() is ignored unless it is called with force.
         /// </summary>
-        internal bool SuppressUpdateVisual { get; set; } = false;
+        internal bool SuppressUpdateVisual { get; set; }
 
         internal void UpdateVisual(bool force = false)
         {

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/AdvancedTextVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/AdvancedTextVisual.cs
@@ -34,10 +34,10 @@ namespace Tizen.NUI.Visuals
     public class AdvancedTextVisual : Visuals.TextVisual
     {
         #region Internal
-        private string textLabelSid = null;
+        private string textLabelSid;
 
         private static Tizen.NUI.SystemLocaleLanguageChanged systemLocaleLanguageChanged = new Tizen.NUI.SystemLocaleLanguageChanged();
-        private bool hasSystemLanguageChanged = false;
+        private bool hasSystemLanguageChanged;
         #endregion
 
         #region Constructor

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
@@ -34,7 +34,7 @@ namespace Tizen.NUI.Visuals
 
         internal static readonly int ActionJumpTo = Tizen.NUI.BaseComponents.AnimatedImageView.ActionJumpTo;
 
-        private List<string> resourceUrls = null;
+        private List<string> resourceUrls;
         #endregion
 
         #region Constructor

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/ImageVisual.cs
@@ -28,9 +28,9 @@ namespace Tizen.NUI.Visuals
     {
         #region Internal And Private
         internal static readonly int ActionReload = Tizen.NUI.BaseComponents.ImageView.ActionReload;
-        internal bool isResourceUrlValid = false;
+        internal bool isResourceUrlValid;
 
-        private PropertyMap temperalStoredPropertyMap = null; // To store property map when resource url is not valid.
+        private PropertyMap temperalStoredPropertyMap; // To store property map when resource url is not valid.
         #endregion
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/VisualBase.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/VisualBase.cs
@@ -39,18 +39,18 @@ namespace Tizen.NUI.Visuals
     public abstract class VisualBase : BaseHandle
     {
         #region Internal And Private
-        internal PropertyMap cachedVisualPropertyMap = null;
-        internal PropertyMap changedPropertyMap = null;
+        internal PropertyMap cachedVisualPropertyMap;
+        internal PropertyMap changedPropertyMap;
 
         internal bool visualCreationRequiredFlag = true; // The first time should create visual.
 
-        internal bool visualCreationManually = false;
+        internal bool visualCreationManually;
 
         private int internalType = (int)Tizen.NUI.Visual.Type.Invalid;
 
-        private bool visualPropertyUpdateProcessAttachedFlag = false;
+        private bool visualPropertyUpdateProcessAttachedFlag;
 
-        private bool visualFittingModeApplied = false; // Whether we use fitting mode, or DontCare.
+        private bool visualFittingModeApplied; // Whether we use fitting mode, or DontCare.
 
         internal class VisualTransformInfo : System.IDisposable
         {

--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -167,8 +167,8 @@ namespace Tizen.NUI.BaseComponents
         private EventHandler<WebViewUserMediaPermissionRequestEventArgs> userMediaPermissionRequestEventHandler;
         private WebViewUserMediaPermissionRequestCallback userMediaPermissionRequestCallback;
 
-        private WebContext webContext = null;
-        private WebCookieManager webCookieManager = null;
+        private WebContext webContext;
+        private WebCookieManager webCookieManager;
 
         /// <summary>
         /// Default constructor to create a WebView.
@@ -2633,7 +2633,7 @@ namespace Tizen.NUI.BaseComponents
         }
 
         private Dictionary<int, JavaScriptMessageHandler> _evaluateJavaScriptHandlerMap = new Dictionary<int, JavaScriptMessageHandler>();
-        private int _evaluateJavaScriptCallbackId = 0;
+        private int _evaluateJavaScriptCallbackId;
 
         /// <summary>
         /// Evaluates JavaScript code represented as a string.

--- a/src/Tizen.NUI/src/public/WebView/WebViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebViewBindableProperty.cs
@@ -22,7 +22,7 @@ namespace Tizen.NUI.BaseComponents
 {
     public partial class WebView
     {
-        private static readonly BindableProperty UrlProperty = null;
+        private static readonly BindableProperty UrlProperty;
 
         internal static void SetInternalUrlProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -39,7 +39,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalUrl();
         }
 
-        private static readonly BindableProperty UserAgentProperty = null;
+        private static readonly BindableProperty UserAgentProperty;
 
         internal static void SetInternalUserAgentProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -56,7 +56,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalUserAgent();
         }
 
-        private static readonly BindableProperty ScrollPositionProperty = null;
+        private static readonly BindableProperty ScrollPositionProperty;
 
         internal static void SetInternalScrollPositionProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -73,7 +73,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalScrollPosition();
         }
 
-        private static readonly BindableProperty ScrollSizeProperty = null;
+        private static readonly BindableProperty ScrollSizeProperty;
 
         internal static object GetInternalScrollSizeProperty(BindableObject bindable)
         {
@@ -81,7 +81,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalScrollSize();
         }
 
-        private static readonly BindableProperty ContentSizeProperty = null;
+        private static readonly BindableProperty ContentSizeProperty;
 
         internal static object GetInternalContentSizeProperty(BindableObject bindable)
         {
@@ -89,7 +89,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalContentSize();
         }
 
-        private static readonly BindableProperty TitleProperty = null;
+        private static readonly BindableProperty TitleProperty;
 
         internal static object GetInternalTitleProperty(BindableObject bindable)
         {
@@ -97,7 +97,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalTitle();
         }
 
-        private static readonly BindableProperty VideoHoleEnabledProperty = null;
+        private static readonly BindableProperty VideoHoleEnabledProperty;
 
         internal static void SetInternalVideoHoleEnabledProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -114,7 +114,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalVideoHoleEnabled();
         }
 
-        private static readonly BindableProperty MouseEventsEnabledProperty = null;
+        private static readonly BindableProperty MouseEventsEnabledProperty;
 
         internal static void SetInternalMouseEventsEnabledProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -131,7 +131,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalMouseEventsEnabled();
         }
 
-        private static readonly BindableProperty KeyEventsEnabledProperty = null;
+        private static readonly BindableProperty KeyEventsEnabledProperty;
 
         internal static void SetInternalKeyEventsEnabledProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -148,7 +148,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalKeyEventsEnabled();
         }
 
-        private static readonly BindableProperty ContentBackgroundColorProperty = null;
+        private static readonly BindableProperty ContentBackgroundColorProperty;
 
         internal static void SetInternalContentBackgroundColorProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -165,7 +165,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalContentBackgroundColor();
         }
 
-        private static readonly BindableProperty TilesClearedWhenHiddenProperty = null;
+        private static readonly BindableProperty TilesClearedWhenHiddenProperty;
 
         internal static void SetInternalTilesClearedWhenHiddenProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -182,7 +182,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalTilesClearedWhenHidden();
         }
 
-        private static readonly BindableProperty TileCoverAreaMultiplierProperty = null;
+        private static readonly BindableProperty TileCoverAreaMultiplierProperty;
 
         internal static void SetInternalTileCoverAreaMultiplierProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -199,7 +199,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalTileCoverAreaMultiplier();
         }
 
-        private static readonly BindableProperty CursorEnabledByClientProperty = null;
+        private static readonly BindableProperty CursorEnabledByClientProperty;
 
         internal static void SetInternalCursorEnabledByClientProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -216,7 +216,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalCursorEnabledByClient();
         }
 
-        private static readonly BindableProperty SelectedTextProperty = null;
+        private static readonly BindableProperty SelectedTextProperty;
 
         internal static object GetInternalSelectedTextProperty(BindableObject bindable)
         {
@@ -224,7 +224,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalSelectedText();
         }
 
-        private static readonly BindableProperty PageZoomFactorProperty = null;
+        private static readonly BindableProperty PageZoomFactorProperty;
 
         internal static void SetInternalPageZoomFactorProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -241,7 +241,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalPageZoomFactor();
         }
 
-        private static readonly BindableProperty TextZoomFactorProperty = null;
+        private static readonly BindableProperty TextZoomFactorProperty;
 
         internal static void SetInternalTextZoomFactorProperty(BindableObject bindable, object oldValue, object newValue)
         {
@@ -258,7 +258,7 @@ namespace Tizen.NUI.BaseComponents
             return webview.GetInternalTextZoomFactor();
         }
 
-        private static readonly BindableProperty LoadProgressPercentageProperty = null;
+        private static readonly BindableProperty LoadProgressPercentageProperty;
 
         internal static object GetInternalLoadProgressPercentageProperty(BindableObject bindable)
         {

--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -32,32 +32,32 @@ namespace Tizen.NUI
         #endregion //Constant Fields
 
         #region Fields
-        private IBorderInterface borderInterface = null;
-        private Layer borderWindowRootLayer = null;
-        private Layer borderWindowBottomLayer = null;
+        private IBorderInterface borderInterface;
+        private Layer borderWindowRootLayer;
+        private Layer borderWindowBottomLayer;
         private WindowOrientation currentOrientation;
 
         // for border area
-        private View rootView = null;
-        private BorderView borderView = null;
-        private View topView = null;
-        private View contentsView = null;
-        private View bottomView = null;
-        private float borderHeight = 0;
-        private int screenWidth = 0;
-        private int screenHeight = 0;
+        private View rootView;
+        private BorderView borderView;
+        private View topView;
+        private View contentsView;
+        private View bottomView;
+        private float borderHeight;
+        private int screenWidth;
+        private int screenHeight;
 
-        private bool isBorderWindow = false;
-        private bool hasTopView = false;
-        private bool hasBottomView = false;
-        private bool isEnabledOverlayMode = false;
-        private bool isMaximized = false;
+        private bool isBorderWindow;
+        private bool hasTopView;
+        private bool hasBottomView;
+        private bool isEnabledOverlayMode;
+        private bool isMaximized;
 
 
         // for config
-        private Size2D minSize = null;
-        private Size2D maxSize = null;
-        private uint borderLineThickness = 0;
+        private Size2D minSize;
+        private Size2D maxSize;
+        private uint borderLineThickness;
         private BorderResizePolicyType borderResizePolicy = BorderResizePolicyType.Free;
         #endregion //Fields
 
@@ -69,7 +69,7 @@ namespace Tizen.NUI
 
         #region Delegates
         internal delegate void BorderCloseDelegate();
-        private BorderCloseDelegate borderCloseDelegate = null;
+        private BorderCloseDelegate borderCloseDelegate;
 
         #endregion //Delegates
 
@@ -706,7 +706,7 @@ namespace Tizen.NUI
         // View class for border view.
         private class BorderView : View
         {
-            private bool isEnabledOverlay = false;
+            private bool isEnabledOverlay;
             private Extents prePadding = new Extents(0, 0, 0, 0);
 
             internal BorderView() : base()

--- a/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
+++ b/src/Tizen.NUI/src/public/Window/DefaultBorder.cs
@@ -67,7 +67,7 @@ namespace Tizen.NUI
 
 
         #region Fields
-        private bool disposed = false;
+        private bool disposed;
         private Color backgroundColor;
         private View borderView;
 
@@ -78,9 +78,8 @@ namespace Tizen.NUI
         private ImageView rightCornerIcon;
 
         private Window.BorderDirection direction = Window.BorderDirection.None;
-        private float preScale = 0;
+        private float preScale;
 
-        private View windowView = null;
         private Timer overlayTimer;
 
         private uint borderLineThickness;
@@ -1058,7 +1057,6 @@ namespace Tizen.NUI
             if (disposing)
             {
                 borderView?.Dispose();
-                windowView?.Dispose();
                 borderPanGestureDetector?.Dispose();
                 backgroundColor?.Dispose();
                 minimalizeIcon?.Dispose();

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2391,7 +2391,7 @@ namespace Tizen.NUI
 
         private static readonly object locker = new object();
 
-        private static int key = 0;
+        private static int key;
 
         private static FrameCallbackType internalHookFrameCallback = OnInternalHookFrameCallback;
 

--- a/src/Tizen.NUI/src/public/Xaml/XamlServiceProvider.cs
+++ b/src/Tizen.NUI/src/public/Xaml/XamlServiceProvider.cs
@@ -127,7 +127,7 @@ namespace Tizen.NUI.Xaml
 
         HydrationContext Context { get; }
         public object TargetObject { get; }
-        public object TargetProperty { get; internal set; } = null;
+        public object TargetProperty { get; internal set; }
 
         IEnumerable<object> IProvideParentValues.ParentObjects
         {

--- a/src/Tizen.NUI/src/public/XamlBinding/Setter.cs
+++ b/src/Tizen.NUI/src/public/XamlBinding/Setter.cs
@@ -36,7 +36,7 @@ namespace Tizen.NUI.Binding
         [EditorBrowsable(EditorBrowsableState.Never)]
         public BindableProperty Property { get; set; }
 
-        private bool isOriginalValue = false;
+        private bool isOriginalValue;
         private object value;
 
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1805

Let we don't initialize known values as default.

warning messages
```
TizenFX/src/Tizen.NUI/src/devel/Lite/UIRect.cs(66,35): warning CA1805: Member 'Zero' is explicitly initialized to its default value
TizenFX/src/Tizen.NUI/src/internal/Application/Application.cs(369,55): warning CA1805: Member 'rootIdleCallback' is explicitly initialized to its default value
...
```

For now, just resolve this errors for internal and devel and some non-touched public recently.

Warning counts 1817 -> 1519 (reduce 298 warnings)

Remained warnings for CA1805 : `BaseComponents`, `Color`, `Renderer`.