### PR TITLE
[NUI] Make Ignored as property with native index

### DIFF
--- a/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
+++ b/src/Tizen.NUI/src/internal/Interop/Interop.ActorProperty.cs
@@ -215,6 +215,12 @@ namespace Tizen.NUI
 
             [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_CHILDREN_DEPTH_INDEX_POLICY_get")]
             public static extern int ChildrenDepthIndexPolicyGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_IGNORED_get")]
+            public static extern int IgnoredGet();
+
+            [global::System.Runtime.InteropServices.DllImport(NDalicPINVOKE.Lib, EntryPoint = "CSharp_Actor_Property_WORLD_IGNORED_get")]
+            public static extern int WorldIgnoredGet();
         }
     }
 }

--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -7225,17 +7225,36 @@ namespace Tizen.NUI.BaseComponents
 
         private void SetInternalIgnored(bool ignored)
         {
-            Interop.Actor.SetIgnored(SwigCPtr, ignored);
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+            Object.InternalSetPropertyBool(SwigCPtr, Property.Ignored, ignored);
         }
 
         private bool IsInternalIgnored()
         {
-            bool isIgnored = Interop.Actor.IsIgnored(SwigCPtr);
-            if (NDalicPINVOKE.SWIGPendingException.Pending)
-                throw NDalicPINVOKE.SWIGPendingException.Retrieve();
-            return isIgnored;
+            return Object.InternalGetPropertyBool(SwigCPtr, Property.Ignored);
+        }
+
+        /// <summary>
+        /// Gets the flag to identify the View is ignored or not currently.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool CurrentIgnored
+        {
+            get
+            {
+                return IsCurrentIgnored();
+            }
+        }
+
+        /// <summary>
+        /// Gets the flag to identify the View is world ignored or not currently.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool WorldIgnored
+        {
+            get
+            {
+                return IsWorldIgnored();
+            }
         }
 
         /// <summary>

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewEnum.cs
@@ -322,6 +322,8 @@ namespace Tizen.NUI.BaseComponents
             internal static readonly int DispatchTouchMotion = Interop.ActorProperty.DispatchTouchMotionGet();
             internal static readonly int DispatchHoverMotion = Interop.ActorProperty.DispatchHoverMotionGet();
             internal static readonly int ChildrenDepthIndexPolicy = Interop.ActorProperty.ChildrenDepthIndexPolicyGet();
+            internal static readonly int Ignored = Interop.ActorProperty.IgnoredGet();
+            internal static readonly int WorldIgnored = Interop.ActorProperty.WorldIgnoredGet();
             internal static readonly int OffScreenRendering = Interop.ViewProperty.OffScreenRenderingGet();
             internal static readonly int InnerShadow = Interop.ViewProperty.InnerShadowGet();
             internal static readonly int Borderline = Interop.ViewProperty.BorderlineGet();

--- a/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/ViewInternal.cs
@@ -889,6 +889,23 @@ namespace Tizen.NUI.BaseComponents
             return internalCurrentWorldColor;
         }
 
+        internal bool IsCurrentIgnored()
+        {
+            // TODO : Need to bind new API for current property getter
+            using var value = Object.GetCurrentProperty(SwigCPtr, Property.Ignored);
+            bool ret = false;
+            if (value != null)
+            {
+                value.Get(out ret);
+            }
+            return ret;
+        }
+
+        internal bool IsWorldIgnored()
+        {
+            return Object.InternalGetPropertyBool(SwigCPtr, Property.WorldIgnored);
+        }
+
         internal void SetDrawMode(DrawModeType drawMode)
         {
             Interop.ActorInternal.SetDrawMode(SwigCPtr, (int)drawMode);

--- a/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackToggleTest.cs
+++ b/test/Tizen.NUI.Samples/Tizen.NUI.Samples/Samples/FrameUpdateCallbackToggleTest.cs
@@ -12,6 +12,11 @@ namespace Tizen.NUI.Samples
         private TextLabel ignoredLabel;
         private IgnoredToggler ignoredToggler;
 
+        private PropertyNotification lessThanNotification;
+        private PropertyNotification greaterThanNotification;
+        private TextLabel lessThanLabel;
+        private TextLabel greaterThanLabel;
+
         // FrameUpdateCallback to toggle the ignored state of an actor
         private class IgnoredToggler : FrameUpdateCallbackInterface
         {
@@ -110,13 +115,67 @@ namespace Tizen.NUI.Samples
             // Pass null as the root view, as the callback doesn't need to be tied to a specific view's lifecycle
             // and Layer cannot be directly cast to View for this method.
             window.AddFrameUpdateCallback(ignoredToggler, null);
+
+            // Create TextLabels to display the property notification
+            lessThanNotification = imageView.AddPropertyNotification("Ignored", PropertyCondition.LessThan(0.5f));
+            lessThanNotification.Notified += (o, e) =>
+            {
+                if (lessThanLabel != null)
+                {
+                    lessThanLabel.Ignored = false;
+                }
+                if (greaterThanLabel != null)
+                {
+                    greaterThanLabel.Ignored = true;
+                }
+            };
+            lessThanLabel = new TextLabel("1 -> 0 Notified")
+            {
+                ParentOrigin = ParentOrigin.TopLeft,
+                PivotPoint = PivotPoint.TopLeft,
+                PositionUsesPivotPoint = true,
+                TextColor = Color.Black,
+                HorizontalAlignment = HorizontalAlignment.Begin,
+                PointSize = 12
+            };
+            window.GetDefaultLayer().Add(lessThanLabel); // Add to window directly
+            lessThanLabel.Ignored = true;
+
+            greaterThanNotification = imageView.AddPropertyNotification("Ignored", PropertyCondition.GreaterThan(0.5f));
+            greaterThanNotification.Notified += (o, e) =>
+            {
+                if (lessThanLabel != null)
+                {
+                    lessThanLabel.Ignored = true;
+                }
+                if (greaterThanLabel != null)
+                {
+                    greaterThanLabel.Ignored = false;
+                }
+            };
+            greaterThanLabel = new TextLabel("0 -> 1 Notified")
+            {
+                ParentOrigin = ParentOrigin.TopRight,
+                PivotPoint = PivotPoint.TopRight,
+                PositionUsesPivotPoint = true,
+                TextColor = Color.Black,
+                HorizontalAlignment = HorizontalAlignment.End,
+                PointSize = 12
+            };
+            window.GetDefaultLayer().Add(greaterThanLabel); // Add to window directly
+            greaterThanLabel.Ignored = true;
+
+            
         }
 
         public void Deactivate()
         {
             if (ignoredToggler != null)
             {
-                window.RemoveFrameUpdateCallback(ignoredToggler);
+                if (window != null)
+                {
+                    window.RemoveFrameUpdateCallback(ignoredToggler);
+                }
                 ignoredToggler = null;
             }
 
@@ -134,8 +193,32 @@ namespace Tizen.NUI.Samples
                 visibleLabel = null;
             }
 
+            if (lessThanLabel != null)
+            {
+                lessThanLabel.Unparent();
+                lessThanLabel.Dispose();
+                lessThanLabel = null;
+            }
+
+            if (greaterThanLabel != null)
+            {
+                greaterThanLabel.Unparent();
+                greaterThanLabel.Dispose();
+                greaterThanLabel = null;
+            }
+
             if (imageView != null)
             {
+                if (lessThanNotification != null)
+                {
+                    imageView.RemovePropertyNotification(lessThanNotification);
+                    lessThanNotification.Dispose();
+                }
+                if (greaterThanNotification != null)
+                {
+                    imageView.RemovePropertyNotification(greaterThanNotification);
+                    greaterThanNotification.Dispose();
+                }
                 imageView.Unparent();
                 imageView.Dispose();
                 imageView = null;


### PR DESCRIPTION
Let we make `Ignored` property also use property index instead of API-only.

Now we can use property notification for Ignored property.

Relative dali patches:

- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-core/+/331147
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-toolkit/+/331305
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-demo/+/331320
- https://review.tizen.org/gerrit/c/platform/core/uifw/dali-csharp-binder/+/331321

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
