### PR TITLE
[NUI] Add StartOffset of GradientVisual

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
+++ b/src/Tizen.NUI/src/internal/Common/PropertyHelper.cs
@@ -53,6 +53,7 @@ namespace Tizen.NUI
             { "imageShadow.Offset",         new VisualPropertyData(View.Property.SHADOW, (int)VisualTransformPropertyType.Offset) },
             { "shadow.CornerRadius",        new VisualPropertyData(View.Property.SHADOW, Visual.Property.CornerRadius, ObjectIntToFloat) },
             { "shadow.CornerSquareness",    new VisualPropertyData(View.Property.SHADOW, Visual.Property.CornerSquareness, ObjectIntToFloat) },
+            { "gradient.StartOffset",       new VisualPropertyData(View.Property.BACKGROUND, GradientVisualProperty.StartOffset, ObjectIntToFloat) },
         };
 
         static PropertyHelper() { }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GradientVisual.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GradientVisual.cs
@@ -44,6 +44,8 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_SPREAD_METHOD_get")]
             public static extern int GradientVisualSpreadMethodGet();
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GRADIENT_VISUAL_START_OFFSET_get")]
+            public static extern int GradientVisualStartOffsetGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/NativeBinding/NDalic.cs
+++ b/src/Tizen.NUI/src/internal/NativeBinding/NDalic.cs
@@ -367,6 +367,7 @@ namespace Tizen.NUI
         internal static readonly int GradientVisualStopColor = Interop.NDalicGradientVisual.GradientVisualStopColorGet();
         internal static readonly int GradientVisualUnits = Interop.NDalicGradientVisual.GradientVisualUnitsGet();
         internal static readonly int GradientVisualSpreadMethod = Interop.NDalicGradientVisual.GradientVisualSpreadMethodGet();
+        internal static readonly int GradientVisualStartOffset = Interop.NDalicGradientVisual.GradientVisualStartOffsetGet();
 
         internal static readonly int ImageVisualUrl = Interop.NDalicImageVisual.ImageVisualUrlGet();
         internal static readonly int ImageVisualAlphaMaskUrl = Interop.NDalicImageVisual.ImageVisualAlphaMaskUrlGet();

--- a/src/Tizen.NUI/src/internal/XamlBinding/NUIConstantExtension.cs
+++ b/src/Tizen.NUI/src/internal/XamlBinding/NUIConstantExtension.cs
@@ -54,6 +54,7 @@ namespace Tizen.NUI.Binding
             { "GradientVisualProperty.StopColor", GradientVisualProperty.StopColor },
             { "GradientVisualProperty.Units", GradientVisualProperty.Units },
             { "GradientVisualProperty.SpreadMethod", GradientVisualProperty.SpreadMethod },
+            { "GradientVisualProperty.StartOffset", GradientVisualProperty.StartOffset },
             // ImageVisualProperty
             { "ImageVisualProperty.URL", ImageVisualProperty.URL },
             { "ImageVisualProperty.AlphaMaskURL", ImageVisualProperty.AlphaMaskURL },

--- a/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
@@ -196,7 +196,7 @@ namespace Tizen.NUI
         /// If not supplied, the default is 0.0f.<br />
         /// Optional.
         /// </summary>
-        /// <since_tizen> 10 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public float StartOffset
         {
             get

--- a/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
@@ -31,6 +31,7 @@ namespace Tizen.NUI
         private PropertyArray _stopColor;
         private GradientVisualUnitsType? _units;
         private GradientVisualSpreadMethodType? _spreadMethod;
+        private float? _startOffset;
 
         /// <summary>
         /// Default constructor of GradientVisual.
@@ -191,6 +192,25 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets or sets the gradient's start position offset.<br />
+        /// If not supplied, the default is 0.0f.<br />
+        /// Optional.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public float StartOffset
+        {
+            get
+            {
+                return _startOffset ?? (0.0f);
+            }
+            set
+            {
+                _startOffset = value;
+                UpdateVisual();
+            }
+        }
+
+        /// <summary>
         /// Compose the out visual map.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
@@ -235,6 +255,11 @@ namespace Tizen.NUI
                 if (_spreadMethod != null)
                 {
                     _outputVisualMap.Add(GradientVisualProperty.SpreadMethod, (int)_spreadMethod);
+                }
+
+                if (_startOffset != null)
+                {
+                    _outputVisualMap.Add(GradientVisualProperty.StartOffset, (float)_startOffset);
                 }
                 base.ComposingPropertyMap();
             }

--- a/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
+++ b/src/Tizen.NUI/src/public/Visuals/GradientVisual.cs
@@ -15,6 +15,8 @@
  *
  */
 
+using System.ComponentModel;
+
 namespace Tizen.NUI
 {
     /// <summary>

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -753,6 +753,11 @@ namespace Tizen.NUI
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
         public static readonly int SpreadMethod = NDalic.GradientVisualSpreadMethod;
+        /// <summary>
+        /// Sets the gradient's start position offset.
+        /// </summary>
+        /// <since_tizen> 10 </since_tizen>
+        public static readonly int StartOffset = NDalic.GradientVisualStartOffset;
     }
 
     /// <summary>

--- a/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualConstants.cs
@@ -756,7 +756,7 @@ namespace Tizen.NUI
         /// <summary>
         /// Sets the gradient's start position offset.
         /// </summary>
-        /// <since_tizen> 10 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static readonly int StartOffset = NDalic.GradientVisualStartOffset;
     }
 


### PR DESCRIPTION
### Description of Change ###
Add StartOffset of GradientVisual.
Start offset is the offset value that shifts the starting position of the gradient.
0.0 is start position of gradient, 1.0 is end position of gradient.
It is possible to set the startOffset outside the [0, 1] range.
For example, you can animate it from 0.5 to 1.5.

How to use:
Animation anim = new Animation(1000);
anim.AnimateTo(bgView, "gradient.StartOffset", 1.0f);
anim.Play();