### PR TITLE
[NUI] Make NUI.Samples use its own binder lib.

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.NDalic.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.NDalic.cs
@@ -98,9 +98,6 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_LowerBelow")]
             public static extern void LowerBelow(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_NewItemLayout")]
-            public static extern global::System.IntPtr NewItemLayout(int jarg1);
-
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_SetCustomAlgorithm")]
             public static extern void SetCustomAlgorithm(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.CubeTransitionEffect.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.CubeTransitionEffect.cs
@@ -21,96 +21,95 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class CubeTransitionEffect
         {
-
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CubeTransitionEffect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_CubeTransitionEffect")]
             public static extern global::System.IntPtr NewCubeTransitionEffect();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CubeTransitionEffect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_CubeTransitionEffect")]
             public static extern void DeleteCubeTransitionEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetTransitionDuration")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetTransitionDuration")]
             public static extern void SetTransitionDuration(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_GetTransitionDuration")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_GetTransitionDuration")]
             public static extern float GetTransitionDuration(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetCubeDisplacement")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetCubeDisplacement")]
             public static extern void SetCubeDisplacement(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_GetCubeDisplacement")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_GetCubeDisplacement")]
             public static extern float GetCubeDisplacement(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_IsTransitioning")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_IsTransitioning")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsTransitioning(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetCurrentTexture")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetCurrentTexture")]
             public static extern void SetCurrentTexture(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetTargetTexture")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_SetTargetTexture")]
             public static extern void SetTargetTexture(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_StartTransition__SWIG1")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_StartTransition__SWIG1")]
             public static extern void StartTransitionSwig1(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_StartTransition__SWIG2")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_StartTransition__SWIG2")]
             public static extern void StartTransitionSwig2(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_PauseTransition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_PauseTransition")]
             public static extern void PauseTransition(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_ResumeTransition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_ResumeTransition")]
             public static extern void ResumeTransition(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_StopTransition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_StopTransition")]
             public static extern void StopTransition(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_TransitionCompletedSignal")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffect_TransitionCompletedSignal")]
             public static extern global::System.IntPtr TransitionCompletedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_Empty")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_Empty")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool CubeTransitionEffectSignalEmpty(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_GetConnectionCount")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_GetConnectionCount")]
             public static extern uint CubeTransitionEffectSignalGetConnectionCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_Connect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_Connect")]
             public static extern void CubeTransitionEffectSignalConnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_Disconnect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionEffectSignal_Disconnect")]
             public static extern void CubeTransitionEffectSignalDisconnect(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_CubeTransitionEffectSignal")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_CubeTransitionEffectSignal")]
             public static extern global::System.IntPtr NewCubeTransitionEffectSignal();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CubeTransitionEffectSignal")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_CubeTransitionEffectSignal")]
             public static extern void DeleteCubeTransitionEffectSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
 
         internal static partial class CubeTransitionWaveEffect
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionWaveEffect_New")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionWaveEffect_New")]
             public static extern global::System.IntPtr New(uint numRows, uint numColumns);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CubeTransitionWaveEffect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_CubeTransitionWaveEffect")]
             public static extern void DeleteCubeTransitionWaveEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
 
         internal static partial class CubeTransitionCrossEffect
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionCrossEffect_New")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionCrossEffect_New")]
             public static extern global::System.IntPtr New(uint numRows, uint numColumns);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CubeTransitionCrossEffect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_CubeTransitionCrossEffect")]
             public static extern void DeleteCubeTransitionCrossEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
         internal static partial class CubeTransitionFoldEffect
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_CubeTransitionFoldEffect_New")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_CubeTransitionFoldEffect_New")]
             public static extern global::System.IntPtr New(uint numRows, uint numColumns);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_CubeTransitionFoldEffect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_CubeTransitionFoldEffect")]
             public static extern void DeleteCubeTransitionFoldEffect(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.Item.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.Item.cs
@@ -21,28 +21,28 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class Item
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Item__SWIG_0")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_Item__SWIG_0")]
             public static extern global::System.IntPtr NewItem();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Item__SWIG_1")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_Item__SWIG_1")]
             public static extern global::System.IntPtr NewItem(uint jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_Item__SWIG_2")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_Item__SWIG_2")]
             public static extern global::System.IntPtr NewItem(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Item_first_set")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_Item_first_set")]
             public static extern void FirstSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Item_first_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_Item_first_get")]
             public static extern uint FirstGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Item_second_set")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_Item_second_set")]
             public static extern void SecondSet(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Item_second_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_Item_second_get")]
             public static extern global::System.IntPtr SecondGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Item")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_Item")]
             public static extern void DeleteItem(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemContainer.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemContainer.cs
@@ -21,70 +21,70 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class ItemContainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_Clear")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_Clear")]
             public static extern void Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_Add")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_Add")]
             public static extern void Add(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_size")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_size")]
             public static extern uint size(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_capacity")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_capacity")]
             public static extern uint capacity(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_reserve")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_reserve")]
             public static extern void reserve(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemContainer__SWIG_0")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemContainer__SWIG_0")]
             public static extern global::System.IntPtr NewItemContainer();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemContainer__SWIG_1")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemContainer__SWIG_1")]
             public static extern global::System.IntPtr NewItemContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemContainer__SWIG_2")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemContainer__SWIG_2")]
             public static extern global::System.IntPtr NewItemContainer(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_getitemcopy")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_getitemcopy")]
             public static extern global::System.IntPtr getitemcopy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_getitem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_getitem")]
             public static extern global::System.IntPtr getitem(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_setitem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_setitem")]
             public static extern void setitem(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_AddRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_AddRange")]
             public static extern void AddRange(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_GetRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_GetRange")]
             public static extern global::System.IntPtr GetRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_Insert")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_Insert")]
             public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_InsertRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_InsertRange")]
             public static extern void InsertRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_RemoveAt")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_RemoveAt")]
             public static extern void RemoveAt(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_RemoveRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_RemoveRange")]
             public static extern void RemoveRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_Repeat")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_Repeat")]
             public static extern global::System.IntPtr Repeat(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_Reverse__SWIG_0")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_Reverse__SWIG_0")]
             public static extern void Reverse(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_Reverse__SWIG_1")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_Reverse__SWIG_1")]
             public static extern void Reverse(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemContainer_SetRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemContainer_SetRange")]
             public static extern void SetRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ItemContainer")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_ItemContainer")]
             public static extern void DeleteItemContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemFactory.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemFactory.cs
@@ -21,25 +21,25 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class ItemFactory
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ItemFactory")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_ItemFactory")]
             public static extern void DeleteItemFactory(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemFactory_GetNumberOfItems")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemFactory_GetNumberOfItems")]
             public static extern uint GetNumberOfItems(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemFactory_NewItem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemFactory_NewItem")]
             public static extern global::System.IntPtr NewItem(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemFactory_ItemReleased")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemFactory_ItemReleased")]
             public static extern void ItemReleased(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemFactory_ItemReleasedSwigExplicitItemFactory")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemFactory_ItemReleasedSwigExplicitItemFactory")]
             public static extern void ItemReleasedSwigExplicitItemFactory(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemFactory")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemFactory")]
             public static extern global::System.IntPtr NewItemFactory();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemFactory_director_connect")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemFactory_director_connect")]
             public static extern void DirectorConnect(global::System.Runtime.InteropServices.HandleRef jarg1, Tizen.NUI.Samples.ItemFactory.SwigDelegateItemFactory0 delegate0,
                 Tizen.NUI.Samples.ItemFactory.SwigDelegateItemFactory1 delegate1, Tizen.NUI.Samples.ItemFactory.SwigDelegateItemFactory2 delegate2);
         }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemIdContainer.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemIdContainer.cs
@@ -21,84 +21,84 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class ItemIdContainer
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Clear")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Clear")]
             public static extern void Clear(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Add")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Add")]
             public static extern void Add(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_size")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_size")]
             public static extern uint size(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_capacity")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_capacity")]
             public static extern uint capacity(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_reserve")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_reserve")]
             public static extern void reserve(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemIdContainer__SWIG_0")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemIdContainer__SWIG_0")]
             public static extern global::System.IntPtr NewItemIdContainer();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemIdContainer__SWIG_1")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemIdContainer__SWIG_1")]
             public static extern global::System.IntPtr NewItemIdContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemIdContainer__SWIG_2")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemIdContainer__SWIG_2")]
             public static extern global::System.IntPtr NewItemIdContainer(int jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_getitemcopy")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_getitemcopy")]
             public static extern uint getitemcopy(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_getitem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_getitem")]
             public static extern uint getitem(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_setitem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_setitem")]
             public static extern void setitem(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_AddRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_AddRange")]
             public static extern void AddRange(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_GetRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_GetRange")]
             public static extern global::System.IntPtr GetRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Insert")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Insert")]
             public static extern void Insert(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, uint jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_InsertRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_InsertRange")]
             public static extern void InsertRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_RemoveAt")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_RemoveAt")]
             public static extern void RemoveAt(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_RemoveRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_RemoveRange")]
             public static extern void RemoveRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Repeat")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Repeat")]
             public static extern global::System.IntPtr Repeat(uint jarg1, int jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Reverse__SWIG_0")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Reverse__SWIG_0")]
             public static extern void Reverse(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Reverse__SWIG_1")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Reverse__SWIG_1")]
             public static extern void Reverse(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_SetRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_SetRange")]
             public static extern void SetRange(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Contains")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Contains")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool Contains(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_IndexOf")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_IndexOf")]
             public static extern int IndexOf(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_LastIndexOf")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_LastIndexOf")]
             public static extern int LastIndexOf(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemIdContainer_Remove")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemIdContainer_Remove")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool Remove(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ItemIdContainer")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_ItemIdContainer")]
             public static extern void DeleteItemIdContainer(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemLayout.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemLayout.cs
@@ -21,64 +21,64 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class ItemLayout
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ItemLayout")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_ItemLayout")]
             public static extern void DeleteItemLayout(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_SetLayoutProperties")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_SetLayoutProperties")]
             public static extern void SetLayoutProperties(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetLayoutProperties")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetLayoutProperties")]
             public static extern global::System.IntPtr GetLayoutProperties(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemSize")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemSize")]
             public static extern void GetItemSize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_SetItemSize")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_SetItemSize")]
             public static extern void SetItemSize(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetMinimumLayoutPosition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetMinimumLayoutPosition")]
             public static extern float GetMinimumLayoutPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetClosestAnchorPosition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetClosestAnchorPosition")]
             public static extern float GetClosestAnchorPosition(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemScrollToPosition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemScrollToPosition")]
             public static extern float GetItemScrollToPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemsWithinArea")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemsWithinArea")]
             public static extern global::System.IntPtr GetItemsWithinArea(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetClosestOnScreenLayoutPosition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetClosestOnScreenLayoutPosition")]
             public static extern float GetClosestOnScreenLayoutPosition(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, float jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetReserveItemCount")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetReserveItemCount")]
             public static extern uint GetReserveItemCount(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetDefaultItemSize")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetDefaultItemSize")]
             public static extern void GetDefaultItemSize(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetScrollDirection")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetScrollDirection")]
             public static extern global::System.IntPtr GetScrollDirection(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetScrollSpeedFactor")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetScrollSpeedFactor")]
             public static extern float GetScrollSpeedFactor(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetMaximumSwipeSpeed")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetMaximumSwipeSpeed")]
             public static extern float GetMaximumSwipeSpeed(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemFlickAnimationDuration")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemFlickAnimationDuration")]
             public static extern float GetItemFlickAnimationDuration(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetNextFocusItemID")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetNextFocusItemID")]
             public static extern int GetNextFocusItemID(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, int jarg3, int jarg4, bool jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetFlickSpeedFactor")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetFlickSpeedFactor")]
             public static extern float GetFlickSpeedFactor(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_ApplyConstraints")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_ApplyConstraints")]
             public static extern void ApplyConstraints(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, int jarg3, global::System.Runtime.InteropServices.HandleRef jarg4, global::System.Runtime.InteropServices.HandleRef jarg5);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemPosition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemLayout_GetItemPosition")]
             public static extern global::System.IntPtr GetItemPosition(global::System.Runtime.InteropServices.HandleRef jarg1, int jarg2, float jarg3, global::System.Runtime.InteropServices.HandleRef jarg4);
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemRange.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemRange.cs
@@ -21,35 +21,35 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class ItemRange
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemRange__SWIG_0")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemRange__SWIG_0")]
             public static extern global::System.IntPtr NewItemRange(uint jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_new_ItemRange__SWIG_1")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_new_ItemRange__SWIG_1")]
             public static extern global::System.IntPtr NewItemRange(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemRange_Assign")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemRange_Assign")]
             public static extern global::System.IntPtr Assign(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemRange_Within")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemRange_Within")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool Within(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemRange_Intersection")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemRange_Intersection")]
             public static extern global::System.IntPtr Intersection(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemRange_begin_set")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemRange_begin_set")]
             public static extern void BeginSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemRange_begin_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemRange_begin_get")]
             public static extern uint BeginGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemRange_end_set")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemRange_end_set")]
             public static extern void EndSet(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemRange_end_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemRange_end_get")]
             public static extern uint EndGet(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ItemRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_ItemRange")]
             public static extern void DeleteItemRange(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemView.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/Interop.ItemView.cs
@@ -21,131 +21,131 @@ namespace Tizen.NUI.Samples
     {
         internal static partial class ItemView
         {
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_MINIMUM_SWIPE_SPEED_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_MINIMUM_SWIPE_SPEED_get")]
             public static extern int MinimumSwipeSpeedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_MINIMUM_SWIPE_DISTANCE_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_MINIMUM_SWIPE_DISTANCE_get")]
             public static extern int MinimumSwipeDistanceGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_WHEEL_SCROLL_DISTANCE_STEP_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_WHEEL_SCROLL_DISTANCE_STEP_get")]
             public static extern int WheelScrollDistanceStepGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_SNAP_TO_ITEM_ENABLED_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_SNAP_TO_ITEM_ENABLED_get")]
             public static extern int SnapToItemEnabledGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_REFRESH_INTERVAL_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_REFRESH_INTERVAL_get")]
             public static extern int RefreshIntervalGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_LAYOUT_POSITION_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_LAYOUT_POSITION_get")]
             public static extern int LayoutPositionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_SCROLL_SPEED_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_SCROLL_SPEED_get")]
             public static extern int ScrollSpeedGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_OVERSHOOT_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_OVERSHOOT_get")]
             public static extern int OvershootGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_SCROLL_DIRECTION_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_SCROLL_DIRECTION_get")]
             public static extern int ScrollDirectionGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_LAYOUT_ORIENTATION_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_LAYOUT_ORIENTATION_get")]
             public static extern int LayoutOrientationGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Property_SCROLL_CONTENT_SIZE_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Property_SCROLL_CONTENT_SIZE_get")]
             public static extern int ScrollContentSizeGet();
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_ItemView")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_delete_ItemView")]
             public static extern void DeleteItemView(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_New")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_New")]
             public static extern global::System.IntPtr New(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetLayoutCount")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetLayoutCount")]
             public static extern uint GetLayoutCount(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_AddLayout")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_AddLayout")]
             public static extern void AddLayout(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_RemoveLayout")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_RemoveLayout")]
             public static extern void RemoveLayout(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetLayout")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetLayout")]
             public static extern global::System.IntPtr GetLayout(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetActiveLayout")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetActiveLayout")]
             public static extern global::System.IntPtr GetActiveLayout(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetCurrentLayoutPosition")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetCurrentLayoutPosition")]
             public static extern float GetCurrentLayoutPosition(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_ActivateLayout")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_ActivateLayout")]
             public static extern void ActivateLayout(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, global::System.Runtime.InteropServices.HandleRef jarg3, float jarg4);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_DeactivateCurrentLayout")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_DeactivateCurrentLayout")]
             public static extern void DeactivateCurrentLayout(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_SetAnchoring")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_SetAnchoring")]
             public static extern void SetAnchoring(global::System.Runtime.InteropServices.HandleRef jarg1, bool jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetAnchoring")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetAnchoring")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool GetAnchoring(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_SetAnchoringDuration")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_SetAnchoringDuration")]
             public static extern void SetAnchoringDuration(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetAnchoringDuration")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetAnchoringDuration")]
             public static extern float GetAnchoringDuration(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_ScrollToItem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_ScrollToItem")]
             public static extern void ScrollToItem(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_Refresh")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_Refresh")]
             public static extern void Refresh(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetItem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetItem")]
             public static extern global::System.IntPtr GetItem(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetItemId")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetItemId")]
             public static extern uint GetItemId(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_InsertItem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_InsertItem")]
             public static extern void InsertItem(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_InsertItems")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_InsertItems")]
             public static extern void InsertItems(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_RemoveItem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_RemoveItem")]
             public static extern void RemoveItem(global::System.Runtime.InteropServices.HandleRef jarg1, uint jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_RemoveItems")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_RemoveItems")]
             public static extern void RemoveItems(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_ReplaceItem")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_ReplaceItem")]
             public static extern void ReplaceItem(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_ReplaceItems")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_ReplaceItems")]
             public static extern void ReplaceItems(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, float jarg3);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_SetItemsParentOrigin")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_SetItemsParentOrigin")]
             public static extern void SetItemsParentOrigin(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetItemsParentOrigin")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetItemsParentOrigin")]
             public static extern global::System.IntPtr GetItemsParentOrigin(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_SetItemsAnchorPoint")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_SetItemsAnchorPoint")]
             public static extern void SetItemsAnchorPoint(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetItemsAnchorPoint")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetItemsAnchorPoint")]
             public static extern global::System.IntPtr GetItemsAnchorPoint(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_GetItemsRange")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_GetItemsRange")]
             public static extern void GetItemsRange(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_ItemView_LayoutActivatedSignal")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_Dali_ItemView_LayoutActivatedSignal")]
             public static extern global::System.IntPtr LayoutActivatedSignal(global::System.Runtime.InteropServices.HandleRef jarg1);
 
-            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_ItemView_Property_LAYOUT_get")]
+            [global::System.Runtime.InteropServices.DllImport(SamplesNDalicPINVOKE.ToolkitDemoLib, EntryPoint = "CSharp_ItemView_Property_LAYOUT_get")]
             public static extern int LayoutGet();
         }
     }

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/NDalicPINVOKE.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Interop/NDalicPINVOKE.cs
@@ -1,10 +1,24 @@
-﻿#if false
-#error
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Tizen.NUI.Samples
 {
-    internal class NDalicPINVOKE
+    internal class SamplesNDalicPINVOKE
     {
-        public const string Lib = "libdali2-csharp-binder.so";
+        public const string ToolkitDemoLib = "libdali2-csharp-binder-toolkit-demo.so";
     }
 }
-#endif

--- a/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/NativeBinding/TSNDalic.cs
+++ b/test/Tizen.NUI.Tests/Tizen.NUI.Devel.Tests/testcase/internal/NativeBinding/TSNDalic.cs
@@ -649,23 +649,6 @@ namespace Tizen.NUI.Devel.Tests
 
         [Test]
         [Category("P1")]
-        [Description("NDalic NewItemLayout.")]
-        [Property("SPEC", "Tizen.NUI.NDalic.NewItemLayout M")]
-        [Property("SPEC_URL", "-")]
-        [Property("CRITERIA", "MR")]
-        [Property("AUTHOR", "guowei.wang@samsung.com")]
-        public void NDalicNewItemLayout()
-        {
-            tlog.Debug(tag, $"NDalicNewItemLayout START");
-
-            var result = NDalic.NewItemLayout(DefaultItemLayoutType.GRID);
-            tlog.Debug(tag, "New item layout :" + result);
-
-            tlog.Debug(tag, $"NDalicNewItemLayout END (OK)");
-        }
-
-        [Test]
-        [Category("P1")]
         [Description("NDalic GetAlphaOffsetAndMask.")]
         [Property("SPEC", "Tizen.NUI.NDalic.GetAlphaOffsetAndMask M")]
         [Property("SPEC_URL", "-")]


### PR DESCRIPTION
- Seperated ItemView & CubeTransitionEffect from NUI.
- Remove an unused Interop API CSharp_Dali_NewItemLayout.

### Description of Change ###
<!-- Describe your changes here. -->

It is related to the patch in binder side:
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/327238

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
