### PR TITLE
[NUI] Add a cache for key event in View.

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -837,6 +837,8 @@ namespace Tizen.NUI.BaseComponents
             keyInputFocusLostEventHandler?.Invoke(this, null);
         }
 
+        private KeyEventArgs keyEventArgs;
+
         private bool OnKeyEvent(IntPtr view, IntPtr keyEvent)
         {
             if (Disposed || IsDisposeQueued)
@@ -851,23 +853,23 @@ namespace Tizen.NUI.BaseComponents
                 return true;
             }
 
-            KeyEventArgs e = new KeyEventArgs();
+            if (keyEventArgs == null)
+            {
+                keyEventArgs = new KeyEventArgs();
+            }
 
             bool result = false;
-
-            e.Key = Tizen.NUI.Key.GetKeyFromPtr(keyEvent);
-
+            using var key = Tizen.NUI.Key.GetKeyFromPtr(keyEvent);
+            keyEventArgs.Key = key;
             if (keyEventHandler != null)
             {
                 Delegate[] delegateList = keyEventHandler.GetInvocationList();
-
-                // Oring the result of each callback.
+                // ORing the result of each callback.
                 foreach (EventHandlerWithReturnType<object, KeyEventArgs, bool> del in delegateList)
                 {
-                    result |= del(this, e);
+                    result |= del(this, keyEventArgs);
                 }
             }
-
             return result;
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
When KeyEvent is triggered frequently, a cache can reduce the peak value of memory usage.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
