### PR TITLE
[NUI][DRGLView] Make `RenderCallbackInput.SizeWidth` and `RenderCallbackInput.SizeHeight` as float type

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/DirectRenderingGLView.cs
@@ -41,12 +41,12 @@ namespace Tizen.NUI.BaseComponents
         {
             Matrix mvp;
             Matrix projection;
-            Size2D size;
+            Vector2 size;
             Color worldColor;
             Rectangle clippingBox;
             ReadOnlyCollection<int> textureBindings;
 
-            public RenderCallbackInput(Matrix mvp, Matrix projection, Size2D size, Color worldColor, Rectangle clippingBox, int[] textureBindings)
+            public RenderCallbackInput(Matrix mvp, Matrix projection, Vector2 size, Color worldColor, Rectangle clippingBox, int[] textureBindings)
             {
                 this.mvp = mvp;
                 this.projection = projection;
@@ -75,7 +75,7 @@ namespace Tizen.NUI.BaseComponents
             /// <summary>
             /// The size of the DirectRenderingGLView
             /// </summary>
-            public Size2D Size
+            public Vector2 Size
             {
                 get { return size; }
             }
@@ -354,7 +354,7 @@ namespace Tizen.NUI.BaseComponents
             {
                 Matrix mvp = Matrix.GetMatrixFromPtr(Interop.GLView.GlViewGetRednerCallbackInputMvp(cPtr));
                 Matrix projection = Matrix.GetMatrixFromPtr(Interop.GLView.GlViewGetRednerCallbackInputProjection(cPtr));
-                Size2D size = Size2D.GetSize2DFromPtr(Interop.GLView.GlViewGetRednerCallbackInputSize(cPtr), false);
+                Vector2 size = Vector2.GetVector2FromPtr(Interop.GLView.GlViewGetRednerCallbackInputSize(cPtr));
                 Color worldColor = Color.GetColorFromPtr(Interop.GLView.GlViewGetRednerCallbackInputWorldColor(cPtr));
                 Rectangle clippingBox = Rectangle.GetRectangleFromPtr(Interop.GLView.GlViewGetRednerCallbackInputClipplingBox(cPtr), false);
                 int[] textureBindings = GetTextureBindings(cPtr);

--- a/test/NUIGLView/NUIDirectRenderingGLViewSample/DirectRenderingGLViewSample.cs
+++ b/test/NUIGLView/NUIDirectRenderingGLViewSample/DirectRenderingGLViewSample.cs
@@ -313,7 +313,7 @@ namespace DRGLApplication
 
             // Note that we should use view port position always (0,0), since it depend on window size
             setViewport(0, 0, localWindowPositionSize.Width, localWindowPositionSize.Height);
-            setSize(input.Size.Width, input.Size.Height);
+            setSize((int)input.Size.Width, (int)input.Size.Height);
             setWorldColor(input.WorldColor.R, input.WorldColor.G, input.WorldColor.B, input.WorldColor.A);
 
             // Note that input.ClippingBox's (0,0) is left-bottom of window (not include rotation!).


### PR DESCRIPTION
To guard ABI Break, let just keep `RenderCallbackInput.Size` as `Size2D` type. Instead, make new API to get float type size of each values.
