### PR TITLE
[NUI] GetRenderEffect() does not attempt to convert null result

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -340,11 +340,14 @@ namespace Tizen.NUI.BaseComponents
             IntPtr cPtr = Interop.View.GetRenderEffect(SwigCPtr);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-            // We do not create new RenderEffect here.
-            RenderEffect renderEffect = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as RenderEffect;
-            Interop.BaseHandle.DeleteBaseHandle(new HandleRef(this, cPtr));
-            NDalicPINVOKE.ThrowExceptionIfExists();
-
+            RenderEffect renderEffect = null;
+            if (cPtr != IntPtr.Zero)
+            {
+                // We do not create new RenderEffect here.
+                renderEffect = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as RenderEffect;
+                Interop.BaseHandle.DeleteBaseHandle(new HandleRef(this, cPtr));
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
             return renderEffect;
         }
 


### PR DESCRIPTION
### Description of Change ###
Avoid converting null pointer of GetRenderEffect result 

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
