### PR TITLE
[NUI] Implement IEquatable for primitive structures and make them immutable

### DIFF
--- a/src/Tizen.NUI/src/devel/Lite/UICorner.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UICorner.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+using System;
 using System.ComponentModel;
 
 namespace Tizen.NUI
@@ -22,7 +23,7 @@ namespace Tizen.NUI
     /// Defines a value type of corner radius.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct UICorner
+    public struct UICorner : IEquatable<UICorner>
     {
         /// <summary>
         /// The default corner. (This is to distinguish from zero corners)
@@ -92,27 +93,81 @@ namespace Tizen.NUI
         /// <summary>
         /// The radius of the top left corner of the rectangle.
         /// </summary>
-        public float TopLeft { get; }
+        public float TopLeft { get; init; }
 
         /// <summary>
         /// The radius of the top right corner of the rectangle.
         /// </summary>
-        public float TopRight { get; }
+        public float TopRight { get; init; }
 
         /// <summary>
         /// The radius of the bottom right corner of the rectangle.
         /// </summary>
-        public float BottomRight { get; }
+        public float BottomRight { get; init; }
 
         /// <summary>
         /// The radius of the bottom left corner of the rectangle.
         /// </summary>
-        public float BottomLeft { get; }
+        public float BottomLeft { get; init; }
 
         /// <summary>
         /// Gets a value indicating whether the values are relative to target box size.
         /// </summary>
-        public bool IsRelative { get; }
+        public bool IsRelative { get; init; }
+
+        /// <summary>
+        /// Compares two value for equality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are equal, otherwise false.</returns>
+        public static bool operator ==(UICorner operand1, UICorner operand2)
+        {
+            return operand1.Equals(operand2);
+        }
+
+        /// <summary>
+        /// Compares two value for inequality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are not equal, otherwise false.</returns>
+        public static bool operator !=(UICorner operand1, UICorner operand2)
+        {
+            return !operand1.Equals(operand2);
+        }
+
+        /// <summary>
+        /// Whether this is equivalent to other.
+        /// </summary>
+        public bool Equals(UICorner other)
+        {
+            return TopLeft == other.TopLeft && TopRight == other.TopRight && BottomRight == other.BottomRight && BottomLeft == other.BottomLeft && IsRelative && other.IsRelative;
+        }
+
+        ///  <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (obj is UICorner other)
+            {
+                return Equals(other);
+            }
+            return base.Equals(obj);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashcode = TopLeft.GetHashCode();
+                hashcode = hashcode * 397 ^ TopRight.GetHashCode();
+                hashcode = hashcode * 397 ^ BottomRight.GetHashCode();
+                hashcode = hashcode * 397 ^ BottomLeft.GetHashCode();
+                hashcode = hashcode * 397 ^ IsRelative.GetHashCode();
+                return hashcode;
+            }
+        }
 
         internal readonly NUI.Vector4 ToReferenceType() => new NUI.Vector4(TopLeft, TopRight, BottomRight, BottomLeft);
     }

--- a/src/Tizen.NUI/src/devel/Lite/UIExtents.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIExtents.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 namespace Tizen.NUI
 {
@@ -6,7 +7,7 @@ namespace Tizen.NUI
     /// Defines the thickness of a border around a control.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct UIExtents
+    public struct UIExtents : IEquatable<UIExtents>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UIExtents"/> struct with the specified uniform size.
@@ -43,22 +44,22 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the width of the left border.
         /// </summary>
-        public float Start { get; set; }
+        public float Start { get; init; }
 
         /// <summary>
         /// Gets or sets the width of the right border.
         /// </summary>
-        public float End { get; set; }
+        public float End { get; init; }
 
         /// <summary>
         /// Gets or sets the width of the top border.
         /// </summary>
-        public float Top { get; set; }
+        public float Top { get; init; }
 
         /// <summary>
         /// Gets or sets the width of the bottom border.
         /// </summary>
-        public float Bottom { get; set; }
+        public float Bottom { get; init; }
 
         /// <summary>
         /// Gets the total width of the horizontal borders.
@@ -89,7 +90,10 @@ namespace Tizen.NUI
             return new UIExtents(uniformSize);
         }
 
-        bool Equals(UIExtents other)
+        /// <summary>
+        /// Whether this is equivalent to other.
+        /// </summary>
+        public bool Equals(UIExtents other)
         {
             return Start.Equals(other.Start) && End.Equals(other.End) && Top.Equals(other.Top) && Bottom.Equals(other.Bottom);
         }

--- a/src/Tizen.NUI/src/devel/Lite/UIRect.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIRect.cs
@@ -18,12 +18,12 @@ using System.ComponentModel;
 using System.Globalization;
 
 namespace Tizen.NUI
-{   
+{
     /// <summary>
     /// Represents a rectangular area by defining its position and size.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct UIRect
+    public struct UIRect : IEquatable<UIRect>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UIRect"/> struct.
@@ -43,22 +43,22 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets or sets the x-coordinate of the upper-left corner of the rectangle.
         /// </summary>
-        public float X { get; set; }
+        public float X { get; init; }
 
         /// <summary>
         /// Gets or sets the y-coordinate of the upper-left corner of the rectangle.
         /// </summary>
-        public float Y { get; set; }
+        public float Y { get; init; }
 
         /// <summary>
         /// Gets or sets the width of the rectangle.
         /// </summary>
-        public float Width { get; set; }
+        public float Width { get; init; }
 
         /// <summary>
         /// Gets or sets the height of the rectangle.
         /// </summary>
-        public float Height { get; set; }
+        public float Height { get; init; }
 
         /// <summary>
         /// Gets a <see cref="UIRect"/> structure with all coordinates and sizes set to zero.
@@ -96,7 +96,7 @@ namespace Tizen.NUI
         public UIVector2 Size
         {
             get => new UIVector2(Width, Height);
-            set
+            init
             {
                 Width = value.Width;
                 Height = value.Height;
@@ -109,7 +109,7 @@ namespace Tizen.NUI
         public UIVector2 Location
         {
             get => new UIVector2(X, Y);
-            set
+            init
             {
                 X = value.X;
                 Y = value.Y;
@@ -272,12 +272,13 @@ namespace Tizen.NUI
         /// <returns>A new rectangle that represents the inflated version of the current rectangle.</returns>
         public UIRect Inflate(float width, float height)
         {
-            UIRect r = this;
-            r.X -= width;
-            r.Y -= height;
-            r.Width += width * 2;
-            r.Height += height * 2;
-            return r;
+            return new ()
+            {
+                X = X - width,
+                Y = Y - height,
+                Width = Width + width * 2,
+                Height = Height + height * 2
+            };
         }
 
         /// <summary>
@@ -288,10 +289,13 @@ namespace Tizen.NUI
         /// <returns>A new rectangle with the offset applied.</returns>
         public UIRect Offset(float dx, float dy)
         {
-            UIRect r = this;
-            r.X += dx;
-            r.Y += dy;
-            return r;
+            return new ()
+            {
+                X = X + dx,
+                Y = Y + dy,
+                Width = Width,
+                Height = Height
+            };
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/devel/Lite/UIState.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIState.cs
@@ -26,7 +26,7 @@ namespace Tizen.NUI
     /// Defines a value type of view state.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public readonly struct UIState
+    public readonly struct UIState : IEquatable<UIState>
     {
         /// <summary>
         /// The All state is used in a selector class. It represents all states, so if this state is defined in a selector, the other states are ignored.

--- a/src/Tizen.NUI/src/devel/Lite/UIVector2.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIVector2.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+using System;
 using System.ComponentModel;
 
 namespace Tizen.NUI
@@ -22,7 +23,7 @@ namespace Tizen.NUI
     /// Defines a value type of vector2.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public readonly struct UIVector2
+    public struct UIVector2 : IEquatable<UIVector2>
     {
         /// <summary>
         /// The zero vector2.
@@ -46,6 +47,7 @@ namespace Tizen.NUI
         public float X
         {
             get;
+            init;
         }
 
         /// <summary>
@@ -54,6 +56,7 @@ namespace Tizen.NUI
         public float Y
         {
             get;
+            init;
         }
 
         public readonly bool IsZero => X == 0 && Y == 0;
@@ -61,12 +64,69 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the width component of the vector2.
         /// </summary>
-        public float Width => X;
+        public float Width
+        {
+            get => X;
+            init => X = value;
+        }
 
         /// <summary>
         /// Gets the height component of the vector2.
         /// </summary>
-        public float Height => Y;
+        public float Height
+        {
+            get => Y;
+            init => Y = value;
+        }
+
+        /// <summary>
+        /// Compares two value for equality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are equal, otherwise false.</returns>
+        public static bool operator ==(UIVector2 operand1, UIVector2 operand2)
+        {
+            return operand1.Equals(operand2);
+        }
+
+        /// <summary>
+        /// Compares two value for inequality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are not equal, otherwise false.</returns>
+        public static bool operator !=(UIVector2 operand1, UIVector2 operand2)
+        {
+            return !operand1.Equals(operand2);
+        }
+
+        /// <summary>
+        /// Whether this is equivalent to other.
+        /// </summary>
+        public bool Equals(UIVector2 other)
+        {
+            return X == other.X && Y == other.Y;
+        }
+
+        ///  <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (obj is UIVector2 other)
+            {
+                return Equals(other);
+            }
+            return base.Equals(obj);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return X.GetHashCode() ^ (Y.GetHashCode() * 397);
+            }
+        }
 
         /// <summary>
         /// Converts the UIVector2 to Vector3 class implicitly.

--- a/src/Tizen.NUI/src/devel/Lite/UIVector3.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIVector3.cs
@@ -23,7 +23,7 @@ namespace Tizen.NUI
     /// Defines a value type of vector3.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public readonly struct UIVector3 : IEquatable<UIVector3>
+    public struct UIVector3 : IEquatable<UIVector3>
     {
         /// <summary>
         /// The zero vector3.
@@ -58,6 +58,7 @@ namespace Tizen.NUI
         public float X
         {
             get;
+            init;
         }
 
         /// <summary>
@@ -66,6 +67,7 @@ namespace Tizen.NUI
         public float Y
         {
             get;
+            init;
         }
 
         /// <summary>
@@ -74,6 +76,7 @@ namespace Tizen.NUI
         public float Z
         {
             get;
+            init;
         }
 
         public readonly bool IsZero => X == 0 && Y == 0 && Z == 0;
@@ -81,17 +84,29 @@ namespace Tizen.NUI
         /// <summary>
         /// Gets the width component of the vector3.
         /// </summary>
-        public float Width => X;
+        public float Width
+        {
+            get => X;
+            init => X = value;
+        }
 
         /// <summary>
         /// Gets the height component of the vector3.
         /// </summary>
-        public float Height => Y;
+        public float Height
+        {
+            get => Y;
+            init => Y = value;
+        }
 
         /// <summary>
         /// Gets the depth component of the vector3.
         /// </summary>
-        public float Depth => Z;
+        public float Depth
+        {
+            get => Z;
+            init => Z = value;
+        }
 
         /// <summary>
         /// Converts the UIVector2 to UIVector3 class implicitly.


### PR DESCRIPTION
### Description of Change ###
Made following IEquatable and immutable
* `UICorner`
* `UIExtents`
* `UIRect`
* `UIState`
* `UIVector2`
* `UIVector3`



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
