### PR TITLE
[NUI] Block `NUIApplication.Preload()` call multiple times

### DIFF
--- a/src/Tizen.NUI/src/public/Application/NUIApplication.cs
+++ b/src/Tizen.NUI/src/public/Application/NUIApplication.cs
@@ -869,6 +869,16 @@ namespace Tizen.NUI
         [EditorBrowsable(EditorBrowsableState.Never)]
         static public void Preload()
         {
+            if (IsPreload)
+            {
+                Log.Error("NUI", "[NUI] Preload() called multiple. Ignore\n");
+                return;
+            }
+            if (Tizen.NUI.Application.Current != null)
+            {
+                Log.Error("NUI", "[NUI] Preload() Should be called before application created. Ignore\n");
+                return;
+            }
             Interop.Application.PreInitialize();
             SupportPreInitializedCreation = Interop.Application.IsSupportPreInitializedCreation();
 


### PR DESCRIPTION
Application call NUIApplication.Preload() whenever they want.

Let we block it if
- `Preload()` already called
- Application constructor called.