### PR TITLE
[NUI] Call ProcessorController.Initialize at application OnInit time

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -731,9 +731,14 @@ namespace Tizen.NUI
         // Callback for Application InitSignal
         private void OnApplicationInit(IntPtr data)
         {
+            Log.Info("NUI", "[NUI] OnApplicationInit: ProcessorController Initialize");
+            Tizen.Tracer.Begin("[NUI] OnApplicationInit: ProcessorController Initialize");
+            ProcessorController.Instance.Initialize();
+            Tizen.Tracer.End();
+
+            // Initialize DisposeQueue Singleton class. This is also required to create DisposeQueue on main thread.
             Log.Info("NUI", "[NUI] OnApplicationInit: DisposeQueue Initialize");
             Tizen.Tracer.Begin("[NUI] OnApplicationInit: DisposeQueue Initialize");
-            // Initialize DisposeQueue Singleton class. This is also required to create DisposeQueue on main thread.
             DisposeQueue.Instance.Initialize();
             Tizen.Tracer.End();
 
@@ -742,6 +747,7 @@ namespace Tizen.NUI
             Window.Instance = Window.Default = GetWindow();
 
 #if !PROFILE_TV
+            Log.Info("NUI", "[NUI] OnApplicationInit: FocusManager.Instance");
             //tv profile never use default focus indicator, so this is not needed!
             _ = FocusManager.Instance;
 #endif

--- a/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
+++ b/src/Tizen.NUI/src/internal/Common/ProcessorController.cs
@@ -91,11 +91,9 @@ namespace Tizen.NUI
             {
                 if (instance == null)
                 {
-                    // Create an instance of ProcessorController with Initialize.
-                    // Legacy note : We were call Initialize() at internal/Application/Application.cs OnApplicationInit().
-                    // Since DisposeQueue can use this class before Application initialized.
-                    // But now, we just make ProcessorController.Initialized state as static. So we don't need to call Initialize() at Application.cs.
-                    instance = new ProcessorController(true);
+                    // Create an instance of ProcessorController without Initialize.
+                    // We will call Initialize() at internal/Application/Application.cs OnApplicationInit().
+                    instance = new ProcessorController(false);
                 }
                 return instance;
             }
@@ -166,8 +164,12 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Awake()
         {
-            Interop.ProcessorController.Awake(SwigCPtr);
-            NDalicPINVOKE.ThrowExceptionIfExists();
+            // We could awake only if Initialize() called before.
+            if (initialized)
+            {
+                Interop.ProcessorController.Awake(SwigCPtr);
+                NDalicPINVOKE.ThrowExceptionIfExists();
+            }
         }
     } // class ProcessorController
 } // namespace Tizen.NUI

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -808,7 +808,8 @@ namespace Tizen.NUI
             Tizen.Log.Info("NUI", $"Support preload time view creation? {SupportPreInitializedCreation}\n");
 
             // Initialize some static utility
-            var disposalbeQueue = DisposeQueue.Instance;
+            var disposableQueue = DisposeQueue.Instance;
+            var processorController = ProcessorController.Instance;
             var registry = Registry.Instance;
 
             // Initialize some BaseComponent static variables now


### PR DESCRIPTION
To make ensure we can call Awake(), we should initialize this instance at mainthread at least once.
