### PR TITLE
[NUI] Apply Global.ruleset what TizenFX using

### DIFF
--- a/src/Tizen.NUI/Tizen.NUI.csproj
+++ b/src/Tizen.NUI/Tizen.NUI.csproj
@@ -12,16 +12,8 @@
         <EnableNETAnalyzers>true</EnableNETAnalyzers>
     </PropertyGroup>
 
-    <Choose>
-        <When Condition="'$(NuiRoslynAnalysis)' == 'true'">
-            <ItemGroup>
-                <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="*">
-                    <PrivateAssets>all</PrivateAssets>
-                    <IncludeAssets>runtime;build;native;contentfiles;analyzers;buildtransitive</IncludeAssets>
-                </PackageReference>
-            </ItemGroup>
-        </When>
-    </Choose>
+    <Import Project="$(MSBuildThisFileDirectory)../../build/analyzers.props"
+            Condition="'$(NuiRoslynAnalysis)' == 'True'" />
 
     <ItemGroup>
         <TizenPreloadFile Include="Tizen.NUI.preload" Sequence="30" />


### PR DESCRIPTION
Let we use `analyzers.props` what `Global.ruleset` defined already.

For NUI csproj hijack, let we don't import duplicated property settings

Build warning : 1523 -> 1407 (Reduce 116)