### PR TITLE
[NUI] Add methods to move ownership of native handle

### DIFF
--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -752,5 +752,54 @@ namespace Tizen.NUI
         {
             nativeBindedHolder.Remove(handle);
         }
+
+        /// <summary>
+        /// Get memory ownership and registry information of the native pointer.
+        /// Please be aware enough about this action before use this method.
+        /// </summary>
+        internal void AcquireOwnership(IntPtr pointer)
+        {
+            if (swigCMemOwn || registerMe || IsDisposedOrQueued)
+            {
+                throw new InvalidOperationException("This should not have ownership of other native handle.");
+            }
+
+            swigCPtr = new System.Runtime.InteropServices.HandleRef(this, pointer);
+            swigCMemOwn = true;
+            registerMe = true;
+
+            if (!Registry.Register(this))
+            {
+                throw new InvalidOperationException("This destination base handle should not have ownership of other native handle.");
+            }
+            _disposeOnlyMainThread = true;
+        }
+
+        /// <summary>
+        /// Remove memory ownership and registry information of this handle.
+        /// Please be aware enough about this action before use this method.
+        /// </summary>
+        internal void RemoveOwnership()
+        {
+            if (!swigCMemOwn || !registerMe || !_disposeOnlyMainThread || IsDisposedOrQueued)
+            {
+                throw new InvalidOperationException("This base handle does not have ownership of the native handle.");
+            }
+
+            UnregisterFromRegistry();
+            swigCMemOwn = false;
+            _disposeOnlyMainThread = false;
+        }
+
+        /// <summary>
+        /// Get memory ownership and registry information of the native pointer.
+        /// Please be aware enough about this action before use this method.
+        /// </summary>
+        internal void MoveOwnership(BaseHandle handle)
+        {
+            IntPtr pointer = swigCPtr.Handle;
+            RemoveOwnership();
+            handle.AcquireOwnership(pointer);
+        }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Adds internal methods that can handle ownership of native pointer.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
