### PR TITLE
[NUI] Extract View's ImageUrl from offscreen rendering output

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.View.cs
@@ -63,6 +63,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetRenderEffect")]
             public static extern global::System.IntPtr GetRenderEffect(global::System.Runtime.InteropServices.HandleRef self);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_GetOffScreenRenderingOutput")]
+            public static extern global::System.IntPtr GetOffScreenRenderingOutput(global::System.Runtime.InteropServices.HandleRef self);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ClearRenderEffect")]
             public static extern void ClearRenderEffect(global::System.Runtime.InteropServices.HandleRef self);
 

--- a/src/Tizen.NUI/src/internal/Interop/Interop.ViewSignal.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ViewSignal.cs
@@ -45,6 +45,12 @@ namespace Tizen.NUI
 
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_ResourceReadySignal_Disconnect")]
             public static extern void ResourceReadyDisconnect(HandleRef view, HandleRef handler);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_OffScreenRenderingFinishedSignal_Connect")]
+            public static extern void OffScreenRenderingFinishedConnect(HandleRef view, HandleRef handler);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_View_OffScreenRenderingFinishedSignal_Disconnect")]
+            public static extern void OffScreenRenderingFinishedDisconnect(HandleRef view, HandleRef handler);
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEvent.cs
@@ -47,6 +47,8 @@ namespace Tizen.NUI.BaseComponents
         private OnRelayoutEventCallbackType onRelayoutEventCallback;
         private EventHandler onWindowEventHandler;
         private OnWindowEventCallbackType onWindowEventCallback;
+        private EventHandler offScreenRenderingFinishedEventHandler;
+        private OnOffScreenRenderingFinishedCallbackType offScreenRenderingFinishedCallback;
         // Resource Ready Signal
         private EventHandler resourcesLoadedEventHandler;
         private ResourcesLoadedCallbackType resourcesLoadedCallback;
@@ -88,6 +90,9 @@ namespace Tizen.NUI.BaseComponents
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate void OnWindowEventCallbackType(IntPtr control);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void OnOffScreenRenderingFinishedCallbackType(IntPtr control);
 
         private ViewEventRareData _viewEventRareData; // NOTE Consider reuse data by using pool
 
@@ -425,6 +430,39 @@ namespace Tizen.NUI.BaseComponents
                     Interop.ActorSignal.OffSceneDisconnect(SwigCPtr, offWindowEventCallback.ToHandleRef(this));
                     NDalicPINVOKE.ThrowExceptionIfExists();
                     offWindowEventCallback = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The OffScreenRenderingFinished event is emitted when the off-screen rendering of the view is finished.
+        /// </summary>
+        /// <remarks>
+        /// This event is sent only when View.OffScreenRendering is set to View.OffScreenRenderingType.RefreshOnce.
+        /// </remarks>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public event EventHandler OffScreenRenderingFinished
+        {
+            add
+            {
+                if (offScreenRenderingFinishedEventHandler == null)
+                {
+                    offScreenRenderingFinishedCallback = OnOffScreenRenderingFinished;
+                    Interop.ViewSignal.OffScreenRenderingFinishedConnect(SwigCPtr, offScreenRenderingFinishedCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                }
+                offScreenRenderingFinishedEventHandler += value;
+            }
+
+            remove
+            {
+                offScreenRenderingFinishedEventHandler -= value;
+                if (offScreenRenderingFinishedEventHandler == null && offScreenRenderingFinishedCallback != null)
+                {
+                    Interop.ViewSignal.OffScreenRenderingFinishedDisconnect(SwigCPtr, offScreenRenderingFinishedCallback.ToHandleRef(this));
+                    NDalicPINVOKE.ThrowExceptionIfExists();
+                    offScreenRenderingFinishedCallback = null;
                 }
             }
         }
@@ -962,6 +1000,17 @@ namespace Tizen.NUI.BaseComponents
             {
                 offWindowEventHandler(this, null);
             }
+        }
+
+        // Callback for the OffScreenRenderingFinished signal
+        private void OnOffScreenRenderingFinished(IntPtr control)
+        {
+            if (Disposed || IsDisposeQueued)
+            {
+                // Ignore native callback if the view is disposed or queued for disposal.
+                return;
+            }
+            offScreenRenderingFinishedEventHandler?.Invoke(this, null);
         }
 
         // Callback for View visibility change signal

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -1424,6 +1424,15 @@ namespace Tizen.NUI.BaseComponents
 
             _viewEventRareData?.ClearSignal();
 
+            if (offScreenRenderingFinishedCallback != null)
+            {
+                NUILog.Debug($"[Dispose] offScreenRenderingFinishedCallback");
+
+                Interop.ViewSignal.OffScreenRenderingFinishedDisconnect(GetBaseHandleCPtrHandleRef, offScreenRenderingFinishedCallback.ToHandleRef(this));
+                NDalicPINVOKE.ThrowExceptionIfExistsDebug();
+                offScreenRenderingFinishedCallback = null;
+            }
+
             if (onRelayoutEventCallback != null)
             {
                 NUILog.Debug($"[Dispose] onRelayoutEventCallback");

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewPublicMethods.cs
@@ -376,6 +376,32 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Retrieves ImageUrl of View's offscreen rendering result.
+        /// </summary>
+        /// <remarks>
+        /// Returns valid url only when View.OffScreenRendering is set to View.OffScreenRenderingType.RenderOnce
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ImageUrl GetOffScreenImageUrl()
+        {
+            IntPtr cPtr = Interop.View.GetOffScreenRenderingOutput(SwigCPtr);
+            if (cPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            ImageUrl url = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as ImageUrl;
+            if (url != null)
+            {
+                Interop.BaseHandle.DeleteBaseHandle(new HandleRef(this, cPtr));
+                NDalicPINVOKE.ThrowExceptionIfExists();
+                return url;
+            }
+            url = new ImageUrl(cPtr, true);
+            return url;
+        }
+
+        /// <summary>
         /// Shows the view.
         /// </summary>
         /// <remarks>

--- a/src/Tizen.NUI/src/public/RenderEffects/BackgroundBlurEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/BackgroundBlurEffect.cs
@@ -100,8 +100,10 @@ namespace Tizen.NUI
         /// The unit is pixel, but the property is in float type since many other platforms use float for blur effect radius.
         /// </summary>
         /// <remarks>
-        /// For performance, blur radius is internally recalculated. It should be greater than or equal to (4 / downscale factor).
-        /// Note that BlurDownscaleFactor is set to 0.25 as default.
+        /// The blurRadius parameter is adjusted due to downscaling and kernel compression, resulting in a smaller effective value.
+        /// This means the blur intensity changes in discrete steps rather than continuously, with the step size determined by (2 / downscale factor).
+        /// For example, with a default BlurDownscaleFactor of 0.25, the step size is 8.
+        /// To ensure proper functionality, a minimum blurRadius value of 2 steps is required, with intensity updates occurring at every step size increment.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public float BlurRadius

--- a/src/Tizen.NUI/src/public/RenderEffects/GaussianBlurEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/GaussianBlurEffect.cs
@@ -100,8 +100,10 @@ namespace Tizen.NUI
         /// The unit is pixel, but the property is in float type since many other platforms use float for blur effect radius.
         /// </summary>
         /// <remarks>
-        /// For performance, blur radius is internally recalculated. It should be greater than or equal to (4 / downscale factor).
-        /// Note that BlurDownscaleFactor is set to 0.25 as default.
+        /// The blurRadius parameter is adjusted due to downscaling and kernel compression, resulting in a smaller effective value.
+        /// This means the blur intensity changes in discrete steps rather than continuously, with the step size determined by (2 / downscale factor).
+        /// For example, with a default BlurDownscaleFactor of 0.25, the step size is 8.
+        /// To ensure proper functionality, a minimum blurRadius value of 2 steps is required, with intensity updates occurring at every step size increment.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public float BlurRadius

--- a/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
+++ b/src/Tizen.NUI/src/public/RenderEffects/RenderEffect.cs
@@ -136,8 +136,10 @@ namespace Tizen.NUI
         /// <param name="blurRadius">The blur radius value. The unit is pixel for standard cases.</param>
         /// <returns>Background blur effect with given blur radius.</returns>
         /// <remarks>
-        /// For performance, blur radius is internally recalculated. It should be greater than or equal to (4 / downscale factor).
-        /// As default downscale factor is set to 0.25, minimum initial blurRadius is 16u.
+        /// The blurRadius parameter is adjusted due to downscaling and kernel compression, resulting in a smaller effective value.
+        /// This means the blur intensity changes in discrete steps rather than continuously, with the step size determined by (2 / downscale factor).
+        /// For example, with a default BlurDownscaleFactor of 0.25, the step size is 8.
+        /// To ensure proper functionality, a minimum blurRadius value of 2 steps is required, with intensity updates occurring at every step size increment.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static BackgroundBlurEffect CreateBackgroundBlurEffect(float blurRadius)
@@ -151,8 +153,10 @@ namespace Tizen.NUI
         /// <param name="blurRadius">The blur radius value. The unit is pixel for standard cases.</param>
         /// <returns>Blur effect with given blur radius.</returns>
         /// <remarks>
-        /// For performance, blur radius is internally recalculated. It should be greater than or equal to (4 / downscale factor).
-        /// As default downscale factor is set to 0.25, minimum initial blurRadius is 16u.
+        /// The blurRadius parameter is adjusted due to downscaling and kernel compression, resulting in a smaller effective value.
+        /// This means the blur intensity changes in discrete steps rather than continuously, with the step size determined by (2 / downscale factor).
+        /// For example, with a default BlurDownscaleFactor of 0.25, the step size is 8.
+        /// To ensure proper functionality, a minimum blurRadius value of 2 steps is required, with intensity updates occurring at every step size increment.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static GaussianBlurEffect CreateGaussianBlurEffect(float blurRadius)


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
Related dali patches are: [329433](https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/329433) [329434](https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/329434)
Visual demo results at: [link](https://confluence.sec.samsung.net/spaces/GFX/pages/1032560551/25?focusedCommentId=1433537593#comment-1433537593)

Precondition: `View.OffScreenRendering` should be set to `OffScreenRenderingType.RefreshOnce`

Includes minor description updates at `RenderEffect`.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
