### PR TITLE
[NUI] Check if WebView is disposed when EvaluateJavaScript is called.

### DIFF
--- a/src/Tizen.NUI/src/public/WebView/WebView.cs
+++ b/src/Tizen.NUI/src/public/WebView/WebView.cs
@@ -2725,7 +2725,12 @@ namespace Tizen.NUI.BaseComponents
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void EvaluateJavaScript(string script)
         {
-            Interop.WebView.EvaluateJavaScript(SwigCPtr, script, new global::System.Runtime.InteropServices.HandleRef(null, global::System.IntPtr.Zero));
+            if (SwigCPtr.Handle == IntPtr.Zero || IsDisposedOrQueued)
+            {
+                Log.Fatal("NUI", $"[ERROR] WebView has been disposed! IntPtr=0x{SwigCPtr.Handle:X} IsDisposedOrQueued={IsDisposedOrQueued}");
+                return;
+            }
+            Interop.WebView.EvaluateJavaScript(SwigCPtr, script, new HandleRef(null, IntPtr.Zero));
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
