### PR TITLE
[NUI] Add PropertyBridge

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.PropertyBridge.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.PropertyBridge.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.Runtime.InteropServices;
+
+namespace Tizen.NUI
+{
+    internal static partial class Interop
+    {
+        internal static partial class PropertyBridge
+        {
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_PropertyBridge_RegisterStringGetter")]
+            public static extern void RegisterStringGetter(IntPtr getter);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextEditor.cs
@@ -30,7 +30,7 @@ namespace Tizen.NUI.BaseComponents
     /// A control which provides a multi-line editable text editor.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    public partial class TextEditor : View
+    public partial class TextEditor : View, IPropertyProvider
     {
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextEditor";
         static private string defaultFontFamily = "BreezeSans";
@@ -264,6 +264,20 @@ namespace Tizen.NUI.BaseComponents
         {
             return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
         }
+
+        // IPropertyProvider
+        /// <summary>
+        /// Gets a string property by name.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The string value of the property, or null if not found.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string GetStringProperty(string propertyName) => propertyName switch
+        {
+            nameof(TranslatableText) => TranslatableText,
+            nameof(TranslatablePlaceholderText) => TranslatablePlaceholderText,
+            _ => null
+        };
 
         /// <summary>
         /// The TranslatableText property.<br />

--- a/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextField.cs
@@ -29,7 +29,7 @@ namespace Tizen.NUI.BaseComponents
     /// A control which provides a single line editable text field.
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    public partial class TextField : View
+    public partial class TextField : View, IPropertyProvider
     {
         static private string defaultStyleName = "Tizen.NUI.BaseComponents.TextField";
         static private string defaultFontFamily = "BreezeSans";
@@ -336,6 +336,21 @@ namespace Tizen.NUI.BaseComponents
         {
             return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
         }
+
+        // IPropertyProvider
+        /// <summary>
+        /// Gets a string property by name.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The string value of the property, or null if not found.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string GetStringProperty(string propertyName) => propertyName switch
+        {
+            nameof(TranslatableText) => TranslatableText,
+            nameof(TranslatablePlaceholderText) => TranslatablePlaceholderText,
+            nameof(TranslatablePlaceholderTextFocused) => TranslatablePlaceholderTextFocused,
+            _ => null
+        };
 
         /// <summary>
         /// The TranslatableText property.<br />

--- a/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/TextLabel.cs
@@ -31,7 +31,7 @@ namespace Tizen.NUI.BaseComponents
     /// Text labels are lightweight, non-editable, and do not respond to the user input.<br />
     /// </summary>
     /// <since_tizen> 3 </since_tizen>
-    public partial class TextLabel : View
+    public partial class TextLabel : View, IPropertyProvider
     {
         internal class TextLabelLayout : LayoutItem
         {
@@ -392,6 +392,19 @@ namespace Tizen.NUI.BaseComponents
         {
             return ThemeManager.GetStyle(this.GetType()) == null ? false : true;
         }
+
+        // IPropertyProvider
+        /// <summary>
+        /// Gets a string property by name.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The string value of the property, or null if not found.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string GetStringProperty(string propertyName) => propertyName switch
+        {
+            nameof(TranslatableText) => TranslatableText,
+            _ => null
+        };
 
         /// <summary>
         /// Requests asynchronous rendering of text with a fixed size.

--- a/src/Tizen.NUI/src/public/PropertyBridge/IPropertyProvider.cs
+++ b/src/Tizen.NUI/src/public/PropertyBridge/IPropertyProvider.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// Provides string properties by name for interop or dynamic access scenarios.
+    /// </summary>
+    internal interface IPropertyProvider
+    {
+        /// <summary>
+        /// Gets a string property by name.
+        /// </summary>
+        /// <param name="propertyName">The name of the property to retrieve.</param>
+        /// <returns>The string value of the property, or null if not found.</returns>
+        string GetStringProperty(string propertyName);
+    }
+}

--- a/src/Tizen.NUI/src/public/PropertyBridge/PropertyBridge.cs
+++ b/src/Tizen.NUI/src/public/PropertyBridge/PropertyBridge.cs
@@ -1,0 +1,56 @@
+/*
+ * Copyright(c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using System;
+using System.Runtime.InteropServices;
+
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI
+{
+    internal static class PropertyBridge
+    {
+        private static StringGetterDelegate _stringGetterDelegate;
+
+        static PropertyBridge()
+        {
+        }
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate string StringGetterDelegate(IntPtr obj, [MarshalAs(UnmanagedType.LPStr)] string propertyName);
+
+        public static void RegisterStringGetter()
+        {
+            _stringGetterDelegate = InternalStringGetter;
+            IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(_stringGetterDelegate);
+            Interop.PropertyBridge.RegisterStringGetter(funcPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        private static string InternalStringGetter(IntPtr obj, string propertyName)
+        {
+            if (obj != IntPtr.Zero)
+            {
+                View view = Registry.GetManagedBaseHandleFromNativePtr(obj) as View;
+                if (view != null && view is IPropertyProvider provider)
+                {
+                    return provider.GetStringProperty(propertyName);
+                }
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Register delegate in NUI first..
PropertyBridge.RegisterStringGetter();

Currently, only StringGetter exists, but additional types can be added as needed. Classes sending properties to DALi must inherit from IPropertyProvider and implement GetStringProperty.

This patch implements TranslatableText (which does not exist in DALi) for Text. Once this is completed, NUI-side preparation is done.

In DALi, it can be used as follows:
std::string sid = Dali::Toolkit::PropertyBridge::Get().GetStringProperty(label, "TranslatableText");

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/328739
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/328740
