### PR TITLE
[NUI] Fix SVACE issue

### DIFF
--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -1349,7 +1349,7 @@ namespace Tizen.NUI
         {
             if (wheelEvent != null)
             {
-                Tizen.Log.Info("NUI", $"FeedWheel {wheelEvent.Point.X}, {wheelEvent.Point.Y}, Type : {wheelEvent.Type}, Direction : {wheelEvent.Direction}");
+                Tizen.Log.Info("NUI", $"FeedWheel {wheelEvent.Point?.X}, {wheelEvent.Point?.Y}, Type : {wheelEvent.Type}, Direction : {wheelEvent.Direction}");
             }
             Interop.Window.FeedWheelEvent(SwigCPtr, Wheel.getCPtr(wheelEvent));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();


### PR DESCRIPTION
### Description of Change ###
[NUI] Fix SVACE issue
- WID:510174 [STATISTICAL] Value wheelEvent.Point, which is result of method invocation with possible null return value, is dereferenced in member access expression wheelEvent.Point.X

### API Changes ###
nothing