### PR TITLE
[NUI] SetNativeImageSourceForCurrentFrame

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.VideoView.cs
@@ -108,6 +108,15 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_GetNativePlayerHandle")]
             public static extern global::System.IntPtr GetNativePlayerHandle(global::System.Runtime.InteropServices.HandleRef jarg1);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetFrameInterpolationInterval")]
+            public static extern void SetFrameInterpolationInterval(global::System.Runtime.InteropServices.HandleRef view, float intervalSeconds);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_GetFrameInterpolationInterval")]
+            public static extern float GetFrameInterpolationInterval(global::System.Runtime.InteropServices.HandleRef view);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_VideoView_SetNativeImageSourceForCurrentFrame")]
+            public static extern void SetNativeImageSourceForCurrentFrame(global::System.Runtime.InteropServices.HandleRef view, global::System.Runtime.InteropServices.HandleRef nativeImageSource);
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/VideoView.cs
@@ -580,6 +580,57 @@ namespace Tizen.NUI.BaseComponents
         }
 
         /// <summary>
+        /// Gets or sets the time interval for frame interpolation in seconds.
+        /// </summary>
+        /// <remarks>
+        /// The interpolation factor will progress from 0.0 to 1.0 over this duration.
+        /// This interval is applied after the next call to SetNativeImageSourceForCurrentFrame.
+        /// The value must be non-negative.
+        /// </remarks>
+        /// <remarks>
+        /// This method must be called on the main thread.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        internal float FrameInterpolationInterval
+        {
+            get
+            {
+                float ret = Interop.VideoView.GetFrameInterpolationInterval(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+            set
+            {
+                if (value < 0.0f)
+                {
+                    throw new ArgumentException("Frame interpolation interval cannot be negative.", nameof(value));
+                }
+                Interop.VideoView.SetFrameInterpolationInterval(SwigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
+        /// <summary>
+        /// Sets the NativeImageSource for the current video frame to be used in frame interpolation.
+        /// The VideoView must be in underlay mode (Underlay = true) and have a valid video size for this to take effect.
+        /// Call SetFrameInterpolationInterval() first to configure the interpolation duration.
+        /// </summary>
+        /// <param name="nativeImageSource">The NativeImageSource for the current frame.</param>
+        /// <remarks>
+        /// This method must be called on the main thread.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)] // Devel API
+        public void SetNativeImageSourceForCurrentFrame(NativeImageSource nativeImageSource)
+        {
+            if (nativeImageSource == null)
+            {
+                throw new ArgumentNullException(nameof(nativeImageSource));
+            }
+            Interop.VideoView.SetNativeImageSourceForCurrentFrame(SwigCPtr, nativeImageSource.SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        /// <summary>
         /// Starts the video playback.
         /// </summary>
         /// <since_tizen> 3 </since_tizen>

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VideoViewWithOffScreenRenderingTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/VideoViewWithOffScreenRenderingTest.cs
@@ -1,0 +1,192 @@
+using global::System;
+using System.Threading.Tasks;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+using NUnit.Framework;
+
+namespace Tizen.NUI.Samples
+{
+    using log = Tizen.Log;
+    public class VideoViewWithOffScreenRenderingTest : IExample
+    {
+        private Window window;
+        private View root;
+        private VideoView videoView;
+        private View blurView;
+        private NativeImageSource[] testNativeImageSources = new NativeImageSource[3];
+        private Timer frameUpdateTimer;
+        private int currentFrameIndex = 0;
+        private const int INIT_WIDTH = 600;
+        private const int INIT_HEIGHT = 400;
+        private const int INIT_BUFFER_WIDTH = 128; //600;
+        private const int INIT_BUFFER_HEIGHT = 128; //400;
+        private const NativeImageSource.ColorDepth COLOR_DEPTH = NativeImageSource.ColorDepth.Bits24;// NativeImageSource.ColorDepth.Bits32;
+
+        public void Activate()
+        {
+            log.Debug(tag, "Activate(): start \n");
+            window = NUIApplication.GetDefaultWindow();
+
+            // Create a root view with blue background
+            root = new View()
+            {
+                Size = new Size(window.WindowSize.Width, window.WindowSize.Height),
+                BackgroundColor = Color.Blue,
+                ParentOrigin = ParentOrigin.Center,
+                PivotPoint = PivotPoint.Center,
+                PositionUsesPivotPoint = true,
+            };
+            window.Add(root);
+
+            // Create a red rectangle view
+            View redRec = new View()
+            {
+                Size = new Size(500, 500),
+                BackgroundColor = Color.Red,
+                ParentOrigin = ParentOrigin.Center,
+                PivotPoint = PivotPoint.Center,
+                PositionUsesPivotPoint = true,
+            };
+            root.Add(redRec);
+
+            // Create VideoView
+            videoView = new VideoView()
+            {
+                ResourceUrl = Tizen.Applications.Application.Current.DirectoryInfo.Resource + "v.mp4",
+                Size = new Size(INIT_WIDTH, INIT_HEIGHT),
+                Position = new Position(500.0f, 0.0f),
+                ParentOrigin = ParentOrigin.Center,
+                PivotPoint = PivotPoint.Center,
+                PositionUsesPivotPoint = true,
+                Looping = true,
+                Muted = false,
+                CornerRadius = new Vector4(150.0f, 150.0f, 150.0f, 150.0f),
+            };
+            root.Add(videoView);
+            videoView.Play();
+
+            // Create a view with BackgroundBlurEffect
+            blurView = new View()
+            {
+                Size = new Size(500, 500),
+                Position = new Position(250, -250),
+                ParentOrigin = ParentOrigin.Center,
+                PivotPoint = PivotPoint.Center,
+                PositionUsesPivotPoint = true,
+            };
+            var blurEffect = RenderEffect.CreateBackgroundBlurEffect(50.0f);
+            blurView.SetRenderEffect(blurEffect); // Blur radius 50
+            root.Add(blurView);
+
+            // Create test NativeImageSources (R, G, B)
+            CreateTestNativeImageSources();
+
+            // Set to underlay mode for frame interpolation
+            videoView.Underlay = true;
+
+            // Set frame interpolation interval (e.g., 0.5s)
+            videoView.FrameInterpolationInterval = 2.5f;
+
+            // Initialize video size by setting the first frame.
+            if (testNativeImageSources[0] != null)
+            {
+                videoView.SetNativeImageSourceForCurrentFrame(testNativeImageSources[0]);
+                currentFrameIndex = (currentFrameIndex + 1) % 3;
+            }
+
+            // Set up timer to update frames
+            frameUpdateTimer = new Timer(2500); // Update every 500ms
+            frameUpdateTimer.Tick += OnFrameUpdateTimerTick;
+            frameUpdateTimer.Start();
+        }
+
+        private void CreateTestNativeImageSources()
+        {
+            testNativeImageSources[0] = CreateColorNativeImageSourceImage(INIT_BUFFER_WIDTH, INIT_BUFFER_HEIGHT, Tizen.Applications.Application.Current.DirectoryInfo.Resource + "images/Dali/ContactCard/gallery-small-14.jpg");
+            testNativeImageSources[1] = CreateColorNativeImageSourceImage(INIT_BUFFER_WIDTH, INIT_BUFFER_HEIGHT, Tizen.Applications.Application.Current.DirectoryInfo.Resource + "images/Dali/ContactCard/gallery-small-18.jpg");
+            testNativeImageSources[2] = CreateColorNativeImageSourceImage(INIT_BUFFER_WIDTH, INIT_BUFFER_HEIGHT, Tizen.Applications.Application.Current.DirectoryInfo.Resource + "images/Dali/ContactCard/gallery-small-19.jpg");
+        }
+
+        private NativeImageSource CreateColorNativeImageSourceImage(int width, int height, string path)
+        {
+            var source = new NativeImageSource((uint)width, (uint)height, COLOR_DEPTH);
+            AssignBufferImage(source, width, height, path);
+            return source;
+        }
+
+        private void AssignBufferImage(NativeImageSource source, int width, int height, string path)
+        {
+            Task task = new Task(() =>
+            {
+                PixelBuffer pixelBuffer = ImageLoader.LoadImageFromFile(path);
+                IntPtr pixelBufferIntPtr = pixelBuffer.GetBuffer();
+
+                int bufferWidth = 0;
+                int bufferHeight = 0;
+                int bufferStride = 0;
+                var buffer = source.AcquireBuffer(ref bufferWidth, ref bufferHeight, ref bufferStride);
+                uint size = (uint)bufferWidth * (uint)bufferHeight * 3;
+
+                Tizen.Log.Error("VIDEO_TEST", $"w : {pixelBuffer.GetWidth()}, h : {pixelBuffer.GetHeight()}\n");
+                unsafe
+                {
+                    byte* sourData = (byte*)pixelBufferIntPtr.ToPointer();
+                    byte* destData = (byte*)buffer.ToPointer();
+                    for (int i = 0; i < size; i += 3)
+                    {
+                        destData[i] = sourData[i + 2];     // R
+                        destData[i + 1] = sourData[i + 1]; // G
+                        destData[i + 2] = sourData[i]; // B
+                    }
+                }
+                Tizen.Log.Error("NUI", $"ReleaseBuffer\n");
+                source.ReleaseBuffer();
+            });
+            task.Start();
+            task.Wait(); // Wait for buffer assignment to complete before using the source
+        }
+
+        private bool OnFrameUpdateTimerTick(object source, Timer.TickEventArgs e)
+        {
+            log.Debug(tag, $"idx : {currentFrameIndex}\n");
+            // Cycle through R, G, B frames
+            if (testNativeImageSources[currentFrameIndex] != null)
+            {
+                videoView.SetNativeImageSourceForCurrentFrame(testNativeImageSources[currentFrameIndex]);
+            }
+            currentFrameIndex = (currentFrameIndex + 1) % 3;
+            return true; // Keep timer running
+        }
+
+        public void Deactivate()
+        {
+            if (frameUpdateTimer != null)
+            {
+                frameUpdateTimer.Stop();
+                frameUpdateTimer.Tick -= OnFrameUpdateTimerTick;
+                frameUpdateTimer.Dispose();
+            }
+
+            if (window != null)
+            {
+                if (root != null)
+                {
+                    window.Remove(root);
+                }
+            }
+
+            if (testNativeImageSources != null)
+            {
+                foreach (var nativeImageSource in testNativeImageSources)
+                {
+                    nativeImageSource?.Dispose();
+                }
+            }
+            videoView?.Dispose();
+            root?.Dispose();
+            blurView?.Dispose();
+        }
+
+        const string tag = "NUITEST";
+    }
+}


### PR DESCRIPTION
### Description of Change ###
This PR introduces a frame interpolation feature to the `VideoView` control, enabling smoother visual transitions between video frames on OffScreen rendering.

- VideoView.SetNativeImageSourceForCurrentFrame(NativeImageSource nativeImageSource)

  - A new internal method that sets the `NativeImageSource` for the current video frame.
  - This frame is used by the underlying native layer to perform interpolation with the previous frame.
  - Requires `VideoView.Underlay` to be `true`.

- VideoView.FrameInterpolationInterval` (Property)

  - A new `float` property to get or set the duration (in seconds) for the frame interpolation animation.
  - The interpolation factor will animate from 0.0 to 1.0 over this interval.
  - Must be non-negative.

This API allows developers to enhance video playback quality by creating smooth cross-fades between frames, reducing choppiness for a more polished user experience.


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
