### PR TITLE
[NUI] Remove interop APIs that are not implemented in csharp-binder.

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/NativeImageInterface.cs
+++ b/src/Tizen.NUI/src/internal/Common/NativeImageInterface.cs
@@ -31,19 +31,6 @@ namespace Tizen.NUI
             throw new global::System.MethodAccessException("C++ destructor does not have public access");
         }
 
-        public virtual bool GlExtensionCreate()
-        {
-            bool ret = Interop.NativeImageInterface.GlExtensionCreate(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return ret;
-        }
-
-        public virtual void GlExtensionDestroy()
-        {
-            Interop.NativeImageInterface.GlExtensionDestroy(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         public virtual uint TargetTexture()
         {
             uint ret = Interop.NativeImageInterface.TargetTexture(SwigCPtr);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.CameraActor.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.CameraActor.cs
@@ -132,9 +132,6 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetOrthographicProjection__SWIG_0")]
             public static extern void SetOrthographicProjection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CameraActor_SetOrthographicProjection__SWIG_1")]
-            public static extern void SetOrthographicProjection(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4, float jarg5, float jarg6, float jarg7);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.GLView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.GLView.cs
@@ -45,9 +45,6 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_GetRenderingMode")]
             public static extern global::System.IntPtr GlViewGetRenderingMode(HandleRef nuiGlView);
 
-            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_GetBackendMode")]
-            public static extern global::System.IntPtr GlViewGetBackendMode(HandleRef nuiGlView);
-
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GlView_RenderOnce")]
             public static extern void GlViewRenderOnce(HandleRef nuiGlView);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Gesture.cs
@@ -27,20 +27,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Gesture")]
             public static extern void DeleteGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_type_set")]
-            public static extern void TypeSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_type_get")]
             public static extern int TypeGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_state_set")]
-            public static extern void StateSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_state_get")]
             public static extern int StateGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_time_set")]
-            public static extern void TimeSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Gesture_time_get")]
             public static extern uint TimeGet(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodOptions.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.InputMethodOptions.cs
@@ -35,10 +35,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodOptions_RetrieveProperty")]
             public static extern void RetrieveProperty(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_InputMethodOptions_CompareAndSet")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool CompareAndSet(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_InputMethodOptions")]
             public static extern void DeleteInputMethodOptions(global::System.Runtime.InteropServices.HandleRef jarg1);
         }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.LongPressGesture.cs
@@ -28,20 +28,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_LongPressGesture")]
             public static extern void DeleteLongPressGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_numberOfTouches_set")]
-            public static extern void NumberOfTouchesSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_numberOfTouches_get")]
             public static extern uint NumberOfTouchesGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_screenPoint_set")]
-            public static extern void ScreenPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_screenPoint_get")]
             public static extern global::System.IntPtr ScreenPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_localPoint_set")]
-            public static extern void LocalPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LongPressGesture_localPoint_get")]
             public static extern global::System.IntPtr LocalPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NativeImageInterface.cs
@@ -21,13 +21,6 @@ namespace Tizen.NUI
     {
         internal static partial class NativeImageInterface
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GlExtensionCreate")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool GlExtensionCreate(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_GlExtensionDestroy")]
-            public static extern void GlExtensionDestroy(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NativeImageInterface_TargetTexture")]
             public static extern uint TargetTexture(global::System.Runtime.InteropServices.HandleRef jarg1);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PanGestureDetector.cs
@@ -135,44 +135,23 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PanGesture")]
             public static extern void DeletePanGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_velocity_set")]
-            public static extern void PanGestureVelocitySet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_velocity_get")]
             public static extern global::System.IntPtr PanGestureVelocityGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_displacement_set")]
-            public static extern void PanGestureDisplacementSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_displacement_get")]
             public static extern global::System.IntPtr PanGestureDisplacementGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_position_set")]
-            public static extern void PanGesturePositionSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_position_get")]
             public static extern global::System.IntPtr PanGesturePositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenVelocity_set")]
-            public static extern void PanGestureScreenVelocitySet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenVelocity_get")]
             public static extern global::System.IntPtr PanGestureScreenVelocityGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenDisplacement_set")]
-            public static extern void PanGestureScreenDisplacementSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenDisplacement_get")]
             public static extern global::System.IntPtr PanGestureScreenDisplacementGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenPosition_set")]
-            public static extern void PanGestureScreenPositionSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_screenPosition_get")]
             public static extern global::System.IntPtr PanGestureScreenPositionGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_numberOfTouches_set")]
-            public static extern void PanGestureNumberOfTouchesSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PanGesture_numberOfTouches_get")]
             public static extern uint PanGestureNumberOfTouchesGet(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ParticleEmitter.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ParticleEmitter.cs
@@ -32,9 +32,6 @@ namespace Tizen.NUI.ParticleSystem
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Assign")]
             internal static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_DownCast")]
-            internal static extern global::System.IntPtr DownCast(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetSource")]
             internal static extern void SetSource(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
@@ -62,9 +59,6 @@ namespace Tizen.NUI.ParticleSystem
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_SetActiveParticlesLimit")]
             internal static extern void SetActiveParticlesLimit(global::System.Runtime.InteropServices.HandleRef jarg1, uint count);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetActiveParticlesLimit")]
-            internal static extern uint GetActiveParticlesLimit(global::System.Runtime.InteropServices.HandleRef jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_Start")]
             internal static extern void Start(global::System.Runtime.InteropServices.HandleRef jarg1);
             
@@ -73,9 +67,6 @@ namespace Tizen.NUI.ParticleSystem
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_RemoveModifierAt")]
             internal static extern void RemoveModifierAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetModifierAt")]
-            internal static extern global::System.IntPtr GetModifierAt(global::System.Runtime.InteropServices.HandleRef jarg1, uint index);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ParticleEmitter_GetParticleList")]
             internal static extern global::System.IntPtr GetParticleList(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.PinchGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PinchGesture.cs
@@ -43,26 +43,14 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_PinchGesture")]
             public static extern void DeletePinchGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_scale_set")]
-            public static extern void ScaleSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_scale_get")]
             public static extern float ScaleGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_speed_set")]
-            public static extern void SpeedSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_speed_get")]
             public static extern float SpeedGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_screenCenterPoint_set")]
-            public static extern void ScreenCenterPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_screenCenterPoint_get")]
             public static extern global::System.IntPtr ScreenCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_localCenterPoint_set")]
-            public static extern void LocalCenterPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PinchGesture_localCenterPoint_get")]
             public static extern global::System.IntPtr LocalCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.RotationGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.RotationGesture.cs
@@ -43,20 +43,11 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_RotationGesture")]
             public static extern void DeleteRotationGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_rotation_set")]
-            public static extern void RotationSet(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_rotation_get")]
             public static extern float RotationGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_screenCenterPoint_set")]
-            public static extern void ScreenCenterPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_screenCenterPoint_get")]
             public static extern global::System.IntPtr ScreenCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_localCenterPoint_set")]
-            public static extern void LocalCenterPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_RotationGesture_localCenterPoint_get")]
             public static extern global::System.IntPtr LocalCenterPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Stage.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Stage.cs
@@ -24,12 +24,6 @@ namespace Tizen.NUI
             {
             }
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_DEFAULT_BACKGROUND_COLOR_get")]
-            public static extern global::System.IntPtr DefaultBackgroundColorGet();
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_DEBUG_BACKGROUND_COLOR_get")]
-            public static extern global::System.IntPtr DebugBackgroundColorGet();
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Stage_GetCurrent")]
             public static extern global::System.IntPtr GetCurrent();
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.TapGesture.cs
@@ -28,26 +28,14 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_TapGesture")]
             public static extern void DeleteTapGesture(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTaps_set")]
-            public static extern void NumberOfTapsSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTaps_get")]
             public static extern uint NumberOfTapsGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTouches_set")]
-            public static extern void NumberOfTouchesSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_numberOfTouches_get")]
             public static extern uint NumberOfTouchesGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_screenPoint_set")]
-            public static extern void ScreenPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_screenPoint_get")]
             public static extern global::System.IntPtr ScreenPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_localPoint_set")]
-            public static extern void LocalPointSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_TapGesture_localPoint_get")]
             public static extern global::System.IntPtr LocalPointGet(global::System.Runtime.InteropServices.HandleRef jarg1);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewImplSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewImplSignal.cs
@@ -165,10 +165,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_OnLongPressSwigExplicitViewImpl")]
             public static extern void OnLongPressSwigExplicitViewImpl(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_EmitKeyEventSignal")]
-            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
-            public static extern bool EmitKeyEventSignal(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ViewImpl_SignalConnected")]
             public static extern void SignalConnected(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 

--- a/src/Tizen.NUI/src/internal/Utility/Camera.cs
+++ b/src/Tizen.NUI/src/internal/Utility/Camera.cs
@@ -252,12 +252,6 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        public void SetOrthographicProjection(float left, float right, float top, float bottom, float near, float far)
-        {
-            Interop.CameraActor.SetOrthographicProjection(SwigCPtr, left, right, top, bottom, near, far);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-        }
-
         // The type of GetType() and SetType() is different from Type property.
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1721: Property names should not match get methods")]
         public string Type

--- a/src/Tizen.NUI/src/public/Events/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Events/Gesture.cs
@@ -226,11 +226,6 @@ namespace Tizen.NUI
 
         private Gesture.GestureType type
         {
-            set
-            {
-                Interop.Gesture.TypeSet(SwigCPtr, (int)value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 Gesture.GestureType ret = (Gesture.GestureType)Interop.Gesture.TypeGet(SwigCPtr);
@@ -241,11 +236,6 @@ namespace Tizen.NUI
 
         private Gesture.StateType state
         {
-            set
-            {
-                Interop.Gesture.StateSet(SwigCPtr, (int)value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 Gesture.StateType ret = (Gesture.StateType)Interop.Gesture.StateGet(SwigCPtr);
@@ -256,11 +246,6 @@ namespace Tizen.NUI
 
         private uint time
         {
-            set
-            {
-                Interop.Gesture.TimeSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 uint ret = Interop.Gesture.TimeGet(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
@@ -85,11 +85,6 @@ namespace Tizen.NUI
 
         private uint numberOfTouches
         {
-            set
-            {
-                Interop.LongPressGesture.NumberOfTouchesSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 uint ret = Interop.LongPressGesture.NumberOfTouchesGet(SwigCPtr);
@@ -100,11 +95,6 @@ namespace Tizen.NUI
 
         private Vector2 screenPoint
         {
-            set
-            {
-                Interop.LongPressGesture.ScreenPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.LongPressGesture.ScreenPointGet(SwigCPtr);
@@ -116,11 +106,6 @@ namespace Tizen.NUI
 
         private Vector2 localPoint
         {
-            set
-            {
-                Interop.LongPressGesture.LocalPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.LongPressGesture.LocalPointGet(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Events/PanGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGesture.cs
@@ -158,11 +158,6 @@ namespace Tizen.NUI
 
         private Vector2 velocity
         {
-            set
-            {
-                Interop.PanGestureDetector.PanGestureVelocitySet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PanGestureDetector.PanGestureVelocityGet(SwigCPtr);
@@ -174,11 +169,6 @@ namespace Tizen.NUI
 
         private Vector2 displacement
         {
-            set
-            {
-                Interop.PanGestureDetector.PanGestureDisplacementSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PanGestureDetector.PanGestureDisplacementGet(SwigCPtr);
@@ -190,11 +180,6 @@ namespace Tizen.NUI
 
         private Vector2 position
         {
-            set
-            {
-                Interop.PanGestureDetector.PanGesturePositionSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PanGestureDetector.PanGesturePositionGet(SwigCPtr);
@@ -206,11 +191,6 @@ namespace Tizen.NUI
 
         private Vector2 screenVelocity
         {
-            set
-            {
-                Interop.PanGestureDetector.PanGestureScreenVelocitySet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PanGestureDetector.PanGestureScreenVelocityGet(SwigCPtr);
@@ -222,11 +202,6 @@ namespace Tizen.NUI
 
         private Vector2 screenDisplacement
         {
-            set
-            {
-                Interop.PanGestureDetector.PanGestureScreenDisplacementSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PanGestureDetector.PanGestureScreenDisplacementGet(SwigCPtr);
@@ -238,11 +213,6 @@ namespace Tizen.NUI
 
         private Vector2 screenPosition
         {
-            set
-            {
-                Interop.PanGestureDetector.PanGestureScreenPositionSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PanGestureDetector.PanGestureScreenPositionGet(SwigCPtr);
@@ -254,11 +224,6 @@ namespace Tizen.NUI
 
         private uint numberOfTouches
         {
-            set
-            {
-                Interop.PanGestureDetector.PanGestureNumberOfTouchesSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 uint ret = Interop.PanGestureDetector.PanGestureNumberOfTouchesGet(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Events/PinchGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGesture.cs
@@ -98,11 +98,6 @@ namespace Tizen.NUI
 
         private float scale
         {
-            set
-            {
-                Interop.PinchGesture.ScaleSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 float ret = Interop.PinchGesture.ScaleGet(SwigCPtr);
@@ -113,11 +108,6 @@ namespace Tizen.NUI
 
         private float speed
         {
-            set
-            {
-                Interop.PinchGesture.SpeedSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 float ret = Interop.PinchGesture.SpeedGet(SwigCPtr);
@@ -128,11 +118,6 @@ namespace Tizen.NUI
 
         private Vector2 screenCenterPoint
         {
-            set
-            {
-                Interop.PinchGesture.ScreenCenterPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PinchGesture.ScreenCenterPointGet(SwigCPtr);
@@ -144,11 +129,6 @@ namespace Tizen.NUI
 
         private Vector2 localCenterPoint
         {
-            set
-            {
-                Interop.PinchGesture.LocalCenterPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.PinchGesture.LocalCenterPointGet(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Events/RotationGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGesture.cs
@@ -87,11 +87,6 @@ namespace Tizen.NUI
 
         private float rotation
         {
-            set
-            {
-                Interop.RotationGesture.RotationSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 float ret = Interop.RotationGesture.RotationGet(SwigCPtr);
@@ -102,11 +97,6 @@ namespace Tizen.NUI
 
         private Vector2 screenCenterPoint
         {
-            set
-            {
-                Interop.RotationGesture.ScreenCenterPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.RotationGesture.ScreenCenterPointGet(SwigCPtr);
@@ -118,11 +108,6 @@ namespace Tizen.NUI
 
         private Vector2 localCenterPoint
         {
-            set
-            {
-                Interop.RotationGesture.LocalCenterPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.RotationGesture.LocalCenterPointGet(SwigCPtr);

--- a/src/Tizen.NUI/src/public/Events/TapGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGesture.cs
@@ -110,11 +110,6 @@ namespace Tizen.NUI
 
         private uint numberOfTaps
         {
-            set
-            {
-                Interop.TapGesture.NumberOfTapsSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 uint ret = Interop.TapGesture.NumberOfTapsGet(SwigCPtr);
@@ -125,11 +120,6 @@ namespace Tizen.NUI
 
         private uint numberOfTouches
         {
-            set
-            {
-                Interop.TapGesture.NumberOfTouchesSet(SwigCPtr, value);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 uint ret = Interop.TapGesture.NumberOfTouchesGet(SwigCPtr);
@@ -140,11 +130,6 @@ namespace Tizen.NUI
 
         private Vector2 screenPoint
         {
-            set
-            {
-                Interop.TapGesture.ScreenPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.TapGesture.ScreenPointGet(SwigCPtr);
@@ -156,11 +141,6 @@ namespace Tizen.NUI
 
         private Vector2 localPoint
         {
-            set
-            {
-                Interop.TapGesture.LocalPointSet(SwigCPtr, Vector2.getCPtr(value));
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            }
             get
             {
                 global::System.IntPtr cPtr = Interop.TapGesture.LocalPointGet(SwigCPtr);

--- a/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
+++ b/src/Tizen.NUI/src/public/ParticleSystem/ParticleEmitter.cs
@@ -179,11 +179,6 @@ namespace Tizen.NUI.ParticleSystem
         [EditorBrowsable(EditorBrowsableState.Never)]
         public uint ActiveParticleLimit
         {
-            get{
-                var value = Interop.ParticleEmitter.GetActiveParticlesLimit(SwigCPtr);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return value;
-            }
             set 
             {
                 Interop.ParticleEmitter.SetActiveParticlesLimit(SwigCPtr, value);
@@ -265,20 +260,6 @@ namespace Tizen.NUI.ParticleSystem
             IntPtr cPtr = Interop.ParticleEmitter.GetSource(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             ParticleSource<T> ret = (cPtr == IntPtr.Zero) ? null : Registry.GetManagedBaseHandleFromNativePtr(cPtr) as ParticleSource<T>;
-            return ret;
-        }
-
-        /// <summary>
-        /// Returns modifier at specified index
-        /// </summary>
-        /// <param name="index">Index within modifier stack</param>
-        /// <returns>Valid ParticleModifier object or null</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public ParticleModifier<ParticleModifierInterface> GetModifierAt(uint index)
-        {
-            IntPtr cPtr = Interop.ParticleEmitter.GetModifierAt(SwigCPtr, index);
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            ParticleModifier<ParticleModifierInterface> ret = (cPtr == IntPtr.Zero) ? null : Registry.GetManagedBaseHandleFromNativePtr(cPtr) as ParticleModifier<ParticleModifierInterface>;
             return ret;
         }
 

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -653,28 +653,6 @@ namespace Tizen.NUI
             }
         }
 
-        internal static Vector4 DEFAULT_BACKGROUND_COLOR
-        {
-            get
-            {
-                global::System.IntPtr cPtr = Interop.Stage.DefaultBackgroundColorGet();
-                Vector4 ret = (cPtr == global::System.IntPtr.Zero) ? null : new Vector4(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
-            }
-        }
-
-        internal static Vector4 DEBUG_BACKGROUND_COLOR
-        {
-            get
-            {
-                global::System.IntPtr cPtr = Interop.Stage.DebugBackgroundColorGet();
-                Vector4 ret = (cPtr == global::System.IntPtr.Zero) ? null : new Vector4(cPtr, false);
-                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-                return ret;
-            }
-        }
-
         internal List<Layer> LayersChildren
         {
             get


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
