### PR TITLE
[NUI] Write comments for `NUIApplication.Exit()`

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -567,6 +567,12 @@ namespace Tizen.NUI
         /// Exits the NUIApplication.
         /// This method causes the application to terminate gracefully.
         /// </summary>
+        /// <remarks>
+        /// This method does not quit the application immediately.
+        /// It waits until all pending events are completely processed,
+        /// then registers a termination request during the main loop's idle state
+        /// and executes the termination at that time.
+        /// </remarks>
         /// <since_tizen> 4 </since_tizen>
         public override void Exit()
         {


### PR DESCRIPTION
Let we write some more informations about `NUIApplication.Exit()` API usage. Since we need to completely processed all pending jobs before main loop finished, we need to doing real-terminate process at idler time.