### PR TITLE
[NUI.WindowSystem] TaskbarService: remove useless checker

### DIFF
--- a/src/Tizen.NUI.WindowSystem/src/public/TaskbarService.cs
+++ b/src/Tizen.NUI.WindowSystem/src/public/TaskbarService.cs
@@ -114,10 +114,6 @@ namespace Tizen.NUI.WindowSystem.Shell
             {
                 throw new ArgumentNullException(nameof(win));
             }
-            if (!(win is Tizen.NUI.Window))
-            {
-                throw new ArgumentNullException("win should be NUI.Window because this is for NUI.WindowSystem");
-            }
 
             _tzsh = tzShell;
             _tzshWin = WindowSystem.Interop.EcoreWl2.GetWindowId(win.WindowHandle);


### PR DESCRIPTION
### Description of Change ###
Remove unnecessary window type checks on init TaskbarService

