### PR TITLE
[NUI] Fix not to dispose Extents.Zero

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -6378,14 +6378,13 @@ namespace Tizen.NUI.BaseComponents
                         {
                             // If View already has a margin set then store it in Layout instead.
                             value.Margin = margin;
-                            using var extents = Extents.Zero;
                             if (NUIApplication.IsUsingXaml)
                             {
-                                SetValue(MarginProperty, extents);
+                                SetValue(MarginProperty, Extents.Zero);
                             }
                             else
                             {
-                                SetInternalMargin(extents);
+                                SetInternalMargin(Extents.Zero);
                             }
                             setMargin = true;
                         }
@@ -6396,14 +6395,13 @@ namespace Tizen.NUI.BaseComponents
                         {
                             // If View already has a padding set then store it in Layout instead.
                             value.Padding = padding;
-                            using var tmpPadding = Extents.Zero;
                             if (NUIApplication.IsUsingXaml)
                             {
-                                SetValue(PaddingProperty, tmpPadding);
+                                SetValue(PaddingProperty, Extents.Zero);
                             }
                             else
                             {
-                                SetInternalPadding(tmpPadding);
+                                SetInternalPadding(Extents.Zero);
                             }
                             setPadding = true;
                         }


### PR DESCRIPTION
Since Extents.Zero is static variable, it should not be disposed.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
