### PR TITLE
[NUI] Do not call `ThemeManager` constructor at Preload case

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -812,6 +812,8 @@ namespace Tizen.NUI
             // Initialize some BaseComponent static variables now
             BaseComponents.View.Preload();
             BaseComponents.ImageView.Preload();
+            BaseComponents.LottieAnimationView.Preload();
+            BaseComponents.AnimatedVectorImageView.Preload();
             BaseComponents.TextLabel.Preload();
             BaseComponents.TextEditor.Preload();
             BaseComponents.TextField.Preload();
@@ -823,7 +825,6 @@ namespace Tizen.NUI
             if (SupportPreInitializedCreation)
             {
                 _ = FocusManager.Instance;
-                _ = ThemeManager.PlatformThemeId;
             }
 
             // Initialize exception tasks. It must be called end of Preload()

--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
@@ -52,6 +52,17 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        static internal new void Preload()
+        {
+            // Do not call LottieAnimationView.Preload(), since we already call it
+            if (NUIApplication.SupportPreInitializedCreation)
+            {
+                using var temp = new AnimatedVectorImageView();
+            }
+
+            // Do nothing. Just call for load static values.
+        }
+
         /// <summary>
         /// Construct VectorAnimationView.
         /// </summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -267,15 +267,11 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
-        internal ImageView(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(cPtr, cMemoryOwn, viewStyle)
+        internal ImageView(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : this(cPtr, cMemoryOwn, null, shown)
         {
-            if (!shown)
-            {
-                SetVisible(false);
-            }
         }
 
-        internal ImageView(global::System.IntPtr cPtr, bool cMemoryOwn, bool shown = true) : base(cPtr, cMemoryOwn, null)
+        internal ImageView(global::System.IntPtr cPtr, bool cMemoryOwn, ViewStyle viewStyle, bool shown = true) : base(cPtr, cMemoryOwn, viewStyle)
         {
             if (!shown)
             {

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -54,6 +54,17 @@ namespace Tizen.NUI.BaseComponents
             }
         }
 
+        static internal new void Preload()
+        {
+            // Do not call ImageView.Preload(), since we already call it
+            if (NUIApplication.SupportPreInitializedCreation)
+            {
+                using var temp = new LottieAnimationView();
+            }
+
+            // Do nothing. Just call for load static values.
+        }
+
         #region Constructor, Destructor, Dispose
         /// <summary>
         /// LottieAnimationView constructor

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -212,7 +212,8 @@ namespace Tizen.NUI.BaseComponents
             // Do not call View.Preload(), since we already call it
             if (NUIApplication.SupportPreInitializedCreation)
             {
-                using var temp = new TextEditor();
+                using var temp = new TextEditor(Interop.TextEditor.New(true), true);
+                using var temp2 = new TextEditor(Interop.TextEditor.New(false), true);
             }
 
             Property.Preload();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -268,7 +268,8 @@ namespace Tizen.NUI.BaseComponents
             // Do not call View.Preload(), since we already call it
             if (NUIApplication.SupportPreInitializedCreation)
             {
-                using var temp = new TextField();
+                using var temp = new TextField(Interop.TextField.New(true), true);
+                using var temp2 = new TextField(Interop.TextField.New(false), true);
             }
 
             Property.Preload();

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -295,7 +295,8 @@ namespace Tizen.NUI.BaseComponents
             // Do not call View.Preload(), since we already call it
             if (NUIApplication.SupportPreInitializedCreation)
             {
-                using var temp = new TextLabel();
+                using var temp = new TextLabel(Interop.TextLabel.New(true), true);
+                using var temp2 = new TextLabel(Interop.TextLabel.New(false), true);
             }
 
             Property.Preload();

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -464,7 +464,13 @@ namespace Tizen.NUI.BaseComponents
         {
             if (NUIApplication.SupportPreInitializedCreation)
             {
-                using var temp = new View();
+                using var temp = new View()
+                {
+                    BackgroundColor = Color.Transparent,
+                };
+#if !PROFILE_TV
+                using var temp2 = new View(ViewResizePolicyMode.Ignore);
+#endif
             }
 
             Container.Preload();

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1539,6 +1539,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void InitializeStyle(ViewStyle style = null)
         {
+            if (!NUIApplication.IsPreload && NUIApplication.SupportPreInitializedCreation)
+            {
+                // TODO : Since we should not call ThemeManager at Preload timing, we should return here.
+                return;
+            }
+
             if (style == null && ThemeManager.InitialThemeDisabled)
             {
                 // Fast return in most TV cases.

--- a/src/Tizen.NUI/src/public/Common/BaseHandle.cs
+++ b/src/Tizen.NUI/src/public/Common/BaseHandle.cs
@@ -541,7 +541,7 @@ namespace Tizen.NUI
         {
             PropertySet?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
-            if (!ThemeManager.InitialThemeDisabled && ChangedPropertiesSetExcludingStyle != null)
+            if (ChangedPropertiesSetExcludingStyle != null && !ThemeManager.InitialThemeDisabled)
             {
                 ChangedPropertiesSetExcludingStyle.Add(propertyName);
             }


### PR DESCRIPTION
Since it is relative with Appfw callback, we must not touch ThemeManager at preload time.
