### PR TITLE
[NUI] Add resets APIs for Vector2/3 and Extents

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/Object.cs
+++ b/src/Tizen.NUI/src/internal/Common/Object.cs
@@ -408,10 +408,7 @@ namespace Tizen.NUI
 
             ReusablePool<Extents>.GetOne((extents, actor, propertyType, value) =>
             {
-                extents.Start = (ushort)value.Start;
-                extents.End = (ushort)value.End;
-                extents.Top = (ushort)value.Top;
-                extents.Bottom = (ushort)value.Bottom;
+                extents.Reset(value);
                 _ = Interop.Actor.InternalSetPropertyExtents(actor, propertyType, extents.SwigCPtr);
                 NDalicPINVOKE.ThrowExceptionIfExists();
             }, actor, propertyType, value);

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Extents.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Extents.cs
@@ -41,6 +41,9 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool NotEqualTo(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_set_all")]
+            public static extern void SetAll(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2, ushort jarg3, ushort jarg4, ushort jarg5);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Extents_start_set")]
             public static extern void StartSet(global::System.Runtime.InteropServices.HandleRef jarg1, ushort jarg2);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Vector2.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Vector2.cs
@@ -124,6 +124,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector2")]
             public static extern void DeleteVector2(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector2_set_all")]
+            public static extern void SetAll(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Vector3.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Vector3.cs
@@ -169,6 +169,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_delete_Vector3")]
             public static extern void DeleteVector3(global::System.Runtime.InteropServices.HandleRef jarg1);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Vector3_set_all")]
+            public static extern void SetAll(global::System.Runtime.InteropServices.HandleRef jarg1, float jarg2, float jarg3, float jarg4);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Common/Extents.cs
+++ b/src/Tizen.NUI/src/public/Common/Extents.cs
@@ -260,6 +260,16 @@ namespace Tizen.NUI
             }
         }
 
+        internal void Reset() => Reset(0, 0, 0, 0);
+
+        internal void Reset(UIExtents extents) => Reset((ushort)extents.Start, (ushort)extents.End, (ushort)extents.Top, (ushort)extents.Bottom);
+
+        internal void Reset(ushort start, ushort end, ushort top, ushort bottom)
+        {
+            Interop.Extents.SetAll(SwigCPtr, start, end, top, bottom);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
+
         /// <summary>
         /// Equality operator.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Common/Vector2.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector2.cs
@@ -164,7 +164,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector2 vector2 = new Vector2();
-        /// vector2.X = 0.1f; 
+        /// vector2.X = 0.1f;
         /// // USE like this
         /// float x = 0.1f, y = 0.5f;
         /// Vector2 vector2 = new Vector2(x, y);
@@ -197,7 +197,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector2 vector2 = new Vector2();
-        /// vector2.Width = 1.0f; 
+        /// vector2.Width = 1.0f;
         /// // USE like this
         /// float width = 1.0f, height = 2.0f;
         /// Vector2 vector2 = new Vector2(x, y);
@@ -230,7 +230,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector2 vector2 = new Vector2();
-        /// vector2.Y = 0.5f; 
+        /// vector2.Y = 0.5f;
         /// // USE like this
         /// float x = 0.1f, y = 0.5f;
         /// Vector2 vector2 = new Vector2(x, y);
@@ -263,7 +263,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector2 vector2 = new Vector2();
-        /// vector2.Height = 2.0f; 
+        /// vector2.Height = 2.0f;
         /// // USE like this
         /// float width = 1.0f, height = 2.0f;
         /// Vector2 vector2 = new Vector2(x, y);
@@ -449,6 +449,16 @@ namespace Tizen.NUI
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Vector2(this);
+
+        internal void Reset() => Reset(0, 0);
+
+        internal void Reset(UIVector2 value) => Reset(value.X, value.Y);
+
+        internal void Reset(float x, float y)
+        {
+            Interop.Vector2.SetAll(SwigCPtr, x, y);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
 
         /// <summary>
         /// Clamps the vector between minimum and maximum vectors.

--- a/src/Tizen.NUI/src/public/Common/Vector3.cs
+++ b/src/Tizen.NUI/src/public/Common/Vector3.cs
@@ -164,7 +164,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.X = 0.1f; 
+        /// vector3.X = 0.1f;
         /// // USE like this
         /// float x = 0.1f, y = 0.5f, z = 0.9f;
         /// Vector3 vector3 = new Vector3(x, y, z);
@@ -197,7 +197,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.Width = 1.0f; 
+        /// vector3.Width = 1.0f;
         /// // USE like this
         /// float width = 1.0f, height = 2.0f, depth = 3.0f;
         /// Vector3 vector3 = new Vector3(width, height, depth);
@@ -230,7 +230,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.R = 0.1f; 
+        /// vector3.R = 0.1f;
         /// // USE like this
         /// float r = 0.1f, g = 0.5f, b = 0.9f;
         /// Vector3 vector3 = new Vector3(r, g, b);
@@ -263,7 +263,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.Y = 0.5f; 
+        /// vector3.Y = 0.5f;
         /// // USE like this
         /// float x = 0.1f, y = 0.5f, z = 0.9f;
         /// Vector3 vector3 = new Vector3(x, y, z);
@@ -296,7 +296,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.Height = 2.0f; 
+        /// vector3.Height = 2.0f;
         /// // USE like this
         /// float width = 1.0f, height = 2.0f, depth = 3.0f;
         /// Vector3 vector3 = new Vector3(width, height, depth);
@@ -329,7 +329,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.G = 0.5f; 
+        /// vector3.G = 0.5f;
         /// // USE like this
         /// float r = 0.1f, g = 0.5f, b = 0.9f;
         /// Vector3 vector3 = new Vector3(r, g, b);
@@ -362,7 +362,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.Z = 0.9f; 
+        /// vector3.Z = 0.9f;
         /// // USE like this
         /// float x = 0.1f, y = 0.5f, z = 0.9f;
         /// Vector3 vector3 = new Vector3(x, y, z);
@@ -395,7 +395,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.Depth = 3.0f; 
+        /// vector3.Depth = 3.0f;
         /// // USE like this
         /// float width = 1.0f, height = 2.0f, depth = 3.0f;
         /// Vector3 vector3 = new Vector3(width, height, depth);
@@ -428,7 +428,7 @@ namespace Tizen.NUI
         /// <code>
         /// // DO NOT use like the followings!
         /// Vector3 vector3 = new Vector3();
-        /// vector3.B = 0.9f; 
+        /// vector3.B = 0.9f;
         /// // USE like this
         /// float r = 0.1f, g = 0.5f, b = 0.9f;
         /// Vector3 vector3 = new Vector3(r, g, b);
@@ -650,6 +650,16 @@ namespace Tizen.NUI
         /// <inheritdoc/>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object Clone() => new Vector3(X, Y, Z);
+
+        internal void Reset() => Reset(0, 0, 0);
+
+        internal void Reset(UIVector3 value) => Reset(value.X, value.Y, value.Z);
+
+        internal void Reset(float x, float y, float z)
+        {
+            Interop.Vector3.SetAll(SwigCPtr, x, y, z);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+        }
 
         internal static Vector3 GetVector3FromPtr(global::System.IntPtr cPtr)
         {


### PR DESCRIPTION
### Description of Change ###
Add internal API to reset all fields in Vector2, Vector3 and Extents to resue them.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
