### PR TITLE
[NUI] Fix height calculation of TextLabelLayout

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -45,7 +45,8 @@ namespace Tizen.NUI.BaseComponents
                 {
                     if (heightMeasureSpec.Mode != MeasureSpecification.ModeType.Exactly)
                     {
-                        totalHeight = Owner.GetHeightForWidth(totalWidth);
+                        var padding = Owner.Padding;
+                        totalHeight = Owner.GetHeightForWidth(totalWidth - (padding.Start + padding.End));
                         heightMeasureSpec = new MeasureSpecification(new LayoutLength(totalHeight), MeasureSpecification.ModeType.Exactly);
                     }
                 }
@@ -68,9 +69,11 @@ namespace Tizen.NUI.BaseComponents
                     else
                     {
                         float width = naturalSize != null ? naturalSize.Width : 0;
-                        float height = naturalSize != null ? naturalSize.Height : 0;
                         // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
                         totalWidth = Math.Max(Math.Min(width, maxWidth < 0 ? Int32.MaxValue : maxWidth), minWidth);
+
+                        var padding = Owner.Padding;
+                        float height = Owner.GetHeightForWidth(totalWidth - (padding.Start + padding.End));
                         totalHeight = Math.Max(Math.Min(height, maxHeight < 0 ? Int32.MaxValue : maxHeight), minHeight);
 
                         heightMeasureSpec = new MeasureSpecification(new LayoutLength(totalHeight), MeasureSpecification.ModeType.Exactly);


### PR DESCRIPTION
When the label's `HeightSpecification` is wrap content, the result of `GetHeightForWidth()` is used to calculate the text height.

The previous behavior simply used `NaturalSize`,
so it could not guarantee the behavior of the case below.

```
var label = new TextLabel
{
    Text = "Something long long text...",
    WidthSpecification = LayoutParamPolicies.WrapContent,
    HeightSpecification = LayoutParamPolicies.WrapContent,
    MaximumSize = new Size(400, 400),
    Padding = new Extents(25, 25, 10, 10),
    MultiLine = true,
};
```
