### PR TITLE
[NUI] Bind `ChildrenDepthIndexPolicy`

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -212,6 +212,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_DISPATCH_HOVER_MOTION_get")]
             public static extern int DispatchHoverMotionGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_CHILDREN_DEPTH_INDEX_POLICY_get")]
+            public static extern int ChildrenDepthIndexPolicyGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -7241,6 +7241,38 @@ namespace Tizen.NUI.BaseComponents
             return isIgnored;
         }
 
+        /// <summary>
+        /// The policy of children depth index generate.
+        /// </summary>
+        /// <remarks>
+        /// Depth index of children determine the order of rendering. But for micro optimization, we could set
+        /// all children of the view has the same rendering order. If then, we can set <see cref='ChildrenDepthIndexPolicyType.Equal'/>.
+        /// Usually if we know that every childrens are not overlapps each other, and has multiple rendering options. (e.g InnerShadow, Shadow, BorderlineWidth).
+        /// Default is <see cref='ChildrenDepthIndexPolicyType.Increase'/>.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ChildrenDepthIndexPolicyType ChildrenDepthIndexPolicy
+        {
+            set => SetInternalChildrenDepthIndexPolicy(value);
+            get => GetInternalChildrenDepthIndexPolicy();
+        }
+
+        private void SetInternalChildrenDepthIndexPolicy(ChildrenDepthIndexPolicyType value)
+        {
+            Object.InternalSetPropertyInt(SwigCPtr, Property.ChildrenDepthIndexPolicy, (int)value);
+        }
+
+        private ChildrenDepthIndexPolicyType GetInternalChildrenDepthIndexPolicy()
+        {
+            int temp = Object.InternalGetPropertyInt(SwigCPtr, Property.ChildrenDepthIndexPolicy);
+            switch (temp)
+            {
+                case 0: return ChildrenDepthIndexPolicyType.Increase;
+                case 1: return ChildrenDepthIndexPolicyType.Equal;
+                default: return ChildrenDepthIndexPolicyType.Default;
+            }
+        }
+
         private LayoutExtraData EnsureLayoutExtraData()
         {
             if (layoutExtraData == null)

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -188,6 +188,31 @@ namespace Tizen.NUI.BaseComponents
           RefreshAlways,
         };
 
+        /// <summary>
+        /// The policy of children depth index generate.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum ChildrenDepthIndexPolicyType
+        {
+          /// <summary>
+          /// Increase depth index automatically.
+          /// </summary>
+          [EditorBrowsable(EditorBrowsableState.Never)]
+          Increase,
+
+          /// <summary>
+          /// Has same depth index for all children.
+          /// </summary>
+          [EditorBrowsable(EditorBrowsableState.Never)]
+          Equal,
+
+          /// <summary>
+          /// Default policy.
+          /// </summary>
+          [EditorBrowsable(EditorBrowsableState.Never)]
+          Default = Increase,
+        };
+
 
         /// <summary>
         /// Actions property value to update visual property.
@@ -296,6 +321,7 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int UpdateAreaHint = Interop.ActorProperty.UpdateAreaHintGet();
             internal static readonly int DispatchTouchMotion = Interop.ActorProperty.DispatchTouchMotionGet();
             internal static readonly int DispatchHoverMotion = Interop.ActorProperty.DispatchHoverMotionGet();
+            internal static readonly int ChildrenDepthIndexPolicy = Interop.ActorProperty.ChildrenDepthIndexPolicyGet();
             internal static readonly int OffScreenRendering = Interop.ViewProperty.OffScreenRenderingGet();
             internal static readonly int InnerShadow = Interop.ViewProperty.InnerShadowGet();
             internal static readonly int Borderline = Interop.ViewProperty.BorderlineGet();

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/InnerShadowSample.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/InnerShadowSample.cs
@@ -141,6 +141,8 @@ namespace Tizen.NUI.Samples
 
                 WidthResizePolicy = ResizePolicyType.FillToParent,
                 HeightResizePolicy = ResizePolicyType.FillToParent,
+
+                ChildrenDepthIndexPolicy = View.ChildrenDepthIndexPolicyType.Equal,
             };
 
             window.Add(rootView);


### PR DESCRIPTION
Depth index of children determine the order of rendering. But for micro optimization, we could set
all children of the view has the same rendering order. If then, we can setChildrenDepthIndexPolicyType.Equal.

Usually if we know that every childrens are not overlapps each other, and has multiple rendering options. (e.g InnerShadow, Shadow, BorderlineWidth).