### PR TITLE
[NUI] Add SetPanGestureMinimumTouchesRequired and SetPanGestureMaximumTouchesRequired() to GestureOptions.

### DIFF
--- a/src/Tizen.NUI/src/public/Events/GestureOptions.cs
+++ b/src/Tizen.NUI/src/public/Events/GestureOptions.cs
@@ -26,6 +26,8 @@ namespace Tizen.NUI
     public sealed class GestureOptions
     {
         private static readonly GestureOptions instance = new GestureOptions();
+        private static uint panGestureMinimumTouchesRequired;
+        private static uint panGestureMaximumTouchesRequired;
 
         /// <summary>
         /// Constructor.
@@ -253,6 +255,44 @@ namespace Tizen.NUI
         {
             Interop.GestureOptions.SetPanGestureMinimumPanEvents(number);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Sets the minimum number of touches required for the pan gesture to be detected.
+        /// </summary>
+        /// <param name="minimum"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetPanGestureMinimumTouchesRequired(uint minimum)
+        {
+            panGestureMinimumTouchesRequired = minimum;
+        }
+
+        /// <summary>
+        /// Gets the minimum number of touches required for the pan gesture to be detected.
+        /// </summary>
+        /// <returns>The minimum number of touches required</returns>
+        internal uint GetPanGestureMinimumTouchesRequired()
+        {
+            return panGestureMinimumTouchesRequired;
+        }
+
+        /// <summary>
+        /// Sets the maximum number of touches required for the pan gesture to be detected.
+        /// </summary>
+        /// <param name="minimum"></param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetPanGestureMaximumTouchesRequired(uint maximum)
+        {
+            panGestureMaximumTouchesRequired = maximum;
+        }
+
+        /// <summary>
+        /// Gets the maximum number of touches required for the pan gesture to be detected.
+        /// </summary>
+        /// <returns>The maximum number of touches required</returns>
+        internal uint GetPanGestureMaximumTouchesRequired()
+        {
+            return panGestureMaximumTouchesRequired;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGestureDetector.cs
@@ -36,7 +36,6 @@ namespace Tizen.NUI
         public PanGestureDetector() : this(Interop.PanGestureDetector.New(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
         }
 
         /// <summary>
@@ -52,10 +51,28 @@ namespace Tizen.NUI
 
         internal PanGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
         {
+            Initialized();
         }
 
         internal PanGestureDetector(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
         {
+            Initialized();
+        }
+
+        private void Initialized()
+        {
+            if (HasBody())
+            {
+                if (GestureOptions.Instance.GetPanGestureMinimumTouchesRequired() > 0)
+                {
+                    SetMinimumTouchesRequired(GestureOptions.Instance.GetPanGestureMinimumTouchesRequired());
+                }
+
+                if (GestureOptions.Instance.GetPanGestureMaximumTouchesRequired() > 0)
+                {
+                    SetMaximumTouchesRequired(GestureOptions.Instance.GetPanGestureMaximumTouchesRequired());
+                }
+            }
         }
 
         private DaliEventHandler<object, DetectedEventArgs> detectedEventHandler;


### PR DESCRIPTION

### Description of Change ###
<!-- Describe your changes here. -->

This sets MinimumTouchesRequired and MaximumTouchesRequired when creating a PanGesture.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
