### PR TITLE
[NUI] Preparing App locale language support

### DIFF
--- a/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
+++ b/src/Tizen.NUI/src/internal/Common/SystemLocaleLanguageChangedManager.cs
@@ -20,6 +20,7 @@ using TizenSystemSettings.Tizen.System;
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 
 namespace Tizen.NUI
 {
@@ -30,7 +31,7 @@ namespace Tizen.NUI
     internal static class SystemLocaleLanguageChangedManager
     {
         private static string localeLanguage = string.Empty;
-        private static string defaultLocaleLanguage = "en_US";
+        private static string defaultLocaleLanguage = CultureInfo.CurrentUICulture.Name;
         private static WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>> proxy = new WeakEvent<EventHandler<LocaleLanguageChangedEventArgs>>();
 
         static SystemLocaleLanguageChangedManager()
@@ -86,6 +87,10 @@ namespace Tizen.NUI
                     try
                     {
                         localeLanguage = SystemSettings.LocaleLanguage;
+                        if (string.IsNullOrEmpty(localeLanguage))
+                        {
+                            localeLanguage = defaultLocaleLanguage;
+                        }
                     }
                     catch (Exception e)
                     {

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -5581,7 +5581,7 @@ namespace Tizen.NUI.BaseComponents
             return (ViewLayoutDirectionType)Object.InternalGetPropertyInt(SwigCPtr, Property.LayoutDirection);
         }
 
-        private void RequestLayoutForInheritLayoutDirection()
+        internal void RequestLayoutForInheritLayoutDirection()
         {
             bool existInheritChild = false;
             foreach (var child in Children)


### PR DESCRIPTION
* Get the default language (fallback) of the SystemLocaleLanguageChangedManager from CultureInfo.
* CultureInfo is set in CoreApplication OnCreate.

* Set the fallback language if SystemSettings.LocaleLanguage does not exist.

* Change View.RequestLayoutForInheritLayoutDirection to internal.

* Bind LayoutDirectionChanged to NUI Layer.
* When supporting app languages, if the root layer's LayoutDirection changes on the DALi side, the NUI layer receives a callback and calls RequestLayoutForInheritLayoutDirection on its children.
