### PR TITLE
[NUI] Dispose Control handle explicitly after use it

### DIFF
--- a/src/Tizen.NUI/src/internal/Accessibility/ViewAccessibilityData.cs
+++ b/src/Tizen.NUI/src/internal/Accessibility/ViewAccessibilityData.cs
@@ -47,110 +47,120 @@ namespace Tizen.NUI.BaseComponents
         private BooleanDataType _accessibilityHighlightedCallback;
         private EventHandler<AccessibilityHighlightChangedEventArgs> _accessibilityHighlightChangedHandler;
 
-        public void AddDescriptionRequestedHandler(View.ControlHandle handle, EventHandler<GetDescriptionEventArgs> value)
+        public void AddDescriptionRequestedHandler(View view, EventHandler<GetDescriptionEventArgs> value)
         {
             if (_getDescriptionHandler == null)
             {
                 _getDescriptionCallback = OnGetAccessibilityDescriptionEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityGetDescriptionConnect(handle, _getDescriptionCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _getDescriptionHandler += value;
         }
 
-        public void RemoveDescriptionRequestedHandler(View.ControlHandle handle, EventHandler<GetDescriptionEventArgs> value)
+        public void RemoveDescriptionRequestedHandler(View view, EventHandler<GetDescriptionEventArgs> value)
         {
             _getDescriptionHandler -= value;
             if (_getDescriptionHandler == null && _getDescriptionCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityGetDescriptionDisconnect(handle, _getDescriptionCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _getDescriptionCallback = null;
             }
         }
 
-        public void AddNameRequestedHandler(View.ControlHandle handle, EventHandler<GetNameEventArgs> value)
+        public void AddNameRequestedHandler(View view, EventHandler<GetNameEventArgs> value)
         {
             if (_getNameHandler == null)
             {
                 _getNameCallback = OnGetAccessibilityNameEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityGetNameConnect(handle, _getNameCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _getNameHandler += value;
         }
 
-        public void RemoveNameRequestedHandler(View.ControlHandle handle, EventHandler<GetNameEventArgs> value)
+        public void RemoveNameRequestedHandler(View view, EventHandler<GetNameEventArgs> value)
         {
             _getNameHandler -= value;
             if (_getNameHandler == null && _getNameCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityGetNameDisconnect(handle, _getNameCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _getNameCallback = null;
             }
         }
 
-        public void AddActivatedHandler(View.ControlHandle handle, EventHandler value)
+        public void AddActivatedHandler(View view, EventHandler value)
         {
             if (_activateHandler == null)
             {
                 _activateCallback = OnAccessibilityActivatedEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityActivateConnect(handle, _activateCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _activateHandler += value;
         }
 
-        public void RemoveActivatedHandler(View.ControlHandle handle, EventHandler value)
+        public void RemoveActivatedHandler(View view, EventHandler value)
         {
             _activateHandler -= value;
             if (_activateHandler == null && _activateCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityActivateDisconnect(handle, _activateCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _activateCallback = null;
             }
         }
 
-        public void AddActionReceivedHandler(View.ControlHandle handle, EventHandler<AccessibilityActionReceivedEventArgs> value)
+        public void AddActionReceivedHandler(View view, EventHandler<AccessibilityActionReceivedEventArgs> value)
         {
             if (_accessibilityActionReceivedHandler == null)
             {
                 _accessibilityActionReceivedCallback = OnAccessibilityActionReceived;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityActionConnect(handle, _accessibilityActionReceivedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _accessibilityActionReceivedHandler += value;
         }
 
-        public void RemoveActionReceivedHandler(View.ControlHandle handle, EventHandler<AccessibilityActionReceivedEventArgs> value)
+        public void RemoveActionReceivedHandler(View view, EventHandler<AccessibilityActionReceivedEventArgs> value)
         {
             _accessibilityActionReceivedHandler -= value;
             if (_accessibilityActionReceivedHandler == null && _accessibilityActionReceivedCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityActionDisconnect(handle, _accessibilityActionReceivedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _accessibilityActionReceivedCallback = null;
             }
         }
 
-        public void AddHighlightChangedHandler(View.ControlHandle handle, EventHandler<AccessibilityHighlightChangedEventArgs> value)
+        public void AddHighlightChangedHandler(View view, EventHandler<AccessibilityHighlightChangedEventArgs> value)
         {
             if (_accessibilityHighlightChangedHandler == null)
             {
                 _accessibilityHighlightedCallback = OnAccessibilityHighlighed;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityHighlightedConnect(handle, _accessibilityHighlightedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _accessibilityHighlightChangedHandler += value;
         }
 
-        public void RemoveHighlightChangedHandler(View.ControlHandle handle, EventHandler<AccessibilityHighlightChangedEventArgs> value)
+        public void RemoveHighlightChangedHandler(View view, EventHandler<AccessibilityHighlightChangedEventArgs> value)
         {
             _accessibilityHighlightChangedHandler -= value;
             if (_accessibilityHighlightChangedHandler == null && _accessibilityHighlightedCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityHighlightedDisconnect(handle, _accessibilityHighlightedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _accessibilityHighlightedCallback = null;

--- a/src/Tizen.NUI/src/internal/Accessibility/ViewAccessibilityRareData.cs
+++ b/src/Tizen.NUI/src/internal/Accessibility/ViewAccessibilityRareData.cs
@@ -56,132 +56,144 @@ namespace Tizen.NUI.BaseComponents
 
         public Dictionary<string, Func<string>> DynamicAttributes => _dynamicAttributes ??= new Dictionary<string, Func<string>>(1);
 
-        public void AddGestureInfoReceivedHandler(View.ControlHandle handle, EventHandler<GestureInfoEventArgs> value)
+        public void AddGestureInfoReceivedHandler(View view, EventHandler<GestureInfoEventArgs> value)
         {
             if (_gestureInfoHandler == null)
             {
                 _gestureInfoCallback = OnAccessibilityGestureInfoEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityDoGestureConnect(handle, _gestureInfoCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _gestureInfoHandler += value;
         }
 
-        public void RemoveGestureInfoReceivedHandler(View.ControlHandle handle, EventHandler<GestureInfoEventArgs> value)
+        public void RemoveGestureInfoReceivedHandler(View view, EventHandler<GestureInfoEventArgs> value)
         {
             _gestureInfoHandler -= value;
             if (_gestureInfoHandler == null && _gestureInfoCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityDoGestureDisconnect(handle, _gestureInfoCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _gestureInfoCallback = null;
             }
         }
 
-        public void AddReadingSkippedHandler(View.ControlHandle handle, EventHandler value)
+        public void AddReadingSkippedHandler(View view, EventHandler value)
         {
             if (_readingSkippedHandler == null)
             {
                 _readingSkippedCallback = OnAccessibilityReadingSkippedEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingSkippedConnect(handle, _readingSkippedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _readingSkippedHandler += value;
         }
 
-        public void RemoveReadingSkippedHandler(View.ControlHandle handle, EventHandler value)
+        public void RemoveReadingSkippedHandler(View view, EventHandler value)
         {
             _readingSkippedHandler -= value;
             if (_readingSkippedHandler == null && _readingSkippedCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingSkippedDisconnect(handle, _readingSkippedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _readingSkippedCallback = null;
             }
         }
 
-        public void AddReadingPausedHandler(View.ControlHandle handle, EventHandler value)
+        public void AddReadingPausedHandler(View view, EventHandler value)
         {
             if (_readingPausedHandler == null)
             {
                 _readingPausedCallback = OnAccessibilityReadingPausedEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingPausedConnect(handle, _readingPausedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _readingPausedHandler += value;
         }
 
-        public void RemoveReadingPausedHandler(View.ControlHandle handle, EventHandler value)
+        public void RemoveReadingPausedHandler(View view, EventHandler value)
         {
             _readingPausedHandler -= value;
             if (_readingPausedHandler == null && _readingPausedCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingPausedDisconnect(handle, _readingPausedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _readingPausedCallback = null;
             }
         }
 
-        public void AddReadingResumedHandler(View.ControlHandle handle, EventHandler value)
+        public void AddReadingResumedHandler(View view, EventHandler value)
         {
             if (_readingResumedHandler == null)
             {
                 _readingResumedCallback = OnAccessibilityReadingResumedEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingResumedConnect(handle, _readingResumedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _readingResumedHandler += value;
         }
 
-        public void RemoveReadingResumedHandler(View.ControlHandle handle, EventHandler value)
+        public void RemoveReadingResumedHandler(View view, EventHandler value)
         {
             _readingResumedHandler -= value;
             if (_readingResumedHandler == null && _readingResumedCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingResumedDisconnect(handle, _readingResumedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _readingResumedCallback = null;
             }
         }
 
-        public void AddReadingCancelledHandler(View.ControlHandle handle, EventHandler value)
+        public void AddReadingCancelledHandler(View view, EventHandler value)
         {
             if (_readingCancelledHandler == null)
             {
                 _readingCancelledCallback = OnAccessibilityReadingCancelledEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingCancelledConnect(handle, _readingCancelledCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _readingCancelledHandler += value;
         }
 
-        public void RemoveReadingCancelledHandler(View.ControlHandle handle, EventHandler value)
+        public void RemoveReadingCancelledHandler(View view, EventHandler value)
         {
             _readingCancelledHandler -= value;
             if (_readingCancelledHandler == null && _readingCancelledCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingCancelledDisconnect(handle, _readingCancelledCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _readingCancelledCallback = null;
             }
         }
 
-        public void AddReadingStoppedHandler(View.ControlHandle handle, EventHandler value)
+        public void AddReadingStoppedHandler(View view, EventHandler value)
         {
             if (_readingStoppedHandler == null)
             {
                 _readingStoppedCallback = OnAccessibilityReadingStoppedEvent;
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingStoppedConnect(handle, _readingStoppedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }
             _readingStoppedHandler += value;
         }
 
-        public void RemoveReadingStoppedHandler(View.ControlHandle handle, EventHandler value)
+        public void RemoveReadingStoppedHandler(View view, EventHandler value)
         {
             _readingStoppedHandler -= value;
             if (_readingStoppedHandler == null && _readingStoppedCallback != null)
             {
+                using var handle = view.GetControl();
                 Interop.AccessibilitySignal.AccessibilityReadingStoppedDisconnect(handle, _readingStoppedCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 _readingStoppedCallback = null;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityEvent.cs
@@ -267,8 +267,8 @@ namespace Tizen.NUI.BaseComponents
         public event EventHandler<GestureInfoEventArgs> AccessibilityGestureInfoReceived
         {
             // This uses DoGestureInfo signal from C++ API.
-            add => EnsureAccessibilityRareData().AddGestureInfoReceivedHandler(GetControl(), value);
-            remove => _accessibilityRareData?.RemoveGestureInfoReceivedHandler(GetControl(), value);
+            add => EnsureAccessibilityRareData().AddGestureInfoReceivedHandler(this, value);
+            remove => _accessibilityRareData?.RemoveGestureInfoReceivedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -282,8 +282,8 @@ namespace Tizen.NUI.BaseComponents
         public event EventHandler<GetDescriptionEventArgs> AccessibilityDescriptionRequested
         {
             // This uses GetDescription signal from C++ API.
-            add => EnsureAccessibilityData().AddDescriptionRequestedHandler(GetControl(), value);
-            remove => _accessibilityData?.RemoveDescriptionRequestedHandler(GetControl(), value);
+            add => EnsureAccessibilityData().AddDescriptionRequestedHandler(this, value);
+            remove => _accessibilityData?.RemoveDescriptionRequestedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -297,8 +297,8 @@ namespace Tizen.NUI.BaseComponents
         public event EventHandler<GetNameEventArgs> AccessibilityNameRequested
         {
             // This uses GetName signal from C++ API.
-            add => EnsureAccessibilityData().AddNameRequestedHandler(GetControl(), value);
-            remove => _accessibilityData?.RemoveNameRequestedHandler(GetControl(), value);
+            add => EnsureAccessibilityData().AddNameRequestedHandler(this, value);
+            remove => _accessibilityData?.RemoveNameRequestedHandler(this, value);
         }
 
         internal bool IsAccessibilityNameSignalEmpty()
@@ -332,8 +332,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler AccessibilityActivated
         {
-            add => EnsureAccessibilityData().AddActivatedHandler(GetControl(), value);
-            remove => _accessibilityData?.RemoveActivatedHandler(GetControl(), value);
+            add => EnsureAccessibilityData().AddActivatedHandler(this, value);
+            remove => _accessibilityData?.RemoveActivatedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -346,8 +346,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler AccessibilityReadingSkipped
         {
-            add => EnsureAccessibilityRareData().AddReadingSkippedHandler(GetControl(), value);
-            remove => _accessibilityRareData?.RemoveReadingSkippedHandler(GetControl(), value);
+            add => EnsureAccessibilityRareData().AddReadingSkippedHandler(this, value);
+            remove => _accessibilityRareData?.RemoveReadingSkippedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -360,8 +360,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler AccessibilityReadingPaused
         {
-            add => EnsureAccessibilityRareData().AddReadingPausedHandler(GetControl(), value);
-            remove => _accessibilityRareData?.RemoveReadingPausedHandler(GetControl(), value);
+            add => EnsureAccessibilityRareData().AddReadingPausedHandler(this, value);
+            remove => _accessibilityRareData?.RemoveReadingPausedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -374,8 +374,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler AccessibilityReadingResumed
         {
-            add => EnsureAccessibilityRareData().AddReadingResumedHandler(GetControl(), value);
-            remove => _accessibilityRareData?.RemoveReadingResumedHandler(GetControl(), value);
+            add => EnsureAccessibilityRareData().AddReadingResumedHandler(this, value);
+            remove => _accessibilityRareData?.RemoveReadingResumedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -388,8 +388,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler AccessibilityReadingCancelled
         {
-            add => EnsureAccessibilityRareData().AddReadingCancelledHandler(GetControl(), value);
-            remove => _accessibilityRareData?.RemoveReadingCancelledHandler(GetControl(), value);
+            add => EnsureAccessibilityRareData().AddReadingCancelledHandler(this, value);
+            remove => _accessibilityRareData?.RemoveReadingCancelledHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -402,8 +402,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler AccessibilityReadingStopped
         {
-            add => EnsureAccessibilityRareData().AddReadingStoppedHandler(GetControl(), value);
-            remove => _accessibilityRareData?.RemoveReadingStoppedHandler(GetControl(), value);
+            add => EnsureAccessibilityRareData().AddReadingStoppedHandler(this, value);
+            remove => _accessibilityRareData?.RemoveReadingStoppedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -416,8 +416,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<AccessibilityActionReceivedEventArgs> AccessibilityActionReceived
         {
-            add => EnsureAccessibilityData().AddActionReceivedHandler(GetControl(), value);
-            remove => _accessibilityData?.RemoveActionReceivedHandler(GetControl(), value);
+            add => EnsureAccessibilityData().AddActionReceivedHandler(this, value);
+            remove => _accessibilityData?.RemoveActionReceivedHandler(this, value);
         }
 
         ///////////////////////////////////////////////////////////////////
@@ -430,8 +430,8 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<AccessibilityHighlightChangedEventArgs> AccessibilityHighlightChanged
         {
-            add => EnsureAccessibilityData().AddHighlightChangedHandler(GetControl(), value);
-            remove => _accessibilityData?.RemoveHighlightChangedHandler(GetControl(), value);
+            add => EnsureAccessibilityData().AddHighlightChangedHandler(this, value);
+            remove => _accessibilityData?.RemoveHighlightChangedHandler(this, value);
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###
This fixes error log showing after applying #7020 


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
