### PR TITLE
[NUI] Add GaussianBlurEffect and blur effect signals

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.BackgroundBlurEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.BackgroundBlurEffect.cs
@@ -50,6 +50,12 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurOpacityAnimation")]
             public static extern void AddBlurOpacityAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_FinishedSignal_Connect")]
+            public static extern void FinishedSignalConnect(HandleRef effect, HandleRef callback);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_FinishedSignal_Disconnect")]
+            public static extern void FinishedSignalDisconnect(HandleRef effect, HandleRef callback);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurEffect.cs
@@ -50,6 +50,12 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_AddBlurOpacityAnimation")]
             public static extern void AddBlurOpacityAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_FinishedSignal_Connect")]
+            public static extern void FinishedSignalConnect(HandleRef effect, HandleRef callback);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_FinishedSignal_Disconnect")]
+            public static extern void FinishedSignalDisconnect(HandleRef effect, HandleRef callback);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GaussianBlurEffect.cs
@@ -21,34 +21,34 @@ namespace Tizen.NUI
 
     internal static partial class Interop
     {
-        internal static class BackgroundBlurEffect
+        internal static class GaussianBlurEffect
         {
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_New__SWIG_1")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_New__SWIG_1")]
             public static extern IntPtr New(uint blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurOnce")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurOnce")]
             public static extern void SetBlurOnce(HandleRef effect, bool blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurOnce")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurOnce")]
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool GetBlurOnce(HandleRef effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurRadius")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurRadius")]
             public static extern void SetBlurRadius(HandleRef effect, uint blurRadius);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurRadius")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurRadius")]
             public static extern uint GetBlurRadius(HandleRef effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_SetBlurDownscaleFactor")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_SetBlurDownscaleFactor")]
             public static extern void SetBlurDownscaleFactor(HandleRef effect, float blurDownscaleFactor);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_GetBlurDownscaleFactor")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_GetBlurDownscaleFactor")]
             public static extern float GetBlurDownscaleFactor(HandleRef effect);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurStrengthAnimation")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_AddBlurStrengthAnimation")]
             public static extern void AddBlurStrengthAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_BackgroundBlurEffect_AddBlurOpacityAnimation")]
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GaussianBlurEffect_AddBlurOpacityAnimation")]
             public static extern void AddBlurOpacityAnimation(HandleRef effect, HandleRef animation, HandleRef alphaFunction, HandleRef timePeriod, float fromValue, float toValue);
         }
     }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
@@ -32,6 +32,9 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Refresh")]
             public static extern void Refresh(HandleRef effect);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_IsActivated")]
+            public static extern bool IsActivated(HandleRef effect);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RenderEffect.cs
@@ -29,6 +29,9 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Deactivate")]
             public static extern void Deactivate(HandleRef effect);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RenderEffect_Refresh")]
+            public static extern void Refresh(HandleRef effect);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
@@ -60,6 +60,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_SetRenderEffect")]
             public static extern void SetRenderEffect(global::System.Runtime.InteropServices.HandleRef self, global::System.Runtime.InteropServices.HandleRef effectRef);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetRenderEffect")]
+            public static extern global::System.IntPtr GetRenderEffect(global::System.Runtime.InteropServices.HandleRef self);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearRenderEffect")]
             public static extern void ClearRenderEffect(global::System.Runtime.InteropServices.HandleRef self);
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -311,11 +311,38 @@ namespace Tizen.NUI.BaseComponents
         /// Sets render effect to the view. The effect is applied to at most one view.
         /// </summary>
         /// <param name="effect">A render effect to set.</param>
+        /// <remarks>
+        /// This call works only if no render effect is set in advance. So if you do, clear before set.
+        /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void SetRenderEffect(RenderEffect effect)
         {
-            Interop.View.SetRenderEffect(SwigCPtr, RenderEffect.getCPtr(effect));
+            if((effect != null) && (GetRenderEffect() == null))
+            {
+                Interop.View.SetRenderEffect(SwigCPtr, RenderEffect.getCPtr(effect));
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            else
+            {
+                Tizen.Log.Error("NUI", "This View is already taken. ClearRenderEffect() before setting something new.\n");
+            }
+        }
+
+        /// <summary>
+        /// Gets render effect.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public RenderEffect GetRenderEffect()
+        {
+            IntPtr cPtr = Interop.View.GetRenderEffect(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            // We do not create new RenderEffect here.
+            RenderEffect renderEffect = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as RenderEffect;
+            Interop.BaseHandle.DeleteBaseHandle(new HandleRef(this, cPtr));
+            NDalicPINVOKE.ThrowExceptionIfExists();
+
+            return renderEffect;
         }
 
         /// <summary>
@@ -324,9 +351,11 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void ClearRenderEffect()
         {
-            Interop.View.ClearRenderEffect(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
+            if(GetRenderEffect() != null)
+            {
+                Interop.View.ClearRenderEffect(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/RenderEffects/BackgroundBlurEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/BackgroundBlurEffect.cs
@@ -15,8 +15,9 @@
  *
  */
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace Tizen.NUI
 {
@@ -53,6 +54,45 @@ namespace Tizen.NUI
                 Interop.BackgroundBlurEffect.SetBlurOnce(SwigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void BlurFinishedEventCallbackType(IntPtr renderTask);
+        private event EventHandler blurFinishedEventHandler;
+        private BlurFinishedEventCallbackType blurFinishedCallback;
+
+        /// <summary>
+        /// Event when blur once finishes rendering. Does nothing when blur once is set to false(which redraws every frame).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler Finished
+        {
+            add
+            {
+                if (blurFinishedEventHandler == null)
+                {
+                    blurFinishedCallback = OnFinished;
+                    Interop.BackgroundBlurEffect.FinishedSignalConnect(SwigCPtr, blurFinishedCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                blurFinishedEventHandler += value;
+            }
+            remove
+            {
+                blurFinishedEventHandler -= value;
+                if (blurFinishedEventHandler == null && blurFinishedCallback != null)
+                {
+                    Interop.BackgroundBlurEffect.FinishedSignalDisconnect(SwigCPtr, blurFinishedCallback.ToHandleRef(this));
+                    blurFinishedCallback = null;
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+
+            }
+        }
+
+        private void OnFinished(IntPtr renderTask)
+        {
+            blurFinishedEventHandler?.Invoke(this, null);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/RenderEffects/GaussianBlurEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/GaussianBlurEffect.cs
@@ -15,8 +15,9 @@
  *
  */
 
-using System.ComponentModel;
 using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace Tizen.NUI
 {
@@ -53,6 +54,45 @@ namespace Tizen.NUI
                 Interop.GaussianBlurEffect.SetBlurOnce(SwigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void BlurFinishedEventCallbackType(IntPtr renderTask);
+        private event EventHandler blurFinishedEventHandler;
+        private BlurFinishedEventCallbackType blurFinishedCallback;
+
+        /// <summary>
+        /// Event when blur once finishes rendering. Does nothing when blur once is set to false(which redraws every frame).
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler Finished
+        {
+            add
+            {
+                if (blurFinishedEventHandler == null)
+                {
+                    blurFinishedCallback = OnFinished;
+                    Interop.GaussianBlurEffect.FinishedSignalConnect(SwigCPtr, blurFinishedCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                blurFinishedEventHandler += value;
+            }
+            remove
+            {
+                blurFinishedEventHandler -= value;
+                if (blurFinishedEventHandler == null && blurFinishedCallback != null)
+                {
+                    Interop.GaussianBlurEffect.FinishedSignalDisconnect(SwigCPtr, blurFinishedCallback.ToHandleRef(this));
+                    blurFinishedCallback = null;
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+
+            }
+        }
+
+        private void OnFinished(IntPtr renderTask)
+        {
+            blurFinishedEventHandler?.Invoke(this, null);
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/RenderEffects/GaussianBlurEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/GaussianBlurEffect.cs
@@ -21,17 +21,17 @@ using System;
 namespace Tizen.NUI
 {
     /// <summary>
-    /// Background blur effect of a View.
-    /// Applications can apply BackgroundBlurEffect as the example below :
+    /// Gaussian blur effect of a View.
+    /// Applications can apply GaussianBlurEffect as the example below :
     /// <code>
-    /// BackgroundBlurEffect effect = new BackgroundBlurEffect();
+    /// GaussianBlurEffect effect = new GaussianBlurEffect();
     /// view.SetRenderEffect(effect);
     /// </code>
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class BackgroundBlurEffect : RenderEffect
+    public class GaussianBlurEffect : RenderEffect
     {
-        internal BackgroundBlurEffect(global::System.IntPtr cPtr) : base(cPtr)
+        internal GaussianBlurEffect(global::System.IntPtr cPtr) : base(cPtr)
         {
         }
 
@@ -43,14 +43,14 @@ namespace Tizen.NUI
         {
             get
             {
-                bool blurOnce = Interop.BackgroundBlurEffect.GetBlurOnce(SwigCPtr);
+                bool blurOnce = Interop.GaussianBlurEffect.GetBlurOnce(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return blurOnce;
             }
 
             set
             {
-                Interop.BackgroundBlurEffect.SetBlurOnce(SwigCPtr, value);
+                Interop.GaussianBlurEffect.SetBlurOnce(SwigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -64,14 +64,14 @@ namespace Tizen.NUI
         {
             get
             {
-                uint blurRadius = Interop.BackgroundBlurEffect.GetBlurRadius(SwigCPtr);
+                uint blurRadius = Interop.GaussianBlurEffect.GetBlurRadius(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return (float)blurRadius;
             }
 
             set
             {
-                Interop.BackgroundBlurEffect.SetBlurRadius(SwigCPtr, (uint)Math.Round(value, 0));
+                Interop.GaussianBlurEffect.SetBlurRadius(SwigCPtr, (uint)Math.Round(value, 0));
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
@@ -85,21 +85,21 @@ namespace Tizen.NUI
         {
             get
             {
-                float downscaleFactor = Interop.BackgroundBlurEffect.GetBlurDownscaleFactor(SwigCPtr);
+                float downscaleFactor = Interop.GaussianBlurEffect.GetBlurDownscaleFactor(SwigCPtr);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
                 return downscaleFactor;
             }
 
             set
             {
-                Interop.BackgroundBlurEffect.SetBlurDownscaleFactor(SwigCPtr, value);
+                Interop.GaussianBlurEffect.SetBlurDownscaleFactor(SwigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
         }
 
         /// <summary>
         /// Adds blur strength animation to the effect.
-        /// Basically it is to animate blurring clear texture, but when starting value(fromValue) is bigger than the end value(toValue), 
+        /// Basically it is to animate blurring clear texture, but when starting value(fromValue) is bigger than the end value(toValue),
         /// it may show a reversed animation that instead clarifies blurred texture.
         /// </summary>
         /// <param name="animation">Animation instance to add blur strength animation.</param>
@@ -113,12 +113,13 @@ namespace Tizen.NUI
         {
             if (animation == null) throw new ArgumentNullException(nameof(animation));
 
-            Interop.BackgroundBlurEffect.AddBlurStrengthAnimation(SwigCPtr, Animation.getCPtr(animation), AlphaFunction.getCPtr(alphaFunction), TimePeriod.getCPtr(timePeriod), fromValue, toValue);
+            Interop.GaussianBlurEffect.AddBlurStrengthAnimation(SwigCPtr, Animation.getCPtr(animation), AlphaFunction.getCPtr(alphaFunction), TimePeriod.getCPtr(timePeriod), fromValue, toValue);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
+
         /// <summary>
         /// Adds blur opacity animation to the effect.
-        /// Basically it is to animate blurring clear texture, but when starting value(fromValue) is bigger than the end value(toValue), 
+        /// Basically it is to animate blurring clear texture, but when starting value(fromValue) is bigger than the end value(toValue),
         /// it may show a reversed animation that instead clarifies blurred texture.
         /// </summary>
         /// <param name="animation">Animation instance to add blur opacity animation.</param>
@@ -132,7 +133,7 @@ namespace Tizen.NUI
         {
             if (animation == null) throw new ArgumentNullException(nameof(animation));
 
-            Interop.BackgroundBlurEffect.AddBlurOpacityAnimation(SwigCPtr, Animation.getCPtr(animation), AlphaFunction.getCPtr(alphaFunction), TimePeriod.getCPtr(timePeriod), fromValue, toValue);
+            Interop.GaussianBlurEffect.AddBlurOpacityAnimation(SwigCPtr, Animation.getCPtr(animation), AlphaFunction.getCPtr(alphaFunction), TimePeriod.getCPtr(timePeriod), fromValue, toValue);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
     }

--- a/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
@@ -70,6 +70,15 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Refreshes render effect
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Refresh()
+        {
+            Interop.RenderEffect.Refresh(SwigCPtr);
+        }
+
+        /// <summary>
         /// Create a background blur effect
         /// </summary>
         /// <param name="blurRadius">The blur radius value. The unit is pixel for standard cases.</param>
@@ -78,6 +87,17 @@ namespace Tizen.NUI
         public static BackgroundBlurEffect CreateBackgroundBlurEffect(float blurRadius)
         {
             return new BackgroundBlurEffect(Interop.BackgroundBlurEffect.New((uint)Math.Round(blurRadius, 0)));
+        }
+
+        /// <summary>
+        /// Create a blur effect
+        /// </summary>
+        /// <param name="blurRadius">The blur radius value. The unit is pixel for standard cases.</param>
+        /// <returns>Blur effect with given blur radius.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static GaussianBlurEffect CreateGaussianBlurEffect(float blurRadius)
+        {
+            return new GaussianBlurEffect(Interop.GaussianBlurEffect.New((uint)Math.Round(blurRadius, 0)));
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
@@ -79,6 +79,16 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Check whether effect is activated or not.
+        /// </summary>
+        /// <returns>True if effect is activated, False otherwise.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsActivated()
+        {
+            return Interop.RenderEffect.IsActivated(SwigCPtr);
+        }
+
+        /// <summary>
         /// Create a background blur effect
         /// </summary>
         /// <param name="blurRadius">The blur radius value. The unit is pixel for standard cases.</param>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Bind `View.GetRenderEffect();` in order to ease explicit `.Dispose();` of an effect.
Add `GaussianBlurEffect` and some public apis(`Refresh()`, `IsActivated()` for `RenderEffect`) / (Get/Set blur downscale factor)
Relative DALi patches are:
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/325249
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/323236
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/326024

Add finished signals of blur effects(`GaussianBlurEffect` and `BackgroundBlurEffect`)
Relative DALi patches are:
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/325249
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/326662


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
