### PR TITLE
[NUI] Bind mutable background blur effect with public functions

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.BackgroundBlurEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BackgroundBlurEffect.cs
@@ -14,15 +14,36 @@
  * limitations under the License.
  *
  */
- 
 namespace Tizen.NUI
 {
+    using global::System;
+    using global::System.Runtime.InteropServices;
+
     internal static partial class Interop
     {
-        internal static partial class BackgroundBlurEffect
+        internal static class BackgroundBlurEffect
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_New__SWIG_1")]
-            public static extern global::System.IntPtr New(uint pixelRadius, bool blurOnce);
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_New__SWIG_1")]
+            public static extern IntPtr New(uint blurRadius);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurOnce")]
+            public static extern void SetBlurOnce(HandleRef effect, bool blurRadius);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurOnce")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static extern bool GetBlurOnce(HandleRef effect);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurRadius")]
+            public static extern void SetBlurRadius(HandleRef effect, uint blurRadius);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurRadius")]
+            public static extern uint GetBlurRadius(HandleRef effect);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurStrengthAnimation")]
+            public static extern void AddBlurStrengthAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurOpacityAnimation")]
+            public static extern void AddBlurOpacityAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
@@ -1,0 +1,34 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Tizen.NUI
+{
+    using global::System;
+    using global::System.Runtime.InteropServices;
+
+    internal static partial class Interop
+    {
+        internal static class RenderEffect
+        {
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Activate")]
+            public static extern void Activate(HandleRef effect);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Deactivate")]
+            public static extern void Deactivate(HandleRef effect);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/RenderEffects/BackgroundBlurEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/BackgroundBlurEffect.cs
@@ -1,0 +1,118 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.ComponentModel;
+using System;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Background blur effect of a View.
+    /// Applications can apply BackgroundBlurEffect as the example below :
+    /// <code>
+    /// BackgroundBlurEffect effect = new BackgroundBlurEffect();
+    /// view.SetRenderEffect(effect);
+    /// </code>
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BackgroundBlurEffect : RenderEffect
+    {
+        internal BackgroundBlurEffect(global::System.IntPtr cPtr) : base(cPtr)
+        {
+        }
+
+        /// <summary>
+        /// The property determines whether to render the effect only once or at every frame update.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool BlurOnce
+        {
+            get
+            {
+                bool blurOnce = Interop.BackgroundBlurEffect.GetBlurOnce(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return blurOnce;
+            }
+
+            set
+            {
+                Interop.BackgroundBlurEffect.SetBlurOnce(SwigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// The property is blur radius value.
+        /// The unit is pixel, but the property is in float type since many other platforms use float for blur effect radius.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public float BlurRadius
+        {
+            get
+            {
+                uint blurRadius = Interop.BackgroundBlurEffect.GetBlurRadius(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return (float)blurRadius;
+            }
+
+            set
+            {
+                Interop.BackgroundBlurEffect.SetBlurRadius(SwigCPtr, (uint)Math.Round(value, 0));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Adds blur strength animation to the effect.
+        /// Basically it is to animate blurring clear texture, but when starting value(fromValue) is bigger than the end value(toValue), 
+        /// it may show a reversed animation that instead clarifies blurred texture.
+        /// </summary>
+        /// <param name="animation">Animation instance to add blur strength animation.</param>
+        /// <param name="alphaFunction">The alpha function to apply. If none, it will use animation's default alpha function.</param>
+        /// <param name="timePeriod">Duration of animation. If none, it will use the animation's duration.</param>
+        /// <param name="fromValue">Starting blur strength value of the animation. The value resides in range of [0,1].</param>
+        /// <param name="toValue">End of blur strength value of the animation. The value resides in range of [0,1].</param>
+        /// <exception cref="ArgumentNullException"> Thrown when the animation is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddBlurStrengthAnimation(Animation animation, AlphaFunction alphaFunction, TimePeriod timePeriod, float fromValue, float toValue)
+        {
+            if (animation == null) throw new ArgumentNullException(nameof(animation));
+
+            Interop.BackgroundBlurEffect.AddBlurStrengthAnimation(SwigCPtr, Animation.getCPtr(animation), AlphaFunction.getCPtr(alphaFunction), TimePeriod.getCPtr(timePeriod), fromValue, toValue);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+        /// <summary>
+        /// Adds blur opacity animation to the effect.
+        /// Basically it is to animate blurring clear texture, but when starting value(fromValue) is bigger than the end value(toValue), 
+        /// it may show a reversed animation that instead clarifies blurred texture.
+        /// </summary>
+        /// <param name="animation">Animation instance to add blur opacity animation.</param>
+        /// <param name="alphaFunction">The alpha function to apply. If none, it will use animation's default alpha function.</param>
+        /// <param name="timePeriod">Duration of animation. If none, it will use the animation's duration.</param>
+        /// <param name="fromValue">Starting blur opacity value of the animation. The value resides in range of [0,1].</param>
+        /// <param name="toValue">End of blur opacity value of the animation. The value resides in range of [0,1].</param>
+        /// <exception cref="ArgumentNullException"> Thrown when the animation is null.</exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void AddBlurOpacityAnimation(Animation animation, AlphaFunction alphaFunction, TimePeriod timePeriod, float fromValue, float toValue)
+        {
+            if (animation == null) throw new ArgumentNullException(nameof(animation));
+
+            Interop.BackgroundBlurEffect.AddBlurOpacityAnimation(SwigCPtr, Animation.getCPtr(animation), AlphaFunction.getCPtr(alphaFunction), TimePeriod.getCPtr(timePeriod), fromValue, toValue);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
@@ -1,5 +1,5 @@
 /*
- * Copyright(c) 2024 Samsung Electronics Co., Ltd.
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,11 @@ namespace Tizen.NUI
     /// View's optional render effect.
     /// Applications can apply RenderEffect as the example below :
     /// <code>
-    ///
-    /// view.SetRenderEffect(RenderEffect.CreateBackgroundBlurEffect(20));
-    /// view.ClearRenderEffect();
-    ///
+    /// BackgroundBlurEffect effect = RenderEffect.CreateBackgroundBlurEffect(20);
+    /// view.SetRenderEffect(effect); // activates effect
+    /// effect.Deactivate();
+    /// effect.Activate();
+    /// view.ClearRenderEffect(); // deactivates effect
     /// </code>
     /// Note that a view owns at most one render effect.
     /// </summary>
@@ -38,18 +39,32 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Activates render effect
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Activate()
+        {
+            Interop.RenderEffect.Activate(SwigCPtr);
+        }
+
+        /// <summary>
+        /// Deactivates render effect
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Deactivate()
+        {
+            Interop.RenderEffect.Deactivate(SwigCPtr);
+        }
+
+        /// <summary>
         /// Create a background blur effect
         /// </summary>
-        /// <remarks>
-        /// Created RenderEffect is immutable.
-        /// </remarks>
         /// <param name="blurRadius">The blur radius value. The unit is pixel for standard cases.</param>
-        /// <param name="blurOnce">Whether to blur once or always.</param>
         /// <returns>Background blur effect with given blur radius.</returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static RenderEffect CreateBackgroundBlurEffect(float blurRadius, bool blurOnce=false)
+        public static BackgroundBlurEffect CreateBackgroundBlurEffect(float blurRadius)
         {
-            return new RenderEffect(Interop.BackgroundBlurEffect.New((uint)Math.Round(blurRadius, 0), blurOnce));
+            return new BackgroundBlurEffect(Interop.BackgroundBlurEffect.New((uint)Math.Round(blurRadius, 0)));
         }
     }
 }


### PR DESCRIPTION
This PR enables mutable RenderEffect. Previously, we could only create an immutable RenderEffect.
This PR opens RenderEffect::Activate(); and RenderEffect::Deactivate(); to public,
while creating a new public class BackgroundBlurEffect with public properties and functions.