### PR TITLE
[NUI] Fix to update layout when LayoutDirection is changed

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -5546,14 +5546,22 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (NUIApplication.IsUsingXaml)
                 {
+                    if (value == (ViewLayoutDirectionType)GetValue(LayoutDirectionProperty))
+                    {
+                        return;
+                    }
                     SetValue(LayoutDirectionProperty, value);
                 }
                 else
                 {
+                    if (value == GetInternalLayoutDirection())
+                    {
+                        return;
+                    }
                     SetInternalLayoutDirection(value);
                 }
                 NotifyPropertyChanged();
-                RequestLayout();
+                RequestLayoutForInheritLayoutDirection();
             }
         }
 
@@ -5565,6 +5573,28 @@ namespace Tizen.NUI.BaseComponents
         private ViewLayoutDirectionType GetInternalLayoutDirection()
         {
             return (ViewLayoutDirectionType)Object.InternalGetPropertyInt(SwigCPtr, Property.LayoutDirection);
+        }
+
+        private void RequestLayoutForInheritLayoutDirection()
+        {
+            bool existInheritChild = false;
+            foreach (var child in Children)
+            {
+                if (child.InheritLayoutDirection)
+                {
+                    child.RequestLayoutForInheritLayoutDirection();
+
+                    if (!existInheritChild)
+                    {
+                        existInheritChild = true;
+                    }
+                }
+            }
+
+            if (!existInheritChild)
+            {
+                RequestLayout();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
If a view's LayoutDirection is changed, then its all descendants which
follow the view's LayoutDirection should update layout.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
