### PR TITLE
[NUI][A11y] Update `Target` of Action arguments to use reference object

### DIFF
--- a/src/Tizen.NUI/src/internal/View/ViewAccessibilityData.cs
+++ b/src/Tizen.NUI/src/internal/View/ViewAccessibilityData.cs
@@ -224,7 +224,7 @@ namespace Tizen.NUI.BaseComponents
             var eventArgs = new AccessibilityActionReceivedEventArgs()
             {
                 ActionType = info.ActionType,
-                Target = Registry.GetManagedBaseHandleFromNativePtr(info.target) as View,
+                Target = Registry.GetManagedBaseHandleFromRefObject(info.target) as View,
                 Handled = false
             };
             _accessibilityActionReceivedHandler?.Invoke(_owner, eventArgs);


### PR DESCRIPTION

### Description of Change ###
- Updates the Target assignment logic in the `AccessibilityActionReceivedEventArgs` initialization to use the `GetManagedBaseHandleFromRefObject` method instead of `GetManagedBaseHandleFromNativePtr`.

- This method includes additional checks and handling mechanisms, such as null pointer validation, weak reference management, and disposal tracking, to ensure robustness and consistency in handling native-to-managed object bindings.

