### PR TITLE
[NUI] Implement InnerShadow + Bind Control Borderline and remove relative codes.

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/Controls/SceneView.cs
@@ -835,34 +835,6 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
-        /// Callback when Borderline property changed.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal override void ApplyBorderline()
-        {
-            base.ApplyBorderline();
-
-            if (backgroundExtraData == null) return;
-
-            // Update corner radius properties to image by ActionUpdateProperty
-            if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.ContentsBorderline))
-            {
-                {
-                    using var setValue = new Tizen.NUI.PropertyValue(backgroundExtraData.BorderlineWidth);
-                    SetProperty(Interop.SceneView.BorderlineWidthGet(), setValue);
-                }
-                {
-                    using var setValue = new Tizen.NUI.PropertyValue((backgroundExtraData.BorderlineColor ?? Color.Black));
-                    SetProperty(Interop.SceneView.BorderlineColorGet(), setValue);
-                }
-                {
-                    using var setValue = new Tizen.NUI.PropertyValue(backgroundExtraData.BorderlineOffset);
-                    SetProperty(Interop.SceneView.BorderlineOffsetGet(), setValue);
-                }
-            }
-        }
-
-        /// <summary>
         /// Release swigCPtr.
         /// </summary>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewProperty.cs
@@ -96,6 +96,12 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_OFFSCREEN_RENDERING_get")]
             public static extern int OffScreenRenderingGet();
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_INNER_SHADOW_get")]
+            public static extern int InnerShadowGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_get")]
+            public static extern int BorderlineGet();
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_RADIUS_POLICY_get")]
             public static extern int CornerRadiusPolicyGet();
 
@@ -104,6 +110,15 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_CORNER_SQUARENESS_get")]
             public static extern int CornerSquarenessGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_WIDTH_get")]
+            public static extern int BorderlineWidthGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_COLOR_get")]
+            public static extern int BorderlineColorGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_Property_BORDERLINE_OFFSET_get")]
+            public static extern int BorderlineOffsetGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -2232,22 +2232,6 @@ namespace Tizen.NUI.BaseComponents
             return ret;
         }
 
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        internal override void ApplyBorderline()
-        {
-            base.ApplyBorderline();
-
-            if (backgroundExtraData == null) return;
-
-            if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.ContentsBorderline))
-            {
-                // Update borderline properties to image by ActionUpdateProperty
-                _ = Interop.View.InternalUpdateVisualPropertyFloat(this.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth);
-                _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.BorderlineColor, Vector4.getCPtr(backgroundExtraData.BorderlineColor ?? Color.Black));
-                _ = Interop.View.InternalUpdateVisualPropertyFloat(this.SwigCPtr, ImageView.Property.IMAGE, Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);
-            }
-        }
-
         internal ResourceLoadingStatusType GetResourceStatus()
         {
             return (ResourceLoadingStatusType)Interop.View.GetVisualResourceStatus(this.SwigCPtr, Property.IMAGE);
@@ -2542,16 +2526,6 @@ namespace Tizen.NUI.BaseComponents
                     cachedImagePropertyMap.Set(NpatchImageVisualProperty.Border, _border);
                 }
             }
-
-            if (backgroundExtraData != null && backgroundExtraData.BorderlineWidth > 0.0f)
-            {
-                cachedImagePropertyMap.Set(Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth);
-                cachedImagePropertyMap.Set(Visual.Property.BorderlineColor, backgroundExtraData.BorderlineColor);
-                cachedImagePropertyMap.Set(Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);
-            }
-
-            // We already applied background extra data now.
-            backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.ContentsBorderline;
 
             UpdateImageMap();
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -240,14 +240,6 @@ namespace Tizen.NUI.BaseComponents
 
                 Image = map;
 
-                if (backgroundExtraData != null)
-                {
-                    if (backgroundExtraData.BorderlineWidth > 0.0f)
-                    {
-                        UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.ContentsBorderline);
-                    }
-                }
-
                 // All states applied well.
                 currentStates.changed = false;
 

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -1221,10 +1221,6 @@ namespace Tizen.NUI.BaseComponents
             if (map == null)
                 return;
 
-            // Background extra data is not valid anymore. We should ignore lazy UpdateBackgroundExtraData
-            backgroundExtraData = null;
-            backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
-
             // Update backgroundImageUrl and backgroundImageSynchronousLoading from Map
             foreach (int key in cachedNUIViewBackgroundImagePropertyKeyList)
             {
@@ -1248,9 +1244,6 @@ namespace Tizen.NUI.BaseComponents
 
         private PropertyMap GetInternalBackground()
         {
-            // Sync as current properties
-            UpdateBackgroundExtraData();
-
             PropertyMap tmp = new PropertyMap();
             var propertyValue = Object.GetProperty(SwigCPtr, Property.BACKGROUND);
             propertyValue.Get(tmp);
@@ -1328,9 +1321,6 @@ namespace Tizen.NUI.BaseComponents
 
         private ImageShadow GetInternalImageShadow()
         {
-            // Sync as current properties
-            UpdateBackgroundExtraData();
-
             using PropertyMap map = new PropertyMap();
             using var shadowProperty = Object.GetProperty(SwigCPtr, Property.SHADOW);
             shadowProperty.Get(map);
@@ -1405,14 +1395,43 @@ namespace Tizen.NUI.BaseComponents
 
         private Shadow GetInternalBoxShadow()
         {
-            // Sync as current properties
-            UpdateBackgroundExtraData();
-
             using PropertyMap map = new PropertyMap();
             using var shadowProperty = Object.GetProperty(SwigCPtr, Property.SHADOW);
             shadowProperty.Get(map);
             var shadow = new Shadow(map);
             return shadow.IsEmpty() ? null : shadow;
+        }
+
+        /// <summary>
+        /// Describes a inner shadow shadow drawing for a View.
+        /// It is null by default.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public InnerShadow InnerShadow
+        {
+            get
+            {
+                return GetInternalInnerShadow();
+            }
+            set
+            {
+                SetInternalInnerShadow(value);
+                NotifyPropertyChanged();
+            }
+        }
+
+        private void SetInternalInnerShadow(InnerShadow innerShadow)
+        {
+            SetInnerShadow(innerShadow);
+        }
+
+        private InnerShadow GetInternalInnerShadow()
+        {
+            using PropertyMap map = new PropertyMap();
+            using var innerShadowProperty = Object.GetProperty(SwigCPtr, Property.InnerShadow);
+            innerShadowProperty.Get(map);
+            var innerShadow = new InnerShadow(map);
+            return innerShadow.IsEmpty() ? null : innerShadow;
         }
 
         /// <summary>
@@ -1598,13 +1617,12 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalBorderlineWidth(float borderlineWidth)
         {
-            (backgroundExtraData ?? (backgroundExtraData = new BackgroundExtraData())).BorderlineWidth = borderlineWidth;
-            UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.Borderline);
+            Object.InternalSetPropertyFloat(SwigCPtr, Property.BorderlineWidth, borderlineWidth);
         }
 
         private float GetInternalBorderlineWidth()
         {
-            return backgroundExtraData == null ? 0.0f : backgroundExtraData.BorderlineWidth;
+            return Object.InternalGetPropertyFloat(SwigCPtr, Property.BorderlineWidth);
         }
 
         /// <summary>
@@ -1668,7 +1686,9 @@ namespace Tizen.NUI.BaseComponents
 
         private Color GetInternalBorderlineColor()
         {
-            return backgroundExtraData == null ? Color.Black : backgroundExtraData.BorderlineColor;
+            Vector4 value = new Vector4();
+            Object.InternalRetrievingPropertyVector4(SwigCPtr, Property.BorderlineColor, value.SwigCPtr);
+            return value;
         }
 
         /// <summary>
@@ -1755,13 +1775,12 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalBorderlineOffset(float borderlineOffset)
         {
-            (backgroundExtraData ?? (backgroundExtraData = new BackgroundExtraData())).BorderlineOffset = borderlineOffset;
-            UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.Borderline);
+            Object.InternalSetPropertyFloat(SwigCPtr, Property.BorderlineOffset, borderlineOffset);
         }
 
         private float GetInternalBorderlineOffset()
         {
-            return backgroundExtraData == null ? 0.0f : backgroundExtraData.BorderlineOffset;
+            return Object.InternalGetPropertyFloat(SwigCPtr, Property.BorderlineOffset);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2173,8 +2173,6 @@ namespace Tizen.NUI.BaseComponents
         {
             if (string.IsNullOrEmpty(value))
             {
-                backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.Background;
-
                 backgroundImageUrl = null;
 
                 var empty = new PropertyValue();
@@ -2214,15 +2212,6 @@ namespace Tizen.NUI.BaseComponents
                 map.Add(Visual.Property.Type, (int)Visual.Type.Image);
             }
 
-            if (backgroundExtraData != null)
-            {
-                map.Add(Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth)
-                   .Add(Visual.Property.BorderlineColor, backgroundExtraData.BorderlineColor == null ? Color.Black : backgroundExtraData.BorderlineColor)
-                   .Add(Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);
-            }
-
-            backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.Background;
-
             using var mapValue = new PropertyValue(map);
             Object.SetProperty(SwigCPtr, Property.BACKGROUND, mapValue);
         }
@@ -2261,9 +2250,6 @@ namespace Tizen.NUI.BaseComponents
                 map.Set(Visual.Property.Type, (int)Visual.Type.NPatch);
             }
 
-            // Background extra data flag is not meanful anymore.
-            backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.Background;
-
             using (var pv = new PropertyValue(map))
             {
                 Tizen.NUI.Object.SetProperty(SwigCPtr, View.Property.BACKGROUND, pv);
@@ -2277,9 +2263,7 @@ namespace Tizen.NUI.BaseComponents
                 return;
             }
 
-            (backgroundExtraData ?? (backgroundExtraData = new BackgroundExtraData())).BorderlineColor = value;
-
-            UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag.Borderline);
+            Object.InternalSetPropertyVector4(SwigCPtr, Property.BorderlineColor, value.SwigCPtr);
         }
 
         private void SetBackgroundColor(Color value)
@@ -2292,24 +2276,7 @@ namespace Tizen.NUI.BaseComponents
             // Background property will be Color after now. Remove background image url information.
             backgroundImageUrl = null;
 
-            if (backgroundExtraData == null)
-            {
-                Object.InternalSetPropertyVector4(SwigCPtr, View.Property.BACKGROUND, ((Color)value).SwigCPtr);
-                return;
-            }
-
-            using var map = new PropertyMap();
-
-            map.Add(Visual.Property.Type, (int)Visual.Type.Color)
-               .Add(ColorVisualProperty.MixColor, value)
-               .Add(Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth)
-               .Add(Visual.Property.BorderlineColor, backgroundExtraData.BorderlineColor == null ? Color.Black : backgroundExtraData.BorderlineColor)
-               .Add(Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);
-
-            backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.Background;
-
-            using var mapValue = new PropertyValue(map);
-            Object.SetProperty(SwigCPtr, Property.BACKGROUND, mapValue);
+            Object.InternalSetPropertyVector4(SwigCPtr, View.Property.BACKGROUND, ((Color)value).SwigCPtr);
         }
 
         private void SetColor(Color value)
@@ -2374,6 +2341,12 @@ namespace Tizen.NUI.BaseComponents
         {
             using var pv = value == null ? new PropertyValue() : value.ToPropertyValue(this);
             Tizen.NUI.Object.SetProperty(SwigCPtr, View.Property.SHADOW, pv);
+        }
+
+        private void SetInnerShadow(ShadowBase value)
+        {
+            using var pv = value == null ? new PropertyValue() : value.ToPropertyValue(this);
+            Tizen.NUI.Object.SetProperty(SwigCPtr, View.Property.InnerShadow, pv);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -293,9 +293,14 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int DispatchTouchMotion = Interop.ActorProperty.DispatchTouchMotionGet();
             internal static readonly int DispatchHoverMotion = Interop.ActorProperty.DispatchHoverMotionGet();
             internal static readonly int OffScreenRendering = Interop.ViewProperty.OffScreenRenderingGet();
+            internal static readonly int InnerShadow = Interop.ViewProperty.InnerShadowGet();
+            internal static readonly int Borderline = Interop.ViewProperty.BorderlineGet();
             internal static readonly int CornerRadiusPolicy = Interop.ViewProperty.CornerRadiusPolicyGet();
             internal static readonly int CornerRadius = Interop.ViewProperty.CornerRadiusGet();
             internal static readonly int CornerSquareness = Interop.ViewProperty.CornerSquarenessGet();
+            internal static readonly int BorderlineWidth = Interop.ViewProperty.BorderlineWidthGet();
+            internal static readonly int BorderlineColor = Interop.ViewProperty.BorderlineColorGet();
+            internal static readonly int BorderlineOffset = Interop.ViewProperty.BorderlineOffsetGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -31,22 +31,6 @@ namespace Tizen.NUI.BaseComponents
     {
         internal string styleName;
 
-        [Flags]
-        internal enum BackgroundExtraDataUpdatedFlag : byte
-        {
-            BackgroundBorderline = 1 << 1,
-            ContentsBorderline = 1 << 4, /// Subclass cases.
-
-            Background = BackgroundBorderline,
-
-            Borderline = BackgroundBorderline | ContentsBorderline,
-
-            None = 0,
-            All = Background,
-        }
-
-        internal BackgroundExtraDataUpdatedFlag backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
-
         // TODO : Re-open this API when we resolve Animation issue.
         // private bool backgroundExtraDataUpdateProcessAttachedFlag = false;
 
@@ -1160,107 +1144,16 @@ namespace Tizen.NUI.BaseComponents
             return (ResourceLoadingStatusType)Interop.View.GetVisualResourceStatus(this.SwigCPtr, Property.BACKGROUND);
         }
 
-        /// <summary>
-        /// Lazy call to UpdateBackgroundExtraData.
-        /// Collect Properties need to be update, and set properties that starts the Processing.
-        /// </summary>
-        internal virtual void UpdateBackgroundExtraData(BackgroundExtraDataUpdatedFlag flag)
-        {
-            if (backgroundExtraData == null)
-            {
-                return;
-            }
-
-            if (!backgroundExtraDataUpdatedFlag.HasFlag(flag))
-            {
-                backgroundExtraDataUpdatedFlag |= flag;
-                // TODO : Re-open this API when we resolve Animation issue.
-                // Instead, let we call UpdateBackgroundExtraData() synchronously.
-                UpdateBackgroundExtraData();
-                // if (!backgroundExtraDataUpdateProcessAttachedFlag)
-                // {
-                //     backgroundExtraDataUpdateProcessAttachedFlag = true;
-                //     ProcessorController.Instance.ProcessorOnceEvent += UpdateBackgroundExtraData;
-                //     // Call process hardly.
-                //     ProcessorController.Instance.Awake();
-                // }
-            }
-        }
-
-        /// <summary>
-        /// Callback function to Lazy UpdateBackgroundExtraData.
-        /// </summary>
-        private void UpdateBackgroundExtraData(object source, EventArgs e)
-        {
-            // Note : To allow event attachment during UpdateBackgroundExtraData, let we make flag as false before call UpdateBackgroundExtraData().
-            // TODO : Re-open this API when we resolve Animation issue.
-            // backgroundExtraDataUpdateProcessAttachedFlag = false;
-            UpdateBackgroundExtraData();
-        }
-
-        /// <summary>
-        /// Update background extra data properties synchronously.
-        /// After call this API, All background extra data properties updated.
-        /// </summary>
-        internal virtual void UpdateBackgroundExtraData()
-        {
-            if (Disposed)
-            {
-                return;
-            }
-
-            if (backgroundExtraData == null)
-            {
-                return;
-            }
-
-            if (!Rectangle.IsNullOrZero(backgroundExtraData.BackgroundImageBorder))
-            {
-                backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.Background;
-            }
-
-            if (backgroundExtraDataUpdatedFlag == BackgroundExtraDataUpdatedFlag.None)
-            {
-                return;
-            }
-
-            if ((backgroundExtraDataUpdatedFlag & BackgroundExtraDataUpdatedFlag.Borderline) != BackgroundExtraDataUpdatedFlag.None)
-            {
-                ApplyBorderline();
-            }
-
-            backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
-        }
-
         [Obsolete("Do not use this, that is deprecated in API13.")]
         internal virtual void ApplyCornerRadius()
         {
             Tizen.Log.Error("NUI", "ApplyCornerRadius() deprecated internally, Please don't use it.\n");
         }
 
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Do not use this, that is deprecated in API13.")]
         internal virtual void ApplyBorderline()
         {
-            if (backgroundExtraData == null) return;
-
-            // ActionUpdateProperty works well only if BACKGROUND visual setup before.
-            // If view don't have BACKGROUND visual, we set transparent background color in default.
-            if (IsBackgroundEmpty())
-            {
-                // BACKGROUND visual doesn't exist.
-                SetBackgroundColor(Color.Transparent);
-                // SetBackgroundColor function apply borderline internally.
-                // So we can just return now.
-                return;
-            }
-
-            // Update borderline properties to background by ActionUpdateProperty
-            if (backgroundExtraDataUpdatedFlag.HasFlag(BackgroundExtraDataUpdatedFlag.BackgroundBorderline))
-            {
-                _ = Interop.View.InternalUpdateVisualPropertyFloat(this.SwigCPtr, View.Property.BACKGROUND, Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth);
-                _ = Interop.View.InternalUpdateVisualPropertyVector4(this.SwigCPtr, View.Property.BACKGROUND, Visual.Property.BorderlineColor, Vector4.getCPtr(backgroundExtraData.BorderlineColor ?? Color.Black));
-                _ = Interop.View.InternalUpdateVisualPropertyFloat(this.SwigCPtr, View.Property.BACKGROUND, Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);
-            }
+            Tizen.Log.Error("NUI", "ApplyBorderline() deprecated internally, Please don't use it.\n");
         }
 
         /// <summary>
@@ -1446,8 +1339,6 @@ namespace Tizen.NUI.BaseComponents
             //Release your own unmanaged resources here.
             //You should not access any managed member here except static instance.
             //because the execution order of Finalizes is non-deterministic.
-
-            backgroundExtraDataUpdatedFlag = BackgroundExtraDataUpdatedFlag.None;
 
             LayoutCount = 0;
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
@@ -27,21 +27,7 @@ namespace Tizen.NUI.BaseComponents
             // Background property will be Color after now. Remove background image url information.
             backgroundImageUrl = null;
 
-            if (backgroundExtraData == null)
-            {
-                Object.InternalSetPropertyColor(SwigCPtr, Property.BACKGROUND, color);
-            }
-            else
-            {
-                using var map = new PropertyMap()
-                    .Append(Visual.Property.Type, (int)Visual.Type.Color)
-                    .Append(ColorVisualProperty.MixColor, color)
-                    .Append(Visual.Property.BorderlineWidth, backgroundExtraData.BorderlineWidth)
-                    .Append(Visual.Property.BorderlineColor, backgroundExtraData.BorderlineColor ?? Color.Black)
-                    .Append(Visual.Property.BorderlineOffset, backgroundExtraData.BorderlineOffset);
-
-                Object.InternalSetPropertyMap(SwigCPtr, Property.BACKGROUND, map.SwigCPtr);
-            }
+            Object.InternalSetPropertyColor(SwigCPtr, Property.BACKGROUND, color);
 
             NotifyPropertyChanged(nameof(BackgroundColor));
             NotifyBackgroundChanged();
@@ -60,9 +46,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal UIShadow GetBoxShadow()
         {
-            // Sync as current properties
-            UpdateBackgroundExtraData();
-
             using PropertyValue shadowMapValue = Object.GetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, Property.SHADOW);
             if (shadowMapValue != null)
             {
@@ -88,9 +71,6 @@ namespace Tizen.NUI.BaseComponents
 
         internal bool UpdateBoxShadowColor(UIColor color)
         {
-            // Sync as current properties
-            UpdateBackgroundExtraData();
-
             using PropertyValue shadowMapValue = Object.GetProperty((System.Runtime.InteropServices.HandleRef)SwigCPtr, Property.SHADOW);
             if (shadowMapValue != null)
             {

--- a/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/BackgroundExtraData.cs
@@ -27,15 +27,11 @@ namespace Tizen.NUI
         private bool disposed;
         internal BackgroundExtraData()
         {
-            BorderlineColor = Tizen.NUI.Color.Black;
         }
 
         internal BackgroundExtraData(BackgroundExtraData other)
         {
             BackgroundImageBorder = other.BackgroundImageBorder;
-            BorderlineWidth = other.BorderlineWidth;
-            BorderlineColor = other.BorderlineColor;
-            BorderlineOffset = other.BorderlineOffset;
         }
 
         private Rectangle backgroundImageBorder;
@@ -62,12 +58,15 @@ namespace Tizen.NUI
         internal VisualTransformPolicyType CornerRadiusPolicy { get; set; } = VisualTransformPolicyType.Absolute;
 
         /// <summary></summary>
+        [Obsolete("Do not use this, that is deprecated in API13.")]
         internal float BorderlineWidth { get; set; }
 
         /// <summary></summary>
+        [Obsolete("Do not use this, that is deprecated in API13.")]
         internal Color BorderlineColor { get; set; }
 
         /// <summary></summary>
+        [Obsolete("Do not use this, that is deprecated in API13.")]
         internal float BorderlineOffset { get; set; }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/Tizen.NUI/src/public/ViewProperty/InnerShadow.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/InnerShadow.cs
@@ -1,0 +1,172 @@
+/*
+ * Copyright(c) 2021 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+
+    /// <summary>
+    /// Represents a inner shadow with inside extents for a View.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class InnerShadow : Shadow
+    {
+        /// <summary>
+        /// Create a InnerShadow with default values.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public InnerShadow() : base()
+        {
+        }
+
+        /// <summary>
+        /// Create a InnerShadow with extents values.
+        /// </summary>
+        /// <param name="insetExtents">The Inset extents for the inner shadow.</param>
+        /// <param name="blurRadius">The blur radius value for the shadow. Bigger value, much blurry.</param>
+        /// <param name="color">The color for the shadow.</param>
+        /// <param name="cutoutPolicy">The policy of the shadow cutout. Default is ColorVisualCutoutPolicyType.CutoutOutsideWithCornerRadius</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public InnerShadow(UIExtents insetExtents, float blurRadius, Color color, ColorVisualCutoutPolicyType cutoutPolicy = ColorVisualCutoutPolicyType.CutoutOutsideWithCornerRadius) : this(GenerateInnerShadowByExtents(insetExtents, blurRadius, color, cutoutPolicy))
+        {
+        }
+
+        /// <summary>
+        /// Copy constructor.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"> Thrown when other is null. </exception>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public InnerShadow(InnerShadow other) : this(other == null ? throw new ArgumentNullException(nameof(other)) : other.ShadowWidth, other.BlurRadius, other.CutoutPolicy, other.Color, other.Offset, other.Extents)
+        {
+        }
+
+        /// <summary>
+        /// Create a InnerShadow with custom values.
+        /// </summary>
+        /// <param name="shadowWidth">The Width value for the shadow.</param>
+        /// <param name="blurRadius">The blur radius value for the shadow. Bigger value, much blurry.</param>
+        /// <param name="cutoutPolicy">The policy of the shadow cutout.</param>
+        /// <param name="color">The color for the shadow.</param>
+        /// <param name="offset">Optional. The position offset value (x, y) from the top left corner. See <see cref="ShadowBase.Offset"/>.</param>
+        /// <param name="extents">Optional. The shadow will extend its size by specified amount of length. See <see cref="ShadowBase.Extents"/>.</param>
+        internal InnerShadow(float shadowWidth, float blurRadius, ColorVisualCutoutPolicyType cutoutPolicy, Color color, Vector2 offset = null, Vector2 extents = null) : base(blurRadius, cutoutPolicy, color, offset, extents)
+        {
+            ShadowWidth = shadowWidth;
+        }
+
+        /// <summary>
+        /// Create a Shadow from a property map.
+        /// </summary>
+        internal InnerShadow(PropertyMap propertyMap) : base(propertyMap)
+        {
+            ShadowWidth = 0.0f;
+            using (PropertyValue shadowWidthValue = propertyMap.Find(Visual.Property.BorderlineWidth))
+            {
+                shadowWidthValue?.Get(ShadowWidth);
+            }
+
+            // Override the MixColor
+            Color = Color.Transparent;
+            using (PropertyValue borderlineColorValue = propertyMap.Find(Visual.Property.BorderlineColor))
+            {
+                borderlineColorValue?.Get(Color);
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object other)
+        {
+            if (!base.Equals(other))
+            {
+                return false;
+            }
+
+            var otherInnerShadow = (InnerShadow)other;
+
+            return ShadowWidth.Equals(otherInnerShadow.ShadowWidth);
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = base.GetHashCode();
+                hash = (hash * 7) + (ShadowWidth.GetHashCode());
+                return hash;
+            }
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public object Clone() => new InnerShadow(this);
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override PropertyMap GetPropertyMap()
+        {
+            var map = base.GetPropertyMap();
+
+            // Override the MixColor
+            map.Set(ColorVisualProperty.MixColor, Color.Transparent);
+
+            map.Set(Visual.Property.BorderlineColor, Color ?? Color.Transparent);
+            map.Set(Visual.Property.BorderlineWidth, ShadowWidth);
+            map.Set(Visual.Property.BorderlineOffset, -1.0f);
+
+            return map;
+        }
+
+        /// <summary>
+        /// The width of shadow, which internally calculated by extents.
+        /// This value only be used when we want to copy the internal shadow.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal float ShadowWidth { get; set; }
+
+        /// <summary>
+        /// Internal helper functions to calculate inner shadow properties by extents.
+        /// </summary>
+        internal static float CalculateShadowWidthByExtents(UIExtents insetExtents, float blurRadius)
+        {
+            return Math.Max(insetExtents.Start, Math.Max(insetExtents.End, Math.Max(insetExtents.Top, insetExtents.Bottom))) + blurRadius;
+        }
+        internal static Vector2 CalculateOffsetByExtents(UIExtents insetExtents)
+        {
+            // Offset from center of view.
+            return new Vector2((insetExtents.Start - insetExtents.End) * 0.5f, (insetExtents.Top - insetExtents.Bottom) * 0.5f);
+        }
+        internal static Vector2 CalculateExtraSizeByExtents(UIExtents insetExtents, float shadowWidth)
+        {
+            const float margin = 0.5f;
+            return new Vector2(shadowWidth * 2.0f - insetExtents.Start - insetExtents.End + 2.0f * margin, shadowWidth * 2.0f - insetExtents.Top - insetExtents.Bottom + 2.0f * margin);
+        }
+
+        internal static InnerShadow GenerateInnerShadowByExtents(UIExtents insetExtents, float blurRadius, Color color, ColorVisualCutoutPolicyType cutoutPolicy)
+        {
+            var shadowWidth = CalculateShadowWidthByExtents(insetExtents, blurRadius);
+            var offset = CalculateOffsetByExtents(insetExtents);
+            var extents = CalculateExtraSizeByExtents(insetExtents, shadowWidth);
+
+            return new InnerShadow(shadowWidth, blurRadius, cutoutPolicy, color, offset, extents);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
+++ b/src/Tizen.NUI/src/public/ViewProperty/ShadowBase.cs
@@ -162,16 +162,6 @@ namespace Tizen.NUI
 
             var map = GetPropertyMap();
 
-            if (attachedView.CornerRadius != null || attachedView.CornerRadius != Vector4.Zero)
-            {
-                map.Set(Visual.Property.CornerRadius, attachedView.CornerRadius);
-                map.Set(Visual.Property.CornerRadiusPolicy, (int)attachedView.CornerRadiusPolicy);
-            }
-            if (attachedView.CornerSquareness != null || attachedView.CornerSquareness != Vector4.Zero)
-            {
-                map.Set(Visual.Property.CornerSquareness, attachedView.CornerSquareness);
-            }
-
             return new PropertyValue(map);
         }
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/InnerShadowSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/InnerShadowSample.cs
@@ -1,0 +1,191 @@
+﻿using Tizen.NUI.BaseComponents;
+using System.Collections.Generic;
+
+namespace Tizen.NUI.Samples
+{
+    public class InnerShadowSample : IExample
+    {
+        Window window = null;
+
+        static private string DEMO_IMAGE_DIR = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "images/";
+
+        static private readonly string[] ImageUrlList = {
+            DEMO_IMAGE_DIR + "PopupTest/circle.jpg", // 360 x 360
+            DEMO_IMAGE_DIR + "PaletteTest/red2.jpg", // 487 x 650
+            DEMO_IMAGE_DIR + "PaletteTest/rock.jpg", // 626 x 469
+            DEMO_IMAGE_DIR + "Dali/DaliDemo/Logo-for-demo.png", // 300 x 208
+        };
+
+        const float viewGap = 24.0f;
+        const float defaultCornerRadius = 16.0f / 320.0f;
+        const float defaultViewSizeWidth = 400.0f;
+        const float defaultViewSizeHeight = 200.0f;
+        const float defaultBorderlineWidth = 10.0f;
+        const float defaultInnerShadowBlurRadius = 16.0f;
+        const float defaultShadowBlurRadius = 24.0f;
+
+        float viewSizeWidth = defaultViewSizeWidth;
+        float viewSizeHeight = defaultViewSizeHeight;
+        float cornerRadius = defaultCornerRadius * 4.0f;
+        float cornerSquareness = 0.0f;
+
+        static private readonly UIExtents[] shadowExtentsList = new UIExtents[]
+        {
+            // begin, end, top, bottom
+            new UIExtents(defaultBorderlineWidth * 2.0f, 0.0f, defaultBorderlineWidth * 2.0f, 0.0f),
+            new UIExtents(0.0f, defaultBorderlineWidth * 2.0f, 0.0f, defaultBorderlineWidth * 2.0f),
+            new UIExtents(defaultBorderlineWidth * 2.0f, 0.0f),
+            new UIExtents(0.0f, defaultBorderlineWidth * 2.0f),
+            new UIExtents(defaultBorderlineWidth * 2.0f),
+            new UIExtents(defaultBorderlineWidth * 4.0f),
+            new UIExtents(defaultBorderlineWidth * 4.0f, 0.0f, 0.0f, 0.0f),
+            new UIExtents(0.0f, defaultBorderlineWidth * 4.0f, 0.0f, 0.0f),
+            new UIExtents(0.0f, 0.0f, defaultBorderlineWidth * 4.0f, 0.0f),
+            new UIExtents(0.0f, 0.0f, 0.0f, defaultBorderlineWidth * 4.0f),
+            new UIExtents(0.0f),
+        };
+
+        uint extentsIndex;
+        UIExtents innerShadowExtents;
+
+        FittingModeType fittingMode = FittingModeType.Fill;
+
+        View rootView;
+
+        ImageView[] imageViewList = new ImageView[4];
+
+        public void Activate()
+        {
+            window = NUIApplication.GetDefaultWindow();
+
+            CreateLayoutViews();
+
+            innerShadowExtents = shadowExtentsList[extentsIndex];
+
+            RegenerateViews();
+
+            window.KeyEvent += WinKeyEvent;
+        }
+
+        private void WinKeyEvent(object sender, Window.KeyEventArgs e)
+        {
+            if (e.Key.State == Key.StateType.Down)
+            {
+                Tizen.Log.Error("NUI", $"Key pressed. {e.Key.KeyPressedName}\n");
+                if (e.Key.KeyPressedName == "1")
+                {
+                    viewSizeWidth -= 20.0f;
+                    viewSizeHeight += 20.0f;
+                    if(viewSizeWidth < defaultViewSizeHeight)
+                    {
+                        viewSizeWidth = defaultViewSizeWidth;
+                        viewSizeHeight = defaultViewSizeHeight;
+                    }
+                    RegenerateViews();
+                }
+                else if(e.Key.KeyPressedName == "2")
+                {
+                    switch(fittingMode)
+                    {
+                        case FittingModeType.ShrinkToFit: fittingMode = FittingModeType.ScaleToFill; break;
+                        case FittingModeType.ScaleToFill: fittingMode = FittingModeType.Center; break;
+                        case FittingModeType.Center:      fittingMode = FittingModeType.Fill; break;
+                        case FittingModeType.Fill:        fittingMode = FittingModeType.FitHeight; break;
+                        case FittingModeType.FitHeight:   fittingMode = FittingModeType.FitWidth; break;
+                        case FittingModeType.FitWidth:    fittingMode = FittingModeType.ShrinkToFit; break;
+                    }
+                    RegenerateViews();
+                }
+                else if(e.Key.KeyPressedName == "3")
+                {
+                    cornerRadius += defaultCornerRadius;
+                    if(cornerRadius > 0.5001f)
+                    {
+                        cornerRadius = defaultCornerRadius;
+                        cornerSquareness = 0.6f - cornerSquareness;
+                    }
+                    RegenerateViews();
+                }
+                else if(e.Key.KeyPressedName == "4")
+                {
+                    extentsIndex = (extentsIndex + 1) % (uint)shadowExtentsList.Length;
+                    innerShadowExtents = shadowExtentsList[extentsIndex];
+                    RegenerateViews();
+                }
+            }
+        }
+
+        public void Deactivate()
+        {
+            window.KeyEvent -= WinKeyEvent;
+
+            rootView?.Unparent();
+            rootView?.Dispose();
+        }
+
+        private void FullGC()
+        {
+            global::System.GC.Collect();
+            global::System.GC.WaitForPendingFinalizers();
+            global::System.GC.Collect();
+        }
+
+        private void CreateLayoutViews()
+        {
+            rootView = new View()
+            {
+                Name = "rootView",
+                BackgroundColor = new Color("#7c9df0"),
+
+                WidthResizePolicy = ResizePolicyType.FillToParent,
+                HeightResizePolicy = ResizePolicyType.FillToParent,
+            };
+
+            window.Add(rootView);
+        }
+
+        private void RegenerateViews()
+        {
+            Tizen.Log.Error("NUITest", $"Generate View with size {viewSizeWidth} x {viewSizeHeight} and fittingmode {fittingMode}, corner radius {cornerRadius} with {cornerSquareness}\n");
+            Tizen.Log.Error("NUITest", $"  InnerShadow extents start : {innerShadowExtents.Start}, end : {innerShadowExtents.End} top : {innerShadowExtents.Top}, bottom : {innerShadowExtents.Bottom}\n");
+
+            for(int i=0; i<4; i++)
+            {
+                imageViewList[i]?.Dispose();
+                imageViewList[i]?.Unparent();
+                imageViewList[i] = CreateImageView(i);
+                rootView.Add(imageViewList[i]);
+            }
+        }
+
+        private ImageView CreateImageView(int id)
+        {
+            ImageView view = new ImageView()
+            {
+                Name = $"ID{id}",
+
+                ResourceUrl = ImageUrlList[id],
+
+                SizeWidth = viewSizeWidth,
+                SizeHeight = viewSizeHeight,
+                FittingMode = fittingMode,
+
+                PositionX = viewGap + (id % 2) * (viewSizeWidth + viewGap),
+                PositionY = viewGap + (id / 2) * (viewSizeHeight + viewGap),
+
+                InnerShadow = new InnerShadow(innerShadowExtents, defaultInnerShadowBlurRadius, Color.Black),
+                BoxShadow = new Shadow(defaultShadowBlurRadius, ColorVisualCutoutPolicyType.CutoutViewWithCornerRadius, new Color(1.0f, 1.0f, 1.0f, 0.5f), new Vector2(0.0f, defaultShadowBlurRadius), new Vector2(defaultShadowBlurRadius, defaultShadowBlurRadius)),
+
+                BorderlineWidth = defaultBorderlineWidth,
+                BorderlineColor = Color.White,
+                BorderlineOffset = -0.875f,
+
+                CornerRadius = cornerRadius,
+                CornerRadiusPolicy = VisualTransformPolicyType.Relative,
+                CornerSquareness = cornerSquareness,
+            };
+
+            return view;
+        }
+    }
+}


### PR DESCRIPTION
Let we make property for InnerShadow.
It will be used when we want to render the shadow inset the view.

Also, Let we make Borderline as top of views, not to touch visual directly. It will be rendered above the inner shadow now.

* How to use

UIExtents = Inset length of each direction's shadow.
BlurRadius = Radius of shadow. Same as BoxShadow usage.
Color = Color of shadow, Same as BoxShadow usage.

```cs
// InnerShadow for top-left
view.InnerShadow = new InnerShadow(new UIExtents(20.0f, 0.0f, 20.0f, 0.0f), blurRadius, color);

// InnerShadow for inset
view.InnerShadow = new InnerShadow(new UIExtents(20.0f), blurRadius, color);
```

* Sample code scene

![Animation5](https://github.com/user-attachments/assets/199e78ac-fb7a-4979-86bf-a5ad8bd8cf47)

