### PR TITLE
[NUI] Support for Multiple Screens

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
@@ -110,6 +110,9 @@ namespace Tizen.NUI
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_IsGeometryHittestEnabled")]
             [return: global::System.Runtime.InteropServices.MarshalAs(global::System.Runtime.InteropServices.UnmanagedType.U1)]
             public static extern bool IsGeometryHittestEnabled();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_GetAvailableScreens")]
+            public static extern global::System.IntPtr GetAvailableScreens();
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Window.cs
@@ -411,6 +411,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetInsets__SWIG_1")]
             public static extern global::System.IntPtr GetInsets(global::System.Runtime.InteropServices.HandleRef window, int insetsFlags);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_SetScreen")]
+            public static extern void SetScreen(global::System.Runtime.InteropServices.HandleRef window, string name);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Window_GetScreen")]
+            public static extern string GetScreen(global::System.Runtime.InteropServices.HandleRef window);
         }
     }
 }

--- a/src/Tizen.NUI/src/internal/Interop/Interop.WindowData.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.WindowData.cs
@@ -54,6 +54,13 @@ namespace Tizen.NUI
             [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetFrontBufferRendering")]
             [return: MarshalAs(UnmanagedType.U1)]
             public static extern bool GetFrontBufferRendering(HandleRef nuiWindowData);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_SetScreen")]
+            public static extern void SetScreen(HandleRef nuiWindowData, string screenName);
+
+            [DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_WindowData_GetScreen")]
+            public static extern string GetScreen(HandleRef nuiWindowData);
+
         }
     }
 }

--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Reflection;
@@ -683,6 +684,51 @@ namespace Tizen.NUI
             return ret;
         }
 
+        /// <summary>
+        /// Retrieves a list of all currently available screens.
+        /// This function queries the window system for all connected and active screens,
+        /// providing essential information for each. It is primarily intended for use
+        /// in multi-screen environments where an application might need to manage
+        /// windows across different displays.
+        /// </summary>
+        /// <returns>The array of screen information</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        static public ScreenInformation[] GetAvailableScreens()
+        {
+            using PropertyArray propertyArray = new PropertyArray(Interop.Application.GetAvailableScreens(), true);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+            ScreenInformation[] screenInformationArray = null;
+            if (propertyArray != null)
+            {
+                uint count = propertyArray.Count();
+                screenInformationArray = new ScreenInformation[count];
+                for (uint i = 0; i < count; i++)
+                {
+                    using (var screenInfoMap = new PropertyMap())
+                    {
+                        using (var propertyValue = propertyArray[i])
+                        {
+                            propertyValue.Get(screenInfoMap);
+                            if (screenInfoMap.Count() > 0)
+                            {
+                                string name = "";
+                                int width = 0;
+                                int height = 0;
+
+                                screenInfoMap["name"].Get(out name);
+                                screenInfoMap["width"].Get(out width);
+                                screenInfoMap["height"].Get(out height);
+
+                                var screenInfo = new ScreenInformation(name, width, height);
+                                screenInformationArray[i] = screenInfo;
+                            }
+                        }
+                    }
+                }
+            }
+            return screenInformationArray;
+        }
 
         /// <summary>
         /// The OnLocaleChanged method is called when the system locale settings have changed.

--- a/src/Tizen.NUI/src/public/Application/ScreenInformation.cs
+++ b/src/Tizen.NUI/src/public/Application/ScreenInformation.cs
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.ComponentModel;
+using Tizen.NUI.Binding;
+
+namespace Tizen.NUI
+{
+    /// <summary>
+    /// ScreenInformation is a struct designed to encapsulate the information of screen. 
+    /// It contains three properties as screen name, width and hegiht.
+    /// The ScreenInformation is especially used to support multiple screen.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public struct ScreenInformation : IEquatable<ScreenInformation>
+    {
+        /// <summary>
+        /// The construct with name, width and height for screen.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ScreenInformation(string name, int width, int height)
+        {
+            Name = name;
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the screen.
+        /// </summary>
+        /// <value>The name of the screen.</value>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Name {get;}
+
+        /// <summary>
+        /// Gets or sets the width of the screen.
+        /// </summary>
+        /// <value>The width of the screen.</value>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Width {get;}
+
+        /// <summary>
+        /// Gets or sets the height of the screen.
+        /// 
+        /// </summary>
+        /// <value>The height of the screen.</value>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public int Height {get;}
+        
+        /// <summary>
+        /// Whether this is equivalent to other.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Equals(ScreenInformation other)
+        {
+            return Name == other.Name &&
+                   Width == other.Width &&
+                   Height == other.Height;
+        }
+
+        ///  <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            if (obj is ScreenInformation other)
+            {
+                return Equals(other);
+            }
+            return base.Equals(obj);
+        }
+
+        /// <inheritdoc/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashcode = Width.GetHashCode();
+                hashcode = hashcode * 397 ^ Height.GetHashCode();
+                return hashcode;
+            }
+        }
+
+        /// <summary>
+        /// Compares two ScreenInformation for equality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are equal, otherwise false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator ==(ScreenInformation operand1, ScreenInformation operand2)
+        {
+            return operand1.Equals(operand2);
+        }
+
+        /// <summary>
+        /// Compares two ScreenInformation for inequality.
+        /// </summary>
+        /// <param name="operand1">The first operand object.</param>
+        /// <param name="operand2">The second operand object.</param>
+        /// <returns>True if both are not equal, otherwise false.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool operator !=(ScreenInformation operand1, ScreenInformation operand2)
+        {
+            return !operand1.Equals(operand2);
+        }
+    }
+}

--- a/src/Tizen.NUI/src/public/Application/WindowData.cs
+++ b/src/Tizen.NUI/src/public/Application/WindowData.cs
@@ -104,6 +104,26 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Gets or sets the screen of window data.
+        /// </summary>
+        /// <value>The screen name of the default window.</value>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Screen
+        {
+            set
+            {
+                Interop.WindowData.SetScreen(SwigCPtr, (string)value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+            get
+            {
+                string ret = (string)Interop.WindowData.GetScreen(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw new InvalidOperationException("FATAL: get Exception", NDalicPINVOKE.SWIGPendingException.Retrieve());
+                return ret;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the front buffer rendering of the default window.
         /// The default value is false.
         /// </summary>

--- a/src/Tizen.NUI/src/public/Window/Window.cs
+++ b/src/Tizen.NUI/src/public/Window/Window.cs
@@ -2773,6 +2773,27 @@ namespace Tizen.NUI
             _attached[typeof(T)] = value;
         }
 
+        /// <summary>
+        /// Gets or sets the screen that has this window is in whether screeen.
+        /// It is for supporting mulitple screen.
+        /// If this window's environment is multple screen, the window can move the other screen by this property.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public string Screen
+        {
+            get
+            {
+                string ret = Interop.Window.GetScreen(SwigCPtr);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                return ret;
+            }
+            set
+            {
+                Interop.Window.SetScreen(SwigCPtr, value);
+                if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            }
+        }
+
         IntPtr IWindowProvider.WindowHandle => GetNativeWindowHandler();
         float IWindowProvider.X => WindowPosition.X;
         float IWindowProvider.Y => WindowPosition.Y;


### PR DESCRIPTION
This feature adds support for multiple screens on Tizen devices. It includes the following functionalities:
    
    - Added a screen information data structure containing name and size.
    - Retrieves available multiple screen information.
    - Provides set/get methods for screen properties of a window. After setting a screen, the window will be moved to the specified screen.
    
    This enhancement improves the application's ability to manage and utilize multiple screens effectively.
