### PR TITLE
[NUI][Accessibility] Add CustomHighlightOverlay

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ControlDevel.cs
@@ -165,6 +165,14 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_Accessible_SetHighlightActor")]
             public static extern void DaliAccessibilityAccessibleSetHighlightActor(HandleRef arg1);
 
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_SetCustomHighlightOverlay")]
+            public static extern void SetCustomHighlightOverlay(global::System.Runtime.InteropServices.HandleRef control, global::System.Runtime.InteropServices.HandleRef position, global::System.Runtime.InteropServices.HandleRef size);
+
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Accessibility_ResetCustomHighlightOverlay")]
+            public static extern void ResetCustomHighlightOverlay(global::System.Runtime.InteropServices.HandleRef control);
+
             // Keep this structure layout binary compatible with the respective C++ structure!
             [EditorBrowsable(EditorBrowsableState.Never)]
             [StructLayout(LayoutKind.Sequential)]

--- a/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
+++ b/src/Tizen.NUI/src/public/Accessibility/Accessibility.cs
@@ -203,6 +203,32 @@ namespace Tizen.NUI.Accessibility
         }
 
         /// <summary>
+        /// Sets a custom highlight overlay at the specified position and size.
+        /// This functionality is only applicable when the CustomHighlight Overlay is a child of the scene-view.  
+        /// In other words, the position and size of the highlight indicator can only be set if the CustomHighlight Overlay is part of the scene-view. 
+        /// </summary>
+        /// <param name="position">A Position2D representing the position of the overlay</param>
+        /// <param name="size">A Size2D representing the size of the overlay</param>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void SetCustomHighlightOverlay(View view, Position2D position, Size2D size)
+        {
+            Interop.ControlDevel.SetCustomHighlightOverlay(View.getCPtr(view), Position2D.getCPtr(position), Position2D.getCPtr(size));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
+        /// Resets the custom highlight overlay
+        /// This functionality is only applicable when the CustomHighlight Overlay is a child of the scene-view.
+        /// </summary>
+        // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void ResetCustomHighlightOverlay(View view)
+        {
+            Interop.ControlDevel.ResetCustomHighlightOverlay(View.getCPtr(view));
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+        /// <summary>
         ///  Get highligted View.
         /// </summary>
         // This will be public opened after ACR done. (Before ACR, need to be hidden as Inhouse API)

--- a/test/Tizen.NUI.Scene3D.Sample/Scene3DSample.cs
+++ b/test/Tizen.NUI.Scene3D.Sample/Scene3DSample.cs
@@ -21,6 +21,7 @@ using Tizen.NUI.BaseComponents;
 using Tizen.NUI.Constants;
 using Tizen.NUI.Scene3D;
 using System.Collections.Generic;
+using Tizen.NUI.Accessibility;
 
 class Scene3DSample : NUIApplication
 {
@@ -34,6 +35,7 @@ class Scene3DSample : NUIApplication
     Model mModel;
     Animation mModelAnimation;
     bool mModelLoadFinished;
+    bool mIsCustomOverlay = false;
 
     // Note : This motion data works well only if model is MorthStressTest!
     MotionData mStaticMotionData;
@@ -159,6 +161,7 @@ class Scene3DSample : NUIApplication
         SetupSceneViewCamera(mSceneView);
 
         mWindow.Add(mSceneView);
+
     }
     private void SetupSceneViewCamera(SceneView sceneView)
     {
@@ -229,7 +232,11 @@ class Scene3DSample : NUIApplication
         mModel = new Model(MODEL_DIR + modelUrl)
         {
             Name = modelUrl,
+            AccessibilityName = "Model",
+            AccessibilityRole = Role.Image,
+            AccessibilityHighlightable = true,
         };
+
         mModel.ResourcesLoaded += (s, e) =>
         {
             Model model = s as Model;
@@ -471,6 +478,21 @@ class Scene3DSample : NUIApplication
                             }
                         }
                     }
+                    break;
+                }
+                case "a":
+                {
+                    if (!mIsCustomOverlay)
+                    {
+                        var newSize = new Size2D(500, 500);
+                        var newPosition = new Position2D(100, 100);
+                        Accessibility.SetCustomHighlightOverlay(mModel, newPosition, newSize);
+                    } 
+                    else
+                    {
+                        Accessibility.ResetCustomHighlightOverlay(mModel);
+                    }
+                    mIsCustomOverlay = !mIsCustomOverlay;
                     break;
                 }
             }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
NUI에서 특정 뷰의 경우 Overlay 상에 원하는 위치(x,y,w,h)에 accessibility highlight indicator를 그릴 수 있도록 추가.
scene-view환경에서는 custom하게 사용할 수 있게 제공한다.
dali-toolkit : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/328484
dali-csharp-binder : https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/328485


참고링크 : 
https://confluence.sec.samsung.net/spaces/GFX/pages/1413814040/Patch+List
