### PR TITLE
[NUI] Do not create `LayoutExtraData` when visibility changed

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -815,7 +815,7 @@ namespace Tizen.NUI.BaseComponents
             if (NDalicPINVOKE.SWIGPendingException.Pending)
                 throw NDalicPINVOKE.SWIGPendingException.Retrieve();
 
-            EnsureLayoutExtraData()?.Layout?.RequestLayout();
+            RequestLayout();
         }
 
         /// <summary>


### PR DESCRIPTION
We can call `Show()` or `Hide()` without layout data.
