### PR TITLE
[NUI][A11y] Fix bit flag values in AccessibilityStatesV2 enum

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityStatesV2.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewAccessibilityStatesV2.cs
@@ -32,27 +32,27 @@ namespace Tizen.NUI.BaseComponents
         /// Indicates whether the view is enabled or not.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Enabled = 0,
+        Enabled = 1 << 0,
         /// <summary>
         /// Indicates whether a selectable element is currently selected or not.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Selected = 1,
+        Selected = 1 << 1,
         /// <summary>
         /// Indicates the state of a checkable element.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Checked = 1 << 1,
+        Checked = 1 << 2,
         /// <summary>
         /// Indicates whether an element is currently busy or not.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Busy = 1 << 2,
+        Busy = 1 << 3,
         /// <summary>
         /// Indicates whether an expandable element is currently expanded or collapsed.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        Expanded = 1 << 3
+        Expanded = 1 << 4
     }
 
     /// <summary>


### PR DESCRIPTION

### Problem

The `AccessibilityStatesV2` enum defined incorrect bit flag values, causing multiple states to be set unintentionally.

For example:
 - `Enabled = 0`
 - `Selected = 1`
 - `Checked = 1 << 1` → This is **2**, which overlaps with `Selected` if `Selected` was also defined as 2 (incorrect).

This caused unexpected behavior where setting `Checked` also caused the system to interpret the state as `Selected`.

### Solution

 - Updated the enum definition to assign correct non-overlapping bit flags:

```csharp
enum AccessibilityStatesV2 {
  Enabled  = 1 << 0, // 1
  Selected = 1 << 1, // 2
  Checked  = 1 << 2, // 4
  Busy     = 1 << 3, // 8
  Expanded = 1 << 4  // 16
}
```

 - Updated related usage and ensured `ChangeAccessibilityStatesV2()` handles state toggling correctly.
