### PR TITLE
[NUI] Fix to move RegisterAccessibilityDelegate() into all modes

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -451,7 +451,6 @@ namespace Tizen.NUI.BaseComponents
         static internal new void Preload()
         {
             Container.Preload();
-            RegisterAccessibilityDelegate();
         }
 
         /// <summary>
@@ -507,16 +506,16 @@ namespace Tizen.NUI.BaseComponents
 
         private static IntPtr NewWithAccessibilityModeAndResizePolicyMode(ViewAccessibilityMode accessibilityMode, ViewResizePolicyMode resizePolicyMode)
         {
+            if (onceForViewAccessibilityModeCustom == false)
+            {
+                onceForViewAccessibilityModeCustom = true;
+                RegisterAccessibilityDelegate();
+            }
+
             switch (accessibilityMode)
             {
                 case ViewAccessibilityMode.Custom:
                 {
-                    if (onceForViewAccessibilityModeCustom == false)
-                    {
-                        onceForViewAccessibilityModeCustom = true;
-                        RegisterAccessibilityDelegate();
-                    }
-
                     switch (resizePolicyMode)
                     {
                         case ViewResizePolicyMode.Ignore:


### PR DESCRIPTION
NUIViewAccessible requires RegisterAccessibilityDelegate().

NUIViewAccessible is used if either an object has
AccessibilityMode.Custom or an object creates ViewWrapperImpl.

Since CustomView creates ViewWrapperImpl with AccessibilityMode.Default, RegisterAccessibilityDelegate() should be called for both accessibility modes default and custom for now.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
