### PR TITLE
[NUI] Print log when IsUsingXaml property changed

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -33,6 +33,8 @@ namespace Tizen.NUI
     /// <since_tizen> 3 </since_tizen>
     public class NUIApplication : CoreApplication
     {
+        private static bool _isUsingXaml = true;
+
         /// <summary>
         /// Set to true if XAML is used.
         /// This must be called before or immediately after the NUIApplication constructor is called.
@@ -42,7 +44,21 @@ namespace Tizen.NUI
         /// This must be called before or immediately after the NUIApplication constructor is called.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        static public bool IsUsingXaml { get; set; } = true;
+        static public bool IsUsingXaml
+        {
+            get
+            {
+                return _isUsingXaml;
+            }
+            set
+            {
+                if (_isUsingXaml != value)
+                {
+                    Tizen.Log.Info("NUI", $"IsUsingXaml changed to {value}");
+                    _isUsingXaml = value;
+                }
+            }
+        }
 
         /// <summary>
         /// Set to true if NUI ThemeManager is used.

--- a/src/Tizen.NUI/src/public/Application/NUIWidgetApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIWidgetApplication.cs
@@ -95,6 +95,8 @@ namespace Tizen.NUI
             core?.AddWidgetInfo(widgetTypes);
         }
 
+        private static bool _isUsingXaml = true;
+
         /// <summary>
         /// Set to true if XAML is used. 
         /// This must be called before or immediately after the NUIWidgetApplication constructor is called.
@@ -104,7 +106,21 @@ namespace Tizen.NUI
         /// This must be called before or immediately after the NUIWidgetApplication constructor is called.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        static public bool IsUsingXaml { get; set; } = true;
+        static public bool IsUsingXaml
+        {
+            get
+            {
+                return _isUsingXaml;
+            }
+            set
+            {
+                if (_isUsingXaml != value)
+                {
+                    Tizen.Log.Info("NUI", $"IsUsingXaml changed to {value}");
+                    _isUsingXaml = value;
+                }
+            }
+        }
 
         internal WidgetApplication ApplicationHandle
         {


### PR DESCRIPTION
Since it is hard to determine whether current application set `IsUsingXaml` value as false or not, let we print log if it is changed.
Default is true so, if the log not printed, mean they using xaml now..