### PR TITLE
[NUI] Fix LayoutItem not to dispose padding and margin

### DIFF
--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -109,7 +109,7 @@ namespace Tizen.NUI
             }
             set
             {
-                margin = new Extents(value);
+                margin = value;
                 RequestLayout();
             }
         }
@@ -126,7 +126,7 @@ namespace Tizen.NUI
             }
             set
             {
-                padding = new Extents(value);
+                padding = value;
                 RequestLayout();
             }
         }
@@ -171,8 +171,8 @@ namespace Tizen.NUI
         {
             LayoutWithTransition = false;
             layoutPositionData = new LayoutData(this, TransitionCondition.Unspecified, 0, 0, 0, 0);
-            padding = new Extents(Extents.Zero);
-            margin = new Extents(Extents.Zero);
+            padding = Extents.Zero;
+            margin = Extents.Zero;
         }
 
         /// <summary>
@@ -643,11 +643,6 @@ namespace Tizen.NUI
                 return;
             }
 
-            if (disposing)
-            {
-                margin?.Dispose();
-                padding?.Dispose();
-            }
             disposed = true;
         }
 


### PR DESCRIPTION
The initial values of padding and margin of LayoutItem is static value Extents.Zero not to allocate memory for zero extents.

If so, those padding and margin should not be disposed.

Like View, LayoutItem is fixed not to dispose padding and margin.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
