### PR TITLE
[NUI] Add creation option to visual factory

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.VisualFactory.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VisualFactory.cs
@@ -31,6 +31,12 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_CreateVisual__SWIG_0")]
             public static extern global::System.IntPtr CreateVisual(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_SetDefaultCreationOptions")]
+            public static extern void SetDefaultCreationOptions(global::System.Runtime.InteropServices.HandleRef jarg1, int creationOptions);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_GetDefaultCreationOptions")]
+            public static extern int GetDefaultCreationOptions(global::System.Runtime.InteropServices.HandleRef jarg1);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VisualFactory_AddPrecompileShader")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool AddPrecompileShader(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);

--- a/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualFactory.cs
@@ -94,6 +94,24 @@ namespace Tizen.NUI
             }
         }
 
+        /// <summary>
+        /// Default creation options for the visual factory.
+        /// </summary>
+        /// <remarks>
+        /// All Visuals will got efforts when we call <see cref="CreateVisual"/>.
+        /// Default value is <see cref="VisualFactoryCreationOptions.None"/>.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public VisualFactoryCreationOptions DefaultCreationOptions
+        {
+            get => (VisualFactoryCreationOptions)Interop.VisualFactory.GetDefaultCreationOptions(SwigCPtr);
+            set
+            {
+                Interop.VisualFactory.SetDefaultCreationOptions(SwigCPtr, (int)value);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
+        }
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void Dispose(bool disposing)
         {

--- a/src/Tizen.NUI/src/public/Visuals/VisualFactoryCreationOptions.cs
+++ b/src/Tizen.NUI/src/public/Visuals/VisualFactoryCreationOptions.cs
@@ -1,0 +1,42 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// The hint options to determine the behavior how to create Visual at VisualFactory.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum VisualFactoryCreationOptions
+    {
+        /// <summary>
+        /// Do not give any hint to visual creation.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        None,
+
+        /// <summary>
+        /// Give hint to factory that it is static image if visual type is image.
+        /// It will load ImageVisual even if file extensions are animtable.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        ImageVisualLoadStaticImagesOnly,
+    }
+}


### PR DESCRIPTION
We need to make some way to create `ImageVisual` forcibly even if it is animation images.

For now, let we make the property to change internal creation options.

Relative dali patch :
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/324608
