### PR TITLE
[NUI] Remove unnecessary padding calculations from the BorderWindow.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -150,12 +150,7 @@ namespace Tizen.NUI
 
                     if (borderView != null)
                     {
-                        Extents extents = borderView.Padding;
-                        ushort start = (extents.Start + diffBorderLine) > 0 ? (ushort)(extents.Start + diffBorderLine) : (ushort)0;
-                        ushort end = (extents.End + diffBorderLine) > 0 ? (ushort)(extents.End + diffBorderLine) : (ushort)0;
-                        ushort top = (extents.Top + diffBorderLine) > 0 ? (ushort)(extents.Top + diffBorderLine) : (ushort)0;
-                        ushort bottom = (extents.Bottom + diffBorderLine) > 0 ? (ushort)(extents.Bottom + diffBorderLine) : (ushort)0;
-                        borderView.Padding = new Extents(start, end, top, bottom);
+                        borderView.Padding = new Extents((ushort)borderLineThickness, (ushort)borderLineThickness, (ushort)borderLineThickness, (ushort)borderLineThickness);
                         if (IsMaximized() == true)
                         {
                             borderView.OnMaximize(true);


### PR DESCRIPTION


### Description of Change ###
<!-- Describe your changes here. -->
Padding can be used as is using BorderLineThickness.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
