### PR TITLE
Fix FlexLayout child having constraint with basis

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -499,7 +499,7 @@ namespace Tizen.NUI
 
         /// <summary>
         /// Hidden API (Inhouse API).
-        /// Dispose. 
+        /// Dispose.
         /// </summary>
         /// <remarks>
         /// Following the guide of https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose.
@@ -851,17 +851,19 @@ namespace Tizen.NUI
 
             LayoutItem childLayout = child.Layout;
             Extents margin = child.Margin;
+            float widthConstraint = MathF.Min(width, parentMeasureSpecificationWidth.Size.AsDecimal()) - (margin.Start + margin.End);
+            float heightConstraint = MathF.Min(height, parentMeasureSpecificationHeight.Size.AsDecimal()) - (margin.Top + margin.Bottom);
 
             MeasureSpecification childWidthMeasureSpec = GetChildMeasureSpecification(
                                     new MeasureSpecification(
-                                        new LayoutLength(parentMeasureSpecificationWidth.Size - (margin.Start + margin.End)),
+                                        new LayoutLength(widthConstraint),
                                         parentMeasureSpecificationWidth.Mode),
                                     new LayoutLength(Padding.Start + Padding.End),
                                     new LayoutLength(child.LayoutWidth));
 
             MeasureSpecification childHeightMeasureSpec = GetChildMeasureSpecification(
                                     new MeasureSpecification(
-                                        new LayoutLength(parentMeasureSpecificationHeight.Size - (margin.Top + margin.Bottom)),
+                                        new LayoutLength(heightConstraint),
                                         parentMeasureSpecificationHeight.Mode),
                                     new LayoutLength(Padding.Top + Padding.Bottom),
                                     new LayoutLength(child.LayoutHeight));


### PR DESCRIPTION
### Description of Change ###
Flex layout params `Basis` should be refered by children when layouting.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
