### PR TITLE
[Tizen.NUI.Gadget] Implement SetServiceFactory method in NUIGadget

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
@@ -278,6 +278,21 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Set serviceFactory and autoClose only Initialized state
+        /// </summary>
+        /// <param name="serviceFactory">The factory that can create OneShotService object</param>
+        /// <param name="autoClose">Whether to automatically close the service after execution</param>
+        /// <since_tizen> 13 </since_tizen>
+        protected void SetServiceFactory(IServiceFactory serviceFactory, bool autoClose = true)
+        {
+            if (State == NUIGadgetLifecycleState.Initialized)
+            {
+                ServiceFactory = serviceFactory;
+                AutoClose = autoClose;
+            }
+        }
+
+        /// <summary>
         /// Override this method to define the behavior when the gadget is pre-created.
         /// Calling 'base.OnPreCreate()' is necessary in order to emit the 'NUIGadgetLifecycleChanged' event with the 'NUIGadgetLifecycleState.PreCreated' state.
         /// </summary>


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
SetServiceFactory method is implemented to easily transmit the member variable of NUIGadget to OneShotService.

If developers want to deliver the member variable of NUIGadget to OneShotService in the existing structure, they must deliver it in the following way. 
[guide](https://github.sec.samsung.net/appfw/guide-docs/blob/main/OneShotService/example/OneShotWithParam/README.md)

However, this method forces ServiceFactory to static, and if the creator does not accidentally put the code that hands over the variables required to run OneShotService to ServiceFactory, it can be an unwanted action.

Therefore, we considered PR that opens the setter to the developer to help create OneShotService safely and comfortably.

To work more safely, we have made it possible to set the NUIGadget's State only when it is Initialized.

If you apply that PR, you can use it as below.
### FileNamesLoadServiceFactory.cs
```csharp
class FileNamesLoadServiceFactory : IServiceFactory
{
    private List<string> FileNames;
    private string RootDirName;
    
    public FileNamesLoadServiceFactory(List<string> fileNames, string rootDirName)
    {
        FileNames = fileNames;
        RootDirName = rootDirName;
    }

    public OneShotService CreateService(string name, bool autoClose)
    {
        return new FileNamesLoadOneShotService(FileNames,RootDirName,name,autoClose);
    }
}
```

### OneShotExample.cs
```csharp
public class OneShotExample : NUIGadget
{
    private List<string> fileNames;
    private string rootDirName;
    
    public OneShotExample() : base(NUIGadgetType.Normal)
    {
        //initialize member variable
        fileNames = new List<string>();
        rootDirName = "/";

        //create service factory and set them
        IServiceFactory serviceFactory = new FileNamesLoadServiceFactory(fileNames,rootDirName);
        SetServiceFactory(serviceFactory);
    }

    ....
}
```

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
