### PR TITLE
[NUI] Add IncrementalDispose at Applicatoin + DisposeQueue more thread safe

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
+++ b/src/Tizen.NUI/src/internal/Common/DisposeQueue.cs
@@ -99,9 +99,14 @@ namespace Tizen.NUI
 
             if (initialized && eventThreadCallback != null)
             {
-                if (!eventThreadCallbackTriggered)
+                bool triggerRequired;
+                lock (listLock)
                 {
+                    triggerRequired = !eventThreadCallbackTriggered;
                     eventThreadCallbackTriggered = true;
+                }
+                if (triggerRequired)
+                {
                     eventThreadCallback.Trigger();
                 }
             }
@@ -121,9 +126,14 @@ namespace Tizen.NUI
 
             if (initialized && eventThreadCallback != null)
             {
-                if (!eventThreadCallbackTriggered)
+                bool triggerRequired;
+                lock (listLock)
                 {
+                    triggerRequired = !eventThreadCallbackTriggered;
                     eventThreadCallbackTriggered = true;
+                }
+                if (triggerRequired)
+                {
                     eventThreadCallback.Trigger();
                 }
             }
@@ -139,10 +149,10 @@ namespace Tizen.NUI
 
         public void ProcessDisposables()
         {
-            eventThreadCallbackTriggered = false;
 
             lock (listLock)
             {
+                eventThreadCallbackTriggered = false;
                 if (disposables.Count > 0)
                 {
                     // Move item from end, due to the performance issue.

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -52,6 +52,13 @@ namespace Tizen.NUI
         public static bool IsUsingThemeManager { get; set; } = true;
 
         /// <summary>
+        /// Set to true if NUI DisposeQueue dispose items incrementally.
+        /// The default value is false.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool IsUsingIncrementalDispose => DisposeQueue.Instance.IncrementalDisposeSupported;
+
+        /// <summary>
         /// The instance of ResourceManager.
         /// </summary>
         private static System.Resources.ResourceManager resourceManager;


### PR DESCRIPTION
Let we make static value for `Application.IsUsingIncrementalDispose` whether we dispose GC queue incrementally or not.

`true` will dispose GC items maximum 20% per each loop, `false` will dispose every items immediately.
Default is false.

The number of maximum GC item is experimental values. Incremental logic could be changed in future, like `StopWatch` used.