### PR TITLE
[NUI] Allow to dispose some Disposable class at workerthread if possible

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/AngleAxis.cs
+++ b/src/Tizen.NUI/src/internal/Common/AngleAxis.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal class AngleAxis : Disposable
     {
-        internal AngleAxis(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal AngleAxis(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/DaliException.cs
+++ b/src/Tizen.NUI/src/internal/Common/DaliException.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal class DaliException : Disposable
     {
-        internal DaliException(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal DaliException(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/Disposable.cs
+++ b/src/Tizen.NUI/src/internal/Common/Disposable.cs
@@ -42,6 +42,8 @@ namespace Tizen.NUI
         private bool swigCMemOwn { get; set; }
         private bool isDisposeQueued;
 
+        private bool _disposeOnlyMainThread;
+
         /// <summary>
         /// Create an instance of Disposable.
         /// </summary>
@@ -50,14 +52,20 @@ namespace Tizen.NUI
         {
             swigCMemOwn = false;
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero);
+            _disposeOnlyMainThread = false;
         }
 
         /// This will not be public.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Disposable(global::System.IntPtr cPtr, bool cMemoryOwn)
+        public Disposable(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, true)
+        {
+        }
+
+        internal Disposable(global::System.IntPtr cPtr, bool cMemoryOwn, bool disposableOnlyMainThread)
         {
             swigCMemOwn = cMemoryOwn;
             swigCPtr = new global::System.Runtime.InteropServices.HandleRef(this, cPtr);
+            _disposeOnlyMainThread = disposableOnlyMainThread;
         }
 
         /// <summary>
@@ -111,6 +119,22 @@ namespace Tizen.NUI
                 // TODO: dispose managed state (managed objects).
                 // Explicit call. user calls Dispose()
 
+                //Throw exception if Dispose() is called in separate thread.
+                if (DisposeOnlyMainThread && !Window.IsInstalled())
+                {
+                    using var process = global::System.Diagnostics.Process.GetCurrentProcess();
+                    var processId = process.Id;
+                    var thread = global::System.Threading.Thread.CurrentThread.ManagedThreadId;
+                    var me = this.GetType().FullName;
+
+                    Tizen.Log.Fatal("NUI", $"[NUI][Disposable] This API called from separate thread. This API must be called from MainThread. \n" +
+                        $" process:{processId} thread:{thread}, disposing:{disposing}, isDisposed:{this.disposed}, isDisposeQueued:{this.isDisposeQueued}, me:{me}\n");
+
+                    //to fix ArtApp black screen issue. this will be enabled after talking with ArtApp team and fixing it.
+                    // throw new global::System.InvalidOperationException("[NUI][Disposable] This API called from separate thread. This API must be called from MainThread. \n" +
+                    //     $" process:{process} thread:{thread}, disposing:{disposing}, isDisposed:{this.disposed}, isDisposeQueued:{this.isDisposeQueued}, me:{me}\n");
+                }
+
                 if (isDisposeQueued)
                 {
                     Tizen.Log.Fatal("NUI", $"[Disposable]should not be here! (dead code) this will be removed!");
@@ -127,10 +151,17 @@ namespace Tizen.NUI
             else
             {
                 // Implicit call. user doesn't call Dispose(), so this object is added into DisposeQueue to be disposed automatically.
-                if (!isDisposeQueued)
+                if (_disposeOnlyMainThread)
                 {
-                    isDisposeQueued = true;
-                    DisposeQueue.Instance.Add(this);
+                    if (!isDisposeQueued)
+                    {
+                        isDisposeQueued = true;
+                        DisposeQueue.Instance.Add(this);
+                    }
+                }
+                else
+                {
+                    Dispose(DisposeTypes.Implicit);
                 }
             }
 
@@ -205,6 +236,12 @@ namespace Tizen.NUI
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected internal bool IsDisposeQueued => isDisposeQueued;
+
+        /// <summary>
+        /// The flag to check if it must be disposed at main thread or not.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal bool DisposeOnlyMainThread => _disposeOnlyMainThread;
     }
 
     internal static class DisposableExtension

--- a/src/Tizen.NUI/src/internal/Common/FontDescription.cs
+++ b/src/Tizen.NUI/src/internal/Common/FontDescription.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
     internal class FontDescription : Disposable
     {
 
-        internal FontDescription(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal FontDescription(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/GlyphInfo.cs
+++ b/src/Tizen.NUI/src/internal/Common/GlyphInfo.cs
@@ -18,7 +18,7 @@ namespace Tizen.NUI
 {
     internal class GlyphInfo : Disposable
     {
-        internal GlyphInfo(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal GlyphInfo(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/Int32Pair.cs
+++ b/src/Tizen.NUI/src/internal/Common/Int32Pair.cs
@@ -26,7 +26,7 @@ namespace Tizen.NUI
     /// </summary>
     internal class Int32Pair : Disposable
     {
-        internal Int32Pair(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Int32Pair(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/StringValuePair.cs
+++ b/src/Tizen.NUI/src/internal/Common/StringValuePair.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal class StringValuePair : Disposable
     {
-        internal StringValuePair(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal StringValuePair(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/Uint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Common/Uint16Pair.cs
@@ -31,7 +31,7 @@ namespace Tizen.NUI
     internal class Uint16Pair : Disposable
     {
 
-        internal Uint16Pair(IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Uint16Pair(IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/VectorBase.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorBase.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal class VectorBase : Disposable
     {
-        internal VectorBase(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal VectorBase(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/VectorBlob.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorBlob.cs
@@ -18,7 +18,7 @@ namespace Tizen.NUI
 {
     internal class VectorBlob : Disposable
     {
-        internal VectorBlob(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal VectorBlob(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/VectorUint16Pair.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorUint16Pair.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal class VectorUint16Pair : Disposable
     {
-        internal VectorUint16Pair(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal VectorUint16Pair(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/VectorUnsignedChar.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorUnsignedChar.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal class VectorUnsignedChar : Disposable
     {
-        internal VectorUnsignedChar(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal VectorUnsignedChar(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/internal/Common/VectorVector2.cs
+++ b/src/Tizen.NUI/src/internal/Common/VectorVector2.cs
@@ -19,7 +19,7 @@ namespace Tizen.NUI
 {
     internal class VectorVector2 : Disposable
     {
-        internal VectorVector2(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal VectorVector2(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TableView.cs
@@ -785,7 +785,7 @@ namespace Tizen.NUI.BaseComponents
             /// <param name="rowSpan">The row span initialized.</param>
             /// <param name="columnSpan">The column span initialized.</param>
             /// <since_tizen> 3 </since_tizen>
-            public CellPosition(uint rowIndex, uint columnIndex, uint rowSpan, uint columnSpan) : this(Interop.TableView.NewTableViewCellPosition(rowIndex, columnIndex, rowSpan, columnSpan), true)
+            public CellPosition(uint rowIndex, uint columnIndex, uint rowSpan, uint columnSpan) : this(Interop.TableView.NewTableViewCellPosition(rowIndex, columnIndex, rowSpan, columnSpan), true, false)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -797,7 +797,7 @@ namespace Tizen.NUI.BaseComponents
             /// <param name="columnIndex">The column index initialized.</param>
             /// <param name="rowSpan">The row span initialized.</param>
             /// <since_tizen> 3 </since_tizen>
-            public CellPosition(uint rowIndex, uint columnIndex, uint rowSpan) : this(Interop.TableView.NewTableViewCellPosition(rowIndex, columnIndex, rowSpan), true)
+            public CellPosition(uint rowIndex, uint columnIndex, uint rowSpan) : this(Interop.TableView.NewTableViewCellPosition(rowIndex, columnIndex, rowSpan), true, false)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -808,7 +808,7 @@ namespace Tizen.NUI.BaseComponents
             /// <param name="rowIndex">The row index initialized.</param>
             /// <param name="columnIndex">The column index initialized.</param>
             /// <since_tizen> 3 </since_tizen>
-            public CellPosition(uint rowIndex, uint columnIndex) : this(Interop.TableView.NewTableViewCellPosition(rowIndex, columnIndex), true)
+            public CellPosition(uint rowIndex, uint columnIndex) : this(Interop.TableView.NewTableViewCellPosition(rowIndex, columnIndex), true, false)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -818,7 +818,7 @@ namespace Tizen.NUI.BaseComponents
             /// </summary>
             /// <param name="rowIndex">The row index initialized.</param>
             /// <since_tizen> 3 </since_tizen>
-            public CellPosition(uint rowIndex) : this(Interop.TableView.NewTableViewCellPosition(rowIndex), true)
+            public CellPosition(uint rowIndex) : this(Interop.TableView.NewTableViewCellPosition(rowIndex), true, false)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
@@ -828,12 +828,16 @@ namespace Tizen.NUI.BaseComponents
             /// Initializes the cell position with default values.
             /// </summary>
             /// <since_tizen> 3 </since_tizen>
-            public CellPosition() : this(Interop.TableView.NewTableViewCellPosition(), true)
+            public CellPosition() : this(Interop.TableView.NewTableViewCellPosition(), true, false)
             {
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             }
 
-            internal CellPosition(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+            internal CellPosition(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, cMemoryOwn)
+            {
+            }
+
+            internal CellPosition(global::System.IntPtr cPtr, bool cMemoryOwn, bool disposableOnlyMainThread) : base(cPtr, cMemoryOwn, disposableOnlyMainThread)
             {
             }
 

--- a/src/Tizen.NUI/src/public/Common/Color.cs
+++ b/src/Tizen.NUI/src/public/Common/Color.cs
@@ -1068,7 +1068,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal Color(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Color(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Degree.cs
+++ b/src/Tizen.NUI/src/public/Common/Degree.cs
@@ -56,7 +56,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Degree(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Degree(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Extents.cs
+++ b/src/Tizen.NUI/src/public/Common/Extents.cs
@@ -73,7 +73,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Extents(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Extents(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Matrix.cs
+++ b/src/Tizen.NUI/src/public/Common/Matrix.cs
@@ -37,7 +37,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Matrix : Disposable
     {
-        internal Matrix(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Matrix(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Matrix3.cs
+++ b/src/Tizen.NUI/src/public/Common/Matrix3.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class Matrix3 : Disposable
     {
-        internal Matrix3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Matrix3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Position.cs
+++ b/src/Tizen.NUI/src/public/Common/Position.cs
@@ -80,7 +80,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Position(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Position(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Position2D.cs
+++ b/src/Tizen.NUI/src/public/Common/Position2D.cs
@@ -71,7 +71,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Position2D(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Position2D(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/PropertyArray.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyArray.cs
@@ -38,7 +38,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PropertyArray(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PropertyArray(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/PropertyKey.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyKey.cs
@@ -46,7 +46,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PropertyKey(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PropertyKey(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/PropertyMap.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyMap.cs
@@ -44,7 +44,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PropertyMap(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PropertyMap(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/PropertyValue.cs
+++ b/src/Tizen.NUI/src/public/Common/PropertyValue.cs
@@ -223,7 +223,7 @@ namespace Tizen.NUI
         internal PropertyValue(Size vectorValue) : this(vectorValue.Width, vectorValue.Height, vectorValue.Depth)
         {
         }
-        internal PropertyValue(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PropertyValue(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Radian.cs
+++ b/src/Tizen.NUI/src/public/Common/Radian.cs
@@ -55,7 +55,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Radian(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Radian(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Rectangle.cs
+++ b/src/Tizen.NUI/src/public/Common/Rectangle.cs
@@ -55,7 +55,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal Rectangle(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Rectangle(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/RelativeVector2.cs
+++ b/src/Tizen.NUI/src/public/Common/RelativeVector2.cs
@@ -68,7 +68,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal RelativeVector2(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal RelativeVector2(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/RelativeVector3.cs
+++ b/src/Tizen.NUI/src/public/Common/RelativeVector3.cs
@@ -334,7 +334,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal RelativeVector3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal RelativeVector3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/RelativeVector4.cs
+++ b/src/Tizen.NUI/src/public/Common/RelativeVector4.cs
@@ -388,7 +388,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal RelativeVector4(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal RelativeVector4(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Rotation.cs
+++ b/src/Tizen.NUI/src/public/Common/Rotation.cs
@@ -458,7 +458,7 @@ namespace Tizen.NUI
             return ret;
         }
 
-        internal Rotation(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Rotation(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Size2D.cs
+++ b/src/Tizen.NUI/src/public/Common/Size2D.cs
@@ -392,7 +392,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Size2D(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Size2D(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/TimePeriod.cs
+++ b/src/Tizen.NUI/src/public/Common/TimePeriod.cs
@@ -27,7 +27,7 @@ namespace Tizen.NUI
     /// <since_tizen> 9 </since_tizen>
     public class TimePeriod : Disposable
     {
-        internal TimePeriod(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal TimePeriod(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Vector2.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector2.cs
@@ -100,7 +100,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Vector2(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Vector2(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Vector3.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector3.cs
@@ -93,7 +93,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Vector3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Vector3(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Common/Vector4.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector4.cs
@@ -91,7 +91,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal Vector4(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal Vector4(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Gesture.cs
+++ b/src/Tizen.NUI/src/public/Events/Gesture.cs
@@ -41,7 +41,11 @@ namespace Tizen.NUI
         {
         }
 
-        internal Gesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal Gesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
+        {
+        }
+
+        internal Gesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister, bool disposableOnlyMainThread) : base(cPtr, cMemoryOwn, cRegister, disposableOnlyMainThread)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Hover.cs
+++ b/src/Tizen.NUI/src/public/Events/Hover.cs
@@ -51,7 +51,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal Hover(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/LongPressGesture.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
         /// </summary>
         /// <param name="state">The state of the gesture</param>
         /// <since_tizen> 3 </since_tizen>
-        public LongPressGesture(Gesture.StateType state) : this(Interop.LongPressGesture.New((int)state), true)
+        public LongPressGesture(Gesture.StateType state) : this(Interop.LongPressGesture.New((int)state), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Events/PanGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PanGesture.cs
@@ -35,7 +35,7 @@ namespace Tizen.NUI
         /// The default constructor of PanGesture class.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public PanGesture() : this(Interop.PanGestureDetector.PanGestureNew(0), true)
+        public PanGesture() : this(Interop.PanGestureDetector.PanGestureNew(0), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -44,7 +44,7 @@ namespace Tizen.NUI
         /// The constructor.
         /// </summary>
         /// <param name="state">The state of the gesture</param>
-        internal PanGesture(Gesture.StateType state) : this(Interop.PanGestureDetector.PanGestureNew((int)state), true)
+        internal PanGesture(Gesture.StateType state) : this(Interop.PanGestureDetector.PanGestureNew((int)state), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -53,7 +53,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal PanGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(Interop.PanGestureDetector.PanGestureUpcast(cPtr), cMemoryOwn, cRegister)
+        internal PanGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(Interop.PanGestureDetector.PanGestureUpcast(cPtr), cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/PinchGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/PinchGesture.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal PinchGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal PinchGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 
@@ -91,7 +91,7 @@ namespace Tizen.NUI
         /// <param name="state">The state of the gesture.</param>
         /// This will be public opened in next tizen after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PinchGesture(Gesture.StateType state) : this(Interop.PinchGesture.New((int)state), true)
+        public PinchGesture(Gesture.StateType state) : this(Interop.PinchGesture.New((int)state), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Events/RotationGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/RotationGesture.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal RotationGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal RotationGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 
@@ -80,7 +80,7 @@ namespace Tizen.NUI
         /// <param name="state">The state of the gesture.</param>
         /// This will be made public in the next tizen release after an ACR is done. Till then, it needs to be hidden as an inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public RotationGesture(Gesture.StateType state) : this(Interop.RotationGesture.New((int)state), true)
+        public RotationGesture(Gesture.StateType state) : this(Interop.RotationGesture.New((int)state), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }

--- a/src/Tizen.NUI/src/public/Events/TapGesture.cs
+++ b/src/Tizen.NUI/src/public/Events/TapGesture.cs
@@ -31,7 +31,7 @@ namespace Tizen.NUI
         /// Default constructor to creates a TapGesture.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public TapGesture() : this(Interop.TapGesture.New(0), true)
+        public TapGesture() : this(Interop.TapGesture.New(0), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -40,7 +40,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal TapGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal TapGesture(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Touch.cs
+++ b/src/Tizen.NUI/src/public/Events/Touch.cs
@@ -32,7 +32,7 @@ namespace Tizen.NUI
         /// Calling member functions with an uninitialized touch handle is not allowed.<br />
         /// </summary>
         /// <since_tizen> 3 </since_tizen>
-        public Touch() : this(Interop.Touch.NewTouch(), true, false)
+        public Touch() : this(Interop.Touch.NewTouch(), true)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -41,7 +41,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal Touch(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal Touch(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Events/Wheel.cs
+++ b/src/Tizen.NUI/src/public/Events/Wheel.cs
@@ -56,7 +56,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal Wheel(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal Wheel(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/EncodedImageBuffer.cs
@@ -106,7 +106,7 @@ namespace Tizen.NUI
             // Note : EncodedImageBuffer don't need to be register in Registry default. So we can create this class from worker thread.
         }
 
-        internal EncodedImageBuffer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal EncodedImageBuffer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelBuffer.cs
@@ -61,7 +61,7 @@ namespace Tizen.NUI
             // Note : PixelBuffer don't need to be register in Registry default. So we can create this class from worker thread.
         }
 
-        internal PixelBuffer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal PixelBuffer(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Images/PixelData.cs
+++ b/src/Tizen.NUI/src/public/Images/PixelData.cs
@@ -78,7 +78,7 @@ namespace Tizen.NUI
             // Note : PixelData don't need to be register in Registry default. So we can create this class from worker thread.
         }
 
-        internal PixelData(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal PixelData(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Input/Key.cs
+++ b/src/Tizen.NUI/src/public/Input/Key.cs
@@ -53,7 +53,7 @@ namespace Tizen.NUI
         {
         }
 
-        internal Key(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister)
+        internal Key(global::System.IntPtr cPtr, bool cMemoryOwn, bool cRegister) : base(cPtr, cMemoryOwn, cRegister, cRegister)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Layouting/PaddingType.cs
+++ b/src/Tizen.NUI/src/public/Layouting/PaddingType.cs
@@ -48,7 +48,7 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal PaddingType(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal PaddingType(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn, false)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Window/MouseInOut.cs
+++ b/src/Tizen.NUI/src/public/Window/MouseInOut.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
         /// The default constructor.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public MouseInOut() : this(Interop.MouseInOut.NewMouseInOut((int)MouseInOut.StateType.None, 0, Vector2.getCPtr(Vector2.Zero), 0), true)
+        public MouseInOut() : this(Interop.MouseInOut.NewMouseInOut((int)MouseInOut.StateType.None, 0, Vector2.getCPtr(Vector2.Zero), 0), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -42,12 +42,16 @@ namespace Tizen.NUI
         /// <param name="point">The coordinates of the cursor relative to the top-left of the screen.</param>
         /// <param name="timeStamp">The time the event is being started.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public MouseInOut(MouseInOut.StateType state, uint modifiers, Vector2 point, uint timeStamp) : this(Interop.MouseInOut.NewMouseInOut((int)state, modifiers, Vector2.getCPtr(point), timeStamp), true)
+        public MouseInOut(MouseInOut.StateType state, uint modifiers, Vector2 point, uint timeStamp) : this(Interop.MouseInOut.NewMouseInOut((int)state, modifiers, Vector2.getCPtr(point), timeStamp), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal MouseInOut(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal MouseInOut(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal MouseInOut(global::System.IntPtr cPtr, bool cMemoryOwn, bool disposableOnlyMainThread) : base(cPtr, cMemoryOwn, disposableOnlyMainThread)
         {
         }
 

--- a/src/Tizen.NUI/src/public/Window/MouseRelative.cs
+++ b/src/Tizen.NUI/src/public/Window/MouseRelative.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI
         /// The default constructor.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public MouseRelative() : this(Interop.MouseRelative.NewMouseRelative((int)MouseRelative.StateType.None, 0, 0, Vector2.getCPtr(Vector2.Zero), Vector2.getCPtr(Vector2.Zero)), true)
+        public MouseRelative() : this(Interop.MouseRelative.NewMouseRelative((int)MouseRelative.StateType.None, 0, 0, Vector2.getCPtr(Vector2.Zero), Vector2.getCPtr(Vector2.Zero)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
@@ -43,12 +43,16 @@ namespace Tizen.NUI
         /// <param name="diffPosition">The coordinates of the cursor relative to the top-left of the screen.</param>
         /// <param name="unaccelatedPosition">The coordinates of the cursor relative to the top-left of the screen.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public MouseRelative(MouseRelative.StateType state, uint modifiers, uint timeStamp, Vector2 diffPosition, Vector2 unaccelatedPosition) : this(Interop.MouseRelative.NewMouseRelative((int)state, modifiers, timeStamp, Vector2.getCPtr(diffPosition), Vector2.getCPtr(unaccelatedPosition)), true)
+        public MouseRelative(MouseRelative.StateType state, uint modifiers, uint timeStamp, Vector2 diffPosition, Vector2 unaccelatedPosition) : this(Interop.MouseRelative.NewMouseRelative((int)state, modifiers, timeStamp, Vector2.getCPtr(diffPosition), Vector2.getCPtr(unaccelatedPosition)), true, false)
         {
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        internal MouseRelative(global::System.IntPtr cPtr, bool cMemoryOwn) : base(cPtr, cMemoryOwn)
+        internal MouseRelative(global::System.IntPtr cPtr, bool cMemoryOwn) : this(cPtr, cMemoryOwn, cMemoryOwn)
+        {
+        }
+
+        internal MouseRelative(global::System.IntPtr cPtr, bool cMemoryOwn, bool disposableOnlyMainThread) : base(cPtr, cMemoryOwn, disposableOnlyMainThread)
         {
         }
 

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AsyncImageLoaderTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/AsyncImageLoaderTest.cs
@@ -113,6 +113,8 @@ namespace Tizen.NUI.Samples
 
         // Per each view
         private View[] subView = new View[totalSubViewCounts];
+        private Renderable[] subViewRenderable = new Renderable[totalSubViewCounts];
+        private Texture[] subViewTexture = new Texture[totalSubViewCounts];
         private TextureSet[] subViewTextureSet = new TextureSet[totalSubViewCounts];
         private uint[] subViewLoadId = new uint[totalSubViewCounts];
 
@@ -182,6 +184,13 @@ namespace Tizen.NUI.Samples
             root?.Unparent();
             root?.DisposeRecursively();
 
+            for(uint i = 0u; i < totalSubViewCounts; ++i)
+            {
+                subViewRenderable[i]?.Dispose();
+                subViewTexture[i]?.Dispose();
+                subViewTextureSet[i]?.Dispose();
+            }
+
             win.KeyEvent -= WindowKeyEvent;
         }
 
@@ -238,8 +247,11 @@ namespace Tizen.NUI.Samples
 
                     uint viewIndex = i * numberOfImagesPerEachType + j;
 
+                    subViewRenderable[viewIndex] = renderable;
+
                     subView[viewIndex] = view;
                     subViewTextureSet[viewIndex] = renderable.TextureSet;
+                    subViewTexture[viewIndex] = renderable.TextureSet.GetTexture(0u);
                     subViewLoadId[viewIndex] = InvalidLoadId;
                 }
                 subViewUrlIndex[i] = (uint)(ImageUrlList.Length - 1);
@@ -316,7 +328,9 @@ namespace Tizen.NUI.Samples
             Texture texture = new Texture(TextureType.TEXTURE_2D, pixelFormat, width, height);
             texture.Upload(e.PixelData);
 
+            subViewTexture[viewIndex]?.Dispose();
             subViewTextureSet[viewIndex].SetTexture(0u, texture);
+            subViewTexture[viewIndex] = texture;
         }
 
         private void OnPixelBufferLoaded(object o, AsyncImageLoader.PixelBufferLoadedEventArgs e)
@@ -357,7 +371,9 @@ namespace Tizen.NUI.Samples
             Texture texture = new Texture(TextureType.TEXTURE_2D, pixelFormat, width, height);
             texture.Upload(pixelData);
 
+            subViewTexture[viewIndex]?.Dispose();
             subViewTextureSet[viewIndex].SetTexture(0u, texture);
+            subViewTexture[viewIndex] = texture;
         }
 
         private void OnPixelBufferLoadedWithCustom(object o, AsyncImageLoader.PixelBufferLoadedEventArgs e)
@@ -403,7 +419,9 @@ namespace Tizen.NUI.Samples
             Texture texture = new Texture(TextureType.TEXTURE_2D, pixelFormat, width, height);
             texture.Upload(pixelData);
 
+            subViewTexture[viewIndex]?.Dispose();
             subViewTextureSet[viewIndex].SetTexture(0u, texture);
+            subViewTexture[viewIndex] = texture;
         }
 
         private void OnPixelBufferLoadedWithColorPalette(object o, AsyncImageLoader.PixelBufferLoadedEventArgs e)
@@ -452,7 +470,9 @@ namespace Tizen.NUI.Samples
             Texture texture = new Texture(TextureType.TEXTURE_2D, pixelFormat, width, height);
             texture.Upload(pixelData);
 
+            subViewTexture[viewIndex]?.Dispose();
             subViewTextureSet[viewIndex].SetTexture(0u, texture);
+            subViewTexture[viewIndex] = texture;
 
             if(colorPick)
             {


### PR DESCRIPTION
Let we call Dispose() for some Disposable classes if we define them possible to call it on worker thread.

For example, let we don't wait main thread wake to release `Vector4` or etc.