### PR TITLE
[NUI] Add SetIgnored to FrameUpdateCallbackInterface and sample

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.FrameUpdateCallbackInterface.cs
@@ -102,6 +102,10 @@ namespace Tizen.NUI
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool FrameCallbackInterfaceBakeColor(global::System.IntPtr proxy, uint id, global::System.Runtime.InteropServices.HandleRef vector);
 
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_SetIgnored")]
+            [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
+            public static extern bool FrameCallbackInterfaceSetIgnored(global::System.IntPtr proxy, uint id, [global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)] bool ignored);
+
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_FrameCallbackInterface_AddFrameCallback")]
             public static extern void FrameCallbackInterfaceAddFrameUpdateCallback(global::System.Runtime.InteropServices.HandleRef jarg1, global::System.Runtime.InteropServices.HandleRef jarg2, global::System.Runtime.InteropServices.HandleRef jarg3);
 

--- a/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
+++ b/src/Tizen.NUI/src/public/Common/FrameUpdateCallbackInterface.cs
@@ -325,6 +325,19 @@ namespace Tizen.NUI
 
         /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
         [EditorBrowsable(EditorBrowsableState.Never)]
+        protected bool SetIgnored(uint id, bool ignored)
+        {
+            if (proxyIntPtr == IntPtr.Zero)
+            {
+                return false;
+            }
+            bool ret = Interop.FrameUpdateCallbackInterface.FrameCallbackInterfaceSetIgnored(proxyIntPtr, id, ignored);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            return ret;
+        }
+
+        /// This will be public opened after ACR done. Before ACR, need to be hidden as inhouse API.
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected bool GetPositionAndSize(uint id, Vector3 Position, Vector3 Size)
         {
             if (proxyIntPtr == IntPtr.Zero)

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackToggleTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackToggleTest.cs
@@ -1,0 +1,162 @@
+using System;
+using Tizen.NUI;
+using Tizen.NUI.BaseComponents;
+
+namespace Tizen.NUI.Samples
+{
+    public class FrameUpdateCallbackToggleTest : IExample
+    {
+        private Window window;
+        private View imageView;
+        private TextLabel visibleLabel;
+        private TextLabel ignoredLabel;
+        private IgnoredToggler ignoredToggler;
+
+        // FrameUpdateCallback to toggle the ignored state of an actor
+        private class IgnoredToggler : FrameUpdateCallbackInterface
+        {
+            private const float IntervalSeconds = 2.0f;
+            private float elapsedTime;
+            private bool currentlyIgnored;
+            private uint imageViewId;
+            private uint visibleLabelId;
+            private uint ignoredLabelId;
+
+            public IgnoredToggler(uint imageViewId, uint visibleLabelId, uint ignoredLabelId)
+                : base(1u) // Use version 1 of the callback to return a boolean
+            {
+                this.imageViewId = imageViewId;
+                this.visibleLabelId = visibleLabelId;
+                this.ignoredLabelId = ignoredLabelId;
+                this.elapsedTime = 0.0f;
+                this.currentlyIgnored = false;
+            }
+
+            public override bool OnUpdate(FrameUpdateCallbackInterface obj, float elapsedSeconds)
+            {
+                elapsedTime += elapsedSeconds;
+
+                if (elapsedTime >= IntervalSeconds)
+                {
+                    currentlyIgnored = !currentlyIgnored;
+                    SetIgnored(imageViewId, currentlyIgnored);
+                    // Control label visibility using SetIgnored to ensure thread safety
+                    SetIgnored(visibleLabelId, currentlyIgnored); // Hide "Visible" label when main actor is ignored
+                    SetIgnored(ignoredLabelId, !currentlyIgnored); // Show "Ignored" label when main actor is ignored
+                    elapsedTime = 0.0f; // Reset timer
+                }
+
+                return true; // Keep the callback alive
+            }
+        }
+
+        public void Activate()
+        {
+            Window window = NUIApplication.GetDefaultWindow();
+            window.BackgroundColor = Color.White;
+            window.KeyEvent += OnKeyEvent;
+
+            // Create an ImageView to visually demonstrate the ignored state
+            imageView = new View()
+            {
+                Size = new Size(200, 200),
+                ParentOrigin = ParentOrigin.Center,
+                PivotPoint = PivotPoint.Center,
+                PositionUsesPivotPoint = true,
+                BackgroundColor = Color.Red,
+                Name = "demoImageView"
+            };
+            window.GetDefaultLayer().Add(imageView);
+
+            // Create TextLabels to display the ignored state
+            // "Visible" Label
+            visibleLabel = new TextLabel("Visible")
+            {
+                ParentOrigin = ParentOrigin.Center,
+                PivotPoint = PivotPoint.Center,
+                PositionUsesPivotPoint = true,
+                TextColor = Color.Black,
+                HorizontalAlignment = HorizontalAlignment.Center,
+                PointSize = 12
+            };
+            window.GetDefaultLayer().Add(visibleLabel); // Add to window directly
+
+            // "Ignored" Label
+            ignoredLabel = new TextLabel("Ignored")
+            {
+                ParentOrigin = ParentOrigin.Center,
+                PivotPoint = PivotPoint.Center,
+                PositionUsesPivotPoint = true,
+                TextColor = Color.Red, // Use red to distinguish
+                HorizontalAlignment = HorizontalAlignment.Center,
+                PointSize = 12
+            };
+            window.GetDefaultLayer().Add(ignoredLabel); // Add to window directly
+
+            // Set initial visibility for labels using SetIgnored for consistency
+            // Initially, ignoredLabel should be in an 'ignored' state so it's not visible.
+            // We call SetIgnored directly here as we are on the main thread.
+            // Note: SetIgnored on an actor from the main thread sends a message to the update thread.
+            // Use the Ignored property directly on the View if available.
+            ignoredLabel.Ignored = true; // Initially ignored
+
+            // Get the actor IDs for the FrameUpdateCallback
+            uint imageViewId = imageView.ID;
+            uint visibleLabelId = visibleLabel.ID;
+            uint ignoredLabelId = ignoredLabel.ID;
+
+            // Create and add the frame callback to toggle the ignored state every 2 seconds
+            ignoredToggler = new IgnoredToggler(imageViewId, visibleLabelId, ignoredLabelId);
+            // Pass null as the root view, as the callback doesn't need to be tied to a specific view's lifecycle
+            // and Layer cannot be directly cast to View for this method.
+            window.AddFrameUpdateCallback(ignoredToggler, null);
+        }
+
+        public void Deactivate()
+        {
+            if (ignoredToggler != null)
+            {
+                window.RemoveFrameUpdateCallback(ignoredToggler);
+                ignoredToggler = null;
+            }
+
+            if (ignoredLabel != null)
+            {
+                ignoredLabel.Unparent();
+                ignoredLabel.Dispose();
+                ignoredLabel = null;
+            }
+
+            if (visibleLabel != null)
+            {
+                visibleLabel.Unparent();
+                visibleLabel.Dispose();
+                visibleLabel = null;
+            }
+
+            if (imageView != null)
+            {
+                imageView.Unparent();
+                imageView.Dispose();
+                imageView = null;
+            }
+
+            if (window != null)
+            {
+                window.KeyEvent -= OnKeyEvent;
+                window = null;
+            }
+        }
+
+        private void OnKeyEvent(object source, Window.KeyEventArgs e)
+        {
+            if (e.Key.State == Key.StateType.Down)
+            {
+                if (e.Key.KeyPressedName == "Escape" || e.Key.KeyPressedName == "Back")
+                {
+                    Deactivate();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
This PR introduces the ability to modify an actor's `ignored` property from within the `FrameUpdateCallbackInterface.OnUpdate` method in NUI, ensuring thread-safe operations.

Key changes include:

- __C++ Binding__: Added `CSharp_Dali_FrameUpdateCallbackInterface_SetIgnored` in `frame-callback-wrap.cpp` to bridge to `Dali::UpdateProxy::SetIgnored`.
- __C# Interop & Public API__: Exposed the `SetIgnored` functionality in `Tizen.NUI.FrameUpdateCallbackInterface` via P/Invoke and a new protected method.
- __Sample Application__: Created `FrameUpdateCallbackToggleTest.cs` to demonstrate the new feature. This sample mirrors the behavior of the C++ `frame-callback-toggle.cpp` example, toggling the visibility of a view and text labels every 2 seconds.

This enhancement allows developers to safely update actor properties that affect the update/render cycle directly from the frame callback, which is essential for complex animations and logic that must run on the update thread.



### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
