### PR TITLE
[NUI] Add GetInsets to Window

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -405,6 +405,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetBlur")]
             public static extern global::System.IntPtr GetBlur(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetInsets__SWIG_0")]
+            public static extern global::System.IntPtr GetInsets(global::System.Runtime.InteropServices.HandleRef window);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetInsets__SWIG_1")]
+            public static extern global::System.IntPtr GetInsets(global::System.Runtime.InteropServices.HandleRef window, int insetsFlags);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -460,6 +460,18 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// The flags of insets part to specify which window insets parts to include.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public enum InsetsPartFlags
+        {
+            None = 0,
+            StatusBar = 1 << 0,
+            Keyboard = 1 << 1,
+            Clipboard = 1 << 2
+        }
+
+        /// <summary>
         /// The stage instance property (read-only).<br />
         /// Gets the current window.<br />
         /// </summary>
@@ -2716,6 +2728,31 @@ namespace Tizen.NUI
                     });
                 }
             });
+        }
+
+        /// <summary>
+        /// Gets the window insets for all parts of the system UI.
+        /// </summary>
+        /// <returns>The window insets from all parts.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Extents GetInsets()
+        {
+            Extents ret = new Extents(Interop.Window.GetInsets(SwigCPtr), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// <summary>
+        /// Gets the combined window insets for the specified parts of the system UI.
+        /// </summary>
+        /// <param name="insetsFlags">A bitwise combination of <see cref="InsetsPartFlags"/> values specifying which window insets parts to include.</param>
+        /// <returns>The combined window insets from the specified parts.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Extents GetInsets(InsetsPartFlags insetsFlags)
+        {
+            Extents ret = new Extents(Interop.Window.GetInsets(SwigCPtr, (int)insetsFlags), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
         }
 
         IntPtr IWindowProvider.WindowHandle => GetNativeWindowHandler();


### PR DESCRIPTION
Window insets are the inner size between window content and window edge.

Window insets are required when status bar, virtual keyboard, or clipboard appears on window to avoid window content obscured by them.

To provide the current window insets changes, GetInsets is added to Window.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
