### PR TITLE
[Tizen.NUI.Gadget] Improve task creation error handling

### DIFF
--- a/src/Tizen.NUI.Gadget/Tizen.NUI/OneShotService.cs
+++ b/src/Tizen.NUI.Gadget/Tizen.NUI/OneShotService.cs
@@ -146,6 +146,7 @@ namespace Tizen.NUI
         /// Initializes the service task and triggers the OnCreate event.
         /// If AutoClose is enabled, automatically destroys the service after execution.
         /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when the task creation fails.</exception>
         /// <since_tizen> 13 </since_tizen>
         public void Run()
         {
@@ -159,6 +160,12 @@ namespace Tizen.NUI
             if (State == OneShotServiceLifecycleState.Initialized)
             {
                 _task = TizenCore.Spawn(Name);
+                if (_task == null)
+                {
+                    Log.Error($"Task creation failed for OneShotService({Name})");
+                    throw new InvalidOperationException($"Failed to create task for OneShotService({Name})");
+                }
+
                 _task.Post(() =>
                 {
                     Create();


### PR DESCRIPTION
### Description of Change ###
<!-- Describe your changes here. -->
In Run method, `TizenCore.Spawn` can return null value.
Therefore, check if the `_task` value is null before _task.Post()

### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR: N/A

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
