### PR TITLE
[Applications.Common] Add KeepAlive for preventing GC

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationInfo.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationInfo.cs
@@ -253,6 +253,9 @@ namespace Tizen.Applications
                             Log.Warn(LogTag, "Failed to get application metadata of " + _applicationId + ". err = " + err);
                         }
                     }
+
+                    GC.KeepAlive(_metadataCallback);
+
                     return metadata;
                 }
             }
@@ -354,6 +357,9 @@ namespace Tizen.Applications
                             Log.Warn(LogTag, "Failed to get application category of " + _applicationId + ". err = " + err);
                         }
                     }
+
+                    GC.KeepAlive(_categoryCallback);
+
                     return categories;
                 }
             }


### PR DESCRIPTION
### Description of Change ###
This patch prevents a crash that occurs when a garbage collection happens during native P/Invoke calls. The issue was manifested as: "A callback was made on a garbage collected delegate of type 'Interop+ApplicationManager+AppInfoMetadataCallback::Invoke'"

Changes:
- Add GC.KeepAlive calls for metadata and category callbacks to ensure they remain alive during native function execution
- This prevents the GC from collecting delegates that might still be referenced by native code during the call


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
