### PR TITLE
[NUI] Rewrite LowerFirstLetter

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
+++ b/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using System.Runtime.CompilerServices;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
@@ -78,7 +79,7 @@ namespace Tizen.NUI
         {
             var propertyName = LowerFirstLetter(stringProperty);
 
-            if(animatable is View)
+            if (animatable is View)
             {
                 View view = animatable as View;
                 return SearchProperty(view, propertyName) ?? SearchVisualProperty(view, propertyName);
@@ -137,11 +138,17 @@ namespace Tizen.NUI
             return result;
         }
 
-        private static string LowerFirstLetter(string original)
+        private static unsafe string LowerFirstLetter(string original)
         {
-            StringBuilder sb = new StringBuilder(original);
-            sb[0] = (char)(sb[0] | 0x20);
-            return sb.ToString();
+            if (string.IsNullOrEmpty(original) || char.IsLower(original[0]))
+                return original;
+
+            fixed (char* chars = original)
+            {
+                chars[0] = char.ToLower(chars[0]);
+            }
+
+            return original;
         }
 
         private static object ObjectColorToVector4(object value)

--- a/src/Tizen.NUI/src/public/Animation/Animatable.cs
+++ b/src/Tizen.NUI/src/public/Animation/Animatable.cs
@@ -16,6 +16,7 @@
  */
 using System.ComponentModel;
 using System.Text;
+using System.Runtime.CompilerServices;
 
 namespace Tizen.NUI
 {
@@ -320,11 +321,17 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        private static string LowerFirstLetter(string original)
+        private static unsafe string LowerFirstLetter(string original)
         {
-            StringBuilder sb = new StringBuilder(original);
-            sb[0] = (char)(sb[0] | 0x20);
-            return sb.ToString();
+            if (string.IsNullOrEmpty(original) || char.IsLower(original[0]))
+                return original;
+
+            fixed (char* chars = original)
+            {
+                chars[0] = char.ToLower(chars[0]);
+            }
+
+            return original;
         }
 
         /// This will not be public opened.


### PR DESCRIPTION
Reduce string creation by `Tizen.NUI.Animation.AnimateTo()`

- Prune unnecessary case
- Unsafe char[] access to avoid string creation

Unit test done in the local but I wish it could be fully tested on various scenario.
**More desirable case is to implement this logic in the native side.**