### PR TITLE
[Markdown] Update markdown style

### DIFF
--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownStyleDefaults.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownStyleDefaults.cs
@@ -25,7 +25,7 @@ namespace Tizen.NUI.MarkdownRenderer
         // Common
         public const int CommonIndent = 40;
         public const int CommonPadding = 10;
-        public const int CommonMargin = 10;
+        public const int CommonItemPadding = 20;
 
         // Paragraph
         public const string ParagraphFontColor = "#000000FF";
@@ -75,5 +75,9 @@ namespace Tizen.NUI.MarkdownRenderer
         public const float CodeTitleFontSize = 16.0f;
         public const int CodePadding = 10;
         public const float CodeCornerRadius = 12.0f;
+
+        // List
+        public const int ListItemMarginTop = 0;
+        public const int ListItemMarginBottom = 10;
     }
 }

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UICode.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UICode.cs
@@ -28,7 +28,6 @@ namespace Tizen.NUI.MarkdownRenderer
     internal class UICode : View
     {
         private readonly CodeStyle code;
-        private readonly CommonStyle common;
 
         private UICodeText uiCodeTitle;
         private UICodeText uiCodeText;
@@ -47,11 +46,10 @@ namespace Tizen.NUI.MarkdownRenderer
             set => uiCodeText.Text = value;
         }
 
-        public UICode(string language, string text, int indent, CodeStyle codeStyle, CommonStyle commonStyle, string hash, bool asyncRendering) : base()
+        public UICode(string language, string text, int indent, CodeStyle codeStyle, string hash, bool asyncRendering) : base()
         {
             ContentHash = hash;
             code = codeStyle;
-            common = commonStyle;
             SetupLayout(indent);
 
             Add(CreateTitle(language, asyncRendering));
@@ -65,7 +63,7 @@ namespace Tizen.NUI.MarkdownRenderer
                 LinearOrientation = LinearLayout.Orientation.Vertical,
             };
             WidthSpecification = LayoutParamPolicies.MatchParent;
-            Margin = new Extents((ushort)indent, 0, (ushort)common.Margin, (ushort)common.Margin);
+            Margin = new Extents((ushort)indent, 0, 0, 0);
             LayoutDirection = ViewLayoutDirectionType.LTR;
         }
 

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIContainer.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIContainer.cs
@@ -41,6 +41,7 @@ namespace Tizen.NUI.MarkdownRenderer
             Layout = new MarkdownLinearLayout()
             {
                 LinearOrientation = LinearLayout.Orientation.Vertical,
+                CellPadding = new Size(0, common.ItemPadding),
             };
             WidthSpecification = LayoutParamPolicies.MatchParent;
             Padding = new Extents((ushort)common.Padding);

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIHeading.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIHeading.cs
@@ -52,13 +52,12 @@ namespace Tizen.NUI.MarkdownRenderer
             }
         }
 
-        public UIHeading(string text, int level, HeadingStyle headingStyle, CommonStyle commonStyle, ParagraphStyle paragraphStyle, string hash, bool asyncRendering) : base(text, paragraphStyle, hash, asyncRendering)
+        public UIHeading(string text, int level, HeadingStyle headingStyle, ParagraphStyle paragraphStyle, string hash, bool asyncRendering) : base(text, paragraphStyle, hash, asyncRendering)
         {
             heading = headingStyle;
 
             Level = level;
             FontFamily = heading.FontFamily;
-            Margin = new Extents(0, 0, (ushort)commonStyle.Margin, (ushort)commonStyle.Margin);
         }
     }
 }

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIList.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIList.cs
@@ -28,6 +28,7 @@ namespace Tizen.NUI.MarkdownRenderer
     /// </summary>
     internal class UIListItemParagraph : View
     {
+        private readonly ListStyle list;
         private readonly ParagraphStyle paragraph;
 
         private UIParagraph uiParagraph;
@@ -40,9 +41,10 @@ namespace Tizen.NUI.MarkdownRenderer
             set => uiParagraph.Text = value;
         }
 
-        public UIListItemParagraph(string text, ParagraphStyle paragraphStyle, string hash, bool asyncRendering) : base()
+        public UIListItemParagraph(string text, ListStyle listStyle, ParagraphStyle paragraphStyle, string hash, bool asyncRendering) : base()
         {
             ContentHash = hash;
+            list = listStyle;
             paragraph = paragraphStyle;
             SetupLayout();
 
@@ -51,9 +53,10 @@ namespace Tizen.NUI.MarkdownRenderer
             Add(uiParagraph);
         }
 
-        public UIListItemParagraph(string text, int number, ParagraphStyle paragraphStyle, string hash, bool asyncRendering) : base()
+        public UIListItemParagraph(string text, int number, ListStyle listStyle, ParagraphStyle paragraphStyle, string hash, bool asyncRendering) : base()
         {
             ContentHash = hash;
+            list = listStyle;
             paragraph = paragraphStyle;
             SetupLayout();
 
@@ -66,6 +69,7 @@ namespace Tizen.NUI.MarkdownRenderer
         {
             Layout = new MarkdownLinearLayout() {};
             WidthSpecification = LayoutParamPolicies.MatchParent;
+            Margin = new Extents(0, 0, (ushort)list.ItemMarginTop, (ushort)list.ItemMarginBottom);
         }
 
         private View CreateBullet()
@@ -132,7 +136,7 @@ namespace Tizen.NUI.MarkdownRenderer
     {
         public static int GetBulletSize(ParagraphStyle paragraph)
         {
-            return Math.Max(5, (int)Math.Round(paragraph.FontSize / 4));
+            return Math.Max(2, (int)Math.Round(paragraph.FontSize / 4));
         }
 
         public static ushort GetBulletMargin(int bulletSize, ParagraphStyle paragraph)
@@ -150,11 +154,8 @@ namespace Tizen.NUI.MarkdownRenderer
             return (ushort)Math.Round(paragraph.LineHeight / 4);
         }
 
-        private readonly CommonStyle common;
-
-        public UIList(CommonStyle commonStyle) : base()
+        public UIList() : base()
         {
-            common = commonStyle;
             SetupLayout();
         }
 
@@ -165,7 +166,6 @@ namespace Tizen.NUI.MarkdownRenderer
                 LinearOrientation = LinearLayout.Orientation.Vertical,
             };
             WidthSpecification = LayoutParamPolicies.MatchParent;
-            Margin = new Extents(0, 0, (ushort)common.Margin, (ushort)common.Margin);
         }
     }
 }

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIQuote.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIQuote.cs
@@ -104,7 +104,7 @@ namespace Tizen.NUI.MarkdownRenderer
             WidthSpecification = LayoutParamPolicies.MatchParent;
 
             int quoteIndent = isHeaderQuote ? common.Indent + barMargin : indent;
-            Margin = new Extents((ushort)quoteIndent, 0, (ushort)common.Margin, (ushort)common.Margin);
+            Margin = new Extents((ushort)quoteIndent, 0, 0, 0);
         }
 
         private View CreateBar()

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UITable.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UITable.cs
@@ -145,12 +145,10 @@ namespace Tizen.NUI.MarkdownRenderer
     internal class UITable : View
     {
         private readonly TableStyle table;
-        private readonly CommonStyle common;
 
-        public UITable(TableStyle tableStyle, CommonStyle commonStyle) : base()
+        public UITable(TableStyle tableStyle) : base()
         {
             table = tableStyle;
-            common = commonStyle;
             SetupLayout();
         }
 
@@ -163,7 +161,6 @@ namespace Tizen.NUI.MarkdownRenderer
             WidthSpecification = LayoutParamPolicies.MatchParent;
             BackgroundColor = new Color(table.BackgroundColor);
             Padding = new Extents((ushort)table.Padding);
-            Margin = new Extents(0, 0, (ushort)common.Margin, (ushort)common.Margin);
             CornerRadius = table.CornerRadius;
         }
     }

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIThematicBreak.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUI/UIThematicBreak.cs
@@ -28,9 +28,9 @@ namespace Tizen.NUI.MarkdownRenderer
     /// </summary>
     internal class UIThematicBreak : View
     {
-        public UIThematicBreak(ThematicBreakStyle thematicBreakStyle, CommonStyle commonStyle) : base()
+        public UIThematicBreak(ThematicBreakStyle thematicBreakStyle) : base()
         {
-            ushort margin = (ushort)(commonStyle.Margin + thematicBreakStyle.Margin);
+            ushort margin = (ushort)thematicBreakStyle.Margin;
 
             WidthSpecification = LayoutParamPolicies.MatchParent;
             HeightSpecification = thematicBreakStyle.Thickness;

--- a/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUIBuilder.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/internal/MarkdownUIBuilder.cs
@@ -303,7 +303,7 @@ namespace Tizen.NUI.MarkdownRenderer
                 case HeadingBlock heading:
                 {
                     string hash = cacheManager.ComputeHash(text);
-                    return new UIHeading(text, heading.Level, style.Heading, style.Common, style.Paragraph, hash, AsyncRendering);
+                    return new UIHeading(text, heading.Level, style.Heading, style.Paragraph, hash, AsyncRendering);
                 }
                 case ParagraphBlock when block.Parent is ListItemBlock listItem:
                 {
@@ -313,11 +313,11 @@ namespace Tizen.NUI.MarkdownRenderer
                         int index = listBlock.IndexOf(listItem);
                         int start = int.TryParse(listBlock.OrderedStart?.ToString(), out var s) ? s : 1;
                         int number = start + index;
-                        return new UIListItemParagraph(text, number, style.Paragraph, hash, AsyncRendering);
+                        return new UIListItemParagraph(text, number, style.List, style.Paragraph, hash, AsyncRendering);
                     }
                     else
                     {
-                        return new UIListItemParagraph(text, style.Paragraph, hash, AsyncRendering);
+                        return new UIListItemParagraph(text, style.List, style.Paragraph, hash, AsyncRendering);
                     }
                 }
                 case ParagraphBlock when block.Parent is QuoteBlock:
@@ -332,14 +332,14 @@ namespace Tizen.NUI.MarkdownRenderer
                 }
                 case ThematicBreakBlock:
                 {
-                    return new UIThematicBreak(style.ThematicBreak, style.Common);
+                    return new UIThematicBreak(style.ThematicBreak);
                 }
                 case FencedCodeBlock fenced:
                 {
                     string language = fenced.Info;
                     string code = fenced.Lines.ToString();
                     string hash = cacheManager.ComputeHash(language + code);
-                    return new UICode(language, code, GetIndent(block), style.Code, style.Common, hash, AsyncRendering);
+                    return new UICode(language, code, GetIndent(block), style.Code, hash, AsyncRendering);
                 }
                 default:
                 {
@@ -361,7 +361,7 @@ namespace Tizen.NUI.MarkdownRenderer
             }
             else if (block is ListBlock)
             {
-                return new UIList(style.Common);
+                return new UIList();
             }
             else if (block is ListItemBlock)
             {
@@ -369,7 +369,7 @@ namespace Tizen.NUI.MarkdownRenderer
             }
             else if (block is Table)
             {
-                return new UITable(style.Table, style.Common);
+                return new UITable(style.Table);
             }
             else if (block is TableRow tableRow)
             {

--- a/src/Tizen.NUI.MarkdownRenderer/src/public/MarkdownStyle.cs
+++ b/src/Tizen.NUI.MarkdownRenderer/src/public/MarkdownStyle.cs
@@ -75,6 +75,11 @@ namespace Tizen.NUI.MarkdownRenderer
         /// CodeStyle.
         /// </summary>
         public CodeStyle Code { get; } = new CodeStyle();
+
+        /// <summary>
+        /// ListStyle.
+        /// </summary>
+        public ListStyle List { get; } = new ListStyle();
     }
 
     /// <summary>
@@ -89,8 +94,8 @@ namespace Tizen.NUI.MarkdownRenderer
         /// Padding.
         public int Padding { get; set; } = StyleDefaults.CommonPadding;
 
-        /// Margin is added in pixels to the top and bottom of Block (Heading, List, Table, Code, Quote, ThematicBreak).
-        public int Margin { get; set; } = StyleDefaults.CommonMargin;
+        /// The spacing between UI items added to the top container of the view tree.
+        public int ItemPadding { get; set; } = StyleDefaults.CommonItemPadding;
     }
 
     /// <summary>
@@ -247,5 +252,18 @@ namespace Tizen.NUI.MarkdownRenderer
 
         /// CornerRadius.
         public float CornerRadius { get; set; } = StyleDefaults.CodeCornerRadius;
+    }
+
+    /// <summary>
+    /// ListStyle.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ListStyle
+    {
+        /// ItemMarginTop.
+        public int ItemMarginTop { get; set; } = StyleDefaults.ListItemMarginTop;
+
+        /// ItemMarginBottom.
+        public int ItemMarginBottom { get; set; } = StyleDefaults.ListItemMarginBottom;
     }
 }


### PR DESCRIPTION
Add `CommonStyle.ItemPadding`:
Adds cell padding to the layout of the Markdown document. 
This provides more consistent and predictable behavior than the previous `CommonStyle.Margin`.

Removing `CommonStyle.Margin` because it is obsolete due to ItemPadding. 
If in the future we need separate Margins for each UI blocks, 
we will add separate Styles. (like `ThematicBreakStyle.Margin`)

Add Top and Bottom margins to `ListStyle` and Item.
This also provides more consistent spacing than the previous behavior.
