### PR TITLE
[PackageManager] Add GC.KeepAlive() for interop callback object

### DIFF
--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/Package.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/Package.cs
@@ -224,6 +224,7 @@ namespace Tizen.Applications
             {
                 Log.Warn(LogTag, string.Format("Failed to application info of {0}. err = {1}", Id, err));
             }
+            GC.KeepAlive(cb);
 
             err = Interop.Package.PackageInfoDestroy(packageInfoHandle);
             if (err != Interop.PackageManager.ErrorCode.None)
@@ -291,7 +292,9 @@ namespace Tizen.Applications
             {
                 tcs.TrySetException(PackageManagerErrorFactory.GetException(err, "Failed to get total package size info of " + Id));
             }
-            return await tcs.Task.ConfigureAwait(false);
+            var result = await tcs.Task.ConfigureAwait(false);
+            GC.KeepAlive(sizeInfoCb);
+            return result;
         }
 
         /// <summary>
@@ -490,6 +493,7 @@ namespace Tizen.Applications
             {
                 Log.Warn(LogTag, string.Format("Failed to get dependency info. err = {0}", err));
             }
+            GC.KeepAlive(dependencyInfoCb);
             return dependencies;
         }
 
@@ -506,6 +510,7 @@ namespace Tizen.Applications
             {
                 Log.Warn(LogTag, string.Format("Failed to get dependency info. err = {0}", err));
             }
+            GC.KeepAlive(dependencyInfoCb);
             return dependencies;
         }
 
@@ -530,6 +535,7 @@ namespace Tizen.Applications
                 {
                     allowedPackagesAndPrivileges.Add(allowedPackage, requiredPrivilegesList);
                 }
+                GC.KeepAlive(requiredPrivCallback);
                 return true;
             };
 
@@ -538,6 +544,7 @@ namespace Tizen.Applications
             {
                 Log.Warn(LogTag, string.Format("Failed to get allowed packages info. err = {0}", err));
             }
+            GC.KeepAlive(allowedPackageCallback);
             return allowedPackagesAndPrivileges;
         }
 

--- a/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
+++ b/src/Tizen.Applications.PackageManager/Tizen.Applications/PackageManager.cs
@@ -508,6 +508,7 @@ namespace Tizen.Applications
                 {
                     Log.Warn(LogTag, string.Format("Failed to get package Informations. err = {0}", err));
                 }
+                GC.KeepAlive(cb);
             }
 
             err = Interop.PackageManager.PackageManagerFilterDestroy(filterHandle);
@@ -553,7 +554,9 @@ namespace Tizen.Applications
             {
                 tcs.TrySetException(PackageManagerErrorFactory.GetException(err, "Failed to get total package size info"));
             }
-            return await tcs.Task.ConfigureAwait(false);
+            var result = await tcs.Task.ConfigureAwait(false);
+            GC.KeepAlive(cb);
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description of Change ###
Sometimes the callback object for the unmanaged API released by GC before the unmanaged API returns.
Add GC.KeepAlive() to prevent this issue.


### API Changes ###
N/A