### PR TITLE
Hide UI state

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/ControlStateImpl.cs
+++ b/src/Tizen.NUI/src/internal/Common/ControlStateImpl.cs
@@ -17,90 +17,87 @@
 
 using System;
 using System.Text;
-using System.ComponentModel;
-using Tizen.NUI.BaseComponents;
 
 namespace Tizen.NUI
 {
     /// <summary>
     /// Defines a value type of view state.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public readonly struct UIState : IEquatable<UIState>
+    internal readonly struct ControlStateImpl : IEquatable<ControlStateImpl>
     {
         /// <summary>
         /// The All state is used in a selector class. It represents all states, so if this state is defined in a selector, the other states are ignored.
         /// </summary>
-        public static readonly UIState All = new (ControlStateUtility.FullMask);
+        public static readonly ControlStateImpl All = new (ControlStateUtility.FullMask);
 
         /// <summary>
         /// Normal State.
         /// </summary>
-        public static readonly UIState Normal = new (0UL);
+        public static readonly ControlStateImpl Normal = new (0UL);
 
         /// <summary>
         /// Focused State.
         /// </summary>
-        public static readonly UIState Focused =  new (nameof(Focused));
+        public static readonly ControlStateImpl Focused = new (nameof(Focused));
 
         /// <summary>
         /// Pressed State.
         /// </summary>
-        public static readonly UIState Pressed = new (nameof(Pressed));
+        public static readonly ControlStateImpl Pressed = new (nameof(Pressed));
 
         /// <summary>
         /// Disabled State.
         /// </summary>
-        public static readonly UIState Disabled = new (nameof(Disabled));
+        public static readonly ControlStateImpl Disabled = new (nameof(Disabled));
 
         /// <summary>
         /// Selected State.
         /// </summary>
-        public static readonly UIState Selected = new (nameof(Selected));
+        public static readonly ControlStateImpl Selected = new (nameof(Selected));
 
         /// <summary>
         /// Pressed caused by key state.
         /// </summary>
-        public static readonly UIState PressedByKey = Pressed + new UIState(nameof(PressedByKey));
+        public static readonly ControlStateImpl PressedByKey = Pressed + new ControlStateImpl(nameof(PressedByKey));
 
         /// <summary>
         /// Pressed caused by touch state.
         /// </summary>
-        public static readonly UIState PressedByTouch = Pressed + new UIState(nameof(PressedByTouch));
+        public static readonly ControlStateImpl PressedByTouch = Pressed + new ControlStateImpl(nameof(PressedByTouch));
 
         /// <summary>
         /// SelectedPressed State.
         /// </summary>
-        public static readonly UIState SelectedPressed = Selected + Pressed;
+        public static readonly ControlStateImpl SelectedPressed = Selected + Pressed;
 
         /// <summary>
         /// DisabledSelected State.
         /// </summary>
-        public static readonly UIState DisabledSelected = Disabled + Selected;
+        public static readonly ControlStateImpl DisabledSelected = Disabled + Selected;
 
         /// <summary>
         /// DisabledFocused State.
         /// </summary>
-        public static readonly UIState DisabledFocused = Disabled + Focused;
+        public static readonly ControlStateImpl DisabledFocused = Disabled + Focused;
 
         /// <summary>
         /// SelectedFocused State.
         /// </summary>
-        public static readonly UIState SelectedFocused = Selected + Focused;
+        public static readonly ControlStateImpl SelectedFocused = Selected + Focused;
 
         /// <summary>
         /// This is used in a selector class. It represents all other states except for states that are already defined in a selector.
         /// </summary>
-        public static readonly UIState Other = new UIState(nameof(Other));
+        public static readonly ControlStateImpl Other = new ControlStateImpl(nameof(Other));
 
         private readonly ulong bitFlags;
 
-        private UIState(ulong bitMask)
+        private ControlStateImpl(ulong bitMask)
         {
             bitFlags = bitMask;
         }
 
-        private UIState(string name) : this(ControlStateUtility.Register(name))
+        private ControlStateImpl(string name) : this(ControlStateUtility.Register(name))
         {
         }
 
@@ -110,15 +107,15 @@ namespace Tizen.NUI
         internal bool IsCombined => (bitFlags != 0UL) && ((bitFlags & (bitFlags - 1UL)) != 0UL);
 
         /// <summary>
-        /// Create an instance of the <see cref="UIState"/> with state name.
+        /// Create an instance of the <see cref="ControlStateImpl"/> with state name.
         /// </summary>
         /// <param name="name">The state name.</param>
-        /// <returns>The <see cref="UIState"/> instance which has single state.</returns>
+        /// <returns>The <see cref="ControlStateImpl"/> instance which has single state.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the given name is null.</exception>
         /// <exception cref="ArgumentException">Thrown when the given name is invalid.</exception>
-        public static UIState Create(string name)
+        public static ControlStateImpl Create(string name)
         {
-            return new UIState(name);
+            return new ControlStateImpl(name);
         }
 
         /// <summary>
@@ -126,14 +123,14 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="state">The state to search for</param>
         /// <returns>true if the state contain a specified state, otherwise, false.</returns>
-        public bool Contains(UIState state) => (bitFlags & state.bitFlags) == state.bitFlags;
+        public bool Contains(ControlStateImpl state) => (bitFlags & state.bitFlags) == state.bitFlags;
 
         /// <summary>
         /// Checks if there is a intersection part between this and the other.
         /// </summary>
         /// <param name="other">The other state to check.</param>
         /// <returns>True if an intersection exists, otherwise false.</returns>
-        public bool HasIntersectionWith(UIState other) => (bitFlags & other.bitFlags) != 0L;
+        public bool HasIntersectionWith(ControlStateImpl other) => (bitFlags & other.bitFlags) != 0L;
 
         ///  <inheritdoc/>
         public override string ToString()
@@ -154,7 +151,10 @@ namespace Tizen.NUI
             {
                 if ((bitFlags & bitMask) > 0)
                 {
-                    if (sbuilder.Length != 0) sbuilder.Append(", ");
+                    if (sbuilder.Length != 0)
+                    {
+                        sbuilder.Append(", ");
+                    }
                     sbuilder.Append(name);
                 }
             }
@@ -165,41 +165,46 @@ namespace Tizen.NUI
         /// <summary>
         /// Compares whether the two ControlStates are same or not.
         /// </summary>
-        /// <param name="lhs">A <see cref="UIState"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="UIState"/> on the right hand side.</param>
+        /// <param name="lhs">A <see cref="ControlStateImpl"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ControlStateImpl"/> on the right hand side.</param>
         /// <returns>true if the ControlStates are equal; otherwise, false.</returns>
-        public static bool operator ==(UIState lhs, UIState rhs) => lhs.Equals(rhs);
+        public static bool operator ==(ControlStateImpl lhs, ControlStateImpl rhs) => lhs.Equals(rhs);
 
         /// <summary>
         /// Compares whether the two ControlStates are different or not.
         /// </summary>
-        /// <param name="lhs">A <see cref="UIState"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="UIState"/> on the right hand side.</param>
+        /// <param name="lhs">A <see cref="ControlStateImpl"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ControlStateImpl"/> on the right hand side.</param>
         /// <returns>true if the ControlStates are not equal; otherwise, false.</returns>
-        public static bool operator !=(UIState lhs, UIState rhs) => !lhs.Equals(rhs);
+        public static bool operator !=(ControlStateImpl lhs, ControlStateImpl rhs) => !lhs.Equals(rhs);
 
         /// <summary>
         /// The addition operator.
         /// </summary>
-        /// <param name="lhs">A <see cref="UIState"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="UIState"/> on the right hand side.</param>
-        /// <returns>The <see cref="UIState"/> containing the result of the addition.</returns>
-        public static UIState operator +(UIState lhs, UIState rhs) => new (lhs.bitFlags | rhs.bitFlags);
+        /// <param name="lhs">A <see cref="ControlStateImpl"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ControlStateImpl"/> on the right hand side.</param>
+        /// <returns>The <see cref="ControlStateImpl"/> containing the result of the addition.</returns>
+        public static ControlStateImpl operator +(ControlStateImpl lhs, ControlStateImpl rhs) => new (lhs.bitFlags | rhs.bitFlags);
 
         /// <summary>
         /// The substraction operator.
         /// </summary>
-        /// <param name="lhs">A <see cref="UIState"/> on the left hand side.</param>
-        /// <param name="rhs">A <see cref="UIState"/> on the right hand side.</param>
-        /// <returns>The <see cref="UIState"/> containing the result of the substraction.</returns>
-        public static UIState operator -(UIState lhs, UIState rhs) => new (lhs.bitFlags & ~(rhs.bitFlags));
+        /// <param name="lhs">A <see cref="ControlStateImpl"/> on the left hand side.</param>
+        /// <param name="rhs">A <see cref="ControlStateImpl"/> on the right hand side.</param>
+        /// <returns>The <see cref="ControlStateImpl"/> containing the result of the substraction.</returns>
+        public static ControlStateImpl operator -(ControlStateImpl lhs, ControlStateImpl rhs) => new (lhs.bitFlags & ~(rhs.bitFlags));
 
-        public bool Equals(UIState other) => bitFlags == other.bitFlags;
+        /// <summary>
+        /// Indicates whether this instance and another specified <see cref="ControlStateImpl"/> structure are equal.
+        /// </summary>
+        /// <param name="other">The <see cref="ControlStateImpl"/> structure to compare with the current instance.</param>
+        /// <returns>true if <paramref name="other"/> and this instance are equal; otherwise, false.</returns>
+        public bool Equals(ControlStateImpl other) => bitFlags == other.bitFlags;
 
         ///  <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (obj is UIState otherState)
+            if (obj is ControlStateImpl otherState)
             {
                 return Equals(otherState);
             }
@@ -208,7 +213,5 @@ namespace Tizen.NUI
 
         ///  <inheritdoc/>
         public override int GetHashCode() => bitFlags.GetHashCode();
-
-        internal ControlState ToReferenceType() => new ControlState(this);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
@@ -722,12 +722,12 @@ namespace Tizen.NUI.BaseComponents
         public enum RepeatModes
         {
             /// <summary>
-            /// When the animation reaches the end and RepeatCount is nonZero, the animation restarts from the beginning. 
+            /// When the animation reaches the end and RepeatCount is nonZero, the animation restarts from the beginning.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             Restart = LoopingModeType.Restart,
             /// <summary>
-            /// When the animation reaches the end and RepeatCount nonZero, the animation reverses direction on every animation cycle. 
+            /// When the animation reaches the end and RepeatCount nonZero, the animation reverses direction on every animation cycle.
             /// </summary>
             [EditorBrowsable(EditorBrowsableState.Never)]
             Reverse = LoopingModeType.AutoReverse

--- a/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ControlState.cs
@@ -35,59 +35,59 @@ namespace Tizen.NUI.BaseComponents
         /// The All state is used in a selector class. It represents all states, so if this state is defined in a selector, the other states are ignored.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState All = new ControlState(UIState.All);
+        public static readonly ControlState All = new ControlState(ControlStateImpl.All);
         /// <summary>
         /// Normal State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Normal = new ControlState(UIState.Normal);
+        public static readonly ControlState Normal = new ControlState(ControlStateImpl.Normal);
         /// <summary>
         /// Focused State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Focused =  new ControlState(UIState.Focused);
+        public static readonly ControlState Focused =  new ControlState(ControlStateImpl.Focused);
         /// <summary>
         /// Pressed State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Pressed = new ControlState(UIState.Pressed);
+        public static readonly ControlState Pressed = new ControlState(ControlStateImpl.Pressed);
         /// <summary>
         /// Disabled State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Disabled = new ControlState(UIState.Disabled);
+        public static readonly ControlState Disabled = new ControlState(ControlStateImpl.Disabled);
         /// <summary>
         /// Selected State.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Selected = new ControlState(UIState.Selected);
+        public static readonly ControlState Selected = new ControlState(ControlStateImpl.Selected);
         /// <summary>
         /// SelectedPressed State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState SelectedPressed = new ControlState(UIState.SelectedPressed);
+        public static readonly ControlState SelectedPressed = new ControlState(ControlStateImpl.SelectedPressed);
         /// <summary>
         /// DisabledSelected State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState DisabledSelected = new ControlState(UIState.DisabledSelected);
+        public static readonly ControlState DisabledSelected = new ControlState(ControlStateImpl.DisabledSelected);
         /// <summary>
         /// DisabledFocused State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState DisabledFocused = new ControlState(UIState.DisabledFocused);
+        public static readonly ControlState DisabledFocused = new ControlState(ControlStateImpl.DisabledFocused);
         /// <summary>
         /// SelectedFocused State.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly ControlState SelectedFocused = new ControlState(UIState.SelectedFocused);
+        public static readonly ControlState SelectedFocused = new ControlState(ControlStateImpl.SelectedFocused);
         /// <summary>
         /// This is used in a selector class. It represents all other states except for states that are already defined in a selector.
         /// </summary>
         /// <since_tizen> 9 </since_tizen>
-        public static readonly ControlState Other = new ControlState(UIState.Other);
+        public static readonly ControlState Other = new ControlState(ControlStateImpl.Other);
 
-        readonly UIState value;
+        readonly ControlStateImpl value;
 
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsCombined => value.IsCombined;
 
-        internal ControlState(UIState value)
+        internal ControlState(ControlStateImpl value)
         {
             this.value = value;
         }
@@ -111,7 +111,7 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public static ControlState Create(string name)
         {
-            return new ControlState(UIState.Create(name));
+            return new ControlState(ControlStateImpl.Create(name));
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static ControlState Create(params ControlState[] states)
         {
-            UIState result = UIState.Normal;
+            ControlStateImpl result = ControlStateImpl.Normal;
 
             for (int i = 0; i < states.Length; i++)
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -550,7 +550,7 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
-        /// Sets or gets the stop behavior of the LottieAnimationView. 
+        /// Sets or gets the stop behavior of the LottieAnimationView.
         /// This property determines how the animation behaves when it stops.
         /// </summary>
         /// <since_tizen> 7 </since_tizen>


### PR DESCRIPTION
### Description of Change ###
Hide `UIState` as internal and rename it `ControlStateImpl`.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
