### PR TITLE
[NUI] Fix wrong equality check of UICorner

### DIFF
--- a/src/Tizen.NUI/src/devel/Lite/UICorner.cs
+++ b/src/Tizen.NUI/src/devel/Lite/UICorner.cs
@@ -142,7 +142,7 @@ namespace Tizen.NUI
         /// </summary>
         public bool Equals(UICorner other)
         {
-            return TopLeft == other.TopLeft && TopRight == other.TopRight && BottomRight == other.BottomRight && BottomLeft == other.BottomLeft && IsRelative && other.IsRelative;
+            return TopLeft == other.TopLeft && TopRight == other.TopRight && BottomRight == other.BottomRight && BottomLeft == other.BottomLeft && IsRelative == other.IsRelative;
         }
 
         ///  <inheritdoc/>
@@ -168,6 +168,9 @@ namespace Tizen.NUI
                 return hashcode;
             }
         }
+
+        ///  <inheritdoc/>
+        public override string ToString() => $"UICorner([relative:{IsRelative}] {TopLeft}, {TopRight}, {BottomRight}, {BottomLeft})";
 
         internal readonly NUI.Vector4 ToReferenceType() => new NUI.Vector4(TopLeft, TopRight, BottomRight, BottomLeft);
     }


### PR DESCRIPTION
### Description of Change ###
Fix wrong equality check logic in `UICorner` and override `ToString` method to check value inside.

⚠️ depends: https://github.sec.samsung.net/NUI/OneUIComponents/pull/259


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
