### PR TITLE
[NUI] Fix Layout to set size with 0

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -543,6 +543,15 @@ namespace Tizen.NUI.BaseComponents
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        // FIXME: DALi has a bug that setting Size property with 0 does not work.
+        //        However, setting SizeWith or SizeHeight property with 0 works.
+        //        So in NUI Layout, size is updated by setting SizeWidth and SizeHeight properties.
+        internal void SetLayoutSize(float width, float height)
+        {
+            Object.InternalSetPropertyFloat(SwigCPtr, Property.SizeWidth, width);
+            Object.InternalSetPropertyFloat(SwigCPtr, Property.SizeHeight, height);
+        }
+
         internal Vector3 GetTargetSize()
         {
 

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -612,13 +612,13 @@ namespace Tizen.NUI
                         if (!Owner.LayoutWidth.IsFixedValue || Owner.LayoutWidth != Owner.SizeWidth ||
                             !Owner.LayoutHeight.IsFixedValue || Owner.LayoutHeight != Owner.SizeHeight)
                         {
-                            Owner.SetSize(right - left, bottom - top);
+                            Owner.SetLayoutSize(right - left, bottom - top);
                             Owner.NotifyLayoutUpdated(false);
                         }
                     }
                     else
                     {
-                        Owner.SetSize(right - left, bottom - top);
+                        Owner.SetLayoutSize(right - left, bottom - top);
                         Owner.SetPosition(left, top);
                         Owner.NotifyLayoutUpdated(false);
                     }


### PR DESCRIPTION
DALi has a bug that setting Size property with 0 does not work. However, setting SizeWidth or SizeHeight property with 0 works. So in NUI Layout, size is updated by setting SizeWidth and SizeHeight properties.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
