### PR TITLE
[NUI] Disable default theme manager

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -45,6 +45,13 @@ namespace Tizen.NUI
         static public bool IsUsingXaml { get; set; } = true;
 
         /// <summary>
+        /// Set to true if NUI ThemeManager is used.
+        /// The default value is true.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool IsUsingThemeManager { get; set; } = true;
+
+        /// <summary>
         /// The instance of ResourceManager.
         /// </summary>
         private static System.Resources.ResourceManager resourceManager;

--- a/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
+++ b/src/Tizen.NUI/src/public/Theme/ThemeManager.cs
@@ -65,6 +65,11 @@ namespace Tizen.NUI
 
         static ThemeManager()
         {
+            if (!NUIApplication.IsUsingThemeManager)
+            {
+                InitialThemeDisabled = true;
+            }
+
             if (InitialThemeDisabled) return;
 
             ExternalThemeManager.Initialize();
@@ -174,9 +179,9 @@ namespace Tizen.NUI
         internal static bool ApplicationThemeChangeSensitive { get; set; }
 
 #if PROFILE_TV
-        internal const bool InitialThemeDisabled = true;
+        internal static bool InitialThemeDisabled = true;
 #else
-        internal const bool InitialThemeDisabled = false;
+        internal static bool InitialThemeDisabled = false;
 #endif
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
For the other frameworks using NUI as a foundation and uses its own theme manager other than NUI's, the option that disable NUI ThemeManager is needed.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
