### PR TITLE
[NUI] Add FlexLayout.MarkDirty to recalculate children

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/Interop/Interop.FlexLayout.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/Interop/Interop.FlexLayout.cs
@@ -116,6 +116,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexLayout_GetFlexGrow")]
             public static extern float GetFlexGrow(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FlexLayout_MarkDirty")]
+            public static extern void MarkDirty(global::System.Runtime.InteropServices.HandleRef jarg1);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
+++ b/src/Tizen.NUI/src/public/Layouting/FlexLayout.cs
@@ -999,6 +999,11 @@ namespace Tizen.NUI
                 Interop.FlexLayout.SetFlexBasis(childHandleRef, flexBasis);
                 Interop.FlexLayout.SetFlexShrink(childHandleRef, flexShrink);
                 Interop.FlexLayout.SetFlexGrow(childHandleRef, flexGrow);
+
+                if (child.GetAttached<LayoutParams>()?.MarkDirty ?? false)
+                {
+                    Interop.FlexLayout.MarkDirty(childHandleRef);
+                }
             }
 
             Interop.FlexLayout.CalculateLayout(swigCPtr, width, height, isLayoutRtl);
@@ -1068,6 +1073,20 @@ namespace Tizen.NUI
             }
         }
 
+        internal static void MarkDirty(View view)
+        {
+            _ = view ?? throw new ArgumentNullException(nameof(view));
+            var layoutParams = view.GetAttached<LayoutParams>();
+            if (layoutParams != null)
+            {
+                layoutParams.MarkDirty = true;
+            }
+            else
+            {
+                view.SetAttached(new LayoutParams() { MarkDirty = true });
+            }
+        }
+
         private class LayoutParams
         {
             /// <summary>
@@ -1130,6 +1149,15 @@ namespace Tizen.NUI
                 get;
                 set;
             } = new HandleRef();
+
+            /// <summary>
+            /// Gets or sets the mark dirty of the flex layout item.
+            /// </summary>
+            public bool MarkDirty
+            {
+                get;
+                set;
+            } = false;
         }
     } // FLexlayout
 } // namesspace Tizen.NUI

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -369,8 +369,14 @@ namespace Tizen.NUI
                 {
                     layoutGroup.RequestLayout();
                 }
-            }
 
+                // FlexLayout requires MarkDirty if child layout's layout properties are changed.
+                // e.g. MarkDirty is required if child layout's Width/HeightSpecification is changed.
+                if (parent is FlexLayout)
+                {
+                    FlexLayout.MarkDirty(Owner);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
FlexLayout requires MarkDirty if child layout's layout properties are changed.
e.g. MarkDirty is required if child layout's Width/HeightSpecification is changed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
