### PR TITLE
[NUI] Checked whether the window is at 0,0 in the Resized and Moved callbacks.

### DIFF
--- a/src/Tizen.NUI/src/public/Window/BorderWindow.cs
+++ b/src/Tizen.NUI/src/public/Window/BorderWindow.cs
@@ -535,6 +535,10 @@ namespace Tizen.NUI
         private void OnBorderWindowMoved(object sender, WindowMovedEventArgs e)
         {
             Tizen.Log.Info("NUI", $"OnBorderWindowMoved {e.WindowPosition.X}, {e.WindowPosition.Y}\n");
+            if (e.WindowPosition.X == 0 && e.WindowPosition.Y == 0)
+            {
+                DoMaximize(IsMaximized());
+            }
             borderInterface.OnMoved(e.WindowPosition.X, e.WindowPosition.Y);
         }
 
@@ -586,7 +590,12 @@ namespace Tizen.NUI
             {
                 contentsView.SizeHeight = resizeHeight - (isEnabledOverlay ? borderHeight : 0);
             }
-            DoMaximize(isMaximized);
+
+            var windowPosition = WindowPosition;
+            if (windowPosition.X == 0 && windowPosition.Y == 0)
+            {
+                DoMaximize(isMaximized);
+            }
 
             DoOverlayMode(isEnabledOverlay);
 


### PR DESCRIPTION
When Maximized is performed, the window is first resized and then moved to 0,0.

DoMaximize() must be performed after all Maximized operations have been performed.

Therefore, I checked whether the window is at 0,0 in the Resized and Moved callbacks.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
