### PR TITLE
[Tizen.System.Session] Fix native struct marshaling bug

### DIFF
--- a/src/Tizen.System.Session/Interop/Interop.Session.cs
+++ b/src/Tizen.System.Session/Interop/Interop.Session.cs
@@ -27,7 +27,7 @@ internal static partial class Interop
         public delegate void SubsessionReplyCallback(int result, IntPtr cb_data);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void SubsessionEventCallback(IntPtr info, IntPtr cb_data);
+        public delegate void SubsessionEventCallback(SubsessionEventInfoNative info, IntPtr cb_data);
 
         [DllImport(Libraries.Session, EntryPoint = "subsession_add_user", CallingConvention = CallingConvention.Cdecl)]
         public static extern SessionError SubsessionAddUser(int session_uid, string user, SubsessionReplyCallback cb, IntPtr data);

--- a/src/Tizen.System.Session/Session/Session.cs
+++ b/src/Tizen.System.Session/Session/Session.cs
@@ -57,7 +57,7 @@ namespace Tizen.System
 
         private int _replyID = 0;
 
-        private delegate void EventDelegate(IntPtr infoNative, IntPtr data);
+        private delegate void EventDelegate(SubsessionEventInfoNative infoNative, IntPtr data);
 
         static Session()
         {
@@ -75,7 +75,7 @@ namespace Tizen.System
         /// <param name="sessionUID">Session UID of a requested Session object instance</param>
         /// <returns>Returns requested Session object</returns>
         /// <remarks>
-        /// To ensure thread safety, expilicit creation of Session object is not allowed.
+        /// To ensure thread safety, explicit creation of Session object is not allowed.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static Session GetInstance(int sessionUID)
@@ -92,7 +92,7 @@ namespace Tizen.System
         public int SessionUID { get; private set; }
 
         /// <summary>
-        /// Gets a list of all availible subsession user IDs for this session.
+        /// Gets a list of all available subsession user IDs for this session.
         /// </summary>
         /// <remarks>
         /// The list of users depends on whether the session UID for this session object exists or not. If it
@@ -296,10 +296,10 @@ namespace Tizen.System
         public void SubsessionEventMarkAsDone(SubsessionEventArgs subsessionEventArgs)
         {
             SessionError ret = Interop.Session.SubsessionEventWaitDone(subsessionEventArgs.SessionInfo);
-            CheckError(ret, $"Interop failed to mark this client's event (of type {subsessionEventArgs.SessionInfo.eventType}) as finished");
+            CheckError(ret, $"Interop failed to mark this client's event (of type {subsessionEventArgs.SessionInfo.EventType}) as finished");
         }
 
-        private void OnAddUserWait(IntPtr infoNative, IntPtr data)
+        private void OnAddUserWait(SubsessionEventInfoNative infoNative, IntPtr data)
         {
             _addUserWaitHandler?.Invoke(this, new AddUserEventArgs(infoNative));
         }
@@ -341,7 +341,7 @@ namespace Tizen.System
             }
         }
 
-        private void OnRemoveUserWait(IntPtr infoNative, IntPtr data)
+        private void OnRemoveUserWait(SubsessionEventInfoNative infoNative, IntPtr data)
         {
             _removeUserWaitHandler?.Invoke(this, new RemoveUserEventArgs(infoNative));
         }
@@ -383,7 +383,7 @@ namespace Tizen.System
             }
         }
 
-        private void OnSwitchUserWait(IntPtr infoNative, IntPtr data)
+        private void OnSwitchUserWait(SubsessionEventInfoNative infoNative, IntPtr data)
         {
             _switchUserWaitHandler?.Invoke(this, new SwitchUserWaitEventArgs(infoNative));
         }
@@ -425,7 +425,7 @@ namespace Tizen.System
             }
         }
 
-        private void OnSwitchUserCompletion(IntPtr infoNative, IntPtr data)
+        private void OnSwitchUserCompletion(SubsessionEventInfoNative infoNative, IntPtr data)
         {
             _switchUserCompletionHandler?.Invoke(this, new SwitchUserCompletionEventArgs(infoNative));
         }
@@ -485,7 +485,7 @@ namespace Tizen.System
 
         static void IntPtrToStringArray(IntPtr unmanagedArray, int size, out string[] managedArray)
         {
-            managedArray = new string[size]; 
+            managedArray = new string[size];
             var curr = unmanagedArray;
 
             for (int iterator = 0; iterator < size; iterator++)

--- a/src/Tizen.System.Session/Session/SessionEventArgs.cs
+++ b/src/Tizen.System.Session/Session/SessionEventArgs.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.ComponentModel;
-using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Tizen.System
 {
@@ -39,15 +39,16 @@ namespace Tizen.System
 
         internal SubsessionEventInfoNative SessionInfo { get; set; }
 
-        internal SubsessionEventArgs(IntPtr infoNativePtr)
+        internal SubsessionEventArgs(SubsessionEventInfoNative eventInfo)
         {
-            SessionInfo = (SubsessionEventInfoNative)Marshal.PtrToStructure(infoNativePtr, typeof(SubsessionEventInfoNative));
-            SessionUID = SessionInfo.sessionUID;
+            SessionUID = eventInfo.SessionUID;
+            SessionInfo = eventInfo;
         }
+
     }
 
     /// <summary>
-    /// An event arguemnt type for AddUserWait event type
+    /// An event argument type for AddUserWait event type
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class AddUserEventArgs : SubsessionEventArgs
@@ -58,15 +59,21 @@ namespace Tizen.System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string UserName { get; internal set; }
 
-        internal AddUserEventArgs(IntPtr infoNativePtr)
-            : base(infoNativePtr)
+        internal AddUserEventArgs(SubsessionEventInfoNative eventInfo)
+            : base(eventInfo)
         {
-            UserName = Marshal.PtrToStringAnsi(IntPtr.Add(infoNativePtr, 8), 20);
+            unsafe
+            {
+                UserName = Encoding.ASCII
+                    .GetString(eventInfo.Union.AddUser.UserName, Session.MaxUserLength)
+                    .TrimEnd('\0');
+            }
         }
+
     }
 
     /// <summary>
-    /// An event arguemnt type for RemoveUserWait event type
+    /// An event argument type for RemoveUserWait event type
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class RemoveUserEventArgs : SubsessionEventArgs
@@ -77,10 +84,15 @@ namespace Tizen.System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string UserName { get; internal set; }
 
-        internal RemoveUserEventArgs(IntPtr infoNativePtr)
-            : base(infoNativePtr)
+        internal RemoveUserEventArgs(SubsessionEventInfoNative eventInfo)
+            : base(eventInfo)
         {
-            UserName = Marshal.PtrToStringAnsi(IntPtr.Add(infoNativePtr, 8), 20);
+            unsafe
+            {
+                UserName = Encoding.ASCII
+                    .GetString(eventInfo.Union.RemoveUser.UserName, Session.MaxUserLength)
+                    .TrimEnd('\0');
+            }
         }
     }
 
@@ -108,30 +120,39 @@ namespace Tizen.System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string UserNameNext { get; internal set; }
 
-        internal SwitchUserEventArgs(IntPtr infoNativePtr)
-            : base(infoNativePtr)
+        internal SwitchUserEventArgs(SubsessionEventInfoNative eventInfo)
+            : base(eventInfo)
         {
-            SwitchID = SessionInfo.switchID;
-            UserNamePrev = Marshal.PtrToStringAnsi(IntPtr.Add(infoNativePtr, 16), 20);
-            UserNameNext = Marshal.PtrToStringAnsi(IntPtr.Add(infoNativePtr, 36), 20);
+            SwitchID = eventInfo.Union.SwitchUser.SwitchID;
+
+            unsafe
+            {
+                UserNamePrev = Encoding.ASCII
+                    .GetString(eventInfo.Union.SwitchUser.UserNamePrev, Session.MaxUserLength)
+                    .TrimEnd('\0');
+
+                UserNameNext = Encoding.ASCII
+                    .GetString(eventInfo.Union.SwitchUser.UserNameNext, Session.MaxUserLength)
+                    .TrimEnd('\0');
+            }
         }
     }
 
     /// <summary>
-    /// An event arguemnt type for SwitchUserWait event type
+    /// An event argument type for SwitchUserWait event type
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class SwitchUserWaitEventArgs : SwitchUserEventArgs
     {
-        internal SwitchUserWaitEventArgs(IntPtr infoNativePtr) : base(infoNativePtr) { }
+        internal SwitchUserWaitEventArgs(SubsessionEventInfoNative eventInfo) : base(eventInfo) { }
     }
 
     /// <summary>
-    /// An event arguemnt type for SwitchUserCompleted event type
+    /// An event argument type for SwitchUserCompleted event type
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class SwitchUserCompletionEventArgs : SwitchUserEventArgs
     {
-        internal SwitchUserCompletionEventArgs(IntPtr infoNativePtr) : base(infoNativePtr) { }
+        internal SwitchUserCompletionEventArgs(SubsessionEventInfoNative eventInfo) : base(eventInfo) { }
     }
 }

--- a/src/Tizen.System.Session/Session/SessionStructs.cs
+++ b/src/Tizen.System.Session/Session/SessionStructs.cs
@@ -22,31 +22,47 @@ using Tizen.Internals;
 
 namespace Tizen.System
 {
-    [NativeStruct("subsession_event_info", Include="sessiond.h", PkgConfig="libsessiond")]
-    [StructLayout(LayoutKind.Explicit)]
+    [NativeStruct("subsession_event_info", Include = "sessiond.h", PkgConfig = "libsessiond")]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     internal struct SubsessionEventInfoNative
     {
+        public SessionEventType EventType;
+
+        public int SessionUID;
+
+        public EventInfoUnion Union;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Pack = 1)]
+    internal struct EventInfoUnion
+    {
         [FieldOffset(0)]
-        public SessionEventType eventType;
-        [FieldOffset(4)]
-        public int sessionUID;
+        public AddUserInfo AddUser;
+        [FieldOffset(0)]
+        public RemoveUserInfo RemoveUser;
+        [FieldOffset(0)]
+        public SwitchUserInfo SwitchUser;
+    }
 
-        [FieldOffset(8)]
-        public Int64 switchID;
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal unsafe struct AddUserInfo
+    {
+        public fixed byte UserName[Session.MaxUserLength];
+    }
 
-        /// The following 4 fields are here just for the record and for the NativeStruct validation
-        /// which is performed as one of the steps during build with GBS.
-        /// However, we've verified that representing the whole structure as IntPtr and accessing
-        /// individual string fields with PtrToStructure with and PtrToStringAnsi + IntPtr.Add is
-        /// the only way to make it work. That's why we do not use these fields and they shouldn't
-        /// be accessed directly.
-        [FieldOffset(8)]
-        private IntPtr AddUserPtr;
-        [FieldOffset(8)]
-        private IntPtr RemoveUserPtr;
-        [FieldOffset(16)]
-        private IntPtr PrevUserPtr;
-        [FieldOffset(36)]
-        private IntPtr NextUserPtr;
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal unsafe struct RemoveUserInfo
+    {
+        public fixed byte UserName[Session.MaxUserLength];
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal unsafe struct SwitchUserInfo
+    {
+        public long SwitchID;
+
+        public fixed byte UserNamePrev[Session.MaxUserLength];
+
+        public fixed byte UserNameNext[Session.MaxUserLength];
     }
 }


### PR DESCRIPTION
### Description of Change ###
On 32-bit system past implementation of `SubsessionEventInfoNative` caused a crash due to misalignment with the native struct. 
The struct now uses fixed size buffers. Some `unsafe` blocks are added, but we can be certain the buffer and struct size will be constant on native side.

Some typos in docs were fixed along the way.

### API Changes ###
 - ACR:
No API changes.
