### PR TITLE
[NUI] Add Voice to PanelLayoutType

### DIFF
--- a/src/Tizen.NUI/src/public/Input/InputMethod.cs
+++ b/src/Tizen.NUI/src/public/Input/InputMethod.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 using System;
+using System.ComponentModel;
 
 namespace Tizen.NUI
 {
@@ -140,7 +141,12 @@ namespace Tizen.NUI
             /// <summary>
             /// Emoticon layout.
             /// </summary>
-            Emoticon
+            Emoticon,
+            /// <summary>
+            /// Voice layout.
+            /// </summary>
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            Voice
         }
 
         /// <summary>


### PR DESCRIPTION
Already applied to DALi:

```
dali-adaptor/dali/internal/input/tizen-wayland/input-method-context-impl-ecore-wl.cpp
```
```
Ecore_IMF_Input_Panel_Layout panelLayoutMap[] =
  {
    ECORE_IMF_INPUT_PANEL_LAYOUT_NORMAL,
    ECORE_IMF_INPUT_PANEL_LAYOUT_NUMBER,
    ECORE_IMF_INPUT_PANEL_LAYOUT_EMAIL,
    ECORE_IMF_INPUT_PANEL_LAYOUT_URL,
    ECORE_IMF_INPUT_PANEL_LAYOUT_PHONENUMBER,
    ECORE_IMF_INPUT_PANEL_LAYOUT_IP,
    ECORE_IMF_INPUT_PANEL_LAYOUT_MONTH,
    ECORE_IMF_INPUT_PANEL_LAYOUT_NUMBERONLY,
    ECORE_IMF_INPUT_PANEL_LAYOUT_HEX,
    ECORE_IMF_INPUT_PANEL_LAYOUT_TERMINAL,
    ECORE_IMF_INPUT_PANEL_LAYOUT_PASSWORD,
    ECORE_IMF_INPUT_PANEL_LAYOUT_DATETIME,
    ECORE_IMF_INPUT_PANEL_LAYOUT_EMOTICON,
    ECORE_IMF_INPUT_PANEL_LAYOUT_VOICE};
```
```
ecore_imf_context_input_panel_layout_set(mIMFContext, panelLayoutMap[index]);
```