### PR TITLE
[NUI.Samples] Make NUI Samples use Renderable instead Renderer

### DIFF
--- a/src/Tizen.NUI/src/internal/Rendering/RendererProperty.cs
+++ b/src/Tizen.NUI/src/internal/Rendering/RendererProperty.cs
@@ -49,5 +49,16 @@ namespace Tizen.NUI
         internal static readonly int StencilOperationOnFail = Interop.Renderer.StencilOperationOnFailGet();
         internal static readonly int StencilOperationOnZFail = Interop.Renderer.StencilOperationOnZFailGet();
         internal static readonly int StencilOperationOnZPass = Interop.Renderer.StencilOperationOnZPassGet();
+        internal static readonly int MixColor = Interop.Renderer.MixColorGet();
+        internal static readonly int MixColorRed = Interop.Renderer.MixColorRedGet();
+        internal static readonly int MixColorGreen = Interop.Renderer.MixColorGreenGet();
+        internal static readonly int MixColorBlue = Interop.Renderer.MixColorBlueGet();
+        internal static readonly int MixColorOpacity = Interop.Renderer.MixColorOpacityGet();
+        internal static readonly int RenderingBehavior = Interop.Renderer.RenderingBehaviorGet();
+        internal static readonly int BlendEquation = Interop.Renderer.BlendEquationGet();
+        internal static readonly int VertexRangeFirst = IndexRangeFirst;
+        internal static readonly int VertexRangeCount = IndexRangeCount;
+        internal static readonly int InstanceCount = Interop.Renderer.InstanceCountGet();
+        internal static readonly int UpdateAreaExtents = Interop.Renderer.UpdateAreaExtentsGet();
     }
 }

--- a/src/Tizen.NUI/src/public/Rendering/Renderable.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Renderable.cs
@@ -396,6 +396,40 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets and Sets extents of partial update area.
+        /// </summary>
+        /// <remarks>
+        /// Extents the area - the position and the size - used for the attached View's partial update area calculation.
+        /// This value be appended after calculate all update area, like visual offset.
+        /// Change  <see cref="Tizen.NUI.BaseComponents.View.UpdateAreaHint"/> value if you want to change View's partial update area.
+        /// Warning : Only 0u ~ 65535u integer values are allowed for each parameters.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public UIExtents UpdateArea
+        {
+            get
+            {
+                // TODO : Clean up below logics after implement Object.InternalGetPropertyExtents
+                using Extents temp = new Extents();
+                using var pValue = Tizen.NUI.Object.GetProperty(SwigCPtr, RendererProperty.UpdateAreaExtents);
+                pValue.Get(temp);
+
+                if (temp == null)
+                {
+                    return new UIExtents(0.0f);
+                }
+                UIExtents result = new UIExtents((float)temp.Start, (float)temp.End, (float)temp.Top, (float)temp.Bottom);
+                return result;
+            }
+            set
+            {
+                // TODO : Clean up below logics after implement Object.InternalSetPropertyExtents
+                using var temp = new Tizen.NUI.PropertyValue((Extents)value);
+                Tizen.NUI.Object.SetProperty(SwigCPtr, RendererProperty.UpdateAreaExtents, temp);
+            }
+        }
+
+        /// <summary>
         /// Gets and Sets Geometry of this Renderable.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AsyncImageLoaderTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AsyncImageLoaderTest.cs
@@ -221,7 +221,6 @@ namespace Tizen.NUI.Samples
             {
                 for (uint j = 0u; j < numberOfImagesPerEachType; ++j)
                 {
-                    // View area is red, and additional renderer area is yellow.
                     View view = new View()
                     {
                         Name = $"subView{i}x{j}",
@@ -232,15 +231,15 @@ namespace Tizen.NUI.Samples
                         PositionY = i * 110.0f + 10.0f,
                     };
 
-                    var renderer = GenerateRenderer();
+                    var renderable = GenerateRenderable();
 
-                    view.AddRenderer(renderer);
+                    view.AddRenderable(renderable);
                     root.Add(view);
 
                     uint viewIndex = i * numberOfImagesPerEachType + j;
 
                     subView[viewIndex] = view;
-                    subViewTextureSet[viewIndex] = renderer.GetTextures();
+                    subViewTextureSet[viewIndex] = renderable.TextureSet;
                     subViewLoadId[viewIndex] = InvalidLoadId;
                 }
                 subViewUrlIndex[i] = (uint)(ImageUrlList.Length - 1);
@@ -501,7 +500,7 @@ namespace Tizen.NUI.Samples
             CreateSwatchLabel("Muted", palette.GetMutedSwatch());
             CreateSwatchLabel("DarkMuted", palette.GetDarkMutedSwatch());
 
-            win.Add(paletteInfoRoot);
+            root.Add(paletteInfoRoot);
         }
 
         private void CreateSwatchLabel(string title, Palette.Swatch swatch)
@@ -561,27 +560,25 @@ namespace Tizen.NUI.Samples
         {
             if (shader == null)
             {
-                shader = new Shader(VERTEX_SHADER, FRAGMENT_SHADER, "RendererUpdateAreaTest");
+                shader = new Shader(VERTEX_SHADER, FRAGMENT_SHADER, "AsyncImageLoaderTest");
             }
             return shader;
         }
 
-        private Renderer GenerateRenderer()
+        private Renderable GenerateRenderable()
         {
-            Renderer renderer = new Renderer();
-            Geometry geometry = GenerateGeometry();
-            Shader shader = GenerateShader();
-            TextureSet textureSet = new TextureSet();
+            Renderable renderable = new Renderable()
+            {
+                Geometry = GenerateGeometry(),
+                Shader = GenerateShader(),
+                TextureSet = new TextureSet(),
+            };
 
             // Set some invalid texture so we can ignore rendering.
             Texture texture = new Texture(TextureType.TEXTURE_2D, PixelFormat.RGBA8888, 1u, 1u);
-            textureSet.SetTexture(0u, texture);
+            renderable.TextureSet.SetTexture(0u, texture);
 
-            renderer.SetGeometry(geometry);
-            renderer.SetShader(shader);
-            renderer.SetTextures(textureSet);
-
-            return renderer;
+            return renderable;
         }
     }
 }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CircularTextSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/CircularTextSample.cs
@@ -69,7 +69,7 @@ namespace Tizen.NUI.Samples
             public Vec2 texCoord;
         };
 
-        private Renderer CreateRenderer()
+        private Renderable CreateRenderable()
         {
             TexturedQuadVertex vertex1 = new TexturedQuadVertex();
             TexturedQuadVertex vertex2 = new TexturedQuadVertex();
@@ -106,10 +106,14 @@ namespace Tizen.NUI.Samples
             // Create the shader
             Shader shader = new Shader( VERTEX_SHADER, FRAGMENT_SHADER, "CircularTextShader" );
 
-            // Create the renderer
-            Renderer renderer = new Renderer( geometry, shader );
+            // Create the renderable
+            Renderable renderable = new Renderable()
+            {
+                Geometry = geometry,
+                Shader = shader,
+            };
 
-            return renderer;
+            return renderable;
         }
 
         private uint GetBytesPerPixel(PixelFormat pixelFormat)
@@ -344,8 +348,8 @@ namespace Tizen.NUI.Samples
             embeddedItems.Add(IMAGE2);
 
             TextureSet textureSet = CreateTextureSet( textParameters, embeddedItems );
-            Renderer renderer = CreateRenderer();
-            renderer.SetTextures( textureSet );
+            Renderable renderable = CreateRenderable();
+            renderable.TextureSet = textureSet;
 
             View actor = new View();
             actor.PivotPoint = PivotPoint.TopLeft;
@@ -354,7 +358,7 @@ namespace Tizen.NUI.Samples
             actor.Size = new Size( 360, 360 );
             actor.Color = Color.White;
 
-            actor.AddRenderer( renderer );
+            actor.AddRenderable( renderable );
             root.Add(actor);
         }
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ClippedImage.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/ContactCard/ClippedImage.cs
@@ -56,12 +56,16 @@ namespace Tizen.NUI.Samples
             View clippedImage = new View();
             clippedImage.ClippingMode = ClippingModeType.ClipChildren;
 
-            // Create the required renderer and add to the clipped image view
+            // Create the required renderable and add to the clipped image view
             Shader shader = CreateShader();
             CreateGeometry();
-            Renderer renderer = new Renderer(geometry, shader);
-            renderer.BlendMode = 2;
-            clippedImage.AddRenderer(renderer);
+            Renderable renderable = new Renderable()
+            {
+                Geometry = geometry,
+                Shader = shader,
+                BlendMode = BlendMode.On,
+            };
+            clippedImage.AddRenderable(renderable);
 
             // Register the property on the clipped image view which will allow animations between a circle and a quad
             int propertyIndex = clippedImage.RegisterProperty("uDelta", new PropertyValue(0.0f));

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DisposeTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/DisposeTest.cs
@@ -234,7 +234,7 @@ namespace Tizen.NUI.Samples
         private string resource;
         private List<Custom3DView> views;
         private List<Custom3DView> depthViews; // List of tree-formed views. 0 indexes view is root.
-        private List<Renderer> renderers;
+        private List<Renderable> renderables;
         private Animation rotateAnimation;
 
         private Dictionary<string, Texture> textureDictionary = new();
@@ -255,7 +255,7 @@ namespace Tizen.NUI.Samples
 
             views = new List<Custom3DView>();
             depthViews = new List<Custom3DView>();
-            renderers = new List<Renderer>();
+            renderables = new List<Renderable>();
             rotateAnimation = new Animation(1500); //1.5s
 
             AddManyViews();
@@ -329,7 +329,7 @@ namespace Tizen.NUI.Samples
             return shader;
         }
 
-        private Renderer GenerateRenderer(string textureUrl)
+        private Renderable GenerateRenderable(string textureUrl)
         {
             Texture texture;
             if (!textureDictionary.TryGetValue(textureUrl, out texture))
@@ -356,12 +356,16 @@ namespace Tizen.NUI.Samples
             TextureSet textureSet = new TextureSet();
             textureSet.SetTexture(0u, texture);
 
-            Renderer renderer = new Renderer(GenerateGeometry(), GenerateShader());
-            renderer.SetTextures(textureSet);
+            Renderable renderable = new Renderable()
+            {
+                Geometry = GenerateGeometry(),
+                Shader = GenerateShader(),
+            };
+            renderable.TextureSet = textureSet;
 
-            renderers.Add(renderer);
+            renderables.Add(renderable);
 
-            return renderer;
+            return renderable;
         }
 
         private void AddManyViews()
@@ -382,7 +386,7 @@ namespace Tizen.NUI.Samples
                     Name = "Auto_" + i.ToString(),
                 };
                 root.Add(view);
-                view.AddRenderer(GenerateRenderer(resource + "/images/PopupTest/circle.jpg"));
+                view.AddRenderable(GenerateRenderable(resource + "/images/PopupTest/circle.jpg"));
 
                 rotateAnimation.AnimateBy(view, "Orientation", new Rotation(new Radian(new Degree(360.0f)), Vector3.YAxis));
             }
@@ -403,7 +407,7 @@ namespace Tizen.NUI.Samples
                 root.Add(view);
                 views.Add(view);
 
-                view.AddRenderer(GenerateRenderer(resource + "/images/PaletteTest/red2.jpg"));
+                view.AddRenderable(GenerateRenderable(resource + "/images/PaletteTest/red2.jpg"));
 
                 rotateAnimation.AnimateBy(view, "Orientation", new Rotation(new Radian(new Degree(-360.0f)), Vector3.YAxis));
             }
@@ -440,7 +444,7 @@ namespace Tizen.NUI.Samples
                 }
                 depthViews.Add(view);
 
-                view.AddRenderer(GenerateRenderer(resource + "/images/PaletteTest/rock.jpg"));
+                view.AddRenderable(GenerateRenderable(resource + "/images/PaletteTest/rock.jpg"));
 
                 //rotateAnimation.AnimateBy(view, "Orientation", new Rotation(new Radian(new Degree(360.0f)), Vector3.ZAxis));
             }
@@ -458,12 +462,12 @@ namespace Tizen.NUI.Samples
             {
                 view?.Dispose();
             }
-            foreach (var renderer in renderers)
+            foreach (var renderable in renderables)
             {
-                renderer?.GetGeometry()?.Dispose();
-                renderer?.GetShader()?.Dispose();
-                renderer?.GetTextures()?.Dispose();
-                renderer?.Dispose();
+                renderable?.Geometry?.Dispose();
+                renderable?.Shader?.Dispose();
+                renderable?.TextureSet?.Dispose();
+                renderable?.Dispose();
             }
             if (depthViews?.Count > 0)
             {
@@ -472,7 +476,7 @@ namespace Tizen.NUI.Samples
 
             views.Clear();
             depthViews.Clear();
-            renderers.Clear();
+            renderables.Clear();
 
             rotateAnimation.Clear();
         }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RendererUpdateAreaTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RendererUpdateAreaTest.cs
@@ -157,7 +157,7 @@ namespace Tizen.NUI.Samples
         {
             for(int i = 0; i < 3; i++)
             {
-                // View area is red, and additional renderer area is yellow.
+                // View area is red, and additional renderable area is yellow.
                 View view = new View()
                 {
                     Color = Color.Yellow,
@@ -168,21 +168,21 @@ namespace Tizen.NUI.Samples
                     PositionY = extraSizeHeight * 0.5f,
                 };
 
-                var renderer = GenerateRenderer();
+                var renderable = GenerateRenderable();
 
                 // Make it draw under the background
-                renderer.DepthIndex = Renderer.Ranges.Background - 1;
+                renderable.DepthIndex = DepthIndexRanges.Background - 1;
 
                 if (i == 1)
                 {
-                    renderer.UpdateArea = new UIExtents(0.0f, extraSizeHeight * 0.5f, 0.0f, extraSizeHeight * 0.5f);
+                    renderable.UpdateArea = new UIExtents(0.0f, extraSizeHeight * 0.5f, 0.0f, extraSizeHeight * 0.5f);
                 }
                 else if (i == 2)
                 {
-                    renderer.UpdateArea = new UIExtents(extraSizeHeight * 0.5f, extraSizeHeight * 0.5f, extraSizeHeight * 0.5f, extraSizeHeight * 0.5f);
+                    renderable.UpdateArea = new UIExtents(extraSizeHeight * 0.5f, extraSizeHeight * 0.5f, extraSizeHeight * 0.5f, extraSizeHeight * 0.5f);
                 }
 
-                view.AddRenderer(renderer);
+                view.AddRenderable(renderable);
 
                 moveXAnimation.AnimateBy(view, "PositionX", 350.0f);
                 moveYAnimation.AnimateBy(view, "PositionY", 200.0f);
@@ -221,18 +221,17 @@ namespace Tizen.NUI.Samples
             return shader;
         }
 
-        private Renderer GenerateRenderer()
+        private Renderable GenerateRenderable()
         {
-            Renderer renderer = new Renderer();
-            Geometry geometry = GenerateGeometry();
-            Shader shader = GenerateShader();
+            Renderable renderable = new Renderable()
+            {
+                Geometry = GenerateGeometry(),
+                Shader = GenerateShader(),
+            };
 
-            renderer.SetGeometry(geometry);
-            renderer.SetShader(shader);
+            renderable.RegisterProperty("uCustomExtraSize", new PropertyValue(new UIVector2(extraSizeWidth, extraSizeHeight)));
 
-            renderer.RegisterProperty("uCustomExtraSize", new PropertyValue(new UIVector2(extraSizeWidth, extraSizeHeight)));
-
-            return renderer;
+            return renderable;
         }
 
         public void Deactivate()


### PR DESCRIPTION
Let we use latest `Renderable` class, instead of `Renderer`.