### PR TITLE
[NUI] Move rarely used `View` fields to the separate object and etc.

### DIFF
--- a/src/Tizen.NUI/src/internal/View/ViewEventRareData.cs
+++ b/src/Tizen.NUI/src/internal/View/ViewEventRareData.cs
@@ -1,0 +1,364 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Tizen.NUI.BaseComponents
+{
+    internal class ViewEventRareData
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate bool WheelEventCallbackType(IntPtr view, IntPtr wheelEvent);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void LayoutDirectionChangedEventCallbackType(IntPtr data, ViewLayoutDirectionType type);
+
+        private View _owner;
+        private EventHandlerWithReturnType<object, View.WheelEventArgs, bool> _interceptWheelHandler;
+        private WheelEventCallbackType _interceptWheelCallback;
+        private EventHandlerWithReturnType<object, View.WheelEventArgs, bool> _wheelEventHandler;
+        private WheelEventCallbackType _wheelEventCallback;
+        private EventHandlerWithReturnType<object, View.TouchEventArgs, bool> _interceptTouchDataEventHandler;
+        private View.TouchDataCallbackType _interceptTouchDataCallback;
+        private EventHandler<View.LayoutDirectionChangedEventArgs> _layoutDirectionChangedEventHandler;
+        private LayoutDirectionChangedEventCallbackType _layoutDirectionChangedEventCallback;
+        private View.TouchDataCallbackType _hitTestResultDataCallback;
+
+        public ViewEventRareData(View owner)
+        {
+            _owner = owner;
+        }
+
+        public event EventHandlerWithReturnType<object, View.TouchEventArgs, bool> InterceptTouchEvent
+        {
+            add
+            {
+                if (_interceptTouchDataEventHandler == null)
+                {
+                    _interceptTouchDataCallback = OnInterceptTouch;
+                    Interop.ActorSignal.InterceptTouchConnect(_owner.SwigCPtr, _interceptTouchDataCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                _interceptTouchDataEventHandler += value;
+            }
+
+            remove
+            {
+                _interceptTouchDataEventHandler -= value;
+                if (_interceptTouchDataEventHandler == null && _interceptTouchDataCallback != null)
+                {
+                    Interop.ActorSignal.InterceptTouchDisconnect(_owner.SwigCPtr, _interceptTouchDataCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    _interceptTouchDataCallback = null;
+                }
+            }
+        }
+
+        public event EventHandlerWithReturnType<object, View.WheelEventArgs, bool> InterceptWheelEvent
+        {
+            add
+            {
+                if (_interceptWheelHandler == null)
+                {
+                    _interceptWheelCallback = OnInterceptWheel;
+                    Interop.ActorSignal.InterceptWheelConnect(_owner.SwigCPtr, _interceptWheelCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                _interceptWheelHandler += value;
+            }
+
+            remove
+            {
+                _interceptWheelHandler -= value;
+                if (_interceptWheelHandler == null && _interceptWheelCallback != null)
+                {
+                    Interop.ActorSignal.InterceptWheelDisconnect(_owner.SwigCPtr, _interceptWheelCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    _interceptWheelCallback = null;
+                }
+            }
+        }
+
+        public event EventHandlerWithReturnType<object, View.WheelEventArgs, bool> WheelEvent
+        {
+            add
+            {
+                if (_wheelEventHandler == null)
+                {
+                    _wheelEventCallback = OnWheelEvent;
+                    Interop.ActorSignal.WheelEventConnect(_owner.SwigCPtr, _wheelEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                _wheelEventHandler += value;
+            }
+
+            remove
+            {
+                _wheelEventHandler -= value;
+                if (_wheelEventHandler == null && _wheelEventCallback != null)
+                {
+                    Interop.ActorSignal.WheelEventDisconnect(_owner.SwigCPtr, _wheelEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    _wheelEventCallback = null;
+                }
+            }
+        }
+
+        public event EventHandler<View.LayoutDirectionChangedEventArgs> LayoutDirectionChanged
+        {
+            add
+            {
+                if (_layoutDirectionChangedEventHandler == null)
+                {
+                    _layoutDirectionChangedEventCallback = OnLayoutDirectionChanged;
+                    Interop.ActorSignal.LayoutDirectionChangedConnect(_owner.SwigCPtr, _layoutDirectionChangedEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+
+                _layoutDirectionChangedEventHandler += value;
+            }
+
+            remove
+            {
+                _layoutDirectionChangedEventHandler -= value;
+
+                if (_layoutDirectionChangedEventHandler == null && _layoutDirectionChangedEventCallback != null)
+                {
+                    Interop.ActorSignal.LayoutDirectionChangedDisconnect(_owner.SwigCPtr, _layoutDirectionChangedEventCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    _layoutDirectionChangedEventCallback = null;
+                }
+            }
+        }
+
+        public void RegisterHitTestCallback(View.TouchDataCallbackType callback)
+        {
+            if (_hitTestResultDataCallback == null)
+            {
+                _hitTestResultDataCallback = callback;
+                Interop.ActorSignal.HitTestResultConnect(_owner.SwigCPtr, _hitTestResultDataCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+            }
+        }
+
+        public void UnregisterHitTestCallback()
+        {
+            if (_hitTestResultDataCallback != null)
+            {
+                Interop.ActorSignal.HitTestResultDisconnect(_owner.SwigCPtr, _hitTestResultDataCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                _hitTestResultDataCallback = null;
+            }
+        }
+
+        public void ClearSignal()
+        {
+            HandleRef handle = _owner.GetBaseHandleCPtrHandleRef;
+
+            if (_interceptWheelCallback != null)
+            {
+                NUILog.Debug($"[Dispose] interceptWheelCallback");
+
+                Interop.ActorSignal.InterceptWheelDisconnect(handle, _interceptWheelCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                _interceptWheelCallback = null;
+            }
+
+            if (_wheelEventCallback != null)
+            {
+                NUILog.Debug($"[Dispose] wheelEventCallback");
+
+                Interop.ActorSignal.WheelEventDisconnect(handle, _wheelEventCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                _wheelEventCallback = null;
+            }
+
+            if (_hitTestResultDataCallback != null)
+            {
+                NUILog.Debug($"[Dispose] hitTestResultDataCallback");
+
+                Interop.ActorSignal.HitTestResultDisconnect(handle, _hitTestResultDataCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                _hitTestResultDataCallback = null;
+            }
+
+            if (_interceptTouchDataCallback != null)
+            {
+                NUILog.Debug($"[Dispose] interceptTouchDataCallback");
+
+                Interop.ActorSignal.InterceptTouchDisconnect(handle, _interceptTouchDataCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                _interceptTouchDataCallback = null;
+            }
+
+            if (_layoutDirectionChangedEventCallback != null)
+            {
+                NUILog.Debug($"[Dispose] layoutDirectionChangedEventCallback");
+
+                Interop.ActorSignal.LayoutDirectionChangedDisconnect(handle, _layoutDirectionChangedEventCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                _layoutDirectionChangedEventCallback = null;
+            }
+        }
+
+        // Callback for View TouchSignal
+        private bool OnInterceptTouch(IntPtr view, IntPtr touchData)
+        {
+            if (_owner.IsDisposedOrQueued)
+            {
+                // Ignore native callback if the view is disposed or queued for disposal.
+                return false;
+            }
+
+            if (touchData == global::System.IntPtr.Zero)
+            {
+                NUILog.Error("touchData should not be null!");
+                return true;
+            }
+
+            // DisallowInterceptTouchEvent prevents the parent from intercepting touch.
+            if (_owner.DisallowInterceptTouchEvent)
+            {
+                return false;
+            }
+
+            View.TouchEventArgs e = new()
+            {
+                Touch = Touch.GetTouchFromPtr(touchData)
+            };
+
+            bool consumed = false;
+
+            if (_interceptTouchDataEventHandler != null)
+            {
+                if (NUIApplication.IsGeometryHittestEnabled())
+                {
+                    Delegate[] delegateList = _interceptTouchDataEventHandler.GetInvocationList();
+                    // Oring the result of each callback.
+                    foreach (EventHandlerWithReturnType<object, View.TouchEventArgs, bool> del in delegateList)
+                    {
+                        consumed |= del(_owner, e);
+                    }
+                }
+                else
+                {
+                    consumed = _interceptTouchDataEventHandler(_owner, e);
+                }
+            }
+
+            return consumed;
+        }
+
+        // Callback for View InterceptWheel signal
+        private bool OnInterceptWheel(IntPtr view, IntPtr wheelEvent)
+        {
+            if (_owner.IsDisposedOrQueued)
+            {
+                // Ignore native callback if the view is disposed or queued for disposal.
+                return false;
+            }
+
+            if (wheelEvent == IntPtr.Zero)
+            {
+                NUILog.Error("wheelEvent should not be null!");
+                return true;
+            }
+
+            // DisallowInterceptWheelEvent prevents the parent from intercepting wheel.
+            if (_owner.DisallowInterceptWheelEvent)
+            {
+                return false;
+            }
+
+            View.WheelEventArgs e = new()
+            {
+                Wheel = Wheel.GetWheelFromPtr(wheelEvent)
+            };
+
+            bool consumed = false;
+
+            if (_interceptWheelHandler != null)
+            {
+                consumed = _interceptWheelHandler(_owner, e);
+            }
+
+            return consumed;
+        }
+
+        // Callback for View Wheel signal
+        private bool OnWheelEvent(IntPtr view, IntPtr wheelEvent)
+        {
+            if (_owner.IsDisposedOrQueued)
+            {
+                // Ignore native callback if the view is disposed or queued for disposal.
+                return false;
+            }
+
+            if (wheelEvent == IntPtr.Zero)
+            {
+                NUILog.Error("wheelEvent should not be null!");
+                return true;
+            }
+
+            if (_owner.DispatchWheelEvents == false)
+            {
+                NUILog.Debug("If DispatchWheelEvents is false, it can not dispatch.");
+                return true;
+            }
+
+            View.WheelEventArgs e = new()
+            {
+                Wheel = Wheel.GetWheelFromPtr(wheelEvent)
+            };
+
+            bool consumed = false;
+
+            if (_wheelEventHandler != null)
+            {
+                consumed = _wheelEventHandler(_owner, e);
+            }
+
+            if (_owner.DispatchParentWheelEvents == false && consumed == false)
+            {
+                NUILog.Debug("If DispatchParentWheelEvents is false, it can not dispatch to parent.");
+                return true;
+            }
+
+            return consumed;
+        }
+
+        // Callback for View layout direction change signal
+        private void OnLayoutDirectionChanged(IntPtr data, ViewLayoutDirectionType type)
+        {
+            if (_owner.IsDisposedOrQueued)
+            {
+                // Ignore native callback if the view is disposed or queued for disposal.
+                return;
+            }
+
+            View.LayoutDirectionChangedEventArgs e = new();
+
+            if (data != IntPtr.Zero)
+            {
+                e.View = Registry.GetManagedBaseHandleFromNativePtr(data) as View;
+            }
+            e.Type = type;
+
+            _layoutDirectionChangedEventHandler?.Invoke(_owner, e);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/internal/View/ViewGestureData.cs
+++ b/src/Tizen.NUI/src/internal/View/ViewGestureData.cs
@@ -1,0 +1,87 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+
+namespace Tizen.NUI.BaseComponents
+{
+    internal class ViewGestureData
+    {
+        private PanGestureDetector _panGestureDetector;
+        private LongPressGestureDetector _longGestureDetector;
+        private PinchGestureDetector _pinchGestureDetector;
+        private TapGestureDetector _tapGestureDetector;
+        private RotationGestureDetector _rotationGestureDetector;
+
+        public void ConfigGestureDetector(View targetView, bool dispatch)
+        {
+            if (dispatch && _panGestureDetector != null)
+            {
+                _panGestureDetector.Detach(targetView);
+                _longGestureDetector.Detach(targetView);
+                _pinchGestureDetector.Detach(targetView);
+                _tapGestureDetector.Detach(targetView);
+                _rotationGestureDetector.Detach(targetView);
+
+                _panGestureDetector.Detected -= OnGestureDetected;
+                _longGestureDetector.Detected -= OnGestureDetected;
+                _pinchGestureDetector.Detected -= OnGestureDetected;
+                _tapGestureDetector.Detected -= OnGestureDetected;
+                _rotationGestureDetector.Detected -= OnGestureDetected;
+            }
+            else if (!dispatch && _panGestureDetector == null)
+            {
+                _panGestureDetector = new PanGestureDetector();
+                _longGestureDetector = new LongPressGestureDetector();
+                _pinchGestureDetector = new PinchGestureDetector();
+                _tapGestureDetector = new TapGestureDetector();
+                _rotationGestureDetector = new RotationGestureDetector();
+
+                _panGestureDetector.Attach(targetView);
+                _longGestureDetector.Attach(targetView);
+                _pinchGestureDetector.Attach(targetView);
+                _tapGestureDetector.Attach(targetView);
+                _rotationGestureDetector.Attach(targetView);
+
+                _panGestureDetector.Detected += OnGestureDetected;
+                _longGestureDetector.Detected += OnGestureDetected;
+                _pinchGestureDetector.Detected += OnGestureDetected;
+                _tapGestureDetector.Detected += OnGestureDetected;
+                _rotationGestureDetector.Detected += OnGestureDetected;
+            }
+        }
+
+        public void Clear()
+        {
+            _panGestureDetector?.Dispose();
+            _panGestureDetector = null;
+            _longGestureDetector?.Dispose();
+            _longGestureDetector = null;
+            _pinchGestureDetector?.Dispose();
+            _pinchGestureDetector = null;
+            _tapGestureDetector?.Dispose();
+            _tapGestureDetector = null;
+            _rotationGestureDetector?.Dispose();
+            _rotationGestureDetector = null;
+        }
+
+        private void OnGestureDetected(object source, EventArgs e)
+        {
+            // Does nothing. This is to consume the gesture.
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -39,7 +39,6 @@ namespace Tizen.NUI.BaseComponents
         private int widthPolicy = LayoutParamPolicies.WrapContent;
         private int heightPolicy = LayoutParamPolicies.WrapContent;
         private LayoutExtraData layoutExtraData;
-        private ThemeData themeData;
         private Dictionary<Type, object> attached;
 
         // Collection of image-sensitive properties, and need to update C# side cache value.
@@ -108,7 +107,7 @@ namespace Tizen.NUI.BaseComponents
             EnableControlState = 1 << 12, // Indicates that this View should listen Touch event to handle its ControlState.
             DispatchAllEvents = DispatchTouch | DispatchParentTouch | DispatchHover | DispatchParentHover | DispatchWheel | DispatchParentWheel | DispatchGesture | DispatchParentGesture,
             AllowAllEvents = AllowInterceptTouch | AllowInterceptWheel,
-            Default =  DispatchAllEvents | AllowAllEvents
+            Default = DispatchAllEvents | AllowAllEvents
         }
 
         static View()
@@ -706,8 +705,7 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                if (themeData == null) themeData = new ThemeData();
-
+                var themeData = EnsureThemeData();
                 if (themeData.viewStyle == null)
                 {
                     ApplyStyle(CreateViewStyle());
@@ -729,7 +727,7 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return themeData == null ? ControlState.Normal : themeData.controlStates;
+                return GetThemeData()?.controlStates ?? ControlState.Normal;
             }
             protected set
             {
@@ -744,7 +742,7 @@ namespace Tizen.NUI.BaseComponents
 
                 var prevState = ControlState;
 
-                if (themeData == null) themeData = new ThemeData();
+                var themeData = EnsureThemeData();
                 themeData.controlStates = value;
 
                 var changeInfo = new ControlStateChangedEventArgs(prevState, value);
@@ -1057,7 +1055,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalBackgroundColor(Selector<Color> selector)
         {
-            themeData?.selectorData?.ClearBackground(this);
+            GetThemeData()?.selectorData?.ClearBackground(this);
             if (selector.HasAll())
             {
                 SetBackgroundColor(selector.All);
@@ -1070,7 +1068,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalBackgroundColor(Color color)
         {
-            themeData?.selectorData?.ClearBackground(this);
+            GetThemeData()?.selectorData?.ClearBackground(this);
             SetBackgroundColor(color);
         }
 
@@ -1125,6 +1123,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalBackgroundImage(Selector<string> selector)
         {
+            var themeData = GetThemeData();
             if (themeData?.selectorData != null)
             {
                 themeData.selectorData.BackgroundColor?.Reset(this);
@@ -1143,6 +1142,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalBackgroundImage(string imageUrl)
         {
+            var themeData = GetThemeData();
             if (themeData?.selectorData != null)
             {
                 themeData.selectorData.BackgroundColor?.Reset(this);
@@ -1190,7 +1190,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalBackgroundImageBorder(Selector<Rectangle> selector)
         {
-            themeData?.selectorData?.BackgroundImageBorder?.Reset(this);
+            GetThemeData()?.selectorData?.BackgroundImageBorder?.Reset(this);
 
             if (selector.HasAll())
             {
@@ -1204,7 +1204,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalBackgroundImageBorder(Rectangle border)
         {
-            themeData?.selectorData?.BackgroundImageBorder?.Reset(this);
+            GetThemeData()?.selectorData?.BackgroundImageBorder?.Reset(this);
             SetBackgroundImageBorder(border);
         }
 
@@ -1333,7 +1333,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalImageShadow(Selector<ImageShadow> shadow)
         {
-            themeData?.selectorData?.ClearShadow(this);
+            GetThemeData()?.selectorData?.ClearShadow(this);
             if (shadow.HasAll())
             {
                 SetShadow(shadow.All);
@@ -1346,7 +1346,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalImageShadow(ImageShadow shadow)
         {
-            themeData?.selectorData?.ClearShadow(this);
+            GetThemeData()?.selectorData?.ClearShadow(this);
             SetShadow(shadow);
         }
 
@@ -1407,7 +1407,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalBoxShadow(Selector<Shadow> shadow)
         {
-            themeData?.selectorData?.ClearShadow(this);
+            GetThemeData()?.selectorData?.ClearShadow(this);
             if (shadow.HasAll())
             {
                 SetShadow(shadow.All);
@@ -1420,7 +1420,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalBoxShadow(Shadow shadow)
         {
-            themeData?.selectorData?.ClearShadow(this);
+            GetThemeData()?.selectorData?.ClearShadow(this);
             SetShadow(shadow);
         }
 
@@ -1713,7 +1713,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalBorderlineColor(Selector<Color> selector)
         {
-            themeData?.selectorData?.BorderlineColor?.Reset(this);
+            GetThemeData()?.selectorData?.BorderlineColor?.Reset(this);
             if (selector.HasAll())
             {
                 SetBorderlineColor(selector.All);
@@ -1726,7 +1726,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalBorderlineColor(Color color)
         {
-            themeData?.selectorData?.BorderlineColor?.Reset(this);
+            GetThemeData()?.selectorData?.BorderlineColor?.Reset(this);
             SetBorderlineColor(color);
         }
 
@@ -1771,7 +1771,7 @@ namespace Tizen.NUI.BaseComponents
 
         private Selector<Color> GetInternalBorderlineColorSelector()
         {
-            var selector = themeData?.selectorData?.BorderlineColor?.Get();
+            var selector = GetThemeData()?.selectorData?.BorderlineColor?.Get();
             return (null != selector) ? selector : new Selector<Color>();
         }
 
@@ -3073,7 +3073,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalOpacity(Selector<float?> selector)
         {
-            themeData?.selectorData?.Opacity?.Reset(this);
+            GetThemeData()?.selectorData?.Opacity?.Reset(this);
             if (selector.HasAll())
             {
                 SetOpacity(selector.All);
@@ -3086,7 +3086,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalOpacity(float opacity)
         {
-            themeData?.selectorData?.Opacity?.Reset(this);
+            GetThemeData()?.selectorData?.Opacity?.Reset(this);
 
             //Selector using code has been removed because the Selector is not used when IsUsingXaml is false
             SetOpacity(opacity);
@@ -6105,7 +6105,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetInternalColor(Selector<Color> selector)
         {
-            themeData?.selectorData?.Color?.Reset(this);
+            GetThemeData()?.selectorData?.Color?.Reset(this);
             if (selector.HasAll())
             {
                 SetColor(selector.All);
@@ -6118,7 +6118,7 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalColor(Color color)
         {
-            themeData?.selectorData?.Color?.Reset(this);
+            GetThemeData()?.selectorData?.Color?.Reset(this);
             SetColor(color);
         }
 
@@ -6672,13 +6672,12 @@ namespace Tizen.NUI.BaseComponents
 
         private bool InternalEnableControlStatePropagation
         {
-            get => themeData?.ControlStatePropagation ?? false;
+            get => GetThemeData()?.ControlStatePropagation ?? false;
             set
             {
                 if (InternalEnableControlStatePropagation == value) return;
 
-                if (themeData == null) themeData = new ThemeData();
-
+                var themeData = EnsureThemeData();
                 themeData.ControlStatePropagation = value;
 
                 foreach (View child in Children)
@@ -7005,7 +7004,7 @@ namespace Tizen.NUI.BaseComponents
         {
             if (ThemeChangeSensitive == themeChangeSensitive) return;
 
-            if (themeData == null) themeData = new ThemeData();
+            var themeData = EnsureThemeData();
 
             themeData.ThemeChangeSensitive = themeChangeSensitive;
 
@@ -7023,7 +7022,7 @@ namespace Tizen.NUI.BaseComponents
 
         private bool GetInternalThemeChangeSensitive()
         {
-            return themeData?.ThemeChangeSensitive ?? ThemeManager.ApplicationThemeChangeSensitive;
+            return GetThemeData()?.ThemeChangeSensitive ?? ThemeManager.ApplicationThemeChangeSensitive;
         }
 
         /// <summary>
@@ -7062,9 +7061,9 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 9 </since_tizen>
         public virtual void ApplyStyle(ViewStyle viewStyle)
         {
-            if (viewStyle == null || themeData?.viewStyle == viewStyle) return;
+            if (viewStyle == null || GetThemeData()?.viewStyle == viewStyle) return;
 
-            if (themeData == null) themeData = new ThemeData();
+            var themeData = EnsureThemeData();
 
             themeData.viewStyle = viewStyle;
 
@@ -7345,5 +7344,17 @@ namespace Tizen.NUI.BaseComponents
                 _viewFlags &= ~flag;
             }
         }
+
+        private ThemeData EnsureThemeData()
+        {
+            var themeData = GetAttached<ThemeData>();
+            if (themeData == null)
+            {
+                SetAttached(themeData = new ThemeData());
+            }
+            return themeData;
+        }
+
+        private ThemeData GetThemeData() => GetAttached<ThemeData>();
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewBindableProperty.cs
@@ -2191,7 +2191,7 @@ namespace Tizen.NUI.BaseComponents
             backgroundImageUrl = value;
 
             // Fast return for usual cases.
-            if (backgroundExtraData == null && !backgroundImageSynchronousLoading)
+            if (backgroundExtraData == null && !_viewFlags.HasFlag(ViewFlags.BackgroundImageSynchronousLoading))
             {
                 Object.InternalSetPropertyString(SwigCPtr, View.Property.BACKGROUND, value);
                 return;
@@ -2200,7 +2200,7 @@ namespace Tizen.NUI.BaseComponents
             using var map = new PropertyMap();
 
             map.Add(ImageVisualProperty.URL, value)
-               .Add(ImageVisualProperty.SynchronousLoading, backgroundImageSynchronousLoading);
+               .Add(ImageVisualProperty.SynchronousLoading, _viewFlags.HasFlag(ViewFlags.BackgroundImageSynchronousLoading));
 
             if ((backgroundExtraData?.BackgroundImageBorder) != null)
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -29,14 +29,8 @@ namespace Tizen.NUI.BaseComponents
     {
         private EventHandler offWindowEventHandler;
         private OffWindowEventCallbackType offWindowEventCallback;
-        private EventHandlerWithReturnType<object, WheelEventArgs, bool> interceptWheelHandler;
-        private WheelEventCallbackType interceptWheelCallback;
-        private EventHandlerWithReturnType<object, WheelEventArgs, bool> wheelEventHandler;
-        private WheelEventCallbackType wheelEventCallback;
         private EventHandlerWithReturnType<object, KeyEventArgs, bool> keyEventHandler;
         private KeyCallbackType keyCallback;
-        private EventHandlerWithReturnType<object, TouchEventArgs, bool> interceptTouchDataEventHandler;
-        private TouchDataCallbackType interceptTouchDataCallback;
         private EventHandlerWithReturnType<object, TouchEventArgs, bool> touchDataEventHandler;
         private TouchDataCallbackType touchDataCallback;
         private EventHandlerWithReturnType<object, HoverEventArgs, bool> hoverEventHandler;
@@ -47,33 +41,26 @@ namespace Tizen.NUI.BaseComponents
         private AggregatedVisibilityChangedEventCallbackType aggregatedVisibilityChangedEventCallback;
         private EventHandler keyInputFocusGainedEventHandler;
         private KeyInputFocusGainedCallbackType keyInputFocusGainedCallback;
-
         private EventHandler keyInputFocusLostEventHandler;
         private KeyInputFocusLostCallbackType keyInputFocusLostCallback;
         private EventHandler onRelayoutEventHandler;
         private OnRelayoutEventCallbackType onRelayoutEventCallback;
         private EventHandler onWindowEventHandler;
         private OnWindowEventCallbackType onWindowEventCallback;
-        private EventHandler<LayoutDirectionChangedEventArgs> layoutDirectionChangedEventHandler;
-        private LayoutDirectionChangedEventCallbackType layoutDirectionChangedEventCallback;
         // Resource Ready Signal
         private EventHandler resourcesLoadedEventHandler;
         private ResourcesLoadedCallbackType resourcesLoadedCallback;
         private EventHandler<BackgroundResourceLoadedEventArgs> backgroundResourceLoadedEventHandler;
         private _backgroundResourceLoadedCallbackType backgroundResourceLoadedCallback;
-        private TouchDataCallbackType hitTestResultDataCallback;
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OffWindowEventCallbackType(IntPtr control);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate bool WheelEventCallbackType(IntPtr view, IntPtr wheelEvent);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool KeyCallbackType(IntPtr control, IntPtr keyEvent);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate bool TouchDataCallbackType(IntPtr view, IntPtr touchData);
+        internal delegate bool TouchDataCallbackType(IntPtr view, IntPtr touchData);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate bool HoverEventCallbackType(IntPtr view, IntPtr hoverEvent);
@@ -102,10 +89,7 @@ namespace Tizen.NUI.BaseComponents
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OnWindowEventCallbackType(IntPtr control);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void LayoutDirectionChangedEventCallbackType(IntPtr data, ViewLayoutDirectionType type);
-
-        // List of dispatch Event
+        private ViewEventRareData _viewEventRareData; // NOTE Consider reuse data by using pool
         private ViewGestureData _viewGestureData;
 
         /// <summary>
@@ -248,25 +232,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandlerWithReturnType<object, TouchEventArgs, bool> InterceptTouchEvent
         {
-            add
-            {
-                if (interceptTouchDataEventHandler == null)
-                {
-                    interceptTouchDataCallback = OnInterceptTouch;
-                    Interop.ActorSignal.InterceptTouchConnect(SwigCPtr, interceptTouchDataCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                }
-                interceptTouchDataEventHandler += value;
-            }
-
+            add => EnsureViewEventRareData().InterceptTouchEvent += value;
             remove
             {
-                interceptTouchDataEventHandler -= value;
-                if (interceptTouchDataEventHandler == null && interceptTouchDataCallback != null)
+                if (_viewEventRareData != null)
                 {
-                    Interop.ActorSignal.InterceptTouchDisconnect(SwigCPtr, interceptTouchDataCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                    interceptTouchDataCallback = null;
+                    _viewEventRareData.InterceptTouchEvent -= value;
                 }
             }
         }
@@ -356,25 +327,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandlerWithReturnType<object, WheelEventArgs, bool> InterceptWheelEvent
         {
-            add
-            {
-                if (interceptWheelHandler == null)
-                {
-                    interceptWheelCallback = OnInterceptWheel;
-                    Interop.ActorSignal.InterceptWheelConnect(SwigCPtr, interceptWheelCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                }
-                interceptWheelHandler += value;
-            }
-
+            add => EnsureViewEventRareData().InterceptWheelEvent += value;
             remove
             {
-                interceptWheelHandler -= value;
-                if (interceptWheelHandler == null && interceptWheelCallback != null)
+                if (_viewEventRareData != null)
                 {
-                    Interop.ActorSignal.InterceptWheelDisconnect(SwigCPtr, interceptWheelCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                    interceptWheelCallback = null;
+                    _viewEventRareData.InterceptWheelEvent -= value;
                 }
             }
         }
@@ -402,25 +360,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 3 </since_tizen>
         public event EventHandlerWithReturnType<object, WheelEventArgs, bool> WheelEvent
         {
-            add
-            {
-                if (wheelEventHandler == null)
-                {
-                    wheelEventCallback = OnWheelEvent;
-                    Interop.ActorSignal.WheelEventConnect(SwigCPtr, wheelEventCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                }
-                wheelEventHandler += value;
-            }
-
+            add => EnsureViewEventRareData().WheelEvent += value;
             remove
             {
-                wheelEventHandler -= value;
-                if (wheelEventHandler == null && wheelEventCallback != null)
+                if (_viewEventRareData != null)
                 {
-                    Interop.ActorSignal.WheelEventDisconnect(SwigCPtr, wheelEventCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                    wheelEventCallback = null;
+                    _viewEventRareData.WheelEvent -= value;
                 }
             }
         }
@@ -570,27 +515,12 @@ namespace Tizen.NUI.BaseComponents
         /// <since_tizen> 4 </since_tizen>
         public event EventHandler<LayoutDirectionChangedEventArgs> LayoutDirectionChanged
         {
-            add
-            {
-                if (layoutDirectionChangedEventHandler == null)
-                {
-                    layoutDirectionChangedEventCallback = OnLayoutDirectionChanged;
-                    Interop.ActorSignal.LayoutDirectionChangedConnect(SwigCPtr, layoutDirectionChangedEventCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                }
-
-                layoutDirectionChangedEventHandler += value;
-            }
-
+            add => EnsureViewEventRareData().LayoutDirectionChanged += value;
             remove
             {
-                layoutDirectionChangedEventHandler -= value;
-
-                if (layoutDirectionChangedEventHandler == null && layoutDirectionChangedEventCallback != null)
+                if (_viewEventRareData != null)
                 {
-                    Interop.ActorSignal.LayoutDirectionChangedDisconnect(SwigCPtr, layoutDirectionChangedEventCallback.ToHandleRef(this));
-                    NDalicPINVOKE.ThrowExceptionIfExists();
-                    layoutDirectionChangedEventCallback = null;
+                    _viewEventRareData.LayoutDirectionChanged -= value;
                 }
             }
         }
@@ -669,7 +599,6 @@ namespace Tizen.NUI.BaseComponents
                 }
                 backgroundResourceLoadedEventHandler += value;
             }
-
             remove
             {
                 backgroundResourceLoadedEventHandler -= value;
@@ -679,7 +608,7 @@ namespace Tizen.NUI.BaseComponents
                     NDalicPINVOKE.ThrowExceptionIfExists();
                     backgroundResourceLoadedCallback = null;
                 }
-            }
+             }
         }
 
         private void OnColorChanged(float r, float g, float b, float a)
@@ -910,52 +839,6 @@ namespace Tizen.NUI.BaseComponents
         }
 
         // Callback for View TouchSignal
-        private bool OnInterceptTouch(IntPtr view, IntPtr touchData)
-        {
-            if (Disposed || IsDisposeQueued)
-            {
-                // Ignore native callback if the view is disposed or queued for disposal.
-                return false;
-            }
-
-            if (touchData == global::System.IntPtr.Zero)
-            {
-                NUILog.Error("touchData should not be null!");
-                return true;
-            }
-
-            // DisallowInterceptTouchEvent prevents the parent from intercepting touch.
-            if (DisallowInterceptTouchEvent)
-            {
-                return false;
-            }
-
-            TouchEventArgs e = new TouchEventArgs();
-            e.Touch = Tizen.NUI.Touch.GetTouchFromPtr(touchData);
-
-            bool consumed = false;
-
-            if (interceptTouchDataEventHandler != null)
-            {
-                if (NUIApplication.IsGeometryHittestEnabled())
-                {
-                    Delegate[] delegateList = interceptTouchDataEventHandler.GetInvocationList();
-                    // Oring the result of each callback.
-                    foreach (EventHandlerWithReturnType<object, TouchEventArgs, bool> del in delegateList)
-                    {
-                        consumed |= del(this, e);
-                    }
-                }
-                else
-                {
-                    consumed = interceptTouchDataEventHandler(this, e);
-                }
-            }
-
-            return consumed;
-        }
-
-        // Callback for View TouchSignal
         private bool OnTouch(IntPtr view, IntPtr touchData)
         {
             if (Disposed || IsDisposeQueued)
@@ -1052,82 +935,6 @@ namespace Tizen.NUI.BaseComponents
             return consumed;
         }
 
-        // Callback for View InterceptWheel signal
-        private bool OnInterceptWheel(IntPtr view, IntPtr wheelEvent)
-        {
-            if (Disposed || IsDisposeQueued)
-            {
-                // Ignore native callback if the view is disposed or queued for disposal.
-                return false;
-            }
-
-            if (wheelEvent == global::System.IntPtr.Zero)
-            {
-                NUILog.Error("wheelEvent should not be null!");
-                return true;
-            }
-
-            // DisallowInterceptWheelEvent prevents the parent from intercepting wheel.
-            if (DisallowInterceptWheelEvent)
-            {
-                return false;
-            }
-
-            WheelEventArgs e = new WheelEventArgs();
-
-            e.Wheel = Tizen.NUI.Wheel.GetWheelFromPtr(wheelEvent);
-
-            bool consumed = false;
-
-            if (interceptWheelHandler != null)
-            {
-                consumed = interceptWheelHandler(this, e);
-            }
-
-            return consumed;
-        }
-
-        // Callback for View Wheel signal
-        private bool OnWheelEvent(IntPtr view, IntPtr wheelEvent)
-        {
-            if (Disposed || IsDisposeQueued)
-            {
-                // Ignore native callback if the view is disposed or queued for disposal.
-                return false;
-            }
-
-            if (wheelEvent == global::System.IntPtr.Zero)
-            {
-                NUILog.Error("wheelEvent should not be null!");
-                return true;
-            }
-
-            if (DispatchWheelEvents == false)
-            {
-                NUILog.Debug("If DispatchWheelEvents is false, it can not dispatch.");
-                return true;
-            }
-
-            WheelEventArgs e = new WheelEventArgs();
-
-            e.Wheel = Tizen.NUI.Wheel.GetWheelFromPtr(wheelEvent);
-
-            bool consumed = false;
-
-            if (wheelEventHandler != null)
-            {
-                consumed = wheelEventHandler(this, e);
-            }
-
-            if (DispatchParentWheelEvents == false && consumed == false)
-            {
-                NUILog.Debug("If DispatchParentWheelEvents is false, it can not dispatch to parent.");
-                return true;
-            }
-
-            return consumed;
-        }
-
         // Callback for View OnWindow signal
         private void OnWindow(IntPtr data)
         {
@@ -1205,28 +1012,6 @@ namespace Tizen.NUI.BaseComponents
             if (aggregatedVisibilityChangedEventHandler != null)
             {
                 aggregatedVisibilityChangedEventHandler(this, e);
-            }
-        }
-
-        // Callback for View layout direction change signal
-        private void OnLayoutDirectionChanged(IntPtr data, ViewLayoutDirectionType type)
-        {
-            if (Disposed || IsDisposeQueued)
-            {
-                // Ignore native callback if the view is disposed or queued for disposal.
-                return;
-            }
-
-            LayoutDirectionChangedEventArgs e = new LayoutDirectionChangedEventArgs();
-            if (data != IntPtr.Zero)
-            {
-                e.View = Registry.GetManagedBaseHandleFromNativePtr(data) as View;
-            }
-            e.Type = type;
-
-            if (layoutDirectionChangedEventHandler != null)
-            {
-                layoutDirectionChangedEventHandler(this, e);
             }
         }
 
@@ -2034,5 +1819,7 @@ namespace Tizen.NUI.BaseComponents
         }
 
         private ViewGestureData EnsureViewGestureData() => _viewGestureData ??= new ViewGestureData();
+
+        private ViewEventRareData EnsureViewEventRareData() => _viewEventRareData ??= new ViewEventRareData(this);
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -90,7 +90,6 @@ namespace Tizen.NUI.BaseComponents
         private delegate void OnWindowEventCallbackType(IntPtr control);
 
         private ViewEventRareData _viewEventRareData; // NOTE Consider reuse data by using pool
-        private ViewGestureData _viewGestureData;
 
         /// <summary>
         /// Event when a child is removed.
@@ -1818,7 +1817,17 @@ namespace Tizen.NUI.BaseComponents
             return false;
         }
 
-        private ViewGestureData EnsureViewGestureData() => _viewGestureData ??= new ViewGestureData();
+        private ViewGestureData EnsureViewGestureData()
+        {
+            var viewGestureData = GetAttached<ViewGestureData>();
+            if (viewGestureData == null)
+            {
+                SetAttached(viewGestureData = new ViewGestureData());
+            }
+            return viewGestureData;
+        }
+
+        private ViewGestureData GetViewGestureData() => GetAttached<ViewGestureData>();
 
         private ViewEventRareData EnsureViewEventRareData() => _viewEventRareData ??= new ViewEventRareData(this);
     }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -106,12 +106,7 @@ namespace Tizen.NUI.BaseComponents
         private delegate void LayoutDirectionChangedEventCallbackType(IntPtr data, ViewLayoutDirectionType type);
 
         // List of dispatch Event
-        private PanGestureDetector panGestureDetector;
-        private LongPressGestureDetector longGestureDetector;
-        private PinchGestureDetector pinchGestureDetector;
-        private TapGestureDetector tapGestureDetector;
-        private RotationGestureDetector rotationGestureDetector;
-        private int configGestureCount;
+        private ViewGestureData _viewGestureData;
 
         /// <summary>
         /// Event when a child is removed.
@@ -1887,7 +1882,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (UpdateViewEventFlag(ViewFlags.DispatchGesture, value))
                 {
-                    ConfigGestureDetector(value);
+                    EnsureViewGestureData().ConfigGestureDetector(this, value);
                 }
             }
         }
@@ -1905,60 +1900,9 @@ namespace Tizen.NUI.BaseComponents
             {
                 if (UpdateViewEventFlag(ViewFlags.DispatchParentGesture, value))
                 {
-                    ConfigGestureDetector(value);
+                    EnsureViewGestureData().ConfigGestureDetector(this, value);
                 }
             }
-        }
-
-        private void ConfigGestureDetector(bool dispatch)
-        {
-            if (panGestureDetector == null) panGestureDetector = new PanGestureDetector();
-            if (longGestureDetector == null) longGestureDetector = new LongPressGestureDetector();
-            if (pinchGestureDetector == null) pinchGestureDetector = new PinchGestureDetector();
-            if (tapGestureDetector == null) tapGestureDetector = new TapGestureDetector();
-            if (rotationGestureDetector == null) rotationGestureDetector = new RotationGestureDetector();
-
-            if (dispatch == true)
-            {
-                configGestureCount = configGestureCount > 0 ? configGestureCount - 1 : 0;
-                if (configGestureCount == 0)
-                {
-                    panGestureDetector.Detach(this);
-                    longGestureDetector.Detach(this);
-                    pinchGestureDetector.Detach(this);
-                    tapGestureDetector.Detach(this);
-                    rotationGestureDetector.Detach(this);
-
-                    panGestureDetector.Detected -= OnGestureDetected;
-                    longGestureDetector.Detected -= OnGestureDetected;
-                    pinchGestureDetector.Detected -= OnGestureDetected;
-                    tapGestureDetector.Detected -= OnGestureDetected;
-                    rotationGestureDetector.Detected -= OnGestureDetected;
-                }
-            }
-            else
-            {
-                if (configGestureCount == 0)
-                {
-                    panGestureDetector.Attach(this);
-                    longGestureDetector.Attach(this);
-                    pinchGestureDetector.Attach(this);
-                    tapGestureDetector.Attach(this);
-                    rotationGestureDetector.Attach(this);
-
-                    panGestureDetector.Detected += OnGestureDetected;
-                    longGestureDetector.Detected += OnGestureDetected;
-                    pinchGestureDetector.Detected += OnGestureDetected;
-                    tapGestureDetector.Detected += OnGestureDetected;
-                    rotationGestureDetector.Detected += OnGestureDetected;
-                }
-                configGestureCount++;
-            }
-        }
-
-        private void OnGestureDetected(object source, EventArgs e)
-        {
-            // Does notting. This is to consume the gesture.
         }
 
         /// <summary>
@@ -2088,5 +2032,7 @@ namespace Tizen.NUI.BaseComponents
             }
             return false;
         }
+
+        private ViewGestureData EnsureViewGestureData() => _viewGestureData ??= new ViewGestureData();
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -112,15 +112,6 @@ namespace Tizen.NUI.BaseComponents
         private TapGestureDetector tapGestureDetector;
         private RotationGestureDetector rotationGestureDetector;
         private int configGestureCount;
-        private bool dispatchTouchEvents = true;
-        private bool dispatchParentTouchEvents = true;
-        private bool dispatchHoverEvents = true;
-        private bool dispatchParentHoverEvents = true;
-        private bool dispatchWheelEvents = true;
-        private bool dispatchParentWheelEvents = true;
-        private bool dispatchGestureEvents = true;
-        private bool dispatchParentGestureEvents = true;
-
 
         /// <summary>
         /// Event when a child is removed.
@@ -295,8 +286,11 @@ namespace Tizen.NUI.BaseComponents
         ///  This prevents the parent from intercepting touch.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool DisallowInterceptTouchEvent { get; set; }
-
+        public bool DisallowInterceptTouchEvent
+        {
+            get => !HasViewEventFlag(ViewFlags.AllowInterceptTouch);
+            set => UpdateViewEventFlag(ViewFlags.AllowInterceptTouch, !value);
+        }
 
         /// <summary>
         /// An event for the touched signal which can be used to subscribe or unsubscribe the event handler provided by the user.<br />
@@ -400,7 +394,11 @@ namespace Tizen.NUI.BaseComponents
         ///  This prevents the parent from intercepting wheel event.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool DisallowInterceptWheelEvent { get; set; }
+        public bool DisallowInterceptWheelEvent
+        {
+            get => !HasViewEventFlag(ViewFlags.AllowInterceptWheel);
+            set => UpdateViewEventFlag(ViewFlags.AllowInterceptWheel, !value);
+        }
 
         /// <summary>
         /// An event for the WheelMoved signal which can be used to subscribe or unsubscribe the event handler provided by the user.<br />
@@ -944,7 +942,7 @@ namespace Tizen.NUI.BaseComponents
 
             if (interceptTouchDataEventHandler != null)
             {
-                if(NUIApplication.IsGeometryHittestEnabled())
+                if (NUIApplication.IsGeometryHittestEnabled())
                 {
                     Delegate[] delegateList = interceptTouchDataEventHandler.GetInvocationList();
                     // Oring the result of each callback.
@@ -990,7 +988,7 @@ namespace Tizen.NUI.BaseComponents
 
             if (touchDataEventHandler != null)
             {
-                if(NUIApplication.IsGeometryHittestEnabled())
+                if (NUIApplication.IsGeometryHittestEnabled())
                 {
                     Delegate[] delegateList = touchDataEventHandler.GetInvocationList();
                     // Oring the result of each callback.
@@ -1005,7 +1003,7 @@ namespace Tizen.NUI.BaseComponents
                 }
             }
 
-            if (enableControlState && !consumed)
+            if (_viewFlags.HasFlag(ViewFlags.EnableControlState) && !consumed)
             {
                 consumed = HandleControlStateOnTouch(e.Touch);
             }
@@ -1179,7 +1177,7 @@ namespace Tizen.NUI.BaseComponents
             if (changedViewCPtr != IntPtr.Zero)
             {
                 e.View = Registry.GetManagedBaseHandleFromNativePtr(changedViewCPtr) as View;
-                if(e.View != null)
+                if (e.View != null)
                 {
                     Interop.BaseHandle.DeleteBaseHandle(new global::System.Runtime.InteropServices.HandleRef(this, changedViewCPtr));
                 }
@@ -1689,16 +1687,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchTouchEvents
         {
-            get
-            {
-                return dispatchTouchEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchTouch);
             set
             {
-                if (dispatchTouchEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchTouch, value))
                 {
-                    dispatchTouchEvents = value;
-                    if (dispatchTouchEvents == false)
+                    if (!value)
                     {
                         TouchEvent += OnDispatchTouchEvent;
                     }
@@ -1726,16 +1720,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchParentTouchEvents
         {
-            get
-            {
-                return dispatchParentTouchEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchParentTouch);
             set
             {
-                if (dispatchParentTouchEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchParentTouch, value))
                 {
-                    dispatchParentTouchEvents = value;
-                    if (dispatchParentTouchEvents == false)
+                    if (!value)
                     {
                         TouchEvent += OnDispatchParentTouchEvent;
                     }
@@ -1763,16 +1753,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchHoverEvents
         {
-            get
-            {
-                return dispatchHoverEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchHover);
             set
             {
-                if (dispatchHoverEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchHover, value))
                 {
-                    dispatchHoverEvents = value;
-                    if (dispatchHoverEvents == false)
+                    if (!value)
                     {
                         HoverEvent += OnDispatchHoverEvent;
                     }
@@ -1800,16 +1786,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchParentHoverEvents
         {
-            get
-            {
-                return dispatchParentHoverEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchParentHover);
             set
             {
-                if (dispatchParentHoverEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchParentHover, value))
                 {
-                    dispatchParentHoverEvents = value;
-                    if (dispatchParentHoverEvents == false)
+                    if (!value)
                     {
                         HoverEvent += OnDispatchParentHoverEvent;
                     }
@@ -1837,16 +1819,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchWheelEvents
         {
-            get
-            {
-                return dispatchWheelEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchWheel);
             set
             {
-                if (dispatchWheelEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchWheel, value))
                 {
-                    dispatchWheelEvents = value;
-                    if (dispatchWheelEvents == false)
+                    if (!value)
                     {
                         WheelEvent += OnDispatchWheelEvent;
                     }
@@ -1874,16 +1852,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchParentWheelEvents
         {
-            get
-            {
-                return dispatchParentWheelEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchParentWheel);
             set
             {
-                if (dispatchParentWheelEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchParentWheel, value))
                 {
-                    dispatchParentWheelEvents = value;
-                    if (dispatchParentWheelEvents == false)
+                    if (!value)
                     {
                         WheelEvent += OnDispatchParentWheelEvent;
                     }
@@ -1908,16 +1882,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchGestureEvents
         {
-            get
-            {
-                return dispatchGestureEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchGesture);
             set
             {
-                if (dispatchGestureEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchGesture, value))
                 {
-                    dispatchGestureEvents = value;
-                    ConfigGestureDetector(dispatchGestureEvents);
+                    ConfigGestureDetector(value);
                 }
             }
         }
@@ -1930,16 +1900,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool DispatchParentGestureEvents
         {
-            get
-            {
-                return dispatchParentGestureEvents;
-            }
+            get => HasViewEventFlag(ViewFlags.DispatchParentGesture);
             set
             {
-                if (dispatchParentGestureEvents != value)
+                if (UpdateViewEventFlag(ViewFlags.DispatchParentGesture, value))
                 {
-                    dispatchParentGestureEvents = value;
-                    ConfigGestureDetector(dispatchParentGestureEvents);
+                    ConfigGestureDetector(value);
                 }
             }
         }
@@ -2101,6 +2067,26 @@ namespace Tizen.NUI.BaseComponents
                 Object.InternalSetPropertyBool(SwigCPtr, View.Property.DispatchHoverMotion, value);
                 NotifyPropertyChanged();
             }
+        }
+
+        private bool HasViewEventFlag(ViewFlags flag) => _viewFlags.HasFlag(flag);
+
+        /// <summary>
+        /// Update flag and return result whether the flag value is changed or not.
+        /// </summary>
+        private bool UpdateViewEventFlag(ViewFlags flag, bool enabling)
+        {
+            if (enabling && !HasViewEventFlag(flag))
+            {
+                _viewFlags |= flag;
+                return true;
+            }
+            else if (!enabling && HasViewEventFlag(flag))
+            {
+                _viewFlags &= ~flag;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1378,16 +1378,7 @@ namespace Tizen.NUI.BaseComponents
                 internalSize2D?.Dispose();
                 internalSize2D = null;
 
-                panGestureDetector?.Dispose();
-                panGestureDetector = null;
-                longGestureDetector?.Dispose();
-                longGestureDetector = null;
-                pinchGestureDetector?.Dispose();
-                pinchGestureDetector = null;
-                tapGestureDetector?.Dispose();
-                tapGestureDetector = null;
-                rotationGestureDetector?.Dispose();
-                rotationGestureDetector = null;
+                _viewGestureData?.Clear();
 
                 internalCurrentParentOrigin?.Dispose();
                 internalCurrentParentOrigin = null;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1378,7 +1378,7 @@ namespace Tizen.NUI.BaseComponents
                 internalSize2D?.Dispose();
                 internalSize2D = null;
 
-                _viewGestureData?.Clear();
+                GetViewGestureData()?.Clear();
 
                 internalCurrentParentOrigin?.Dispose();
                 internalCurrentParentOrigin = null;

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1296,7 +1296,7 @@ namespace Tizen.NUI.BaseComponents
 
         internal void SetThemeApplied()
         {
-            if (themeData == null) themeData = new ThemeData();
+            var themeData = EnsureThemeData();
             themeData.ThemeApplied = true;
 
             if (ThemeChangeSensitive && !themeData.ListeningThemeChangeEvent)
@@ -1427,6 +1427,7 @@ namespace Tizen.NUI.BaseComponents
                     }
                 }
 
+                var themeData = GetThemeData();
                 if (themeData != null)
                 {
                     themeData.selectorData?.Reset(this);
@@ -1769,7 +1770,7 @@ namespace Tizen.NUI.BaseComponents
 
         private ViewSelectorData EnsureSelectorData()
         {
-            if (themeData == null) themeData = new ThemeData();
+            var themeData = EnsureThemeData();
 
             return themeData.selectorData ?? (themeData.selectorData = new ViewSelectorData());
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1524,7 +1524,7 @@ namespace Tizen.NUI.BaseComponents
                 {
                     State = View.States.Normal;
                 }
-                if (enableControlState)
+                if (_viewFlags.HasFlag(ViewFlags.EnableControlState))
                 {
                     ControlState -= ControlState.Disabled;
                 }
@@ -1532,7 +1532,7 @@ namespace Tizen.NUI.BaseComponents
             else
             {
                 State = View.States.Disabled;
-                if (enableControlState)
+                if (_viewFlags.HasFlag(ViewFlags.EnableControlState))
                 {
                     ControlState += ControlState.Disabled;
                 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1544,6 +1544,8 @@ namespace Tizen.NUI.BaseComponents
             NUILog.Debug($"[Dispose] View.DisConnectFromSignals() type:{GetType()} copyNativeHandle:{GetBaseHandleCPtrHandleRef.Handle.ToString("X8")}");
             NUILog.Debug($"[Dispose] ID:{Interop.Actor.GetId(GetBaseHandleCPtrHandleRef)} Name:{Interop.Actor.GetName(GetBaseHandleCPtrHandleRef)}");
 
+            _viewEventRareData?.ClearSignal();
+
             if (onRelayoutEventCallback != null)
             {
                 NUILog.Debug($"[Dispose] onRelayoutEventCallback");
@@ -1571,23 +1573,6 @@ namespace Tizen.NUI.BaseComponents
                 onWindowEventCallback = null;
             }
 
-            if (interceptWheelCallback != null)
-            {
-                NUILog.Debug($"[Dispose] interceptWheelCallback");
-
-                Interop.ActorSignal.InterceptWheelDisconnect(GetBaseHandleCPtrHandleRef, interceptWheelCallback.ToHandleRef(this));
-                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
-                interceptWheelCallback = null;
-            }
-
-            if (wheelEventCallback != null)
-            {
-                NUILog.Debug($"[Dispose] wheelEventCallback");
-
-                Interop.ActorSignal.WheelEventDisconnect(GetBaseHandleCPtrHandleRef, wheelEventCallback.ToHandleRef(this));
-                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
-                wheelEventCallback = null;
-            }
 
             if (hoverEventCallback != null)
             {
@@ -1598,15 +1583,6 @@ namespace Tizen.NUI.BaseComponents
                 hoverEventCallback = null;
             }
 
-            if (hitTestResultDataCallback != null)
-            {
-                NUILog.Debug($"[Dispose] hitTestResultDataCallback");
-
-                Interop.ActorSignal.HitTestResultDisconnect(GetBaseHandleCPtrHandleRef, hitTestResultDataCallback.ToHandleRef(this));
-                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
-                hitTestResultDataCallback = null;
-            }
-
             if (visibilityChangedEventCallback != null)
             {
                 NUILog.Debug($"[Dispose] visibilityChangedEventCallback");
@@ -1614,24 +1590,6 @@ namespace Tizen.NUI.BaseComponents
                 Interop.ActorSignal.VisibilityChangedDisconnect(SwigCPtr, visibilityChangedEventCallback.ToHandleRef(this));
                 NDalicPINVOKE.ThrowExceptionIfExists();
                 visibilityChangedEventCallback = null;
-            }
-
-            if (interceptTouchDataCallback != null)
-            {
-                NUILog.Debug($"[Dispose] interceptTouchDataCallback");
-
-                Interop.ActorSignal.InterceptTouchDisconnect(GetBaseHandleCPtrHandleRef, interceptTouchDataCallback.ToHandleRef(this));
-                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
-                interceptTouchDataCallback = null;
-            }
-
-            if (layoutDirectionChangedEventCallback != null)
-            {
-                NUILog.Debug($"[Dispose] layoutDirectionChangedEventCallback");
-
-                Interop.ActorSignal.LayoutDirectionChangedDisconnect(SwigCPtr, layoutDirectionChangedEventCallback.ToHandleRef(this));
-                NDalicPINVOKE.ThrowExceptionIfExists();
-                layoutDirectionChangedEventCallback = null;
             }
 
             if (touchDataCallback != null)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewLiteProperty.cs
@@ -22,7 +22,7 @@ namespace Tizen.NUI.BaseComponents
         /// NOTE This can replace SetBackgroundColor(NUI.Color) after sufficient verification
         internal void SetBackgroundColor(UIColor color)
         {
-            themeData?.selectorData?.ClearBackground(this);
+            GetThemeData()?.selectorData?.ClearBackground(this);
 
             // Background property will be Color after now. Remove background image url information.
             backgroundImageUrl = null;
@@ -53,7 +53,7 @@ namespace Tizen.NUI.BaseComponents
         /// NOTE This can replace SetInternalBoxShadowProperty() after sufficient verification
         internal void SetBoxShadow(UIShadow shadow)
         {
-            themeData?.selectorData?.ClearShadow(this);
+            GetThemeData()?.selectorData?.ClearShadow(this);
 
             backgroundExtraDataUpdatedFlag &= ~BackgroundExtraDataUpdatedFlag.Shadow;
 

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -966,15 +966,7 @@ namespace Tizen.NUI.BaseComponents
         /// This is a hidden API(inhouse API) only for internal purpose.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void RegisterHitTestCallback()
-        {
-            if (hitTestResultDataCallback == null)
-            {
-                hitTestResultDataCallback = OnHitTestResult;
-                Interop.ActorSignal.HitTestResultConnect(SwigCPtr, hitTestResultDataCallback.ToHandleRef(this));
-                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
-            }
-        }
+        protected void RegisterHitTestCallback() => EnsureViewEventRareData().RegisterHitTestCallback(OnHitTestResult);
 
         /// <summary>
         /// Unregister custom HitTest function.
@@ -983,15 +975,7 @@ namespace Tizen.NUI.BaseComponents
         /// This is a hidden API(inhouse API) only for internal purpose.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void UnregisterHitTestCallback()
-        {
-            if (hitTestResultDataCallback != null)
-            {
-                Interop.ActorSignal.HitTestResultDisconnect(SwigCPtr, hitTestResultDataCallback.ToHandleRef(this));
-                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
-                hitTestResultDataCallback = null;
-            }
-        }
+        protected void UnregisterHitTestCallback() => _viewEventRareData?.UnregisterHitTestCallback();
 
         /// <summary>
         /// Calculate the screen position of the view.<br />


### PR DESCRIPTION
### Description of Change ###

#### Move rarely used fields to the separate object
* Fields moved to `ViewGestureData`
  * panGestureDetector
  * longGestureDetector
  * pinchGestureDetector
  * tapGestureDetector
  * rotationGestureDetector
* Fields moved to `ViewEventRareData`
  * interceptWheelHandler
  * interceptWheelCallback
  * wheelEventHandler
  * wheelEventCallback
  * interceptTouchDataEventHandler
  * interceptTouchDataCallback
  * layoutDirectionChangedEventHandler
  * layoutDirectionChangedEventCallback
  * hitTestResultDataCallback

#### Combine boolean type fields to enum flag of int32
* dispatchTouchEvents
* dispatchParentTouchEvents
* dispatchHoverEvents
* dispatchParentHoverEvents
* dispatchWheelEvents
* dispatchParentWheelEvents
* dispatchGestureEvents
* dispatchParentGestureEvents
* DisallowInterceptTouchEvent
* DisallowInterceptWheelEvent
* isThemeChanged
* backgroundImageSynchronousLoading
* enableControlState

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
