### PR TITLE
[NUI] Recover NUI.Components in tv profile

### DIFF
--- a/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj
+++ b/src/Tizen.NUI.Components/Tizen.NUI.Components.csproj
@@ -13,10 +13,6 @@
     </When>
   </Choose>
 
-  <PropertyGroup>
-    <SupportedProfiles>mobile</SupportedProfiles>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Tizen.Log\Tizen.Log.csproj" />
     <ProjectReference Include="..\Tizen.NUI\Tizen.NUI.csproj" />


### PR DESCRIPTION
### Description of Change ###
[NUI] Recover NUI.Components in tv profile
- By TCSACR-606, NUI.Components has been deprecated in tv profile only.
- Because, it is deprecated ACR, so the package should not be removed.
- The remove ACR will be processed after the future 2 versions of tizen release.

### API Changes ###
nothing