### PR TITLE
[NUI] Bump Ubuntu version in github action to 24.04

### DIFF
--- a/.github/workflows/nui-code-style-review.yml
+++ b/.github/workflows/nui-code-style-review.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   NUIStyleReview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: repository checkout (저장소 체크아웃)
         uses: actions/checkout@v3


### PR DESCRIPTION
Add missing jobs #6848

Also, bump-up the version as 24.04, not 22.04
(24.04 is latest)