### PR TITLE
[NUI] Fix a crash When WebView.EvaluateJavaScript is called frequently.

### DIFF
--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -2729,7 +2729,7 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
-        private Dictionary<int, JavaScriptMessageHandler> _evaluateJavaScriptHandlerMap = new Dictionary<int, JavaScriptMessageHandler>();
+        private Dictionary<int, HandleRef> _evaluateJavaScriptHandlerMap = new Dictionary<int, HandleRef>();
         private int _evaluateJavaScriptCallbackId;
 
         /// <summary>
@@ -2746,9 +2746,10 @@ namespace Tizen.NUI.BaseComponents
                 handler(msg);
                 _evaluateJavaScriptHandlerMap.Remove(id);
             };
-            _evaluateJavaScriptHandlerMap.Add(id, wrapper);
-            System.IntPtr ip = System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(wrapper);
-            Interop.WebView.EvaluateJavaScript(SwigCPtr, script, new global::System.Runtime.InteropServices.HandleRef(this, ip));
+            System.IntPtr ip = Marshal.GetFunctionPointerForDelegate(wrapper);
+            HandleRef handleRef = new HandleRef(this, ip);
+            _evaluateJavaScriptHandlerMap.Add(id, handleRef);
+            Interop.WebView.EvaluateJavaScript(SwigCPtr, script, handleRef);
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
The callstack:
Process terminated. A callback was made on a garbage collected delegate of type 'Tizen.NUI!Tizen.NUI.BaseComponents.WebView+JavaScriptMessageHandler::Invoke'.
   at Tizen.NUI.NDalicPINVOKE.ApplicationMainLoop(System.Runtime.InteropServices.HandleRef)
   at Tizen.NUI.Application.MainLoop()
   at Tizen.NUI.NUICoreBackend.Run(System.String[])
   at Tizen.Applications.CoreApplication.Run(System.String[])
   at Tizen.NUI.NUIApplication.Run(System.String[])
   at Tizen.TV.FLUX.FluxApplication.Run(System.String[])
   at Tizen.TV.Service.CNCapsule.Program.Main(System.String[])
DotNET onSigabrt called on com.samsung.tv.cnvoice-assistant / DN_ce-assistant(20535) onSigabrt called

The reason might be that a local variable is gc-ed, but it is still used in unmanaged code, according to [1] and [2].

[1] https://stackoverflow.com/questions/6193711/call-has-been-made-on-garbage-collected-delegate-in-c
[2] https://learn.microsoft.com/en-us/dotnet/framework/debug-trace-profile/callbackoncollecteddelegate-mda

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
