### PR TITLE
[NUI] Reduce more build warnings : CA1707, CA2211, CA1815, CA1720

### DIFF
--- a/src/Tizen.NUI/src/deprecated/Rendering/FilterModeType_Deprecated.cs
+++ b/src/Tizen.NUI/src/deprecated/Rendering/FilterModeType_Deprecated.cs
@@ -23,6 +23,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public enum FilterModeType
     {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
         /// <summary>
         /// Use GL defaults (minification NEAREST_MIPMAP_LINEAR, magnification LINEAR).
         /// </summary>
@@ -64,4 +65,5 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         LINEAR_MIPMAP_LINEAR
     }
+#pragma warning restore CA1707 // Identifiers should not contain underscores
 }

--- a/src/Tizen.NUI/src/deprecated/Rendering/Geometry_Deprecated.cs
+++ b/src/Tizen.NUI/src/deprecated/Rendering/Geometry_Deprecated.cs
@@ -32,6 +32,7 @@ namespace Tizen.NUI
         /// <since_tizen> 3 </since_tizen>
         public enum Type
         {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
             /// <summary>
             /// Individual points.
             /// </summary>
@@ -66,6 +67,7 @@ namespace Tizen.NUI
             /// A strip of triangles (after the first triangle, following triangles need only 1 point).
             /// </summary>
             TRIANGLE_STRIP
+#pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/deprecated/Rendering/Shader_Deprecated.cs
+++ b/src/Tizen.NUI/src/deprecated/Rendering/Shader_Deprecated.cs
@@ -55,6 +55,7 @@ namespace Tizen.NUI
             /// <since_tizen> 3 </since_tizen>
             public enum Value
             {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
                 /// <summary>
                 /// No hints.
                 /// </summary>
@@ -72,6 +73,7 @@ namespace Tizen.NUI
                 /// </summary>
                 /// <since_tizen> 3 </since_tizen>
                 MODIFIES_GEOMETRY = 0x02
+#pragma warning restore CA1707 // Identifiers should not contain underscores
             }
         }
     }

--- a/src/Tizen.NUI/src/deprecated/Rendering/TextureType_Deprecated.cs
+++ b/src/Tizen.NUI/src/deprecated/Rendering/TextureType_Deprecated.cs
@@ -23,6 +23,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public enum TextureType
     {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
         /// <summary>
         /// One 2D image
         /// </summary>
@@ -33,5 +34,6 @@ namespace Tizen.NUI
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         TEXTURE_CUBE
+#pragma warning restore CA1707 // Identifiers should not contain underscores
     }
 }

--- a/src/Tizen.NUI/src/devel/Lite/UIExtents.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIExtents.cs
@@ -159,7 +159,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Represents a <see cref="UIExtents"/> with all values set to 0.
         /// </summary>
-        public static UIExtents Zero = new UIExtents(0);
+        public static readonly UIExtents Zero = new (0);
 
         /// <summary>
         /// Adds the specified <see cref="float"/> to each component of the <see cref="UIExtents"/>.

--- a/src/Tizen.NUI/src/devel/Lite/UIShadow.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIShadow.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+using System;
 using System.ComponentModel;
 using Tizen.NUI.BaseComponents;
 
@@ -23,7 +24,7 @@ namespace Tizen.NUI
     /// Defines a value type of shadow.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct UIShadow
+    public struct UIShadow : IEquatable<UIShadow>
     {
         private static readonly UIColor s_defaultColor = UIColor.Black;
 
@@ -148,6 +149,68 @@ namespace Tizen.NUI
         /// Whether this shadow is default.
         /// </summary>
         public bool IsDefault => BlurRadius == 0 && Color == UIColor.Transparent && OffsetX == 0 && OffsetY == 0 && ExtraWidth == 0 && ExtraHeight == 0 && CutoutPolicy == ColorVisualCutoutPolicyType.None;
+
+        /// <summary>
+        /// Whether this is equivalent to other.
+        /// </summary>
+        public bool Equals(UIShadow other)
+        {
+            return BlurRadius == other.BlurRadius &&
+                   Color == other.Color &&
+                   OffsetX == other.OffsetX &&
+                   OffsetY == other.OffsetY &&
+                   ExtraWidth == other.ExtraWidth &&
+                   ExtraHeight == other.ExtraHeight &&
+                   CutoutPolicy == other.CutoutPolicy;
+        }
+
+        ///  <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (obj is UIShadow other)
+            {
+                return Equals(other);
+            }
+            return base.Equals(obj);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashcode = BlurRadius.GetHashCode();
+                hashcode = hashcode * 397 ^ Color.GetHashCode();
+                hashcode = hashcode * 397 ^ OffsetX.GetHashCode();
+                hashcode = hashcode * 397 ^ OffsetY.GetHashCode();
+                hashcode = hashcode * 397 ^ ExtraWidth.GetHashCode();
+                hashcode = hashcode * 397 ^ ExtraHeight.GetHashCode();
+                hashcode = hashcode * 397 ^ ((int)CutoutPolicy).GetHashCode();
+                return hashcode;
+            }
+        }
+
+        /// <summary>
+        /// Compares two UIShadow for equality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are equal, otherwise false.</returns>
+        public static bool operator ==(UIShadow operand1, UIShadow operand2)
+        {
+            return operand1.Equals(operand2);
+        }
+
+        /// <summary>
+        /// Compares two UIShadow for inequality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are not equal, otherwise false.</returns>
+        public static bool operator !=(UIShadow operand1, UIShadow operand2)
+        {
+            return !operand1.Equals(operand2);
+        }
 
         internal readonly NUI.Shadow ToShadow() => new NUI.Shadow(BlurRadius, Color.ToReferenceType(), new (OffsetX, OffsetY), new (ExtraWidth, ExtraHeight));
 

--- a/src/Tizen.NUI/src/devel/Lite/UIVector3.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UIVector3.cs
@@ -147,7 +147,13 @@ namespace Tizen.NUI
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return X.GetHashCode() ^ (Y.GetHashCode() * 397) ^ Z.GetHashCode();
+            unchecked
+            {
+                int hashcode = X.GetHashCode();
+                hashcode = hashcode * 397 ^ Y.GetHashCode();
+                hashcode = hashcode * 397 ^ Z.GetHashCode();
+                return hashcode;
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
+++ b/src/Tizen.NUI/src/internal/Common/DaliEnumConstants.cs
@@ -16,6 +16,7 @@
  */
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Tizen.NUI
@@ -44,6 +45,7 @@ namespace Tizen.NUI
         /// Enumeration for the direction
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
         public struct Direction
         {
             /// <summary>
@@ -69,13 +71,15 @@ namespace Tizen.NUI
         /// Tooltip
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
         public struct Tooltip
         {
             /// <summary>
             /// The properties used for a Tooltip.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716: Identifiers should not match keywords")]
+            [SuppressMessage("Naming", "CA1716: Identifiers should not match keywords")]
+            [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
             public struct Property
             {
                 /// <summary>
@@ -129,6 +133,7 @@ namespace Tizen.NUI
             /// Background Property
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
             public struct BackgroundProperty
             {
                 /// <summary>
@@ -147,6 +152,7 @@ namespace Tizen.NUI
             /// The properties of the tail used by the tooltip.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+            [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
             public struct TailProperty
             {
                 /// <summary>
@@ -214,7 +220,6 @@ namespace Tizen.NUI
             [Obsolete("Do not use this ViewMode.StereoInterlaced(Deprecated).")]
             StereoInterlaced
         }
-
     } // namespace Constants
 
 

--- a/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
+++ b/src/Tizen.NUI/src/internal/Common/FrameBuffer.cs
@@ -39,10 +39,10 @@ namespace Tizen.NUI
             /// <since_tizen> 3 </since_tizen>
             public enum Mask
             {
-                NONE = 0,
-                DEPTH = 1 << 0,
-                STENCIL = 1 << 1,
-                DEPTH_STENCIL = DEPTH | STENCIL
+                None = 0,
+                Depth = 1 << 0,
+                Stencil = 1 << 1,
+                DepthStencil = Depth | Stencil
             }
         }
 

--- a/src/Tizen.NUI/src/internal/Common/RenderBufferFormat.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderBufferFormat.cs
@@ -19,9 +19,9 @@ namespace Tizen.NUI
 {
     internal enum RenderBufferFormat
     {
-        COLOR,
-        COLOR_DEPTH,
-        COLOR_STENCIL,
-        COLOR_DEPTH_STENCIL
+        Color,
+        ColorDepth,
+        ColorStencil,
+        ColorDepthStencil,
     }
 }

--- a/src/Tizen.NUI/src/internal/Common/RenderTask.cs
+++ b/src/Tizen.NUI/src/internal/Common/RenderTask.cs
@@ -66,68 +66,12 @@ namespace Tizen.NUI
             internal static readonly int RequiresSync = Interop.RenderTask.RequiresSyncGet();
         }
 
-
-        public static bool DEFAULT_EXCLUSIVE
-        {
-            get
-            {
-                //this originates to Dali::RenderTask::DEFAULT_EXCLUSIVE
-                return false;
-            }
-        }
-
-        public static bool DEFAULT_INPUT_ENABLED
-        {
-            get
-            {
-                //this originates to Dali::RenderTask::DEFAULT_INPUT_ENABLED
-                return true;
-            }
-        }
-
-        private static Vector4 defaultClearColor;
-
-        public static Vector4 DEFAULT_CLEAR_COLOR
-        {
-            get
-            {
-                //this originates to Dali::RenderTask::DEFAULT_CLEAR_COLOR
-                if (null == defaultClearColor)
-                {
-                    defaultClearColor = new Vector4(0.0f, 0.0f, 0.0f, 1.0f);
-                }    
-
-                return defaultClearColor;
-            }
-        }
-
-        public static bool DEFAULT_CLEAR_ENABLED
-        {
-            get
-            {
-                //this originates to Dali::RenderTask::DEFAULT_CLEAR_ENABLED
-                return false;
-            }
-        }
-
-        public static bool DEFAULT_CULL_MODE
-        {
-            get
-            {
-                //this originates to Dali::RenderTask::DEFAULT_CULL_MODE
-                return true;
-            }
-        }
-
-        public static uint DEFAULT_REFRESH_RATE
-        {
-            get
-            {
-                //this originates to Dali::RenderTask::DEFAULT_REFRESH_RATE
-                return 1;
-            }
-        }
-#pragma warning restore CA1707
+        public const bool DefaultExclusive = false; //this originates to Dali::RenderTask::DEFAULT_EXCLUSIVE
+        public const bool DefaultInputEnabled = true; //this originates to Dali::RenderTask::DEFAULT_INPUT_ENABLED
+        public const bool DefaultClearEnabled = false; //this originates to Dali::RenderTask::DEFAULT_CLEAR_ENABLED
+        public const bool DefaultCullMode = true; //this originates to Dali::RenderTask::DEFAULT_CULL_MODE
+        public const uint DefaultRefreshRate = 1; //this originates to Dali::RenderTask::DEFAULT_REFRESH_RATE
+        public static readonly Vector4 DefaultClearColor = new Vector4(0.0f, 0.0f, 0.0f, 1.0f); //this originates to Dali::RenderTask::DEFAULT_CLEAR_COLOR
 
         public RenderTask() : this(Interop.RenderTask.NewRenderTask(), true)
         {
@@ -165,8 +109,16 @@ namespace Tizen.NUI
 
         public View GetSourceView()
         {
-            // TODO : Fix me, to avoid memory leak issue.
-            View ret = new View(Interop.RenderTask.GetSourceActor(SwigCPtr), true);
+            IntPtr cPtr = Interop.RenderTask.GetSourceActor(SwigCPtr);
+            View ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as View;
+            if (ret != null)
+            {
+                Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, cPtr));
+            }
+            else
+            {
+                ret = new View(cPtr, true);
+            }
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ItemFactory.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ItemFactory.cs
@@ -40,8 +40,8 @@ namespace Tizen.NUI
             public static extern global::System.IntPtr NewItemFactory();
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemFactory_director_connect")]
-            public static extern void DirectorConnect(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.ItemFactory.SwigDelegateItemFactory_0 delegate0,
-                Tizen.NUI.ItemFactory.SwigDelegateItemFactory_1 delegate1, Tizen.NUI.ItemFactory.SwigDelegateItemFactory_2 delegate2);
+            public static extern void DirectorConnect(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.ItemFactory.SwigDelegateItemFactory0 delegate0,
+                Tizen.NUI.ItemFactory.SwigDelegateItemFactory1 delegate1, Tizen.NUI.ItemFactory.SwigDelegateItemFactory2 delegate2);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Utility/ItemFactory.cs
+++ b/src/Tizen.NUI/src/internal/Utility/ItemFactory.cs
@@ -73,11 +73,11 @@ namespace Tizen.NUI
         private void SwigDirectorConnect()
         {
             if (SwigDerivedClassHasMethod("GetNumberOfItems", swigMethodTypes0))
-                swigDelegate0 = new SwigDelegateItemFactory_0(SwigDirectorGetNumberOfItems);
+                swigDelegate0 = new SwigDelegateItemFactory0(SwigDirectorGetNumberOfItems);
             if (SwigDerivedClassHasMethod("NewItem", swigMethodTypes1))
-                swigDelegate1 = new SwigDelegateItemFactory_1(SwigDirectorNewItem);
+                swigDelegate1 = new SwigDelegateItemFactory1(SwigDirectorNewItem);
             if (SwigDerivedClassHasMethod("ItemReleased", swigMethodTypes2))
-                swigDelegate2 = new SwigDelegateItemFactory_2(SwigDirectorItemReleased);
+                swigDelegate2 = new SwigDelegateItemFactory2(SwigDirectorItemReleased);
             Interop.ItemFactory.DirectorConnect(SwigCPtr, swigDelegate0, swigDelegate1, swigDelegate2);
         }
 
@@ -106,19 +106,19 @@ namespace Tizen.NUI
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public delegate uint SwigDelegateItemFactory_0();
+        public delegate uint SwigDelegateItemFactory0();
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public delegate global::System.IntPtr SwigDelegateItemFactory_1(uint itemId);
+        public delegate global::System.IntPtr SwigDelegateItemFactory1(uint itemId);
 
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public delegate void SwigDelegateItemFactory_2(uint itemId, global::System.IntPtr actor);
+        public delegate void SwigDelegateItemFactory2(uint itemId, global::System.IntPtr actor);
 
-        private SwigDelegateItemFactory_0 swigDelegate0;
-        private SwigDelegateItemFactory_1 swigDelegate1;
-        private SwigDelegateItemFactory_2 swigDelegate2;
+        private SwigDelegateItemFactory0 swigDelegate0;
+        private SwigDelegateItemFactory1 swigDelegate1;
+        private SwigDelegateItemFactory2 swigDelegate2;
 
         private static global::System.Type[] swigMethodTypes0 = System.Array.Empty<global::System.Type>();
         private static global::System.Type[] swigMethodTypes1 = new global::System.Type[] { typeof(uint) };

--- a/src/Tizen.NUI/src/public/Animation/Animatable.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animatable.cs
@@ -98,7 +98,9 @@ namespace Tizen.NUI
             /// New properties are registered by calling RegisterProperty() with an unused property name.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
+#pragma warning disable CA1707 // Identifiers should not contain underscores
             DYNAMIC_PROPERTIES = 0x01
+#pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Common/NUIConstants.cs
+++ b/src/Tizen.NUI/src/public/Common/NUIConstants.cs
@@ -1233,6 +1233,7 @@ namespace Tizen.NUI
     /// The HiddenInput property.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct HiddenInputProperty
     {
         /// <summary>
@@ -1261,6 +1262,7 @@ namespace Tizen.NUI
     /// The SelectionPopupStyle property.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct SelectionPopupStyleProperty
     {
         /// <summary>
@@ -1338,6 +1340,7 @@ namespace Tizen.NUI
     /// ParentOrigin constants.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct ParentOrigin
     {
         private static readonly Position topLeft = new Position(Left, Top, Middle);
@@ -1444,6 +1447,7 @@ namespace Tizen.NUI
     /// PivotPoint constants.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct PivotPoint
     {
         /// <summary>
@@ -1535,6 +1539,7 @@ namespace Tizen.NUI
     /// PositionAxis constants.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct PositionAxis
     {
         private static readonly Position xaxis = new Position(1.0f, 0.0f, 0.0f);
@@ -1592,6 +1597,7 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     [Obsolete("Do not use this, that will be deprecated. Use as PivotPoint instead.")]
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct AnchorPoint
     {
         /// <summary>
@@ -1723,6 +1729,7 @@ namespace Tizen.NUI
     /// FontSizeScale constant.
     /// </summary>
     /// <since_tizen> 9 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct FontSizeScale
     {
         /// <summary>
@@ -1736,6 +1743,7 @@ namespace Tizen.NUI
     /// FontFamily constant.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct FontFamily
     {
         /// <summary>
@@ -1749,6 +1757,7 @@ namespace Tizen.NUI
     /// Offset has left, right, bottom, top value.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct Offset
     {
         /// <summary>
@@ -1790,7 +1799,6 @@ namespace Tizen.NUI
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int Top {get; set;}
-
     }
 
     /// <summary>
@@ -1878,6 +1886,7 @@ namespace Tizen.NUI
         /// <summary>
         /// The double underline type.
         /// </summary>
+        [SuppressMessage("Naming", "CA1720: Identifiers should not contain type names", Justification = "This is not a type name.")]
         Double
     }
 
@@ -1929,6 +1938,7 @@ namespace Tizen.NUI
     /// Pre-defined SlideTransition Direction
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct SlideTransitionDirection
     {
         private static readonly Vector2 top = new Vector2(0, -1);

--- a/src/Tizen.NUI/src/public/Layouting/MeasureSpecification.cs
+++ b/src/Tizen.NUI/src/public/Layouting/MeasureSpecification.cs
@@ -25,6 +25,7 @@ namespace Tizen.NUI
     /// A MeasureSpecification is used during the Measure pass by a LayoutGroup to inform it's children how to be measured.
     /// For instance, it may measure a child with an exact width and an unspecified height in order to determine height for width.
     /// </summary>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct MeasureSpecification
     {
         /// <summary>

--- a/src/Tizen.NUI/src/public/Layouting/MeasuredSize.cs
+++ b/src/Tizen.NUI/src/public/Layouting/MeasuredSize.cs
@@ -17,12 +17,14 @@
 
 using System.ComponentModel;
 using Tizen.NUI.BaseComponents;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Tizen.NUI
 {
     /// <summary>
     /// Class that encodes a measurement and a measure state, which is set if the measured size is too small.
     /// </summary>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct MeasuredSize
     {
         /// <summary>

--- a/src/Tizen.NUI/src/public/ParticleSystem/Particle.cs
+++ b/src/Tizen.NUI/src/public/ParticleSystem/Particle.cs
@@ -39,7 +39,7 @@ namespace Tizen.NUI.ParticleSystem
         Opacity       = 1 << 5, // float, opacity (0.0-1.0)
         Velocity      = 1 << 6, // Vector3, vector of velocity
         Lifetime      = 1 << 7, // float, remaining lifetime
-        Lifetime_Base = 1 << 8, // float, initial lifetime
+        LifetimeBase  = 1 << 8, // float, initial lifetime
     }
 
     /// <summary>
@@ -466,14 +466,14 @@ namespace Tizen.NUI.ParticleSystem
         {
             get
             {
-                var streamIndex = GetStreamIndex(ParticleStream.Lifetime_Base);
+                var streamIndex = GetStreamIndex(ParticleStream.LifetimeBase);
                 var ret = Interop.Particle.ReadFloat(mEmitterRef, (uint)streamIndex, mIndex);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return ret;
             }
             set
             {
-                SetStreamValue( value, ParticleStream.Lifetime_Base);
+                SetStreamValue( value, ParticleStream.LifetimeBase);
             }
         }
 

--- a/src/Tizen.NUI/src/public/Rendering/Texture.cs
+++ b/src/Tizen.NUI/src/public/Rendering/Texture.cs
@@ -76,7 +76,7 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Upload(PixelData pixelData, TextureUploadProperties properties)
         {
-            bool ret = Interop.Texture.Upload(SwigCPtr, PixelData.getCPtr(pixelData), properties.layer, properties.mipmap, properties.xOffset, properties.yOffset, properties.width, properties.height);
+            bool ret = Interop.Texture.Upload(SwigCPtr, PixelData.getCPtr(pixelData), properties.Layer, properties.Mipmap, properties.XOffset, properties.YOffset, properties.Width, properties.Height);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }

--- a/src/Tizen.NUI/src/public/Rendering/TextureUploadProperties.cs
+++ b/src/Tizen.NUI/src/public/Rendering/TextureUploadProperties.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Tizen.NUI
 {
@@ -24,42 +25,43 @@ namespace Tizen.NUI
     /// Structure to define properties for texture upload
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct TextureUploadProperties
     {
         /// <summary>
         /// The layer of a cube map or array texture.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint layer;
+        public uint Layer { get; set; }
 
         /// <summary>
         /// The level-of-detail number. Level 0 is the base image level. Level n is the nth mipmap reduction image.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint mipmap;
+        public uint Mipmap { get; set; }
 
         /// <summary>
         /// The horizontal offset of the rectangular area in the texture that will be updated.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint xOffset;
+        public uint XOffset { get; set; }
 
         /// <summary>
         /// The vertical offset of the rectangular area in the texture that will be updated.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint yOffset;
+        public uint YOffset { get; set; }
 
         /// <summary>
         /// The width of the rectangular area in the texture that will be updated.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint width;
+        public uint Width { get; set; }
 
         /// <summary>
         /// height of the rectangular area in the texture that will be updated.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public uint height;
+        public uint Height { get; set; }
     }
 }

--- a/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
+++ b/src/Tizen.NUI/src/public/Utility/AccumulatingVelocityTrackerStrategy.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Tizen.NUI.Utility
 {
@@ -35,6 +36,7 @@ namespace Tizen.NUI.Utility
         /// <summary>
         /// Positions and event time information
         /// </summary>
+        [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
         protected struct Movement
         {
             public uint EventTime;

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Tizen.NUI
 {
@@ -403,6 +404,7 @@ namespace Tizen.NUI
     /// This specifies visual types.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct Visual
     {
         /// <summary>
@@ -482,7 +484,8 @@ namespace Tizen.NUI
         /// This specifies visual properties.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716: Identifiers should not match keywords")]
+        [SuppressMessage("Naming", "CA1716: Identifiers should not match keywords")]
+        [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
         public struct Property
         {
             /// <summary>
@@ -563,6 +566,7 @@ namespace Tizen.NUI
         /// This specifies shader properties.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
+        [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
         public struct ShaderProperty
         {
             /// <summary>
@@ -650,6 +654,7 @@ namespace Tizen.NUI
     /// This specifies properties of the BorderVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct BorderVisualProperty
     {
         /// <summary>
@@ -673,6 +678,7 @@ namespace Tizen.NUI
     /// This specifies properties of the ColorVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct ColorVisualProperty
     {
         /// <summary>
@@ -704,6 +710,7 @@ namespace Tizen.NUI
     /// This specifies properties of the GradientVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct GradientVisualProperty
     {
         /// <summary>
@@ -752,6 +759,7 @@ namespace Tizen.NUI
     /// This specifies properties of the ImageVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct ImageVisualProperty
     {
         /// <summary>
@@ -1069,6 +1077,7 @@ namespace Tizen.NUI
     /// This specifies properties of the MeshVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct MeshVisualProperty
     {
         /// <summary>
@@ -1117,6 +1126,7 @@ namespace Tizen.NUI
     /// This specifies properties of the PrimitiveVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct PrimitiveVisualProperty
     {
         /// <summary>
@@ -1185,6 +1195,7 @@ namespace Tizen.NUI
     /// This specifies properties of the TextVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct TextVisualProperty
     {
         /// <summary>
@@ -1258,6 +1269,7 @@ namespace Tizen.NUI
     /// This specifies properties of the NpatchImageVisual.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     public struct NpatchImageVisualProperty
     {
         /// <summary>
@@ -1320,6 +1332,7 @@ namespace Tizen.NUI
     /// <summary>
     /// This specifies properties of the ArcVisual.
     /// </summary>
+    [SuppressMessage("Performance", "CA1815: Override equals and operator equals on value types", Justification = "This is a struct and does not need to override equals.")]
     internal struct ArcVisualProperty
     {
         /// <summary>

--- a/src/Tizen.NUI/src/public/Window/WindowBlurInfo.cs
+++ b/src/Tizen.NUI/src/public/Window/WindowBlurInfo.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     /// including the type of blur, its intensity, and the corner rounding for the background blur.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public struct WindowBlurInfo
+    public struct WindowBlurInfo : IEquatable<WindowBlurInfo>
     {
         /// <summary>
         /// The construct with blur type, radius and corner radius for background type.
@@ -76,5 +76,64 @@ namespace Tizen.NUI
         /// <value>The corner radius of the window.</value>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public int BackgroundCornerRadius {get; set;}
+        
+        /// <summary>
+        /// Whether this is equivalent to other.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Equals(WindowBlurInfo other)
+        {
+            return BlurType == other.BlurType &&
+                   BlurRadius == other.BlurRadius &&
+                   BackgroundCornerRadius == other.BackgroundCornerRadius;
+        }
+
+        ///  <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            if (obj is WindowBlurInfo other)
+            {
+                return Equals(other);
+            }
+            return base.Equals(obj);
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashcode = ((int)BlurType).GetHashCode();
+                hashcode = hashcode * 397 ^ BlurRadius.GetHashCode();
+                hashcode = hashcode * 397 ^ BackgroundCornerRadius.GetHashCode();
+                return hashcode;
+            }
+        }
+
+        /// <summary>
+        /// Compares two WindowBlurInfo for equality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are equal, otherwise false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator ==(WindowBlurInfo operand1, WindowBlurInfo operand2)
+        {
+            return operand1.Equals(operand2);
+        }
+
+        /// <summary>
+        /// Compares two WindowBlurInfo for inequality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are not equal, otherwise false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !=(WindowBlurInfo operand1, WindowBlurInfo operand2)
+        {
+            return !operand1.Equals(operand2);
+        }
     }
 }

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Common/TSRenderTask.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/Common/TSRenderTask.cs
@@ -111,58 +111,8 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("RenderTask DEFAULT_SCREEN_TO_FRAMEBUFFER_FUNCTION.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.DEFAULT_SCREEN_TO_FRAMEBUFFER_FUNCTION A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void RenderTaskDefaultScreenToFrameBufferFunction()
-        {
-            tlog.Debug(tag, $"RenderTaskDefaultScreenToFrameBufferFunction START");
-
-            try
-            {
-                var result = RenderTask.DEFAULT_SCREEN_TO_FRAMEBUFFER_FUNCTION;
-                tlog.Debug(tag, "DEFAULT_SCREEN_TO_FRAMEBUFFER_FUNCTION : " + result);
-            }
-            catch (Exception e)
-            {
-                tlog.Debug(tag, e.Message.ToString());
-                Assert.Fail("Caught Exception : Failed!");
-            }
-
-            tlog.Debug(tag, $"RenderTaskDefaultScreenToFrameBufferFunction END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("RenderTask FULLSCREEN_FRAMEBUFFER_FUNCTION.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.FULLSCREEN_FRAMEBUFFER_FUNCTION A")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "PRO")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void RenderTaskFullScreenFrameBufferFunction()
-        {
-            tlog.Debug(tag, $"RenderTaskFullScreenFrameBufferFunction START");
-
-            try
-            {
-                var result = RenderTask.FULLSCREEN_FRAMEBUFFER_FUNCTION;
-                tlog.Debug(tag, "FULLSCREEN_FRAMEBUFFER_FUNCTION : " + result);
-            }
-            catch (Exception e)
-            {
-                tlog.Debug(tag, e.Message.ToString());
-                Assert.Fail("Caught Exception : Failed!");
-            }
-
-            tlog.Debug(tag, $"RenderTaskFullScreenFrameBufferFunction END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
-        [Description("RenderTask DEFAULT_EXCLUSIVE.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.DEFAULT_EXCLUSIVE A")]
+        [Description("RenderTask DefaultExclusive.")]
+        [Property("SPEC", "Tizen.NUI.RenderTask.DefaultExclusive A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "PRO")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
@@ -172,8 +122,8 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                var result = RenderTask.DEFAULT_EXCLUSIVE;
-                tlog.Debug(tag, "DEFAULT_EXCLUSIVE : " + result);
+                var result = RenderTask.DefaultExclusive;
+                tlog.Debug(tag, "DefaultExclusive : " + result);
             }
             catch (Exception e)
             {
@@ -186,8 +136,8 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("RenderTask DEFAULT_INPUT_ENABLED.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.DEFAULT_INPUT_ENABLED A")]
+        [Description("RenderTask DefaultInputEnabled.")]
+        [Property("SPEC", "Tizen.NUI.RenderTask.DefaultInputEnabled A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "PRO")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
@@ -197,8 +147,8 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                var result = RenderTask.DEFAULT_INPUT_ENABLED;
-                tlog.Debug(tag, "DEFAULT_INPUT_ENABLED : " + result);
+                var result = RenderTask.DefaultInputEnabled;
+                tlog.Debug(tag, "DefaultInputEnabled : " + result);
             }
             catch (Exception e)
             {
@@ -211,8 +161,8 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("RenderTask DEFAULT_CLEAR_COLOR.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.DEFAULT_CLEAR_COLOR A")]
+        [Description("RenderTask DefaultClearColor.")]
+        [Property("SPEC", "Tizen.NUI.RenderTask.DefaultClearColor A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "PRO")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
@@ -222,8 +172,8 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                var result = RenderTask.DEFAULT_CLEAR_COLOR;
-                tlog.Debug(tag, "DEFAULT_CLEAR_COLOR : " + result);
+                var result = RenderTask.DefaultClearColor;
+                tlog.Debug(tag, "DefaultClearColor : " + result);
             }
             catch (Exception e)
             {
@@ -236,8 +186,8 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("RenderTask DEFAULT_CLEAR_ENABLED.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.DEFAULT_CLEAR_ENABLED A")]
+        [Description("RenderTask DefaultClearEnabled.")]
+        [Property("SPEC", "Tizen.NUI.RenderTask.DefaultClearEnabled A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "PRO")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
@@ -247,8 +197,8 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                var result = RenderTask.DEFAULT_CLEAR_ENABLED;
-                tlog.Debug(tag, "DEFAULT_CLEAR_ENABLED : " + result);
+                var result = RenderTask.DefaultClearEnabled;
+                tlog.Debug(tag, "DefaultClearEnabled : " + result);
             }
             catch (Exception e)
             {
@@ -261,8 +211,8 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("RenderTask DEFAULT_CULL_MODE.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.DEFAULT_CULL_MODE A")]
+        [Description("RenderTask DefaultCullMode.")]
+        [Property("SPEC", "Tizen.NUI.RenderTask.DefaultCullMode A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "PRO")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
@@ -272,8 +222,8 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                var result = RenderTask.DEFAULT_CULL_MODE;
-                tlog.Debug(tag, "DEFAULT_CULL_MODE : " + result);
+                var result = RenderTask.DefaultCullMode;
+                tlog.Debug(tag, "DefaultCullMode : " + result);
             }
             catch (Exception e)
             {
@@ -286,8 +236,8 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("RenderTask DEFAULT_REFRESH_RATE.")]
-        [Property("SPEC", "Tizen.NUI.RenderTask.DEFAULT_REFRESH_RATE A")]
+        [Description("RenderTask DefaultRefreshRate.")]
+        [Property("SPEC", "Tizen.NUI.RenderTask.DefaultRefreshRate A")]
         [Property("SPEC_URL", "-")]
         [Property("CRITERIA", "PRO")]
         [Property("AUTHOR", "guowei.wang@samsung.com")]
@@ -297,8 +247,8 @@ namespace Tizen.NUI.Devel.Tests
 
             try
             {
-                var result = RenderTask.DEFAULT_REFRESH_RATE;
-                tlog.Debug(tag, "DEFAULT_REFRESH_RATE : " + result);
+                var result = RenderTask.DefaultRefreshRate;
+                tlog.Debug(tag, "DefaultRefreshRate : " + result);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
- CA1707: Remove the underscores from member name
- CA2211: Non-constant fields should not be visible
- CA1815: {Strut} should override the equality (==) and inequality (!=) operators
- CA1720: Identifier 'Double' contains type namew

Build warning counts 1524 -> 1426 (Reduce 98)

Build command : dotnet build /p:NuiRoslynAnalysis=true