### PR TITLE
Bump Ubuntu version in github actions to 22.04

### DIFF
--- a/.github/workflows/build-branches.yml
+++ b/.github/workflows/build-branches.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 
@@ -66,7 +66,7 @@ jobs:
 
   check-api:
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3

--- a/.github/workflows/check-api-level.yml
+++ b/.github/workflows/check-api-level.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   add-labels:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Get Branch Metadata

--- a/.github/workflows/deploy-documents-for-tizen-docs.yml
+++ b/.github/workflows/deploy-documents-for-tizen-docs.yml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: tizendotnet/tizenfx-build-worker:2.5
       options: --ulimit nofile=10240:10240
@@ -54,7 +54,7 @@ jobs:
 
   deploy:
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: tizendotnet/tizenfx-build-worker:2.5
       options: --ulimit nofile=10240:10240
@@ -45,7 +45,7 @@ jobs:
 
   deploy:
     needs: [build]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/deploy-packages.yml
+++ b/.github/workflows/deploy-packages.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   nightly:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/postback-pull-request.yml
+++ b/.github/workflows/postback-pull-request.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   postback:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Download Artifacts from Build


### PR DESCRIPTION
### Description of Change ###
As of April 15th, Github actions no longer supports Ubuntu 20.04.
For more details, see https://github.com/actions/runner-images/issues/11101

This PR is to update the workflows to use Ubuntu 22.04 instead.

