### PR TITLE
[NUI] Fix Layout not to exceed constraint if parent has AtMost option

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -337,8 +337,11 @@ namespace Tizen.NUI
                         }
                         else
                         {
-                            // Child wants a specific size... so be it
-                            resultSize = childDimension;
+                            // Child wants a specific size. It can't be bigger than us.
+                            if (childDimension.AsDecimal() < resultSize.AsDecimal())
+                            {
+                                resultSize = childDimension;
+                            }
                             resultMode = MeasureSpecification.ModeType.Exactly;
                         }
 


### PR DESCRIPTION
AtMost option means that cannot exceed constraint. Therefore, if parent has AtMost option, then parent cannot exceed constarint and its children also cannot exceed constraint.

Otherwise, the following case occurs.
- LinearLayout parent with WrapContent and Padding.
- AbsoluteLayout children with fixed Sizes.
- The children exceed the parent region and ignore parent's Padding.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
