### PR TITLE
[NUI] Add property Disposed to LayoutItem like BaseHandle

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -688,5 +688,11 @@ namespace Tizen.NUI
         {
             return false;
         }
+
+        /// <summary>
+        /// The flag to check if it is already disposed of.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected internal bool Disposed => disposed;
     }
 }


### PR DESCRIPTION
Since LayoutItem implements IDisposable but it does not inherit from BaseHandle, so property Disposed is added to LayoutItem like BaseHandle.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
