### PR TITLE
[NUI.Samples] Fix rendering bugs at RendererUpdateAreaTest

### DIFF
--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RendererUpdateAreaTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/RendererUpdateAreaTest.cs
@@ -229,7 +229,7 @@ namespace Tizen.NUI.Samples
                 Shader = GenerateShader(),
             };
 
-            renderable.RegisterProperty("uCustomExtraSize", new PropertyValue(new UIVector2(extraSizeWidth, extraSizeHeight)));
+            renderable.RegisterProperty("uCustomExtraSize", new PropertyValue(extraSizeWidth, extraSizeHeight));
 
             return renderable;
         }


### PR DESCRIPTION
We should match shader uniform's value type and
registered value type.

Unfortunatly, UIVector2 become Vector3 when we make it input of PropertyValue.