### PR TITLE
[NUI.Gadget] Add OnPreCreate() Method

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
@@ -46,6 +46,7 @@ namespace Tizen.NUI
         {
             Type = type;
             State = NUIGadgetLifecycleState.Initialized;
+            NotifyLifecycleChanged();
         }
 
         internal event EventHandler<NUIGadgetLifecycleChangedEventArgs> LifecycleChanged;
@@ -124,12 +125,23 @@ namespace Tizen.NUI
             get;
         }
 
+        internal void PreCreate()
+        {
+            if (State == NUIGadgetLifecycleState.Initialized)
+            {
+                OnPreCreate();
+            }
+        }
+
         internal bool Create()
         {
-            MainView = OnCreate();
-            if (MainView == null)
+            if (State == NUIGadgetLifecycleState.PreCreated)
             {
-                return false;
+                MainView = OnCreate();
+                if (MainView == null)
+                {
+                    return false;
+                }
             }
 
             return true;
@@ -138,19 +150,25 @@ namespace Tizen.NUI
         internal void Resume()
         {
             if (State == NUIGadgetLifecycleState.Created || State == NUIGadgetLifecycleState.Paused)
+            {
                 OnResume();
+            }
         }
 
         internal void Pause()
         {
             if (State == NUIGadgetLifecycleState.Resumed)
+            {
                 OnPause();
+            }
         }
 
         internal void Destroy()
         {
             if (State == NUIGadgetLifecycleState.Created || State == NUIGadgetLifecycleState.Paused)
+            {
                 OnDestroy();
+            }
         }
 
         internal void HandleAppControlReceivedEvent(AppControlReceivedEventArgs args)
@@ -189,6 +207,17 @@ namespace Tizen.NUI
             args.State = State;
             args.Gadget = this;
             LifecycleChanged?.Invoke(null, args);
+        }
+
+        /// <summary>
+        /// Override this method to define the behavior when the gadget is pre-created.
+        /// Calling 'base.OnPreCreate()' is necessary in order to emit the 'NUIGadgetLifecycleChanged' event with the 'NUIGadgetLifecycleState.PreCreated' state.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        protected virtual void OnPreCreate()
+        {
+            State = NUIGadgetLifecycleState.PreCreated;
+            NotifyLifecycleChanged();
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
@@ -46,7 +46,6 @@ namespace Tizen.NUI
         {
             Type = type;
             State = NUIGadgetLifecycleState.Initialized;
-            NotifyLifecycleChanged();
         }
 
         internal event EventHandler<NUIGadgetLifecycleChangedEventArgs> LifecycleChanged;

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleState.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetLifecycleState.cs
@@ -33,31 +33,38 @@ namespace Tizen.NUI
         Initialized = 0,
 
         /// <summary>
+        /// The pre-created state.
+        /// This state is set when the gadget is pre-created. The 'OnPreCreate()' method of the NUIGadget is called.
+        /// </summary>
+        /// <since_tizen> 13 </since_tizen>
+        PreCreated = 1,
+
+        /// <summary>
         /// The created state.
         /// This state is set when the gadget is created. The 'OnCreate()' method of the NUIGadget is called.
         /// </summary>
         /// <since_tizen> 10 </since_tizen>
-        Created = 1,
+        Created = 2,
 
         /// <summary>
         /// The resumed state.
         /// This state is set when the gadget is resumed. The 'OnResume()' method of the NUIGadget is called.
         /// </summary>
         /// <since_tizen> 10 </since_tizen>
-        Resumed = 2,
+        Resumed = 3,
 
         /// <summary>
         /// The paused state.
         /// This state is set when the gadget is paused. The 'OnPause()' method of the NUIGadget is called.
         /// </summary>
         /// <since_tizen> 10 </since_tizen>
-        Paused = 3,
+        Paused = 4,
 
         /// <summary>
         /// The destroyed state.
         /// This state is set when the gadget is destroyed. The 'OnDestroy()' method of the NUIGadget is called.
         /// </summary>
         /// <since_tizen> 10 </since_tizen>
-        Destroyed = 4,
+        Destroyed = 5,
     }
 }

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -249,11 +249,8 @@ namespace Tizen.NUI
             var gadget = CreateInstance(resourceType, className, useDefaultContext);
             if (gadget != null)
             {
-                gadget.PreCreate();
-                if (!gadget.Create())
-                {
-                    throw new InvalidOperationException("The View MUST be created");
-                }
+                PreCreate(gadget);
+                Create(gadget);
             }
             return gadget;
         }
@@ -311,7 +308,6 @@ namespace Tizen.NUI
             gadget.ClassName = className;
             gadget.NUIGadgetResourceManager = new NUIGadgetResourceManager(info);
             gadget.LifecycleChanged += OnNUIGadgetLifecycleChanged;
-            _gadgets.TryAdd(gadget, 0);
             return gadget;
         }
 
@@ -326,11 +322,6 @@ namespace Tizen.NUI
             if (gadget == null)
             {
                 throw new ArgumentNullException(nameof(gadget));
-            }
-
-            if (!_gadgets.ContainsKey(gadget))
-            {
-                return;
             }
 
             Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
@@ -351,8 +342,9 @@ namespace Tizen.NUI
                 throw new ArgumentNullException(nameof(gadget));
             }
 
-            if (!_gadgets.ContainsKey(gadget))
+            if (_gadgets.ContainsKey(gadget))
             {
+                Log.Error("Already exists. ResourceType:" + gadget.NUIGadgetInfo.ResourceType);
                 return;
             }
 
@@ -361,6 +353,7 @@ namespace Tizen.NUI
             {
                 throw new InvalidOperationException("The View MUST be created");
             }
+            _gadgets.TryAdd(gadget, 0);
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -319,7 +319,7 @@ namespace Tizen.NUI
         /// Executes the pre-creation process of the NUIGadget.
         /// </summary>
         /// <param name="gadget">The NUIGadget object to perform the pre-creation process.</param>
-        /// <exception cref="ArgumentException">Thrown when failed because of a invalid argument.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if the 'gadget' argument is null.</exception>
         /// <since_tizen> 13 </since_tizen>
         public static void PreCreate(NUIGadget gadget)
         {

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -246,30 +246,15 @@ namespace Tizen.NUI
         /// <since_tizen> 10 </since_tizen>
         public static NUIGadget Add(string resourceType, string className, bool useDefaultContext)
         {
-            if (string.IsNullOrWhiteSpace(resourceType) || string.IsNullOrWhiteSpace(className))
+            var gadget = CreateInstance(resourceType, className, useDefaultContext);
+            if (gadget != null)
             {
-                throw new ArgumentException("Invalid argument");
+                gadget.PreCreate();
+                if (!gadget.Create())
+                {
+                    throw new InvalidOperationException("The View MUST be created");
+                }
             }
-
-            NUIGadgetInfo info = Find(resourceType);
-            LoadInternal(info, useDefaultContext);
-
-            NUIGadget gadget = useDefaultContext ? info.Assembly.CreateInstance(className, true) as NUIGadget : info.NUIGadgetAssembly.CreateInstance(className);
-            if (gadget == null)
-            {
-                throw new InvalidOperationException("Failed to create instance. className: " + className);
-            }
-
-            gadget.NUIGadgetInfo = info;
-            gadget.ClassName = className;
-            gadget.NUIGadgetResourceManager = new NUIGadgetResourceManager(info);
-            gadget.LifecycleChanged += OnNUIGadgetLifecycleChanged;
-            if (!gadget.Create())
-            {
-                throw new InvalidOperationException("The View MUST be created");
-            }
-
-            _gadgets.TryAdd(gadget, 0);
             return gadget;
         }
 
@@ -291,6 +276,92 @@ namespace Tizen.NUI
         /// <returns>An enumerable list of NUIGadgetInfo objects.</returns>
         /// <since_tizen> 10 </since_tizen>
         public static IEnumerable<NUIGadgetInfo> GetGadgetInfos() => _gadgetInfos.Values;
+
+
+        /// <summary>
+        /// Creates a new NUIGadget instance.
+        /// </summary>
+        /// <remarks>
+        /// To use Unload() method, the useDefaultContext must be'false'.
+        /// </remarks>
+        /// <param name="resourceType">The resource type of the NUIGadget package.</param>
+        /// <param name="className">The class name of the NUIGadget.</param>
+        /// <param name="useDefaultContext">The flag it true, use a default context. Otherwise, use a new load context.</param>
+        /// <returns>The NUIGadget object.</returns>
+        /// <exception cref="ArgumentException">Thrown when failed because of a invalid argument.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        public static NUIGadget CreateInstance(string resourceType, string className, bool useDefaultContext)
+        {
+            if (string.IsNullOrWhiteSpace(resourceType) || string.IsNullOrWhiteSpace(className))
+            {
+                throw new ArgumentException("Invalid argument");
+            }
+
+            NUIGadgetInfo info = Find(resourceType);
+            LoadInternal(info, useDefaultContext);
+
+            NUIGadget gadget = useDefaultContext ? info.Assembly.CreateInstance(className, true) as NUIGadget : info.NUIGadgetAssembly.CreateInstance(className);
+            if (gadget == null)
+            {
+                throw new InvalidOperationException("Failed to create instance. className: " + className);
+            }
+
+            gadget.NUIGadgetInfo = info;
+            gadget.ClassName = className;
+            gadget.NUIGadgetResourceManager = new NUIGadgetResourceManager(info);
+            gadget.LifecycleChanged += OnNUIGadgetLifecycleChanged;
+            _gadgets.TryAdd(gadget, 0);
+            return gadget;
+        }
+
+        /// <summary>
+        /// Executes the pre-creation process of the NUIGadget.
+        /// </summary>
+        /// <param name="gadget">The NUIGadget object to perform the pre-creation process.</param>
+        /// <exception cref="ArgumentException">Thrown when failed because of a invalid argument.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        public static void PreCreate(NUIGadget gadget)
+        {
+            if (gadget == null)
+            {
+                throw new ArgumentNullException(nameof(gadget));
+            }
+
+            if (!_gadgets.ContainsKey(gadget))
+            {
+                return;
+            }
+
+            Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
+            gadget.PreCreate();
+        }
+
+        /// <summary>
+        /// Executes the creation process of the NUIGadget.
+        /// </summary>
+        /// <param name="gadget">The NUIGadget object to perform the creation process.</param>
+        /// <exception cref="ArgumentNullException">Thrown if the 'gadget' argument is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when failed because of an invalid operation.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        public static void Create(NUIGadget gadget)
+        {
+            if (gadget == null)
+            {
+                throw new ArgumentNullException(nameof(gadget));
+            }
+
+            if (!_gadgets.ContainsKey(gadget))
+            {
+                return;
+            }
+
+            Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
+            if (!gadget.Create())
+            {
+                throw new InvalidOperationException("The View MUST be created");
+            }
+        }
 
         /// <summary>
         /// Removes the specified NUIGadget from the NUIGadgetManager.
@@ -343,17 +414,6 @@ namespace Tizen.NUI
         /// </remarks>
         /// <param name="gadget">The NUIGadget object whose execution needs to be resumed.</param>
         /// <exception cref="ArgumentNullException">Thrown if the 'gadget' argument is null.</exception>
-        /// <example>
-        /// To resume the execution of a specific NUIGadget named 'MyGadget', you can call the following code snippet:
-        ///
-        /// <code>
-        /// // Get the reference to the NUIGadget object
-        /// NUIGadget MyGadget = ...;
-        ///
-        /// // Resume its execution
-        /// GadgetResume(MyGadget);
-        /// </code>
-        /// </example>
         /// <since_tizen> 10 </since_tizen>
         public static void Resume(NUIGadget gadget)
         {


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
This patch adds a OnPreCreate() method that can perform pre initialzation. 
NUIGadget Viewer developers can control Gadget by calling Load(), CreateInstance(), PreCreate(), and Create().

Added:
 - void NUIGadget.OnPreCreate();
 - NUIGadget NUIGadgetManager.CreateInstance(string resourceType, string className, bool useDefaultContext);
 - void NUIGadgetManager.PreCreate(NUIGadget gadget);
 - void NUIGadgetManager.Create(NUIGadget gadget);
 - NUIGadgetLifecycleState.PreCreated // Enumeration