### PR TITLE
[Applications] Fix RemountSubsession

### DIFF
--- a/src/Tizen.Applications.Common/Tizen.Applications/Application.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/Application.cs
@@ -125,6 +125,19 @@ namespace Tizen.Applications
             s_CurrentApplication = this;
         }
 
+        internal static void ResetCurrentApplicationDirectoryInfo()
+        {
+            if (s_CurrentApplication == null)
+            {
+                return;
+            }
+
+            lock (s_CurrentApplication._lock)
+            {
+                s_CurrentApplication._directoryInfo = null;
+            }
+        }
+
         /// <summary>
         /// Exits the main loop of the application.
         /// </summary>

--- a/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
+++ b/src/Tizen.Applications.Common/Tizen.Applications/ApplicationManager.cs
@@ -856,7 +856,7 @@ namespace Tizen.Applications
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void RemountSubsession(string subsessionId)
         {
-            if (string.IsNullOrEmpty(subsessionId))
+            if (subsessionId == null)
             {
                 throw new ArgumentException("Invalid argument.");
             }
@@ -877,6 +877,10 @@ namespace Tizen.Applications
                     case Interop.ApplicationManager.ErrorCode.NoSuchApp:
                         throw new InvalidOperationException("No such application.");
                 }
+            }
+            else
+            {
+                Application.ResetCurrentApplicationDirectoryInfo();
             }
         }
     }


### PR DESCRIPTION
Allow empty string input to change to default user 
Initialization of Applications.Current.DirectoryInfo managed by static because the value of DirectoryInfo may change after RemountSubsession