### PR TITLE
[NUI] Fix layout sibiling order changes by RaiseToTop and LowerToBottom

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -391,8 +391,7 @@ namespace Tizen.NUI.BaseComponents
                 parentChildren.Remove(this);
                 parentChildren.Add(this);
 
-                LayoutGroup layout = Layout as LayoutGroup;
-                layout?.ChangeLayoutSiblingOrder(parentChildren.Count - 1);
+                Layout?.ChangeLayoutSiblingOrder(parentChildren.Count - 1);
 
                 Interop.NDalic.RaiseToTop(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending)
@@ -418,8 +417,7 @@ namespace Tizen.NUI.BaseComponents
                 parentChildren.Remove(this);
                 parentChildren.Insert(0, this);
 
-                LayoutGroup layout = Layout as LayoutGroup;
-                layout?.ChangeLayoutSiblingOrder(0);
+                Layout?.ChangeLayoutSiblingOrder(0);
 
                 Interop.NDalic.LowerToBottom(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->

ChangeLayoutSiblingOrder will change layout sequence of parent layout,
so current view layout does not need to be layout group.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
