### PR TITLE
[NUI] Fix some CA2000 warnings in NUI.

### DIFF
--- a/src/Tizen.NUI/src/internal/Animation/Constraint.cs
+++ b/src/Tizen.NUI/src/internal/Animation/Constraint.cs
@@ -467,13 +467,14 @@ namespace Tizen.NUI
             if (ret != null)
             {
                 Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, cPtr));
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return ret;
             }
             else
             {
                 ret = new Animatable(cPtr, true);
+                return ret;
             }
-            NDalicPINVOKE.ThrowExceptionIfExists();
-            return ret;
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/Common/PropertyArray.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyArray.cs
@@ -173,7 +173,6 @@ namespace Tizen.NUI
         public PropertyArray Add(PropertyValue value)
         {
             PropertyArray ret = new PropertyArray(Interop.Property.ArrayAdd(SwigCPtr, PropertyValue.getCPtr(value)), false);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
 

--- a/src/Tizen.NUI/src/public/Events/Wheel.cs
+++ b/src/Tizen.NUI/src/public/Events/Wheel.cs
@@ -28,12 +28,11 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class Wheel : BaseHandle
     {
-
         /// <summary>
         /// The default constructor of Wheel class.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public Wheel() : this(Interop.Wheel.New(0, 0, 0u, Vector2.getCPtr(new Vector2(0.0f, 0.0f)), 0, 0u), true)
+        public Wheel() : this(Interop.Wheel.New(0, 0, 0u, Vector2.getCPtr(Vector2.Zero), 0, 0u), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Utility/Capture.cs
+++ b/src/Tizen.NUI/src/public/Utility/Capture.cs
@@ -154,7 +154,8 @@ namespace Tizen.NUI
             {
                 using var posVector2 = new Vector2(position.X, position.Y);
                 using var sizeVector2 = new Vector2(size.Width, size.Height);
-                Interop.Capture.Start4(SwigCPtr, source.SwigCPtr, posVector2.SwigCPtr, sizeVector2.SwigCPtr, path, new Vector4(color.R, color.G, color.B, color.A).SwigCPtr);
+                using var colorVector4 = new Vector4(color.R, color.G, color.B, color.A);
+                Interop.Capture.Start4(SwigCPtr, source.SwigCPtr, posVector2.SwigCPtr, sizeVector2.SwigCPtr, path, colorVector4.SwigCPtr);
 
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -199,7 +200,8 @@ namespace Tizen.NUI
             if (source is View || source is Layer)
             {
                 using var sizeVector2 = new Vector2(size.Width, size.Height);
-                Interop.Capture.Start3(SwigCPtr, source.SwigCPtr, sizeVector2.SwigCPtr, path, new Vector4(color.R, color.G, color.B, color.A).SwigCPtr, quality);
+                using var colorVector4 = new Vector4(color.R, color.G, color.B, color.A);
+                Interop.Capture.Start3(SwigCPtr, source.SwigCPtr, sizeVector2.SwigCPtr, path, colorVector4.SwigCPtr, quality);
 
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -239,7 +241,8 @@ namespace Tizen.NUI
             if (source is View || source is Layer)
             {
                 using var sizeVector2 = new Vector2(size.Width, size.Height);
-                Interop.Capture.Start1(SwigCPtr, source.SwigCPtr, sizeVector2.SwigCPtr, path, new Vector4(color.R, color.G, color.B, color.A).SwigCPtr);
+                using var colorVector4 = new Vector4(color.R, color.G, color.B, color.A);
+                Interop.Capture.Start1(SwigCPtr, source.SwigCPtr, sizeVector2.SwigCPtr, path, colorVector4.SwigCPtr);
 
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }

--- a/src/Tizen.NUI/src/public/Visuals/AnimatedImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/AnimatedImageVisual.cs
@@ -176,8 +176,10 @@ namespace Tizen.NUI
                     using var urlArray = new PropertyArray();
                     foreach (var url in urls)
                     {
-                        var pv = new PropertyValue(url);
-                        using var _ = urlArray.Add(pv);
+                        using (var pv = new PropertyValue(url))
+                        {
+                            using var _ = urlArray.Add(pv);
+                        }
                     }
                     using (var temp = new PropertyValue(urlArray))
                     {

--- a/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualObject/AnimatedImageVisual.cs
@@ -296,8 +296,10 @@ namespace Tizen.NUI.Visuals
                 using var urlArray = new PropertyArray();
                 foreach (var url in resourceUrls)
                 {
-                    var urlValue = new PropertyValue(url);
-                    using var _ = urlArray.Add(urlValue);
+                    using (var urlValue = new PropertyValue(url))
+                    {
+                        using var _ = urlArray.Add(urlValue);
+                    }
                 }
 
                 if (cachedVisualPropertyMap != null)

--- a/src/Tizen.NUI/src/public/Window/MouseInOut.cs
+++ b/src/Tizen.NUI/src/public/Window/MouseInOut.cs
@@ -25,12 +25,11 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class MouseInOut : Disposable
     {
-
         /// <summary>
         /// The default constructor.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public MouseInOut() : this(Interop.MouseInOut.NewMouseInOut((int)MouseInOut.StateType.None, 0, Vector2.getCPtr(new Vector2(0, 0)), 0), true)
+        public MouseInOut() : this(Interop.MouseInOut.NewMouseInOut((int)MouseInOut.StateType.None, 0, Vector2.getCPtr(Vector2.Zero), 0), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Window/MouseRelative.cs
+++ b/src/Tizen.NUI/src/public/Window/MouseRelative.cs
@@ -25,12 +25,11 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class MouseRelative : Disposable
     {
-
         /// <summary>
         /// The default constructor.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public MouseRelative() : this(Interop.MouseRelative.NewMouseRelative((int)MouseRelative.StateType.None, 0, 0, Vector2.getCPtr(new Vector2(0, 0)), Vector2.getCPtr(new Vector2(0, 0))), true)
+        public MouseRelative() : this(Interop.MouseRelative.NewMouseRelative((int)MouseRelative.StateType.None, 0, 0, Vector2.getCPtr(Vector2.Zero), Vector2.getCPtr(Vector2.Zero)), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }


### PR DESCRIPTION
Meanwhile some memory leaks are fixed. For example, Vector2.Dispose is not called in Wheel constructor.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
