### PR TITLE
[UIGadget] Fix LifecycleEvents pending issue

### DIFF
--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetLifecycleManager.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetLifecycleManager.cs
@@ -57,11 +57,17 @@ namespace Tizen.Applications
             }
 
             _processing = true;
+            var retry = 3;
             while (!_lifecycleEvents.IsEmpty)
             {
                 if (!_lifecycleEvents.TryDequeue(out LifecycleEvent lifecycleEvent))
                 {
-                    return;
+                    if ((!_lifecycleEvents.IsEmpty) && (retry-- > 0)) {
+                        Log.Warn("Fail to deque lifecycle events, retry " + retry);
+                        continue;
+                    } else {
+                        break;
+                    }
                 }
 
                 var action = lifecycleEvent.Action;

--- a/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetLifecycleManager.cs
+++ b/src/Tizen.Applications.UIGadget/Tizen.Applications/UIGadgetLifecycleManager.cs
@@ -72,6 +72,7 @@ namespace Tizen.Applications
 
                 var action = lifecycleEvent.Action;
                 action?.Invoke();
+                retry = 3;
             }
             _processing = false;
         }


### PR DESCRIPTION
When TryDequeue Fail, the function return without resetting '_processing' flag. To handle the case, it should not return during the loop.

Also, to handle the TryDequeue fail properly, it requires some retry count.
