### PR TITLE
[NUI.Gadget] Add new methods for adding delay

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.Glib.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Glib.cs
@@ -44,5 +44,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.Glib, EntryPoint = "g_main_context_get_thread_default", CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr MainContextGetThreadDefault();
+
+        [DllImport(Libraries.Glib, EntryPoint = "g_timeout_source_new", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern IntPtr TimeoutSourceNew(uint interval);
     }
 }

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -383,6 +383,28 @@ namespace Tizen.Applications
         }
 
         /// <summary>
+        /// Dispatches an asynchronous message to a main loop of the CoreApplication after the delay.
+        /// </summary>
+        /// <remarks>
+        /// If an application uses UI thread App Model, the asynchronous message will be delivered to the UI thread.
+        /// If not, the asynchronous message will be delivered to the main thread.
+        /// </remarks>
+        /// <param name="runner">The runner callaback.</param>
+        /// <param name="delay">The delay time.(milliseconds)</param>
+        /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void PostDelayed(Action runner, uint delay)
+        {
+            if (runner == null)
+            {
+                throw new ArgumentNullException(nameof(runner));
+            }
+
+            GSourceManager.PostDelayed(runner, delay, true);
+        }
+
+        /// <summary>
         /// Releases any unmanaged resources used by this object. Can also dispose any other disposable objects.
         /// </summary>
         /// <param name="disposing">If true, disposes any disposable objects. If false, does not dispose disposable objects.</param>

--- a/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/CoreApplication.cs
@@ -394,7 +394,7 @@ namespace Tizen.Applications
         /// <exception cref="ArgumentNullException">Thrown when the runner is null.</exception>
         /// <since_tizen> 13 </since_tizen>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static void PostDelayed(Action runner, uint delay)
+        public static void Post(Action runner, uint delay)
         {
             if (runner == null)
             {

--- a/src/Tizen.Applications.Common/Tizen.Applications/GSourceManager.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/GSourceManager.cs
@@ -40,6 +40,20 @@ namespace Tizen.Applications
             Interop.Glib.SourceUnref(source);
         }
 
+        public static void PostDelayed(Action action, uint delay, bool useTizenGlibContext = false)
+        {
+            int id = 0;
+            lock (_transactionLock)
+            {
+                id = _transactionId++;
+            }
+            _handlerMap.TryAdd(id, action);
+            IntPtr source = Interop.Glib.TimeoutSourceNew(delay);
+            Interop.Glib.SourceSetCallback(source, _wrapperHandler, (IntPtr)id, IntPtr.Zero);
+            _ = Interop.Glib.SourceAttach(source, useTizenGlibContext ? Interop.AppCoreUI.GetTizenGlibContext() : IntPtr.Zero);
+            Interop.Glib.SourceUnref(source);
+        }
+
         private static bool Handler(IntPtr userData)
         {
             int key = (int)userData;

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -428,6 +428,37 @@ namespace Tizen.NUI
         }
 
         /// <summary>
+        /// Resumes the execution of the specified NUIGadget after the delay.
+        /// </summary>
+        /// <remarks>
+        /// By calling this method, you can resume the execution of the currently suspended NUIGadget.
+        /// It takes the NUIGadget object as an argument which represents the target gadget that needs to be resumed.
+        /// </remarks>
+        /// <param name="gadget">The NUIGadget object whose execution needs to be resumed.</param>
+        /// <param name="delay">The delay time. (milliseconds)</param>
+        /// <exception cref="ArgumentNullException">Thrown if the 'gadget' argument is null.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        public static void ResumeDelayed(NUIGadget gadget, uint delay)
+        {
+            if (gadget == null)
+            {
+                throw new ArgumentNullException(nameof(gadget));
+            }
+
+            if (!_gadgets.ContainsKey(gadget))
+            {
+                return;
+            }
+
+            Log.Info("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", Delay: " + delay.ToString());
+            CoreApplication.PostDelayed(() =>
+            {
+                Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
+                gadget.Resume();
+            }, delay);
+        }
+
+        /// <summary>
         /// Pauses the execution of the specified NUIGadget.
         /// </summary>
         /// <remarks>
@@ -453,6 +484,36 @@ namespace Tizen.NUI
                 Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
                 gadget.Pause();
             });
+        }
+
+        /// <summary>
+        /// Pauses the execution of the specified NUIGadget after the delay.
+        /// </summary>
+        /// <remarks>
+        /// Calling this method pauses the currently executing NUIGadget. It does not affect any other gadgets that may be running simultaneously.
+        /// </remarks>
+        /// <param name="gadget">The NUIGadget object whose execution needs to be paused.</param>
+        /// <param name="delay">The delay time. (milliseconds)</param>
+        /// <exception cref="ArgumentNullException">Thrown if the argument 'gadget' is null.</exception>
+        /// <since_tizen> 13 </since_tizen>
+        public static void PauseDelayed(NUIGadget gadget, uint delay)
+        {
+            if (gadget == null)
+            {
+                throw new ArgumentNullException(nameof(gadget));
+            }
+
+            if (!_gadgets.ContainsKey(gadget))
+            {
+                return;
+            }
+
+            Log.Info("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", Delay: " + delay.ToString());
+            CoreApplication.PostDelayed(() =>
+            {
+                Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
+                gadget.Pause();
+            }, delay);
         }
 
         /// <summary>

--- a/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/NUIGadgetManager.cs
@@ -438,7 +438,7 @@ namespace Tizen.NUI
         /// <param name="delay">The delay time. (milliseconds)</param>
         /// <exception cref="ArgumentNullException">Thrown if the 'gadget' argument is null.</exception>
         /// <since_tizen> 13 </since_tizen>
-        public static void ResumeDelayed(NUIGadget gadget, uint delay)
+        public static void Resume(NUIGadget gadget, uint delay)
         {
             if (gadget == null)
             {
@@ -451,7 +451,7 @@ namespace Tizen.NUI
             }
 
             Log.Info("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", Delay: " + delay.ToString());
-            CoreApplication.PostDelayed(() =>
+            CoreApplication.Post(() =>
             {
                 Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
                 gadget.Resume();
@@ -496,7 +496,7 @@ namespace Tizen.NUI
         /// <param name="delay">The delay time. (milliseconds)</param>
         /// <exception cref="ArgumentNullException">Thrown if the argument 'gadget' is null.</exception>
         /// <since_tizen> 13 </since_tizen>
-        public static void PauseDelayed(NUIGadget gadget, uint delay)
+        public static void Pause(NUIGadget gadget, uint delay)
         {
             if (gadget == null)
             {
@@ -509,7 +509,7 @@ namespace Tizen.NUI
             }
 
             Log.Info("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", Delay: " + delay.ToString());
-            CoreApplication.PostDelayed(() =>
+            CoreApplication.Post(() =>
             {
                 Log.Warn("ResourceType: " + gadget.NUIGadgetInfo.ResourceType + ", State: " + gadget.State);
                 gadget.Pause();


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
The NUIGadgetManager.ResumeDelayed() and the NUIGadgetManager.PauseDelayed() are added to add the delay. When Application repeatedly calls Resume() and Pause(), Gadget's OnResume() and OnPause() are called repeatedly. In this case, if key event is passed, it will not be processed immediately. All event of glib must be processed to operate in a structure in which fd handler of ecore is processed.
This patch is to solve the problem.

