### PR TITLE
[NUI] Add EnableApplicationFrameworkLocaleCallback

### DIFF
--- a/src/Tizen.NUI/src/internal/Application/Application.cs
+++ b/src/Tizen.NUI/src/internal/Application/Application.cs
@@ -2100,6 +2100,12 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
         }
 
+        public void EnableApplicationFrameworkLocaleCallback()
+        {
+            Interop.Application.EnableApplicationFrameworkLocaleCallback(SwigCPtr);
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static List<Window> GetWindowList()
         {

--- a/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.Application.cs
@@ -116,6 +116,9 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_SetApplicationLocale")]
             public static extern void SetApplicationLocale(global::System.Runtime.InteropServices.HandleRef application, string locale);
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Dali_Application_EnableFrameworkLocaleCallback")]
+            public static extern void EnableApplicationFrameworkLocaleCallback(global::System.Runtime.InteropServices.HandleRef application);
         }
     }
 }


### PR DESCRIPTION
Enables the use of the Application Framework locale change callback in DALi.
Once enabled, DALi will receive and process locale change notifications
from the Application Framework instead of relying on the legacy system-settings locale change callback.

The legacy system locale change callback remains available for backward compatibility,
but the Application Framework callback is the recommended and future-proof mechanism.

https://review.tizen.org/gerrit/c/platform/core/uifw/dali-adaptor/+/330882
https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/330883