### PR TITLE
[NUI] Add UpdateLayout in Window

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -202,7 +202,7 @@ namespace Tizen.NUI
 
         // Traverse the tree looking for a root node that is a layout.
         // Once found, it's children can be assigned Layouts and the Measure process started.
-        private void FindRootLayouts(View rootNode, float parentWidth, float parentHeight)
+        internal void FindRootLayouts(View rootNode, float parentWidth, float parentHeight)
         {
             if (rootNode.Layout != null)
             {

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2668,6 +2668,31 @@ namespace Tizen.NUI
             }            
         }
 
+        /// <summary>
+        /// Calculates sizes and positions of views in all layers if the view's layout is required to be updated.
+        /// e.g. RequestLayout() is called for the view.
+        /// Since UpdateLayout calculates sizes and positions of views manually right now, do not abuse calling it.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void UpdateLayout()
+        {
+            using var size = GetSize();
+
+            LayersChildren?.ForEach(layer =>
+            {
+                if (layer?.LayoutCount > 0)
+                {
+                    layer?.Children?.ForEach(view =>
+                    {
+                        if (view != null)
+                        {
+                            LayoutController.FindRootLayouts(view, size.Width, size.Height);
+                        }
+                    });
+                }
+            });
+        }
+
         IntPtr IWindowProvider.WindowHandle => GetNativeWindowHandler();
         float IWindowProvider.X => WindowPosition.X;
         float IWindowProvider.Y => WindowPosition.Y;


### PR DESCRIPTION
UpdateLayout calculates sizes and positions of views in all layers if the view's layout is required to be updated.
e.g. RequestLayout() is called for the view.

Since UpdateLayout calculates sizes and positions of views manually right now, do not abuse calling it.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
