### PR TITLE
[NUI] Api12 layout

### DIFF
--- a/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
+++ b/src/Tizen.NUI.Components/Controls/ScrollableBase.cs
@@ -183,12 +183,12 @@ namespace Tizen.NUI.Components
                         // or Width for horizontal scrolling
                         if (scrollingDirection == Direction.Vertical)
                         {
-                            MeasureSpecification unrestrictedMeasureSpec = new MeasureSpecification(heightMeasureSpec.Size, MeasureSpecification.ModeType.Unspecified);
+                            MeasureSpecification unrestrictedMeasureSpec = new MeasureSpecification(new LayoutLength(int.MaxValue), MeasureSpecification.ModeType.AtMost);
                             MeasureChildWithMargins(childLayout, widthMeasureSpec, new LayoutLength(0), unrestrictedMeasureSpec, new LayoutLength(0)); // Height unrestricted by parent
                         }
                         else
                         {
-                            MeasureSpecification unrestrictedMeasureSpec = new MeasureSpecification(widthMeasureSpec.Size, MeasureSpecification.ModeType.Unspecified);
+                            MeasureSpecification unrestrictedMeasureSpec = new MeasureSpecification(new LayoutLength(int.MaxValue), MeasureSpecification.ModeType.AtMost);
                             MeasureChildWithMargins(childLayout, unrestrictedMeasureSpec, new LayoutLength(0), heightMeasureSpec, new LayoutLength(0)); // Width unrestricted by parent
                         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -45,7 +45,8 @@ namespace Tizen.NUI.BaseComponents
                 {
                     if (heightMeasureSpec.Mode != MeasureSpecification.ModeType.Exactly)
                     {
-                        totalHeight = Owner.GetHeightForWidth(totalWidth);
+                        var padding = Owner.Padding;
+                        totalHeight = Owner.GetHeightForWidth(totalWidth - (padding.Start + padding.End));
                         heightMeasureSpec = new MeasureSpecification(new LayoutLength(totalHeight), MeasureSpecification.ModeType.Exactly);
                     }
                 }
@@ -65,8 +66,11 @@ namespace Tizen.NUI.BaseComponents
                     else
                     {
                         float width = naturalSize != null ? naturalSize.Width : 0;
-                        float height = naturalSize != null ? naturalSize.Height : 0;
+                        // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
                         totalWidth = Math.Min(Math.Max(width, minSize.Width), (maxSize.Width < 0 ? Int32.MaxValue : maxSize.Width));
+
+                        var padding = Owner.Padding;
+                        float height = Owner.GetHeightForWidth(totalWidth - (padding.Start + padding.End));
                         totalHeight = Math.Min(Math.Max(height, minSize.Height), (maxSize.Height < 0 ? Int32.MaxValue : maxSize.Height));
 
                         heightMeasureSpec = new MeasureSpecification(new LayoutLength(totalHeight), MeasureSpecification.ModeType.Exactly);

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -65,7 +65,9 @@ namespace Tizen.NUI.BaseComponents
                     }
                     else
                     {
-                        float width = naturalSize != null ? naturalSize.Width : 0;
+                        float width = naturalSize?.Width ?? 0;
+                        width = Math.Min(width, totalWidth);
+
                         // Since priority of MinimumSize is higher than MaximumSize in DALi, here follows it.
                         totalWidth = Math.Min(Math.Max(width, minSize.Width), (maxSize.Width < 0 ? Int32.MaxValue : maxSize.Width));
 


### PR DESCRIPTION
Bug fix when the width and height specification of the text label is wrap, wrap.
I think even if the width is wrap, it should not exceed the size of the parent.
But I can not predict what compatibility this will break.