### PR TITLE
[Tizen.Application.Common] Fix ULocale

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/SystemLocaleConverter.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/SystemLocaleConverter.cs
@@ -194,7 +194,7 @@ namespace Tizen.Applications
                 {
                     if (string.IsNullOrEmpty(_language))
                     {
-                        _language = GetLanguage(locale);
+                        _language = GetLanguage(Locale);
                     }
                     return _language;
                 }
@@ -209,7 +209,7 @@ namespace Tizen.Applications
                 {
                     if (string.IsNullOrEmpty(_script))
                     {
-                        _script = GetScript(locale);
+                        _script = GetScript(Locale);
                     }
                     return _script;
                 }
@@ -223,7 +223,7 @@ namespace Tizen.Applications
                 {
                     if (string.IsNullOrEmpty(_country))
                     {
-                        _country = GetCountry(locale);
+                        _country = GetCountry(Locale);
                     }
                     return _country;
                 }
@@ -238,7 +238,7 @@ namespace Tizen.Applications
                 {
                     if (string.IsNullOrEmpty(_variant))
                     {
-                        _variant = GetVariant(locale);
+                        _variant = GetVariant(Locale);
                     }
                     return _variant;
                 }
@@ -251,7 +251,7 @@ namespace Tizen.Applications
                 get
                 {
                     if (_lcid == -1) {
-                        _lcid = GetLCID(locale);
+                        _lcid = GetLCID(Locale);
                     }
                     return _lcid;
                 }


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
There is a something error that uses the constructor's parameter locale string.
Therefore, Changed to use Canonicalized locale.

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
