### PR TITLE
[NUI.Scene3D] Convert MotionIndex as each class before return as interface

### DIFF
--- a/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.MotionIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/internal/Interop/Interop.MotionIndex.cs
@@ -57,6 +57,9 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_BlendShapeIndex_Assign")]
             public static extern global::System.IntPtr BlendShapeIndexAssign(global::System.Runtime.InteropServices.HandleRef blendShapeIndex, global::System.Runtime.InteropServices.HandleRef sourceBlendShapeIndex);
 
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_BlendShapeIndex_DownCast")]
+            public static extern global::System.IntPtr BlendShapeIndexDownCast(global::System.Runtime.InteropServices.HandleRef sourceBaseHandle);
+
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_BlendShapeIndex_SetBlendShapeId")]
             public static extern void SetBlendShapeId(global::System.Runtime.InteropServices.HandleRef blendShapeIndex, global::System.Runtime.InteropServices.HandleRef modelNodeId);
 
@@ -80,6 +83,9 @@ namespace Tizen.NUI.Scene3D
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionPropertyIndex_Assign")]
             public static extern global::System.IntPtr MotionPropertyIndexAssign(global::System.Runtime.InteropServices.HandleRef motionPropertyIndex, global::System.Runtime.InteropServices.HandleRef sourceMotionPropertyIndex);
 
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionPropertyIndex_DownCast")]
+            public static extern global::System.IntPtr MotionPropertyIndexDownCast(global::System.Runtime.InteropServices.HandleRef sourceBaseHandle);
+
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionPropertyIndex_SetPropertyId")]
             public static extern void SetPropertyId(global::System.Runtime.InteropServices.HandleRef motionPropertyIndex, global::System.Runtime.InteropServices.HandleRef propertyKey);
 
@@ -102,6 +108,9 @@ namespace Tizen.NUI.Scene3D
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionTransformIndex_Assign")]
             public static extern global::System.IntPtr MotionTransformIndexAssign(global::System.Runtime.InteropServices.HandleRef motionTransformIndex, global::System.Runtime.InteropServices.HandleRef sourceMotionTransformIndex);
+
+            [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionTransformIndex_DownCast")]
+            public static extern global::System.IntPtr MotionTransformIndexDownCast(global::System.Runtime.InteropServices.HandleRef sourceBaseHandle);
 
             [global::System.Runtime.InteropServices.DllImport(Libraries.Scene3D, EntryPoint = "CSharp_Dali_MotionTransformIndex_SetTransformType")]
             public static extern void SetTransformType(global::System.Runtime.InteropServices.HandleRef motionTransformIndex, int transformType);

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionData.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionData.cs
@@ -191,25 +191,17 @@ namespace Tizen.NUI.Scene3D
         public MotionIndex GetIndex(uint index)
         {
             IntPtr cPtr = Interop.MotionData.GetIndex(SwigCPtr, index);
-            MotionIndex ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as MotionIndex;
+            MotionIndex ret;
+
+            // Try to downcast as all valid type of indeces.
+            ret = MotionTransformIndex.DownCastCPtr(cPtr);
             if (ret == null)
             {
-                // Register new animation into Registry.
-                ret = new MotionIndex(cPtr, true);
+                ret = BlendShapeIndex.DownCastCPtr(cPtr);
             }
-            else
+            if (ret == null)
             {
-                // We found matched NUI animation. Reduce cPtr reference count.
-                HandleRef handle = new HandleRef(this, cPtr);
-                Interop.MotionIndex.DeleteMotionIndex(handle);
-                handle = new HandleRef(null, IntPtr.Zero);
-            }
-            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-
-            if (!ret.HasBody())
-            {
-                ret.Dispose();
-                ret = null;
+                ret = MotionPropertyIndex.DownCastCPtr(cPtr);
             }
             return ret;
         }

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/BlendShapeIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/BlendShapeIndex.cs
@@ -139,6 +139,57 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// DownCast operator by raw pointer.
+        /// </summary>
+        /// <param name="sourceBaseHandleCPtr">Source object's cPtr to downcast.</param>
+        /// <returns>DownCast object with memory ownership. Or null if failed</returns>
+        internal static BlendShapeIndex DownCastCPtr(IntPtr sourceBaseHandleCPtr)
+        {
+            if (sourceBaseHandleCPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var dummyObject = new object();
+            var tempSourceSwigCPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObject, sourceBaseHandleCPtr);
+            IntPtr cPtr = Interop.MotionIndex.BlendShapeIndexDownCast(tempSourceSwigCPtr);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            if (cPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            // Check whether it has body
+            var tempSwigCPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObject, cPtr);
+            if (!Tizen.NUI.Interop.BaseHandle.HasBody(tempSwigCPtr))
+            {
+                Tizen.NUI.Interop.BaseHandle.DeleteBaseHandle(cPtr);
+                return null;
+            }
+
+            // Check whether it is already registered
+            BlendShapeIndex ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as BlendShapeIndex;
+            if (ret == null)
+            {
+                // Register new BlendShapeIndex into Registry.
+                ret = new BlendShapeIndex(cPtr, true);
+            }
+            else
+            {
+                // We found matched NUI BlendShapeIndex. Reduce cPtr reference count.
+                Tizen.NUI.Interop.BaseHandle.DeleteBaseHandle(cPtr);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
+
+            if (!ret.HasBody())
+            {
+                ret.Dispose();
+                ret = null;
+            }
+            return ret;
+        }
+
+        /// <summary>
         /// The key of blend shape.
         /// </summary>
         /// <since_tizen> 11 </since_tizen>

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionPropertyIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionPropertyIndex.cs
@@ -107,6 +107,57 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// DownCast operator by raw pointer.
+        /// </summary>
+        /// <param name="sourceBaseHandleCPtr">Source object's cPtr to downcast.</param>
+        /// <returns>DownCast object with memory ownership. Or null if failed</returns>
+        internal static MotionPropertyIndex DownCastCPtr(IntPtr sourceBaseHandleCPtr)
+        {
+            if (sourceBaseHandleCPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var dummyObject = new object();
+            var tempSourceSwigCPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObject, sourceBaseHandleCPtr);
+            IntPtr cPtr = Interop.MotionIndex.MotionPropertyIndexDownCast(tempSourceSwigCPtr);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            if (cPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            // Check whether it has body
+            var tempSwigCPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObject, cPtr);
+            if (!Tizen.NUI.Interop.BaseHandle.HasBody(tempSwigCPtr))
+            {
+                Tizen.NUI.Interop.BaseHandle.DeleteBaseHandle(cPtr);
+                return null;
+            }
+
+            // Check whether it is already registered
+            MotionPropertyIndex ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as MotionPropertyIndex;
+            if (ret == null)
+            {
+                // Register new MotionPropertyIndex into Registry.
+                ret = new MotionPropertyIndex(cPtr, true);
+            }
+            else
+            {
+                // We found matched NUI MotionPropertyIndex. Reduce cPtr reference count.
+                Tizen.NUI.Interop.BaseHandle.DeleteBaseHandle(cPtr);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
+
+            if (!ret.HasBody())
+            {
+                ret.Dispose();
+                ret = null;
+            }
+            return ret;
+        }
+
+        /// <summary>
         /// The key of property
         /// </summary>
         /// <since_tizen> 11 </since_tizen>

--- a/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionTransformIndex.cs
+++ b/src/Tizen.NUI.Scene3D/src/public/ModelMotion/MotionIndex/MotionTransformIndex.cs
@@ -172,6 +172,57 @@ namespace Tizen.NUI.Scene3D
         }
 
         /// <summary>
+        /// DownCast operator by raw pointer.
+        /// </summary>
+        /// <param name="sourceBaseHandleCPtr">Source object's cPtr to downcast.</param>
+        /// <returns>DownCast object with memory ownership. Or null if failed</returns>
+        internal static MotionTransformIndex DownCastCPtr(IntPtr sourceBaseHandleCPtr)
+        {
+            if (sourceBaseHandleCPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var dummyObject = new object();
+            var tempSourceSwigCPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObject, sourceBaseHandleCPtr);
+            IntPtr cPtr = Interop.MotionIndex.MotionTransformIndexDownCast(tempSourceSwigCPtr);
+            NDalicPINVOKE.ThrowExceptionIfExists();
+            if (cPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            // Check whether it has body
+            var tempSwigCPtr = new global::System.Runtime.InteropServices.HandleRef(dummyObject, cPtr);
+            if (!Tizen.NUI.Interop.BaseHandle.HasBody(tempSwigCPtr))
+            {
+                Tizen.NUI.Interop.BaseHandle.DeleteBaseHandle(cPtr);
+                return null;
+            }
+
+            // Check whether it is already registered
+            MotionTransformIndex ret = Registry.GetManagedBaseHandleFromNativePtr(cPtr) as MotionTransformIndex;
+            if (ret == null)
+            {
+                // Register new MotionTransformIndex into Registry.
+                ret = new MotionTransformIndex(cPtr, true);
+            }
+            else
+            {
+                // We found matched NUI MotionTransformIndex. Reduce cPtr reference count.
+                Tizen.NUI.Interop.BaseHandle.DeleteBaseHandle(cPtr);
+            }
+            NDalicPINVOKE.ThrowExceptionIfExists();
+
+            if (!ret.HasBody())
+            {
+                ret.Dispose();
+                ret = null;
+            }
+            return ret;
+        }
+
+        /// <summary>
         /// The transform property type what this MotionIndex want to control.
         /// </summary>
         /// <since_tizen> 11 </since_tizen>


### PR DESCRIPTION
Before return MotionIndex as abstract class directly, let we try to downcast as each type of MotionIndex.

Required dali patch :
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/331098
