### PR TITLE
[Tizen.Network.WiFiDirect] Add VSIE and connection related APIs

### DIFF
--- a/src/Tizen.Network.WiFiDirect/Interop/Interop.WiFiDirect.cs
+++ b/src/Tizen.Network.WiFiDirect/Interop/Interop.WiFiDirect.cs
@@ -229,5 +229,19 @@ internal static partial class Interop
         internal static extern int SetSessionTimer(int seconds);
         [DllImport(Libraries.WiFiDirect,EntryPoint = "wifi_direct_set_auto_group_removal")]
         internal static extern int SetAutoGroupRemoval(bool enable);
+        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_add_vsie")]
+        internal static extern int AddVsie(WiFiDirectVsieFrameType frameType, string vsie);
+        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_vsie")]
+        internal static extern int GetVsie(WiFiDirectVsieFrameType frameType, out string vsie);
+        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_remove_vsie")]
+        internal static extern int RemoveVsie(WiFiDirectVsieFrameType frameType, string vsie);
+        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_connecting_peer_info")]
+        internal static extern int GetConnectingPeerInfo(out IntPtr peer);
+        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_get_peer_vsie")]
+        internal static extern int GetPeerVsie(string macAddress, out string vsie);
+        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_accept_connection")]
+        internal static extern int AcceptConnection(string macAddress);
+        [DllImport(Libraries.WiFiDirect, EntryPoint = "wifi_direct_reject_connection")]
+        internal static extern int RejectConnection(string macAddress);
     }
 }

--- a/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectEnumerations.cs
+++ b/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectEnumerations.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.ComponentModel;
 using Tizen.Internals.Errors;
 
 namespace Tizen.Network.WiFiDirect
@@ -657,5 +658,70 @@ namespace Tizen.Network.WiFiDirect
         /// Connection cancelled by the local device.
         /// </summary>
         ConnectionCancelled = -0x01C60000 | 0x10
+    }
+
+    /// <summary>
+    /// Enumeration for Wi-Fi frame type.
+    /// </summary>
+    /// <since_tizen> 13 </since_tizen>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum WiFiDirectVsieFrameType
+    {
+        /// <summary>
+        /// P2P probe request frame.
+        /// </summary>
+        P2PProbeRequest,
+        /// <summary>
+        /// P2P probe response frame.
+        /// </summary>
+        P2PProbeResponse,
+        /// <summary>
+        ///P2P group owner probe response frame.
+        /// </summary>
+        P2PGOProbeResponse,
+        /// <summary>
+        /// P2P probe request frame.
+        /// </summary>
+        P2PGOBeacon,
+        /// <summary>
+        /// P2P provision discovery request frame.
+        /// </summary>
+        P2PProvisionDiscoveryRequest,
+        /// <summary>
+        /// P2P provision discovery response frame.
+        /// </summary>
+        P2PProvisionDiscoveryResponse,
+        /// <summary>
+        /// P2P probe request frame.
+        /// </summary>
+        P2PGONegotiationRequest,
+        /// <summary>
+        /// P2P group owner negotiation response frame.
+        /// </summary>
+        P2PGONegotiationResponse,
+        /// <summary>
+        /// P2P group owner negotiation confirmation frame.
+        /// </summary>
+        P2PGONegotiationConfirmation,
+        /// <summary>
+        /// P2P invitation request frame.
+        /// </summary>
+        P2PInvitationRequest,
+        /// <summary>
+        /// P2P invitation response frame.
+        /// </summary>
+        P2PInvitationResponse,
+        /// <summary>
+        /// P2P association request frame.
+        /// </summary>
+        P2PAssociationRequest,
+        /// <summary>
+        /// P2P association response frame.
+        /// </summary>
+        P2PAssociationResponse,
+        /// <summary>
+        /// Association request frame.
+        /// </summary>
+        AssociationRequest
     }
 }

--- a/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectManager.cs
+++ b/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectManager.cs
@@ -1709,5 +1709,205 @@ namespace Tizen.Network.WiFiDirect
                 WiFiDirectErrorFactory.ThrowWiFiDirectException((int)WiFiDirectError.NotPermitted);
             }
         }
+
+        /// <summary>
+        /// Adds the Wi-Fi Vendor Specific Information Element (VSIE) to specific frame type.
+        /// </summary>
+        /// <param name="frameType">frame type for setting VSIE.</param>
+        /// <param name="vsie">VSIE value. A valid string contains hexadecimal characters i.e. [0-9a-f]</param>
+        /// <privilege>
+        /// http://tizen.org/privilege/wifidirect
+        /// </privilege>
+        /// <feature>
+        /// http://tizen.org/feature/network.wifidirect
+        /// </feature>
+        /// <remarks>
+        /// Wi-Fi Direct must be activated.
+        /// <paramref name="vsie"/> for <paramref name="frameType"/> will be in effect until Wi-Fi Direct is deactivated.
+        /// A valid value will be concatenated to already added VSIE values. If vsie value is invalid, InvalidOperationException
+        /// will be thrown. If same value for given frameType is already in effect, then there will be no change.
+        /// VSIE data structure is described in 802.11 specification.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The object is in invalid state.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when application does not have privilege to access this method.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AddVsie(WiFiDirectVsieFrameType frameType, string vsie)
+        {
+            if (Globals.IsActivated)
+            {
+                WiFiDirectManagerImpl.Instance.AddVsie(frameType, vsie);
+            }
+
+            else
+            {
+                Log.Error(Globals.LogTag, "Wifi-direct is not activated");
+                WiFiDirectErrorFactory.ThrowWiFiDirectException((int)WiFiDirectError.NotPermitted);
+            }
+        }
+
+        /// <summary>
+        /// Gets the Wi-Fi Vendor Specific Information Elements (VSIE) from specific frame type.
+        /// </summary>
+        /// <param name="frameType">frame type for getting VSIE.</param>
+        /// <returns>VSIE value if success else null value.</returns>
+        /// <privilege>
+        /// http://tizen.org/privilege/wifidirect
+        /// </privilege>
+        /// <feature>
+        /// http://tizen.org/feature/network.wifidirect
+        /// </feature>
+        /// <remarks>
+        /// Wi-Fi Direct must be activated.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The object is in invalid state.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when application does not have privilege to access this method.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static string GetVsie(WiFiDirectVsieFrameType frameType)
+        {
+            if (Globals.IsActivated)
+            {
+                return WiFiDirectManagerImpl.Instance.GetVsie(frameType);
+            }
+
+            else
+            {
+                Log.Error(Globals.LogTag, "Wifi-direct is not activated");
+                WiFiDirectErrorFactory.ThrowWiFiDirectException((int)WiFiDirectError.NotPermitted);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Removes the Wi-Fi Vendor Specific Information Element (VSIE) from specific frame type.
+        /// </summary>
+        /// <param name="frameType">frame type for removing VSIE.</param>
+        /// <param name="vsie">VSIE value</param>
+        /// <privilege>
+        /// http://tizen.org/privilege/wifidirect
+        /// </privilege>
+        /// <feature>
+        /// http://tizen.org/feature/network.wifidirect
+        /// </feature>
+        /// <remarks>
+        /// Wi-Fi Direct must be activated.
+        /// A VSIE value if already added, will be removed from VSIE value else InvalidOperationException will be thrown.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The object is in invalid state.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when application does not have privilege to access this method.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void RemoveVsie(WiFiDirectVsieFrameType frameType, string vsie)
+        {
+            if (Globals.IsActivated)
+            {
+                WiFiDirectManagerImpl.Instance.RemoveVsie(frameType, vsie);
+            }
+
+            else
+            {
+                Log.Error(Globals.LogTag, "Wifi-direct is not activated");
+                WiFiDirectErrorFactory.ThrowWiFiDirectException((int)WiFiDirectError.NotPermitted);
+            }
+        }
+
+        /// <summary>
+        /// Gets the information of peer devices which is in the connecting state.
+        /// </summary>
+        /// <returns>Connecting peer object.</returns>
+        /// <privilege>
+        /// http://tizen.org/privilege/wifidirect
+        /// </privilege>
+        /// <feature>
+        /// http://tizen.org/feature/network.wifidirect
+        /// </feature>
+        /// <remarks>
+        /// Wi-Fi Direct service must be in connecting state.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The object is in invalid state.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when application does not have privilege to access this method.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static WiFiDirectPeer GetConnectingPeer()
+        {
+            if (Globals.IsActivated)
+            {
+                return WiFiDirectManagerImpl.Instance.GetConnectingPeer();
+            }
+
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Accepts a connection requested from peer.
+        /// </summary>
+        /// <param name="peerMacAddress">MAC Address of the peer.</param>
+        /// <privilege>
+        /// http://tizen.org/privilege/wifidirect
+        /// </privilege>
+        /// <feature>
+        /// http://tizen.org/feature/network.wifidirect
+        /// </feature>
+        /// <remarks>
+        /// Wi-Fi Direct must be activated.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The object is in invalid state.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when application does not have privilege to access this method.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void AcceptConnection(string peerMacAddress)
+        {
+            if (Globals.IsActivated)
+            {
+                WiFiDirectManagerImpl.Instance.AcceptConnection(peerMacAddress);
+            }
+
+            else
+            {
+                Log.Error(Globals.LogTag, "Wifi-direct is not activated");
+                WiFiDirectErrorFactory.ThrowWiFiDirectException((int)WiFiDirectError.NotPermitted);
+            }
+        }
+
+        /// <summary>
+        /// Rejects the connection request from other device now in progress.
+        /// </summary>
+        /// <param name="peerMacAddress">The MAC address of rejected device.</param>
+        /// <privilege>
+        /// http://tizen.org/privilege/wifidirect
+        /// </privilege>
+        /// <feature>
+        /// http://tizen.org/feature/network.wifidirect
+        /// </feature>
+        /// <remarks>
+        /// Wi-Fi Direct must be activated.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The object is in invalid state.</exception>
+        /// <exception cref="NotSupportedException">The required feature is not supported.</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when application does not have privilege to access this method.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void RejectConnection(string peerMacAddress)
+        {
+            if (Globals.IsActivated)
+            {
+                WiFiDirectManagerImpl.Instance.RejectConnection(peerMacAddress);
+            }
+
+            else
+            {
+                Log.Error(Globals.LogTag, "Wifi-direct is not activated");
+                WiFiDirectErrorFactory.ThrowWiFiDirectException((int)WiFiDirectError.NotPermitted);
+            }
+        }
     }
 }

--- a/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectManagerImpl.cs
+++ b/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectManagerImpl.cs
@@ -1254,5 +1254,81 @@ namespace Tizen.Network.WiFiDirect
                 UnregisterConnectionStatusChangedEvent();
             }
         }
+
+        internal void AddVsie(WiFiDirectVsieFrameType frameType, string vsie)
+        {
+            int ret = Interop.WiFiDirect.AddVsie(frameType, vsie);
+
+            if (ret != (int)WiFiDirectError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to add vsie, Error - " + (WiFiDirectError)ret);
+                WiFiDirectErrorFactory.ThrowWiFiDirectException(ret);
+            }
+        }
+
+        internal string GetVsie(WiFiDirectVsieFrameType frameType)
+        {
+            string vsie;
+            int ret = Interop.WiFiDirect.GetVsie(frameType, out vsie);
+
+            if (ret != (int)WiFiDirectError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to get vsie, Error - " + (WiFiDirectError)ret);
+                WiFiDirectErrorFactory.ThrowWiFiDirectException(ret);
+                vsie = null;
+            }
+
+            return vsie;
+        }
+
+        internal void RemoveVsie(WiFiDirectVsieFrameType frameType, string vsie)
+        {
+            int ret = Interop.WiFiDirect.RemoveVsie(frameType, vsie);
+
+            if (ret != (int)WiFiDirectError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to remove vsie, Error - " + (WiFiDirectError)ret);
+                WiFiDirectErrorFactory.ThrowWiFiDirectException(ret);
+            }
+        }
+
+        internal WiFiDirectPeer GetConnectingPeer()
+        {
+            IntPtr peer;
+            int ret = Interop.WiFiDirect.GetConnectingPeerInfo(out peer);
+
+            if (ret != (int)WiFiDirectError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to get connecting peer info, Error - " + (WiFiDirectError)ret);
+                WiFiDirectErrorFactory.ThrowWiFiDirectException(ret);
+                return null;
+            }
+
+            DiscoveredPeerStruct peerStruct = (DiscoveredPeerStruct)Marshal.PtrToStructure(peer, typeof(DiscoveredPeerStruct));
+
+            return WiFiDirectUtils.ConvertStructToDiscoveredPeer(peerStruct);
+        }
+
+        internal void AcceptConnection(string peerMacAddress)
+        {
+            int ret = Interop.WiFiDirect.AcceptConnection(peerMacAddress);
+
+            if (ret != (int)WiFiDirectError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to accept connection, Error - " + (WiFiDirectError)ret);
+                WiFiDirectErrorFactory.ThrowWiFiDirectException(ret);
+            }
+        }
+
+        internal void RejectConnection(string peerMacAddress)
+        {
+            int ret = Interop.WiFiDirect.RejectConnection(peerMacAddress);
+
+            if (ret != (int)WiFiDirectError.None)
+            {
+                Log.Error(Globals.LogTag, "Failed to reject connection, Error - " + (WiFiDirectError)ret);
+                WiFiDirectErrorFactory.ThrowWiFiDirectException(ret);
+            }
+        }
     }
 }

--- a/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectPeer.cs
+++ b/src/Tizen.Network.WiFiDirect/Tizen.Network.WiFiDirect/WiFiDirectPeer.cs
@@ -20,6 +20,7 @@ using System.Runtime.InteropServices;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace Tizen.Network.WiFiDirect
 {
@@ -779,6 +780,36 @@ namespace Tizen.Network.WiFiDirect
             {
                 Log.Error(Globals.LogTag, "Wifi-direct is not activated");
                 WiFiDirectErrorFactory.ThrowWiFiDirectException((int)WiFiDirectError.NotPermitted);
+            }
+        }
+
+        /// <summary>
+        /// The vendor specific information element (VSIE) of a peer.
+        /// </summary>
+        /// <remarks>
+        /// Wi-Fi Direct must be activated.
+        /// If there is any error, null will be returned.
+        /// </remarks>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Vsie
+        {
+            get
+            {
+                if (Globals.IsActivated)
+                {
+                    string vsie;
+                    int ret = Interop.WiFiDirect.GetPeerVsie(_peerMacAddress, out vsie);
+
+                    if (ret != (int)WiFiDirectError.None)
+                    {
+                        Log.Error(Globals.LogTag, "Failed to get the peer VSIE, Error - " + (WiFiDirectError)ret);
+                        return null;
+                    }
+
+                    return vsie;
+                }
+                return null;
             }
         }
     }


### PR DESCRIPTION

**Description of Change**

Add new wifi-direct C# APIs for following CAPIs

```
int wifi_direct_add_vsie(wifi_direct_vsie_frames_e frame_id, const char *vsie_str);

int wifi_direct_get_vsie(wifi_direct_vsie_frames_e frame_id, char **vsie_str);
 
int wifi_direct_remove_vsie(wifi_direct_vsie_frames_e frame_id, const char *vsie_str);

int wifi_direct_get_peer_vsie(char *mac_address, char **vsie);

int wifi_direct_get_connecting_peer_info(wifi_direct_discovered_peer_info_s **peer_info);

int wifi_direct_accept_connection(char *mac_address);

int wifi_direct_reject_connection(char  #*mac_address);
```

**API Changes**


- ACR: NA
These are internal APIs, They are being backported from API Level 13.

Added:

- enum WiFiDirectVsieFrameType
- string Vsie {get; }
- void AddVsie(WiFiDirectVsieFrameType frameId, string vsie)
- string GetVsie(WiFiDirectVsieFrameType frameId)
- void RemoveVsie(WiFiDirectVsieFrameType frameId, string vsie)
- WiFiDirectPeer GetConnectingPeer()
- void AcceptConnection(string peerMacAddress)
- void RejectConnection(string peerMacAddress)

**Related**
#6755