### PR TITLE
[Tizen.NUI.Gadget] Refactor PreCreate internal logic

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadget.cs
@@ -66,6 +66,8 @@ namespace Tizen.NUI
         {
             AutoClose = autoClose;
             ServiceFactory = serviceFactory;
+            Service = ServiceFactory.CreateService(GenerateOneShotServiceName(), AutoClose);
+            Service.LifecycleStateChanged += OnOneShotServiceLifecycleChanged;
         }
 
         internal event EventHandler<NUIGadgetLifecycleChangedEventArgs> LifecycleChanged;
@@ -175,14 +177,12 @@ namespace Tizen.NUI
         {
             if (State == NUIGadgetLifecycleState.Initialized)
             {
-                if (ServiceFactory != null)
+                OnPreCreate();
+                if (Service != null)
                 {
-                    Service = ServiceFactory.CreateService(GenerateOneShotServiceName(), AutoClose);
-                    Service.LifecycleStateChanged += OnOneShotServiceLifecycleChanged;
                     Log.Info($"PreCreate(), Service.Name = {Service.Name}");
                     Service.Run();
                 }
-                OnPreCreate();
             }
         }
 


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
before : service-run -> OnPreCreate
after : OnPreCreate -> service.run

Reason : It can make it easier for developers to
initialize OneShorService's variables in `NUIGadget.OnPreCreate()`

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
