### PR TITLE
Fix AbsoluteLayout to request layout for LayoutBounds and LayoutFlags

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/AbsoluteLayout.cs
@@ -75,11 +75,16 @@ namespace Tizen.NUI
             var layoutParams = view.GetAttached<LayoutParams>();
             if (layoutParams != null)
             {
-                layoutParams.LayoutBounds = rect;
+                if (layoutParams.LayoutBounds != rect)
+                {
+                    layoutParams.LayoutBounds = rect;
+                    view.Layout?.RequestLayout();
+                }
             }
             else
             {
                 view.SetAttached(new LayoutParams() { LayoutBounds = rect });
+                view.Layout?.RequestLayout();
             }
         }
 
@@ -117,11 +122,16 @@ namespace Tizen.NUI
             var layoutParams = view.GetAttached<LayoutParams>();
             if (layoutParams != null)
             {
-                layoutParams.LayoutFlags = flags;
+                if (layoutParams.LayoutFlags != flags)
+                {
+                    layoutParams.LayoutFlags = flags;
+                    view.Layout?.RequestLayout();
+                }
             }
             else
             {
                 view.SetAttached(new LayoutParams() { LayoutFlags = flags });
+                view.Layout?.RequestLayout();
             }
         }
 


### PR DESCRIPTION
To recalculate layout automatically for LayoutBounds and LayoutFlags, AbsoluteLayout is fixed to call RequestLayout when those are changed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
