### PR TITLE
[NUI] Accessibility event return should not null

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -331,7 +331,7 @@ namespace Tizen.NUI.BaseComponents
             };
             getDescriptionHandler?.Invoke(this, arg);
 
-            Interop.StringToVoidSignal.SetResult(data, arg.Description);
+            Interop.StringToVoidSignal.SetResult(data, arg.Description ?? string.Empty);
         }
 
         /// <summary>
@@ -386,7 +386,7 @@ namespace Tizen.NUI.BaseComponents
             };
             getNameHandler?.Invoke(this, arg);
 
-            Interop.StringToVoidSignal.SetResult(data, arg.Name);
+            Interop.StringToVoidSignal.SetResult(data, arg.Name ?? string.Empty);
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###

`AccessibilityNameRequested` and `AccessibilityDescriptionRequested` don't allow null string return. (Occur crash)


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
