### PR TITLE
[NUI] Do not create `BaseComponents` at NUI.preload time

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -820,12 +820,6 @@ namespace Tizen.NUI
             Color.Preload();
             NUIConstants.Preload();
 
-            // Initialize some static instance
-            if (SupportPreInitializedCreation)
-            {
-                _ = FocusManager.Instance;
-            }
-
             // Initialize exception tasks. It must be called end of Preload()
             NDalicPINVOKE.Preload();
 

--- a/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/AnimatedVectorImageView.cs
@@ -55,10 +55,6 @@ namespace Tizen.NUI.BaseComponents
         static internal new void Preload()
         {
             // Do not call LottieAnimationView.Preload(), since we already call it
-            if (NUIApplication.SupportPreInitializedCreation)
-            {
-                using var temp = new AnimatedVectorImageView();
-            }
 
             // Do nothing. Just call for load static values.
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ImageView.cs
@@ -90,10 +90,6 @@ namespace Tizen.NUI.BaseComponents
         static internal new void Preload()
         {
             // Do not call View.Preload(), since we already call it
-            if (NUIApplication.SupportPreInitializedCreation)
-            {
-                using var temp = new ImageView();
-            }
 
             Property.Preload();
             // Do nothing. Just call for load static values.

--- a/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/LottieAnimationView.cs
@@ -57,10 +57,6 @@ namespace Tizen.NUI.BaseComponents
         static internal new void Preload()
         {
             // Do not call ImageView.Preload(), since we already call it
-            if (NUIApplication.SupportPreInitializedCreation)
-            {
-                using var temp = new LottieAnimationView();
-            }
 
             // Do nothing. Just call for load static values.
         }

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -210,11 +210,6 @@ namespace Tizen.NUI.BaseComponents
         static internal new void Preload()
         {
             // Do not call View.Preload(), since we already call it
-            if (NUIApplication.SupportPreInitializedCreation)
-            {
-                using var temp = new TextEditor(Interop.TextEditor.New(true), true);
-                using var temp2 = new TextEditor(Interop.TextEditor.New(false), true);
-            }
 
             Property.Preload();
             // Do nothing. Just call for load static values.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -266,11 +266,6 @@ namespace Tizen.NUI.BaseComponents
         static internal new void Preload()
         {
             // Do not call View.Preload(), since we already call it
-            if (NUIApplication.SupportPreInitializedCreation)
-            {
-                using var temp = new TextField(Interop.TextField.New(true), true);
-                using var temp2 = new TextField(Interop.TextField.New(false), true);
-            }
 
             Property.Preload();
             // Do nothing. Just call for load static values.

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -293,11 +293,6 @@ namespace Tizen.NUI.BaseComponents
         static internal new void Preload()
         {
             // Do not call View.Preload(), since we already call it
-            if (NUIApplication.SupportPreInitializedCreation)
-            {
-                using var temp = new TextLabel(Interop.TextLabel.New(true), true);
-                using var temp2 = new TextLabel(Interop.TextLabel.New(false), true);
-            }
 
             Property.Preload();
             // Do nothing. Just call for load static values.

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -462,17 +462,6 @@ namespace Tizen.NUI.BaseComponents
 
         static internal new void Preload()
         {
-            if (NUIApplication.SupportPreInitializedCreation)
-            {
-                using var temp = new View()
-                {
-                    BackgroundColor = Color.Transparent,
-                };
-#if !PROFILE_TV
-                using var temp2 = new View(ViewResizePolicyMode.Ignore);
-#endif
-            }
-
             Container.Preload();
             RegisterAccessibilityDelegate();
         }


### PR DESCRIPTION
Let we make them determine by NUI preload user, not platform itself.